### PR TITLE
Update register link

### DIFF
--- a/pages/home/custom-tools.mdx
+++ b/pages/home/custom-tools.mdx
@@ -11,7 +11,7 @@ First, make sure you have these pre-requisites installed on your system:
 
 - **Python 3.10** or higher <br/> Verify your Python version by running `python --version` or `python3 --version` in your terminal.
 - **pip**: The Python package installer should be available. It's typically included with Python.
-- **Arcade Account**: Sign up for an [Arcade account](https://account.arcade.dev/registerOrRedirect?return_to=https%3A%2F%2Fapi.arcade.dev%2Fdashboard&new_user_return_to=https%3A%2F%2Fapi.arcade.dev%2Fdashboard%2Fwelcome) if you haven't already.
+- **Arcade Account**: Sign up for an [Arcade account](https://api.arcade.dev/signup) if you haven't already.
 
 Let's set up Arcade and give it a try!
 

--- a/pages/home/install/local.mdx
+++ b/pages/home/install/local.mdx
@@ -16,7 +16,7 @@ Before you begin, make sure you have the following:
 
 - **Python 3.10 or higher**
 - **pip**: The Python package installer should be available. It's typically included with Python.
-- **Arcade Account**: Sign up for an [Arcade account](https://account.arcade.dev/registerOrRedirect?return_to=https%3A%2F%2Fapi.arcade.dev%2Fdashboard&new_user_return_to=https%3A%2F%2Fapi.arcade.dev%2Fdashboard%2Fwelcome) if you haven't already.
+- **Arcade Account**: Sign up for an [Arcade account](https://api.arcade.dev/signup) if you haven't already.
 - **Package Manager**: Either Brew (macOS) or Apt (linux) to install the engine binary.
 
 Verify your Python version by running `python --version` or `python3 --version` in your terminal.

--- a/pages/home/quickstart.mdx
+++ b/pages/home/quickstart.mdx
@@ -14,7 +14,7 @@ import { Prerequisites } from "@components/pages/quickstart/Prerequisites/prereq
 
 First, make sure you have these pre-requisites installed on your system:
 
-- **Arcade Account**: Sign up for an [Arcade account](https://account.arcade.dev/registerOrRedirect?return_to=https%3A%2F%2Fapi.arcade.dev%2Fdashboard&new_user_return_to=https%3A%2F%2Fapi.arcade.dev%2Fdashboard%2Fwelcome) if you haven't already.
+- **Arcade Account**: Sign up for an [Arcade account](https://api.arcade.dev/signup) if you haven't already.
 
 <Prerequisites />
 

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -37,9 +37,7 @@ const config: DocsThemeConfig = {
   navbar: {
     extraContent: (
       <>
-        <NavBarButton href="https://account.arcade.dev/registerOrRedirect?
-    return_to=https%3A%2F%2Fapi.arcade.dev%2Fdashboard&
-    new_user_return_to=https%3A%2F%2Fapi.arcade.dev%2Fdashboard%2Fwelcome"text="Sign Up" />
+        <NavBarButton href="https://api.arcade.dev/signup"text="Sign Up" />
         <NavBarButton href="https://api.arcade.dev/dashboard/playground/chat" text="Dashboard"
         variant="outline" />
       </>


### PR DESCRIPTION
In #156 I found a problem with one of our signup links. Then I realized we should have a much shorter link for this. Tada

I've created https://api.arcade.dev/signup at the Cloudflare level so that it always points to the correct registration URL, whatever we may need to change that to be in the future.