### PR TITLE
Add some JS examples to our docs

### DIFF
--- a/examples/code/home/use-tools/call-tools-directly/math_add_directly.js
+++ b/examples/code/home/use-tools/call-tools-directly/math_add_directly.js
@@ -1,0 +1,11 @@
+import Arcade from "@arcadeai/arcadejs";
+
+const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
+
+const response = await client.tools.execute({
+  tool_name: "Math.Sqrt",
+  input: { a: "625" },
+  user_id: "user@example.com",
+});
+
+console.log(response.output.value); // 25

--- a/examples/code/home/use-tools/call-tools-directly/math_add_directly.py
+++ b/examples/code/home/use-tools/call-tools-directly/math_add_directly.py
@@ -4,7 +4,7 @@ client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
 response = client.tools.execute(
     tool_name="Math.Sqrt",
-    input={"number": 625},
+    input={"a": 625},
     user_id="user@example.com",
 )
 

--- a/examples/code/home/use-tools/call-tools-with-models/single_model_call.js
+++ b/examples/code/home/use-tools/call-tools-with-models/single_model_call.js
@@ -1,0 +1,27 @@
+import OpenAI from "openai";
+
+// Initialize the OpenAI client, pointing to Arcade AI
+const client = new OpenAI({
+  apiKey: process.env.ARCADE_API_KEY,
+  baseURL: "https://api.arcade.dev/v1",
+});
+
+// Get a unique identifier for your end user
+const userId = "you@example.com";
+
+// Use a tool and generate a response
+const response = await client.chat.completions.create({
+  messages: [
+    { role: "system", content: "You are a helpful assistant." },
+    {
+      role: "user",
+      content: "Star the ArcadeAI/arcade-ai repo on GitHub",
+    },
+  ],
+  model: "gpt-4o",
+  user: userId,
+  tools: ["GitHub.SetStarred", "GitHub.CountStargazers"],
+  tool_choice: "generate",
+});
+
+console.log(response);

--- a/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_all_tools.js
+++ b/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_all_tools.js
@@ -1,0 +1,9 @@
+import Arcade from "@arcadeai/arcadejs";
+
+const client = new Arcade();
+
+// Get all tools formatted for OpenAI
+const allTools = await client.tools.formatted.list({ format: "openai" });
+
+// Print the number of tools
+console.log(allTools.total_count);

--- a/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_all_tools.py
+++ b/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_all_tools.py
@@ -2,7 +2,6 @@ from arcadepy import Arcade
 
 client = Arcade()
 
-
 # Get all tools formatted for OpenAI
 all_tools = list(client.tools.formatted.list(format="openai"))
 

--- a/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_tool.js
+++ b/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_tool.js
@@ -1,0 +1,10 @@
+import Arcade from "@arcadeai/arcadejs";
+
+const client = new Arcade();
+
+// Get a specific tool formatted for OpenAI
+const githubStarRepo = await client.tools.formatted.get("Github.SetStarred", {
+  format: "openai",
+});
+
+console.log(githubStarRepo);

--- a/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_tool.py
+++ b/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_tool.py
@@ -3,8 +3,6 @@ from arcadepy import Arcade
 client = Arcade()
 
 # Get a specific tool formatted for OpenAI
-github_star_repo = client.tools.formatted.get(
-    tool_id="Github.SetStarred", format="openai"
-)
+github_star_repo = client.tools.formatted.get(name="Github.SetStarred", format="openai")
 
 print(github_star_repo)

--- a/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_toolkit.js
+++ b/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_toolkit.js
@@ -1,0 +1,12 @@
+import Arcade from "@arcadeai/arcadejs";
+
+const client = new Arcade();
+
+// Get all tools in the Github toolkit formatted for OpenAI
+const githubTools = await client.tools.formatted.list({
+  format: "openai",
+  toolkit: "github",
+});
+
+// Print the number of tools in the Github toolkit
+console.log(githubTools.total_count);

--- a/pages/home/auth/auth-tool-calling.mdx
+++ b/pages/home/auth/auth-tool-calling.mdx
@@ -5,7 +5,7 @@ description: "Guide on calling tools that require authentication"
 
 # Calling Tools with Authentication
 
-import { Steps } from "nextra/components";
+import { Steps, Tabs } from "nextra/components";
 
 <Steps>
 
@@ -13,18 +13,31 @@ import { Steps } from "nextra/components";
 
 Import the Arcade AI client in a Python script. The client automatically finds API keys set by `arcade login`.
 
+<Tabs items={["Python", "JavaScript"]}>
+<Tabs.Tab>
 ```python
 from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 ```
+</Tabs.Tab>
+<Tabs.Tab>
+```js
+import Arcade from "@arcadeai/arcadejs";
+
+const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
+```
+</Tabs.Tab>
+</Tabs>
 
 ### Authorize a tool directly
 
-Many tools require authorization. For example, the `Google.GetEmails` tool requires authorization with Google.
+Many tools require authorization. For example, the `Google.ListEmails` tool requires authorization with Google.
 
 This authorization must be approved by the user. By approving, the user allows your agent or app to access only the data they've approved.
 
+<Tabs items={["Python", "JavaScript"]}>
+<Tabs.Tab>
 ```python
 # As the developer, you must identify the user you're authorizing
 # and pass a unique identifier for them (e.g. an email or user ID) to Arcade:
@@ -32,12 +45,29 @@ THE_USER_ID = "you@example.com"
 
 # Request access to the user's Gmail account
 auth_response = client.tools.authorize(
-    tool_name="Google.GetEmails",
+    tool_name="Google.ListEmails",
     user_id=THE_USER_ID,
 )
 
 print(f"Click this link to authorize: {auth_response.url}")
 ```
+</Tabs.Tab>
+<Tabs.Tab>
+```js
+// As the developer, you must identify the user you're authorizing
+// and pass a unique identifier for them (e.g. an email or user ID) to Arcade:
+const THE_USER_ID = "you@example.com";
+
+// Request access to the user's Gmail account
+const auth_response = await client.tools.authorize({
+  tool_name: "Google.ListEmails",
+  user_id: THE_USER_ID,
+});
+
+console.log(`Click this link to authorize: ${auth_response.url}`);
+```
+</Tabs.Tab>
+</Tabs>
 
 This will print a URL that the user must visit to approve the authorization.
 
@@ -45,23 +75,46 @@ This will print a URL that the user must visit to approve the authorization.
 
 It may take a few minutes for the user to approve the authorization.
 
-Use the `client.auth.wait_for_completion()` method to wait for the authorization to complete:
+You can wait for the authorization to complete using the following methods:
 
+<Tabs items={["Python", "JavaScript"]}>
+<Tabs.Tab>
 ```python
-auth_response = client.auth.wait_for_completion(auth_response)
+auth_status = client.auth.wait_for_completion(auth_response)
 ```
+</Tabs.Tab>
+<Tabs.Tab>
+```js
+const auth_status = await client.auth.waitForCompletion(auth_response);
+```
+</Tabs.Tab>
+</Tabs>
 
 ### Call the tool with authorization
 
 Once the user has approved the action, you can run the tool. You only need to pass the `user_id`:
 
+<Tabs items={["Python", "JavaScript"]}>
+<Tabs.Tab>
 ```python
 emails_response = client.tools.execute(
-    tool_name="Google.GetEmails",
-    user_id=MY_USER_ID,
+    tool_name="Google.ListEmails",
+    user_id=THE_USER_ID,
 )
 print(emails_response)
 ```
+</Tabs.Tab>
+<Tabs.Tab>
+```js
+const emails_response = await client.tools.execute({
+  tool_name: "Google.ListEmails",
+  user_id: THE_USER_ID,
+});
+
+console.log(emails_response);
+```
+</Tabs.Tab>
+</Tabs>
 
 ### How it works
 

--- a/pages/home/use-tools/call-tools-directly.mdx
+++ b/pages/home/use-tools/call-tools-directly.mdx
@@ -3,7 +3,7 @@ title: "Call tools directly"
 description: "Learn how to call tools programmatically using Arcade AI"
 ---
 
-import { Steps } from "nextra/components";
+import { Steps, Tabs } from "nextra/components";
 
 # Call tools directly
 
@@ -29,19 +29,33 @@ You can find your API key in `~/.arcade/credentials.yaml`.
 
 ### Initialize the client
 
-Import the `Arcade()` client in a Python script. The client automatically uses the `ARCADE_API_KEY` environment variable.
+Import and initialize the Arcade client. The client automatically uses the `ARCADE_API_KEY` environment variable.
 
+<Tabs items={["Python", "JavaScript"]}>
+<Tabs.Tab>
 ```python file=<rootDir>/examples/code/home/use-tools/call-tools-directly/math_add_directly.py#L1-L3
-
 ```
+</Tabs.Tab>
+<Tabs.Tab>
+```js file=<rootDir>/examples/code/home/use-tools/call-tools-directly/math_add_directly.js#L1-L3
+```
+</Tabs.Tab>
+</Tabs>
 
 ### Call a tool
 
 Let's use the `Math.Sqrt` tool from the Arcade Math toolkit to calculate the square root of 625.
 
+<Tabs items={["Python", "JavaScript"]}>
+<Tabs.Tab>
 ```python file=<rootDir>/examples/code/home/use-tools/call-tools-directly/math_add_directly.py#L5-L11
-
 ```
+</Tabs.Tab>
+<Tabs.Tab>
+```js file=<rootDir>/examples/code/home/use-tools/call-tools-directly/math_add_directly.js#L5-L11
+```
+</Tabs.Tab>
+</Tabs>
 
 Is this tool call too simple for your needs? Try executing a [tool with authentication](/home/auth/auth-tool-calling).
 

--- a/pages/home/use-tools/get-tool-definitions.mdx
+++ b/pages/home/use-tools/get-tool-definitions.mdx
@@ -21,12 +21,12 @@ To do this, you can use the `client.tools.formatted.get` method and specify the 
 <Tabs.Tab>
 ```python file=<rootDir>/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_tool.py
 
-````
+```
 </Tabs.Tab>
 <Tabs.Tab>
 ```js file=<rootDir>/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_tool.js
 
-````
+```
 
 </Tabs.Tab>
 </Tabs>

--- a/pages/home/use-tools/get-tool-definitions.mdx
+++ b/pages/home/use-tools/get-tool-definitions.mdx
@@ -3,6 +3,8 @@ title: "Get Formatted Tool Definitions"
 description: "Learn how to get formatted tool definitions using Arcade AI"
 ---
 
+import { Tabs } from "nextra/components";
+
 # Get Formatted Tool Definitions
 
 When calling tools directly, it can be useful to get tool definitions in a specific model provider's format. The Arcade Client provides methods for getting a tool's definition and also for listing the definitions of multiple tools in a specific model provider's format.
@@ -15,9 +17,19 @@ It can be useful to get a tool's definition in a specific model provider's forma
 
 To do this, you can use the `client.tools.formatted.get` method and specify the tool name and format.
 
+<Tabs items={["Python", "JavaScript"]}>
+<Tabs.Tab>
 ```python file=<rootDir>/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_tool.py
 
-```
+````
+</Tabs.Tab>
+<Tabs.Tab>
+```js file=<rootDir>/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_tool.js
+
+````
+
+</Tabs.Tab>
+</Tabs>
 
 <ToggleContent showText="See output" hideText="Hide output">
 
@@ -33,14 +45,33 @@ It can be useful to list tool definitions for a toolkit in a specific model prov
 
 To do this, you can use the `client.tools.formatted.list` method and specify the toolkit and format. Since this method returns an iterator of pages, you can cast to a list to get all the tools.
 
+<Tabs items={["Python", "JavaScript"]}>
+<Tabs.Tab>
 ```python file=<rootDir>/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_toolkit.py
 
 ```
+</Tabs.Tab>
+<Tabs.Tab>
+```js file=<rootDir>/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_toolkit.js
+
+```
+
+</Tabs.Tab>
+</Tabs>
 
 ## Get all tool definitions formatted for a model
 
 To get all tools formatted for OpenAI, you can use the `client.tools.formatted.list` method without specifying a toolkit.
 
+<Tabs items={["Python", "JavaScript"]}>
+<Tabs.Tab>
 ```python file=<rootDir>/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_all_tools.py
 
 ```
+</Tabs.Tab>
+<Tabs.Tab>
+```js file=<rootDir>/examples/code/home/use-tools/get-formatted-tool-definitions/get_openai_formatted_all_tools.js
+
+```
+</Tabs.Tab>
+</Tabs>

--- a/pages/home/use-tools/specify-tools.mdx
+++ b/pages/home/use-tools/specify-tools.mdx
@@ -3,6 +3,8 @@ title: Use specific tools
 description: Understand how to specify which tools are available to the AI model
 ---
 
+import { Tabs } from "nextra/components";
+
 # Use specific tools
 
 Applies to:
@@ -11,9 +13,16 @@ Applies to:
 
 When you use a language model with Arcade AI, you can specify what tool(s) it can use:
 
+<Tabs items={["Python", "JavaScript"]}>
+<Tabs.Tab>
 ```python file=<rootDir>/examples/code/home/use-tools/call-tools-with-models/single_model_call.py#L14-L29 {11-14}
-
 ```
+</Tabs.Tab>
+<Tabs.Tab>
+```js file=<rootDir>/examples/code/home/use-tools/call-tools-with-models/single_model_call.js#L13-L25 {11}
+```
+</Tabs.Tab>
+</Tabs>
 
 The `tools` parameter accepts:
 

--- a/pages/home/use-tools/tool-choice.mdx
+++ b/pages/home/use-tools/tool-choice.mdx
@@ -3,6 +3,8 @@ title: Control tool choice
 description: Understand how to control how the AI model uses the tools you provide
 ---
 
+import { Tabs } from "nextra/components";
+
 # Control tool choice
 
 Applies to:
@@ -13,9 +15,19 @@ Applies to:
 
 When you use a language model with Arcade AI, you can control how it selects and uses the [available tools](specify-tools) with the `tool_choice` parameter:
 
+<Tabs items={["Python", "JavaScript"]}>
+<Tabs.Tab>
 ```python file=<rootDir>/examples/code/home/use-tools/call-tools-with-models/single_model_call.py#L14-L29 {15}
 
 ```
+</Tabs.Tab>
+<Tabs.Tab>
+```js file=<rootDir>/examples/code/home/use-tools/call-tools-with-models/single_model_call.js#L13-L25 {12}
+
+```
+
+</Tabs.Tab>
+</Tabs>
 
 Arcade extends the OpenAI `tool_choice` parameter to accept these options:
 


### PR DESCRIPTION
This PR adds JavaScript examples to these pages.

<img width="220" alt="Screenshot 2025-01-23 at 11 33 31 PM" src="https://github.com/user-attachments/assets/5518388f-33db-48d1-ae17-d08e492e3803" />

 I still need to review and add more examples, but this is the initial batch. Additionally, I have fixed and tested some of the Python examples to ensure they align with the new client API.

