### PR TITLE
Add step for setting env var

### DIFF
--- a/pages/home/use-tools/call-tools-directly.mdx
+++ b/pages/home/use-tools/call-tools-directly.mdx
@@ -19,9 +19,17 @@ You still get the benefits of Arcade AI managing authorization and tool executio
 
 - [Set up Arcade AI](/home/quickstart)
 
+### Set environment variables
+
+```bash
+export ARCADE_API_KEY=<your-api-key>
+```
+
+You can find your API key in `~/.arcade/credentials.yaml`.
+
 ### Initialize the client
 
-Import the `Arcade()` client in a Python script. The client automatically finds API keys set by `arcade login`.
+Import the `Arcade()` client in a Python script. The client automatically uses the `ARCADE_API_KEY` environment variable.
 
 ```python file=<rootDir>/examples/code/home/use-tools/call-tools-directly/github_star_directly.py#L1-L3
 


### PR DESCRIPTION
Specifically calls out setting `ARCADE_API_KEY` the first time the user needs it.