### PR TITLE
Update eval examples

### DIFF
--- a/pages/home/evaluate-tools/create-an-evaluation-suite.mdx
+++ b/pages/home/evaluate-tools/create-an-evaluation-suite.mdx
@@ -250,7 +250,7 @@ suite.add_case(
             },
         ),
         ExpectedToolCall(
-            name="Hello",
+            name=hello,
             args={
                 "name": "Alice",
                 "emotion": Emotion.SLIGHTLY_HAPPY,

--- a/pages/home/evaluate-tools/create-an-evaluation-suite.mdx
+++ b/pages/home/evaluate-tools/create-an-evaluation-suite.mdx
@@ -73,7 +73,7 @@ def hello_eval_suite() -> EvalSuite:
         user_message="Say hello to Alice",
         expected_tool_calls=[
             ExpectedToolCall(
-                name="Hello",
+                func=hello,
                 args={
                     "name": "Alice",
                 },
@@ -191,7 +191,7 @@ suite.add_case(
     user_message="Say hello to Bob sadly",
     expected_tool_calls=[
         ExpectedToolCall(
-            name="Hello",
+            func=hello,
             args={
                 "name": "Bob",
                 "emotion": Emotion.SAD,
@@ -213,7 +213,7 @@ suite.add_case(
     user_message="Say hello to Bob based on my current mood.",
     expected_tool_calls=[
         ExpectedToolCall(
-            name="Hello",
+            func=hello,
             args={
                 "name": "Bob",
                 "emotion": Emotion.HAPPY,
@@ -243,7 +243,7 @@ suite.add_case(
     user_message="Say hello to Bob based on my current mood. And then say hello to Alice with slightly less of that emotion.",
     expected_tool_calls=[
         ExpectedToolCall(
-            name="Hello",
+            func=hello,
             args={
                 "name": "Bob",
                 "emotion": Emotion.HAPPY,

--- a/pages/home/evaluate-tools/create-an-evaluation-suite.mdx
+++ b/pages/home/evaluate-tools/create-an-evaluation-suite.mdx
@@ -250,7 +250,7 @@ suite.add_case(
             },
         ),
         ExpectedToolCall(
-            name=hello,
+            func=hello,
             args={
                 "name": "Alice",
                 "emotion": Emotion.SLIGHTLY_HAPPY,


### PR DESCRIPTION
The examples were incorrect and never worked. This PR updates the example to use the preferred `ExpectedToolCall` usage for 0.1.7+

ONLY MERGE AFTER arcade-ai 0.1.7 is released