### PR TITLE
Center content in landing page and fix logo in mobile

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -98,7 +98,7 @@ export function LandingPage() {
         </div>
       </section>
       <section className="relative py-16">
-        <div className="container relative px-4">
+        <div className="container relative mx-auto px-4">
           <div className="mx-auto max-w-2xl text-center">
             <h2 className="mb-4 text-3xl font-bold tracking-tight text-white md:text-4xl">
               Start Building in Minutes
@@ -136,7 +136,7 @@ export function LandingPage() {
         </div>
       </section>
       <section className="py-8">
-        <div className="container px-4">
+        <div className="container mx-auto px-4">
           <div className="mx-auto max-w-3xl text-center">
             <h2 className="mb-4 text-3xl font-bold tracking-tight text-white md:text-4xl">
               The Hard Parts of AI Development
@@ -213,7 +213,7 @@ export function LandingPage() {
       </section>
 
       <section className="py-12">
-        <div className="container px-4">
+        <div className="container mx-auto px-4">
           <div className="max-w-2xl">
             <h2 className="mb-4 text-3xl font-bold tracking-tight text-white md:text-4xl">
               Sample Applications

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,22 +1,34 @@
 export function Logo() {
   return (
-    <div className="mr-16 flex w-40 items-center">
-      <img
-        className="dark:hidden"
-        loading="lazy"
-        src={"/images/logo/arcade-ai-logo.png"}
-        alt="Arcade AI Logo"
-        width={150}
-        height={30}
-      />
-      <img
-        className="hidden dark:block"
-        loading="lazy"
-        src={"/images/logo/arcadeai-title-dark.png"}
-        alt="Arcade AI Logo"
-        width={150}
-        height={30}
-      />
-    </div>
+    <>
+      <div className="mr-16 hidden w-40 items-center md:block">
+        <img
+          className="dark:hidden"
+          loading="lazy"
+          src={"/images/logo/arcade-ai-logo.png"}
+          alt="Arcade AI Logo"
+          width={150}
+          height={30}
+        />
+        <img
+          className="hidden dark:block"
+          loading="lazy"
+          src={"/images/logo/arcadeai-title-dark.png"}
+          alt="Arcade AI Logo"
+          width={150}
+          height={30}
+        />
+      </div>
+      <div className="mr-16 block w-6 md:hidden">
+        <img
+          className="dark:block"
+          loading="lazy"
+          src={"/images/logo/arcadeai.png"}
+          alt="Arcade AI Logo"
+          width={30}
+          height={30}
+        />
+      </div>
+    </>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -423,7 +423,8 @@ article pre {
 /* Media Queries */
 @media (max-width: 640px) {
   .nextra-nav-container nav {
-    padding: 0 1.5rem;
+    padding: 0rem 1.5rem;
+    margin-right: 0rem;
   }
 
   /* Layout */


### PR DESCRIPTION
This PR fixes this: 
![image](https://github.com/user-attachments/assets/8ba3f1cf-acfb-4814-8c72-12099bd85806)

and this
<img width="438" alt="Screenshot 2025-01-24 at 3 04 08 PM" src="https://github.com/user-attachments/assets/dbcd8486-805b-4019-9a84-215b9194eb8f" />

Before:
<img width="439" alt="Screenshot 2025-01-24 at 3 02 24 PM" src="https://github.com/user-attachments/assets/0d2d0b90-fd53-43f2-8a2b-d0ed5b5b6ad1" />
