### PR TITLE
Remove spaces from register link

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -37,9 +37,7 @@ const config: DocsThemeConfig = {
   navbar: {
     extraContent: (
       <>
-        <NavBarButton href="https://account.arcade.dev/registerOrRedirect?
-    return_to=https%3A%2F%2Fapi.arcade.dev%2Fdashboard&
-    new_user_return_to=https%3A%2F%2Fapi.arcade.dev%2Fdashboard%2Fwelcome"text="Sign Up" />
+        <NavBarButton href="https://account.arcade.dev/registerOrRedirect?return_to=https%3A%2F%2Fapi.arcade.dev%2Fdashboard&new_user_return_to=https%3A%2F%2Fapi.arcade.dev%2Fdashboard%2Fwelcome"text="Sign Up" />
         <NavBarButton href="https://api.arcade.dev/dashboard/playground/chat" text="Dashboard"
         variant="outline" />
       </>


### PR DESCRIPTION
Currently the href of the "Sign up" button on the live docs is: `https://account.arcade.dev/registerOrRedirect?%20return_to=https%3A%2F%2Fapi.arcade.dev%2Fdashboard&%20new_user_return_to=https%3A%2F%2Fapi.arcade.dev%2Fdashboard%2Fwelcome`

Note the `?%20return_to...` and `&%20new_user_return_to=`
The link still seems to work for me in Chrome, but I don't know if every browser would be forgiving of the extra spaces.

This PR removes the unintended extra spaces (`%20`). 