### PR TITLE
Set root key when installing locally

### DIFF
--- a/pages/home/install/local.mdx
+++ b/pages/home/install/local.mdx
@@ -70,13 +70,19 @@ To see all available toolkits, view the [Toolkits Page](/toolkits).
 
 ### Set OpenAI API key
 
-Before starting the Engine, we need to set an OpenAI API Key that the Engine can use to connect to OpenAI.
+Before starting the Engine, you need to set an OpenAI API Key that the Engine can use to connect to OpenAI:
 
 ```bash
 export OPENAI_API_KEY="<your_openai_api_key>"
 ```
 
-To make the API key persistent or to change other configurations, see the [Configuration Overview](/home/configure/overview).
+You also need to add a root encryption key, which is used to encrypt sensitive data at rest:
+
+```bash
+export ROOT_KEY_1="<a long random string>"
+```
+
+> Note: These environment variables are referenced in the `engine.yaml` file. To understand how the engine config is used, see the [Configuration Overview](/home/configure/overview).
 
 ### Start the Engine and worker
 


### PR DESCRIPTION
Without this, the Engine will not run properly.