### PR TITLE
Mark toolkits that require custom auth and Callout auth providers without a default app

### DIFF
--- a/pages/home/auth-providers/atlassian.mdx
+++ b/pages/home/auth-providers/atlassian.mdx
@@ -1,7 +1,7 @@
 # Atlassian auth provider
 
 <Note>
-  At this time, Arcade does not offer a default Atlassian Auth Provider. To use Atlassian auth, you must create a custom Auth Provider with your own Atlassian OAuth2 credentials.
+  At this time, Arcade does not offer a default Atlassian Auth Provider. To use Atlassian auth, you must create a custom Auth Provider with your own Atlassian OAuth 2.0 credentials.
 </Note>
 
 The Atlassian auth provider enables tools and agents to call the Atlassian API on behalf of a user. Behind the scenes, the Arcade Engine and the Atlassian auth provider seamlessly manage Atlassian OAuth 2.0 authorization for your users.

--- a/pages/home/auth-providers/atlassian.mdx
+++ b/pages/home/auth-providers/atlassian.mdx
@@ -1,5 +1,9 @@
 # Atlassian auth provider
 
+<Note>
+  At this time, Arcade does not offer a default Atlassian auth provider. To use this auth provider, you must create your own custom Auth Provider by providing your own Atlassian app credentials.
+</Note>
+
 The Atlassian auth provider enables tools and agents to call the Atlassian API on behalf of a user. Behind the scenes, the Arcade Engine and the Atlassian auth provider seamlessly manage Atlassian OAuth 2.0 authorization for your users.
 
 ### What's documented here

--- a/pages/home/auth-providers/atlassian.mdx
+++ b/pages/home/auth-providers/atlassian.mdx
@@ -1,7 +1,7 @@
 # Atlassian auth provider
 
 <Note>
-  At this time, Arcade does not offer a default Atlassian auth provider. To use this auth provider, you must create your own custom Auth Provider by providing your own Atlassian app credentials.
+  At this time, Arcade does not offer a default Atlassian Auth Provider. To use Atlassian auth, you must create a custom Auth Provider with your own Atlassian OAuth2 credentials.
 </Note>
 
 The Atlassian auth provider enables tools and agents to call the Atlassian API on behalf of a user. Behind the scenes, the Arcade Engine and the Atlassian auth provider seamlessly manage Atlassian OAuth 2.0 authorization for your users.

--- a/pages/home/auth-providers/discord.mdx
+++ b/pages/home/auth-providers/discord.mdx
@@ -1,7 +1,7 @@
 # Discord auth provider
 
 <Note>
-  At this time, Arcade does not offer a default Discord auth provider. To use this auth provider, you must create your own custom Auth Provider by providing your own Discord app credentials.
+  At this time, Arcade does not offer a default Discord Auth Provider. To use Discord auth, you must create a custom Auth Provider with your own Discord OAuth2 credentials.
 </Note>
 
 The Discord auth provider enables tools and agents to call the Discord API on behalf of a user. Behind the scenes, the Arcade Engine and the Discord auth provider seamlessly manage Discord OAuth 2.0 authorization for your users.

--- a/pages/home/auth-providers/discord.mdx
+++ b/pages/home/auth-providers/discord.mdx
@@ -1,7 +1,7 @@
 # Discord auth provider
 
 <Note>
-  At this time, Arcade does not offer a default Discord Auth Provider. To use Discord auth, you must create a custom Auth Provider with your own Discord OAuth2 credentials.
+  At this time, Arcade does not offer a default Discord Auth Provider. To use Discord auth, you must create a custom Auth Provider with your own Discord OAuth 2.0 credentials.
 </Note>
 
 The Discord auth provider enables tools and agents to call the Discord API on behalf of a user. Behind the scenes, the Arcade Engine and the Discord auth provider seamlessly manage Discord OAuth 2.0 authorization for your users.

--- a/pages/home/auth-providers/discord.mdx
+++ b/pages/home/auth-providers/discord.mdx
@@ -1,5 +1,9 @@
 # Discord auth provider
 
+<Note>
+  At this time, Arcade does not offer a default Discord auth provider. To use this auth provider, you must create your own custom Auth Provider by providing your own Discord app credentials.
+</Note>
+
 The Discord auth provider enables tools and agents to call the Discord API on behalf of a user. Behind the scenes, the Arcade Engine and the Discord auth provider seamlessly manage Discord OAuth 2.0 authorization for your users.
 
 ### What's documented here

--- a/pages/home/auth-providers/dropbox.mdx
+++ b/pages/home/auth-providers/dropbox.mdx
@@ -1,5 +1,9 @@
 # Dropbox auth provider
 
+<Note>
+  At this time, Arcade does not offer a default Dropbox auth provider. To use this auth provider, you must create your own custom Auth Provider by providing your own Dropbox app credentials.
+</Note>
+
 The Dropbox auth provider enables tools and agents to call the Dropbox API on behalf of a user. Behind the scenes, the Arcade Engine and the Dropbox auth provider seamlessly manage Dropbox OAuth 2.0 authorization for your users.
 
 ### What's documented here

--- a/pages/home/auth-providers/dropbox.mdx
+++ b/pages/home/auth-providers/dropbox.mdx
@@ -1,7 +1,7 @@
 # Dropbox auth provider
 
 <Note>
-  At this time, Arcade does not offer a default Dropbox auth provider. To use this auth provider, you must create your own custom Auth Provider by providing your own Dropbox app credentials.
+  At this time, Arcade does not offer a default Dropbox Auth Provider. To use Dropbox auth, you must create a custom Auth Provider with your own Dropbox OAuth2 credentials.
 </Note>
 
 The Dropbox auth provider enables tools and agents to call the Dropbox API on behalf of a user. Behind the scenes, the Arcade Engine and the Dropbox auth provider seamlessly manage Dropbox OAuth 2.0 authorization for your users.

--- a/pages/home/auth-providers/dropbox.mdx
+++ b/pages/home/auth-providers/dropbox.mdx
@@ -1,7 +1,7 @@
 # Dropbox auth provider
 
 <Note>
-  At this time, Arcade does not offer a default Dropbox Auth Provider. To use Dropbox auth, you must create a custom Auth Provider with your own Dropbox OAuth2 credentials.
+  At this time, Arcade does not offer a default Dropbox Auth Provider. To use Dropbox auth, you must create a custom Auth Provider with your own Dropbox OAuth 2.0 credentials.
 </Note>
 
 The Dropbox auth provider enables tools and agents to call the Dropbox API on behalf of a user. Behind the scenes, the Arcade Engine and the Dropbox auth provider seamlessly manage Dropbox OAuth 2.0 authorization for your users.

--- a/pages/home/auth-providers/microsoft.mdx
+++ b/pages/home/auth-providers/microsoft.mdx
@@ -1,7 +1,7 @@
 # Microsoft auth provider
 
 <Note>
-  At this time, Arcade does not offer a default Microsoft auth provider. To use this auth provider, you must create your own custom Auth Provider by providing your own Microsoft app credentials.
+  At this time, Arcade does not offer a default Microsoft Auth Provider. To use Microsoft auth, you must create a custom Auth Provider with your own Microsoft OAuth2 credentials.
 </Note>
 
 The Microsoft auth provider enables tools and agents to call the Microsoft Graph API on behalf of a user. Behind the scenes, the Arcade Engine and the Microsoft auth provider seamlessly manage Microsoft OAuth 2.0 authorization for your users.

--- a/pages/home/auth-providers/microsoft.mdx
+++ b/pages/home/auth-providers/microsoft.mdx
@@ -1,5 +1,9 @@
 # Microsoft auth provider
 
+<Note>
+  At this time, Arcade does not offer a default Microsoft auth provider. To use this auth provider, you must create your own custom Auth Provider by providing your own Microsoft app credentials.
+</Note>
+
 The Microsoft auth provider enables tools and agents to call the Microsoft Graph API on behalf of a user. Behind the scenes, the Arcade Engine and the Microsoft auth provider seamlessly manage Microsoft OAuth 2.0 authorization for your users.
 
 ### What's documented here

--- a/pages/home/auth-providers/microsoft.mdx
+++ b/pages/home/auth-providers/microsoft.mdx
@@ -1,7 +1,7 @@
 # Microsoft auth provider
 
 <Note>
-  At this time, Arcade does not offer a default Microsoft Auth Provider. To use Microsoft auth, you must create a custom Auth Provider with your own Microsoft OAuth2 credentials.
+  At this time, Arcade does not offer a default Microsoft Auth Provider. To use Microsoft auth, you must create a custom Auth Provider with your own Microsoft OAuth 2.0 credentials.
 </Note>
 
 The Microsoft auth provider enables tools and agents to call the Microsoft Graph API on behalf of a user. Behind the scenes, the Arcade Engine and the Microsoft auth provider seamlessly manage Microsoft OAuth 2.0 authorization for your users.

--- a/pages/home/auth-providers/spotify.mdx
+++ b/pages/home/auth-providers/spotify.mdx
@@ -1,7 +1,7 @@
 # Spotify auth provider
 
 <Note>
-  At this time, Arcade does not offer a default Spotify Auth Provider. To use Spotify auth, you must create a custom Auth Provider with your own Spotify OAuth2 credentials.
+  At this time, Arcade does not offer a default Spotify Auth Provider. To use Spotify auth, you must create a custom Auth Provider with your own Spotify OAuth 2.0 credentials.
 </Note>
 
 The Spotify auth provider enables tools and agents to call the Spotify API on behalf of a user. Behind the scenes, the Arcade Engine and the Spotify auth provider seamlessly manage Spotify OAuth 2.0 authorization for your users.

--- a/pages/home/auth-providers/spotify.mdx
+++ b/pages/home/auth-providers/spotify.mdx
@@ -1,5 +1,9 @@
 # Spotify auth provider
 
+<Note>
+  At this time, Arcade does not offer a default Spotify auth provider. To use this auth provider, you must create your own custom Auth Provider by providing your own Spotify app credentials.
+</Note>
+
 The Spotify auth provider enables tools and agents to call the Spotify API on behalf of a user. Behind the scenes, the Arcade Engine and the Spotify auth provider seamlessly manage Spotify OAuth 2.0 authorization for your users.
 
 ### What's documented here

--- a/pages/home/auth-providers/spotify.mdx
+++ b/pages/home/auth-providers/spotify.mdx
@@ -1,7 +1,7 @@
 # Spotify auth provider
 
 <Note>
-  At this time, Arcade does not offer a default Spotify auth provider. To use this auth provider, you must create your own custom Auth Provider by providing your own Spotify app credentials.
+  At this time, Arcade does not offer a default Spotify Auth Provider. To use Spotify auth, you must create a custom Auth Provider with your own Spotify OAuth2 credentials.
 </Note>
 
 The Spotify auth provider enables tools and agents to call the Spotify API on behalf of a user. Behind the scenes, the Arcade Engine and the Spotify auth provider seamlessly manage Spotify OAuth 2.0 authorization for your users.

--- a/pages/home/auth-providers/zoom.mdx
+++ b/pages/home/auth-providers/zoom.mdx
@@ -1,5 +1,9 @@
 # Zoom auth provider
 
+<Note>
+  At this time, Arcade does not offer a default Zoom auth provider. To use this auth provider, you must create your own custom Auth Provider by providing your own Zoom app credentials.
+</Note>
+
 The Zoom auth provider enables tools and agents to call the Zoom API on behalf of a user. Behind the scenes, the Arcade Engine and the Zoom auth provider seamlessly manage Zoom OAuth 2.0 authorization for your users.
 
 ### What's documented here

--- a/pages/home/auth-providers/zoom.mdx
+++ b/pages/home/auth-providers/zoom.mdx
@@ -1,7 +1,7 @@
 # Zoom auth provider
 
 <Note>
-  At this time, Arcade does not offer a default Zoom auth provider. To use this auth provider, you must create your own custom Auth Provider by providing your own Zoom app credentials.
+  At this time, Arcade does not offer a default Zoom Auth Provider. To use Zoom auth, you must create a custom Auth Provider with your own Zoom OAuth2 credentials.
 </Note>
 
 The Zoom auth provider enables tools and agents to call the Zoom API on behalf of a user. Behind the scenes, the Arcade Engine and the Zoom auth provider seamlessly manage Zoom OAuth 2.0 authorization for your users.

--- a/pages/home/auth-providers/zoom.mdx
+++ b/pages/home/auth-providers/zoom.mdx
@@ -1,7 +1,7 @@
 # Zoom auth provider
 
 <Note>
-  At this time, Arcade does not offer a default Zoom Auth Provider. To use Zoom auth, you must create a custom Auth Provider with your own Zoom OAuth2 credentials.
+  At this time, Arcade does not offer a default Zoom Auth Provider. To use Zoom auth, you must create a custom Auth Provider with your own Zoom OAuth 2.0 credentials.
 </Note>
 
 The Zoom auth provider enables tools and agents to call the Zoom API on behalf of a user. Behind the scenes, the Arcade Engine and the Zoom auth provider seamlessly manage Zoom OAuth 2.0 authorization for your users.

--- a/pages/toolkits/entertainment/spotify.mdx
+++ b/pages/toolkits/entertainment/spotify.mdx
@@ -12,6 +12,7 @@ import TableOfContents from "@/components/TableOfContents";
   authType="oauth2"
   authProviderName="Spotify"
   versions={["0.1.0"]}
+  note="This tool is not available when using the arcade-spotify Auth Provider in the Arcade Cloud. To use this tool, you must create your own Auth Provider."
 />
 
 <Badges repo="arcadeai/arcade_spotify" />
@@ -36,31 +37,52 @@ pip install arcade_spotify
     ["GetTrackFromId", "Get information about a track"],
     [
       "AdjustPlaybackPosition",
-      "Adjust the playback position within the currently playing track.",
+      "Adjust the playback position within the currently playing track. Note: This tool currently requires a custom Auth Provider.",
     ],
     [
       "SkipToPreviousTrack",
-      "Skip to the previous track in the user's queue, if any",
+      "Skip to the previous track in the user's queue, if any. Note: This tool currently requires a custom Auth Provider.",
     ],
-    ["SkipToNextTrack", "Skip to the next track in the user's queue, if any"],
-    ["PausePlayback", "Pause the currently playing track, if any"],
-    ["ResumePlayback", "Resume the currently playing track, if any"],
-    ["StartTracksPlaybackById", "Start playback of a list of tracks (songs)"],
+    [
+      "SkipToNextTrack",
+      "Skip to the next track in the user's queue, if any. Note: This tool currently requires a custom Auth Provider.",
+    ],
+    [
+      "PausePlayback",
+      "Pause the currently playing track, if any. Note: This tool currently requires a custom Auth Provider.",
+    ],
+    [
+      "ResumePlayback",
+      "Resume the currently playing track, if any. Note: This tool currently requires a custom Auth Provider.",
+    ],
+    [
+      "StartTracksPlaybackById",
+      "Start playback of a list of tracks (songs). Note: This tool currently requires a custom Auth Provider.",
+    ],
     [
       "GetPlaybackState",
-      "Get information about the user's current playback state, including track or episode, and active device.",
+      "Get information about the user's current playback state, including track or episode, and active device. Note: This tool currently requires a custom Auth Provider.",
     ],
     [
       "GetCurrentlyPlaying",
-      "Get information about the user's currently playing track",
+      "Get information about the user's currently playing track. Note: This tool currently requires a custom Auth Provider.",
     ],
     [
       "PlayArtistByName",
-      "Plays a song by an artist and queues four more songs by the same artist",
+      "Plays a song by an artist and queues four more songs by the same artist. Note: This tool currently requires a custom Auth Provider.",
     ],
-    ["PlayTrackByName", "Plays a song by name"],
-    ["GetAvailableDevices", "Get the available devices"],
-    ["Search", "Search Spotify catalog information"],
+    [
+      "PlayTrackByName",
+      "Plays a song by name. Note: This tool currently requires a custom Auth Provider.",
+    ],
+    [
+      "GetAvailableDevices",
+      "Get the available devices. Note: This tool currently requires a custom Auth Provider.",
+    ],
+    [
+      "Search",
+      "Search Spotify catalog information. Note: This tool currently requires a custom Auth Provider.",
+    ],
   ]}
 />
 

--- a/pages/toolkits/entertainment/spotify.mdx
+++ b/pages/toolkits/entertainment/spotify.mdx
@@ -12,7 +12,7 @@ import TableOfContents from "@/components/TableOfContents";
   authType="oauth2"
   authProviderName="Spotify"
   versions={["0.1.0"]}
-  note="This tool is not available when using the arcade-spotify Auth Provider in the Arcade Cloud. To use this tool, you must create your own Auth Provider."
+  note="This Toolkit is not available in Arcade Cloud. You can use these tools with a self-hosted instance of Arcade."
 />
 
 <Badges repo="arcadeai/arcade_spotify" />
@@ -37,51 +37,51 @@ pip install arcade_spotify
     ["GetTrackFromId", "Get information about a track"],
     [
       "AdjustPlaybackPosition",
-      "Adjust the playback position within the currently playing track. Note: This tool currently requires a custom Auth Provider.",
+      "Adjust the playback position within the currently playing track. Note: This tool currently requires a self-hosted instance of Arcade.",
     ],
     [
       "SkipToPreviousTrack",
-      "Skip to the previous track in the user's queue, if any. Note: This tool currently requires a custom Auth Provider.",
+      "Skip to the previous track in the user's queue, if any. Note: This tool currently requires a self-hosted instance of Arcade.",
     ],
     [
       "SkipToNextTrack",
-      "Skip to the next track in the user's queue, if any. Note: This tool currently requires a custom Auth Provider.",
+      "Skip to the next track in the user's queue, if any. Note: This tool currently requires a self-hosted instance of Arcade.",
     ],
     [
       "PausePlayback",
-      "Pause the currently playing track, if any. Note: This tool currently requires a custom Auth Provider.",
+      "Pause the currently playing track, if any. Note: This tool currently requires a self-hosted instance of Arcade.",
     ],
     [
       "ResumePlayback",
-      "Resume the currently playing track, if any. Note: This tool currently requires a custom Auth Provider.",
+      "Resume the currently playing track, if any. Note: This tool currently requires a self-hosted instance of Arcade.",
     ],
     [
       "StartTracksPlaybackById",
-      "Start playback of a list of tracks (songs). Note: This tool currently requires a custom Auth Provider.",
+      "Start playback of a list of tracks (songs). Note: This tool currently requires a self-hosted instance of Arcade.",
     ],
     [
       "GetPlaybackState",
-      "Get information about the user's current playback state, including track or episode, and active device. Note: This tool currently requires a custom Auth Provider.",
+      "Get information about the user's current playback state, including track or episode, and active device. Note: This tool currently requires a self-hosted instance of Arcade.",
     ],
     [
       "GetCurrentlyPlaying",
-      "Get information about the user's currently playing track. Note: This tool currently requires a custom Auth Provider.",
+      "Get information about the user's currently playing track. Note: This tool currently requires a self-hosted instance of Arcade.",
     ],
     [
       "PlayArtistByName",
-      "Plays a song by an artist and queues four more songs by the same artist. Note: This tool currently requires a custom Auth Provider.",
+      "Plays a song by an artist and queues four more songs by the same artist. Note: This tool currently requires a self-hosted instance of Arcade.",
     ],
     [
       "PlayTrackByName",
-      "Plays a song by name. Note: This tool currently requires a custom Auth Provider.",
+      "Plays a song by name. Note: This tool currently requires a self-hosted instance of Arcade.",
     ],
     [
       "GetAvailableDevices",
-      "Get the available devices. Note: This tool currently requires a custom Auth Provider.",
+      "Get the available devices. Note: This tool currently requires a self-hosted instance of Arcade.",
     ],
     [
       "Search",
-      "Search Spotify catalog information. Note: This tool currently requires a custom Auth Provider.",
+      "Search Spotify catalog information. Note: This tool currently requires a self-hosted instance of Arcade.",
     ],
   ]}
 />

--- a/pages/toolkits/productivity/google/docs.mdx
+++ b/pages/toolkits/productivity/google/docs.mdx
@@ -12,7 +12,7 @@ import TableOfContents from "@/components/TableOfContents";
   authType="oauth2"
   authProviderName="Google"
   versions={["0.1.0"]}
-  note="This tool is not available when using the arcade-google Auth Provider in the Arcade Cloud. To use this tool, you must create your own Auth Provider."
+  note="This Toolkit is not available in Arcade Cloud. You can use these tools with a self-hosted instance of Arcade."
 />
 
 <Badges repo="arcadeai/arcade_google" />
@@ -34,19 +34,19 @@ pip install arcade_google
   data={[
     [
       "GetDocumentById",
-      "Retrieve a Google Docs document by ID. Note: This tool currently requires a custom Auth Provider.",
+      "Retrieve a Google Docs document by ID. Note: This tool currently requires a self-hosted instance of Arcade.",
     ],
     [
       "InsertTextAtEndOfDocument",
-      "Insert text at the end of a Google Docs document. Note: This tool currently requires a custom Auth Provider.",
+      "Insert text at the end of a Google Docs document. Note: This tool currently requires a self-hosted instance of Arcade.",
     ],
     [
       "CreateBlankDocument",
-      "Create a new blank Google Docs document with a title. Note: This tool currently requires a custom Auth Provider.",
+      "Create a new blank Google Docs document with a title. Note: This tool currently requires a self-hosted instance of Arcade.",
     ],
     [
       "CreateDocumentFromText",
-      "Create a new Google Docs document with specified text content. Note: This tool currently requires a custom Auth Provider.",
+      "Create a new Google Docs document with specified text content. Note: This tool currently requires a self-hosted instance of Arcade.",
     ],
   ]}
 />

--- a/pages/toolkits/productivity/google/docs.mdx
+++ b/pages/toolkits/productivity/google/docs.mdx
@@ -12,6 +12,7 @@ import TableOfContents from "@/components/TableOfContents";
   authType="oauth2"
   authProviderName="Google"
   versions={["0.1.0"]}
+  note="This tool is not available when using the arcade-google Auth Provider in the Arcade Cloud. To use this tool, you must create your own Auth Provider."
 />
 
 <Badges repo="arcadeai/arcade_google" />
@@ -31,18 +32,21 @@ pip install arcade_google
 <TableOfContents
   headers={["Tool Name", "Description"]}
   data={[
-    ["GetDocumentById", "Retrieve a Google Docs document by ID."],
+    [
+      "GetDocumentById",
+      "Retrieve a Google Docs document by ID. Note: This tool currently requires a custom Auth Provider.",
+    ],
     [
       "InsertTextAtEndOfDocument",
-      "Insert text at the end of a Google Docs document.",
+      "Insert text at the end of a Google Docs document. Note: This tool currently requires a custom Auth Provider.",
     ],
     [
       "CreateBlankDocument",
-      "Create a new blank Google Docs document with a title.",
+      "Create a new blank Google Docs document with a title. Note: This tool currently requires a custom Auth Provider.",
     ],
     [
       "CreateDocumentFromText",
-      "Create a new Google Docs document with specified text content.",
+      "Create a new Google Docs document with specified text content. Note: This tool currently requires a custom Auth Provider.",
     ],
   ]}
 />

--- a/pages/toolkits/productivity/google/drive.mdx
+++ b/pages/toolkits/productivity/google/drive.mdx
@@ -12,7 +12,7 @@ import TableOfContents from "@/components/TableOfContents";
   authType="oauth2"
   authProviderName="Google"
   versions={["0.1.0"]}
-  note="This tool is not available when using the arcade-google Auth Provider in the Arcade Cloud. To use this tool, you must create your own Auth Provider."
+  note="This Toolkit is not available in Arcade Cloud. You can use these tools with a self-hosted instance of Arcade."
 />
 
 <Badges repo="arcadeai/arcade_google" />
@@ -31,7 +31,7 @@ pip install arcade_google
 
 <TableOfContents
   headers={["Tool Name", "Description"]}
-  data={[["ListDocuments", "List documents in the user's Google Drive. Note: This tool currently requires a custom Auth Provider.",]]}
+  data={[["ListDocuments", "List documents in the user's Google Drive. Note: This tool currently requires a self-hosted instance of Arcade."]]}
 />
 
 <Tip>

--- a/pages/toolkits/productivity/google/drive.mdx
+++ b/pages/toolkits/productivity/google/drive.mdx
@@ -12,6 +12,7 @@ import TableOfContents from "@/components/TableOfContents";
   authType="oauth2"
   authProviderName="Google"
   versions={["0.1.0"]}
+  note="This tool is not available when using the arcade-google Auth Provider in the Arcade Cloud. To use this tool, you must create your own Auth Provider."
 />
 
 <Badges repo="arcadeai/arcade_google" />
@@ -30,7 +31,7 @@ pip install arcade_google
 
 <TableOfContents
   headers={["Tool Name", "Description"]}
-  data={[["ListDocuments", "List documents in the user's Google Drive."]]}
+  data={[["ListDocuments", "List documents in the user's Google Drive. Note: This tool currently requires a custom Auth Provider.",]]}
 />
 
 <Tip>

--- a/pages/toolkits/productivity/google/gmail.mdx
+++ b/pages/toolkits/productivity/google/gmail.mdx
@@ -42,7 +42,7 @@ These tools are currently available in the Arcade AI GitHub toolkit.
     ["WriteDraftEmail", "Compose a new email draft using the Gmail API."],
     ["UpdateDraftEmail", "Update an existing email draft."],
     ["DeleteDraftEmail", "Delete a draft email using the Gmail API."],
-    ["TrashEmail", "Move an email to the trash folder. Note: This tool currently requires a custom Auth Provider."],
+    ["TrashEmail", "Move an email to the trash folder. Note: This tool currently requires a self-hosted instance of Arcade."],
     ["ListDraftEmails", "List draft emails in the user's mailbox."],
     ["ListEmailsByHeader", "Search for emails by header using the Gmail API."],
     ["ListEmails", "Read emails and extract plain text content."],

--- a/pages/toolkits/productivity/google/gmail.mdx
+++ b/pages/toolkits/productivity/google/gmail.mdx
@@ -42,7 +42,7 @@ These tools are currently available in the Arcade AI GitHub toolkit.
     ["WriteDraftEmail", "Compose a new email draft using the Gmail API."],
     ["UpdateDraftEmail", "Update an existing email draft."],
     ["DeleteDraftEmail", "Delete a draft email using the Gmail API."],
-    ["TrashEmail", "Move an email to the trash folder."],
+    ["TrashEmail", "Move an email to the trash folder. Note: This tool currently requires a custom Auth Provider."],
     ["ListDraftEmails", "List draft emails in the user's mailbox."],
     ["ListEmailsByHeader", "Search for emails by header using the Gmail API."],
     ["ListEmails", "Read emails and extract plain text content."],

--- a/src/components/ToolInfo.tsx
+++ b/src/components/ToolInfo.tsx
@@ -9,6 +9,7 @@ interface ToolInfoProps {
   authProviderName?: string;
   authProviderDocsUrl?: string;
   versions: string[];
+  note?: string;
 }
 
 const ToolInfo: React.FC<ToolInfoProps> = ({
@@ -18,6 +19,7 @@ const ToolInfo: React.FC<ToolInfoProps> = ({
   authType,
   authProviderName,
   authProviderDocsUrl,
+  note,
 }) => {
   authProviderDocsUrl =
     authProviderName && !authProviderDocsUrl
@@ -56,6 +58,12 @@ const ToolInfo: React.FC<ToolInfoProps> = ({
           authType
         )}
       </p>
+      {note && (
+        <p>
+          <strong>Note: </strong>
+          {note}
+        </p>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This is probably a short-term thing, but wanted to doc it for now somehow.

![Screenshot 2025-01-23 at 14 28 33](https://github.com/user-attachments/assets/fddb4db2-c6d2-4ea0-8e0a-e73384f7c6f5)

![Screenshot 2025-01-23 at 14 28 16](https://github.com/user-attachments/assets/42f4e5e2-ba31-4799-a9c4-d400eccb9330)
