### PR TITLE
Remove all json.dumps (no longer needed)

### DIFF
--- a/public/examples/integrations/toolkits/github/count_stargazers_example_2.py
+++ b/public/examples/integrations/toolkits/github/count_stargazers_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/github/create_issue_comment_example_2.py
+++ b/public/examples/integrations/toolkits/github/create_issue_comment_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/github/create_issue_example_2.py
+++ b/public/examples/integrations/toolkits/github/create_issue_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/github/create_reply_for_review_comment_example_2.py
+++ b/public/examples/integrations/toolkits/github/create_reply_for_review_comment_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/github/create_review_comment_example_2.py
+++ b/public/examples/integrations/toolkits/github/create_review_comment_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/github/get_pull_request_example_2.py
+++ b/public/examples/integrations/toolkits/github/get_pull_request_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/github/get_repository_example_2.py
+++ b/public/examples/integrations/toolkits/github/get_repository_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/github/list_org_repositories_example_2.py
+++ b/public/examples/integrations/toolkits/github/list_org_repositories_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/github/list_pull_request_commits_example_2.py
+++ b/public/examples/integrations/toolkits/github/list_pull_request_commits_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/github/list_pull_requests_example_2.py
+++ b/public/examples/integrations/toolkits/github/list_pull_requests_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/github/list_repository_activities_example_2.py
+++ b/public/examples/integrations/toolkits/github/list_repository_activities_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/github/list_review_comments_in_a_repository_example_2.py
+++ b/public/examples/integrations/toolkits/github/list_review_comments_in_a_repository_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/github/list_review_comments_on_pull_request_example_2.py
+++ b/public/examples/integrations/toolkits/github/list_review_comments_on_pull_request_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/github/set_starred_example_2.py
+++ b/public/examples/integrations/toolkits/github/set_starred_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/github/update_pull_request_example_2.py
+++ b/public/examples/integrations/toolkits/github/update_pull_request_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/calendar/create_event_example_2.py
+++ b/public/examples/integrations/toolkits/google/calendar/create_event_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/calendar/delete_event_example_2.py
+++ b/public/examples/integrations/toolkits/google/calendar/delete_event_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/calendar/list_events_example_2.py
+++ b/public/examples/integrations/toolkits/google/calendar/list_events_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/calendar/update_event_example_2.py
+++ b/public/examples/integrations/toolkits/google/calendar/update_event_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/docs/create_blank_document_example_2.py
+++ b/public/examples/integrations/toolkits/google/docs/create_blank_document_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/docs/create_document_from_text_example_2.py
+++ b/public/examples/integrations/toolkits/google/docs/create_document_from_text_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/docs/get_document_by_id_example_2.py
+++ b/public/examples/integrations/toolkits/google/docs/get_document_by_id_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/docs/insert_text_at_end_of_document_example_2.py
+++ b/public/examples/integrations/toolkits/google/docs/insert_text_at_end_of_document_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/drive/list_documents_example_2.py
+++ b/public/examples/integrations/toolkits/google/drive/list_documents_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/gmail/delete_draft_email_example_2.py
+++ b/public/examples/integrations/toolkits/google/gmail/delete_draft_email_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/gmail/list_draft_emails_example_2.py
+++ b/public/examples/integrations/toolkits/google/gmail/list_draft_emails_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/gmail/list_emails_by_header_example_2.py
+++ b/public/examples/integrations/toolkits/google/gmail/list_emails_by_header_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/gmail/list_emails_example_2.py
+++ b/public/examples/integrations/toolkits/google/gmail/list_emails_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/gmail/send_draft_email_example_2.py
+++ b/public/examples/integrations/toolkits/google/gmail/send_draft_email_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/gmail/send_email_example_2.py
+++ b/public/examples/integrations/toolkits/google/gmail/send_email_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/gmail/trash_email_example_2.py
+++ b/public/examples/integrations/toolkits/google/gmail/trash_email_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/gmail/update_draft_email_example_2.py
+++ b/public/examples/integrations/toolkits/google/gmail/update_draft_email_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/google/gmail/write_draft_email_example_2.py
+++ b/public/examples/integrations/toolkits/google/gmail/write_draft_email_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/search/search_google_example_2.py
+++ b/public/examples/integrations/toolkits/search/search_google_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/slack/send_dm_to_user_example_2.py
+++ b/public/examples/integrations/toolkits/slack/send_dm_to_user_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/slack/send_message_to_channel_example_2.py
+++ b/public/examples/integrations/toolkits/slack/send_message_to_channel_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/x/delete_tweet_by_id_example_2.py
+++ b/public/examples/integrations/toolkits/x/delete_tweet_by_id_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/x/lookup_single_user_by_username_example_2.py
+++ b/public/examples/integrations/toolkits/x/lookup_single_user_by_username_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/x/post_tweet_example_2.py
+++ b/public/examples/integrations/toolkits/x/post_tweet_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/x/search_recent_tweets_by_keywords_example_2.py
+++ b/public/examples/integrations/toolkits/x/search_recent_tweets_by_keywords_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()

--- a/public/examples/integrations/toolkits/x/search_recent_tweets_by_username_example_2.py
+++ b/public/examples/integrations/toolkits/x/search_recent_tweets_by_username_example_2.py
@@ -1,4 +1,3 @@
-import json
 from arcade.client import Arcade
 
 client = Arcade()


### PR DESCRIPTION
The Engine no longer requires string `inputs` as of: https://github.com/ArcadeAI/Engine/pull/144

And actually, we fixed this even earlier in the client by accepting a `dict | str`. 
So this syntax is no longer needed either way!