### PR TITLE
Documenting new Slack tools and modifications to existing tools

### DIFF
--- a/pages/toolkits/social-communication/slack.mdx
+++ b/pages/toolkits/social-communication/slack.mdx
@@ -24,6 +24,9 @@ The Arcade Slack toolkit provides a comprehensive set of tools for interacting w
 - Access conversation messages
 - Manage conversation metadata
 - Retrieve user information
+- List users
+- List conversations
+- Retrieve conversation metadata
 
 ## Install
 
@@ -43,8 +46,8 @@ pip install arcade_slack
       "Retrieve members of a conversation using its ID.",
     ],
     [
-      "GetMembersInConversationByName",
-      "Retrieve members of a conversation using its name.",
+      "GetMembersInChannelByName",
+      "Retrieve members of a channel using its name.",
     ],
     [
       "GetMessagesInConversationById",
@@ -55,12 +58,20 @@ pip install arcade_slack
       "Fetch the messages in a channel using its name.",
     ],
     [
+      "GetMessagesInDirectMessageConversationByUsername",
+      "Fetch the messages in a direct message conversation using the username of the other participant.",
+    ],
+    [
       "GetConversationMetadataById",
       "Retrieve metadata of a conversation using its ID.",
     ],
     [
-      "GetConversationMetadataByName",
-      "Retrieve metadata of a conversation using its name.",
+      "GetChannelMetadataByName",
+      "Retrieve metadata of a channel using its name.",
+    ],
+    [
+      "GetDirectMessageConversationMetadataByUsername",
+      "Retrieve metadata of a direct message conversation using the username of the other participant.",
     ],
     ["ListConversationsMetadata", "List metadata for Slack conversations."],
     [
@@ -197,7 +208,7 @@ Get the members of a conversation in Slack by the conversation's ID.
 
 ---
 
-## GetMembersInConversationByName
+## GetMembersInChannelByName
 
 <br />
 <TabbedCodeBlock
@@ -206,28 +217,28 @@ Get the members of a conversation in Slack by the conversation's ID.
       label: "Call the Tool with User Authorization",
       content: {
         Python: [
-          "/examples/integrations/toolkits/slack/get_members_in_conversation_by_name_example_call_tool.py",
+          "/examples/integrations/toolkits/slack/get_members_in_channel_by_name_example_call_tool.py",
         ],
-        JavaScript: ["/examples/integrations/toolkits/slack/get_members_in_conversation_by_name_example_call_tool.js"],
+        JavaScript: ["/examples/integrations/toolkits/slack/get_members_in_channel_by_name_example_call_tool.js"],
       },
     },
     {
       label: "Execute the Tool with OpenAI",
       content: {
         Python: [
-          "/examples/integrations/toolkits/slack/get_members_in_conversation_by_name_example_llm_oai.py",
+          "/examples/integrations/toolkits/slack/get_members_in_channel_by_name_example_llm_oai.py",
         ],
-        JavaScript: ["/examples/integrations/toolkits/slack/get_members_in_conversation_by_name_example_llm_oai.js"],
+        JavaScript: ["/examples/integrations/toolkits/slack/get_members_in_channel_by_name_example_llm_oai.js"],
       },
     },
   ]}
 />
 
-Get the members of a conversation in Slack by the conversation's name.
+Get the members of a channel in Slack by the channel's name.
 
 **Parameters**
 
-- **`conversation_name`** _(string, required)_ The name of the conversation to get members for.
+- **`channel_name`** _(string, required)_ The name of the channel to get members for.
 - **`limit`** _(int, optional)_ The maximum number of members to return. Defaults to 200.
 - **`next_cursor`** _(string, optional)_ The cursor to use for pagination.
 
@@ -304,12 +315,52 @@ Get the messages in a channel in Slack.
 **Parameters**
 
 - **`channel_name`** _(string, required)_ The name of the channel to get messages for.
-- **`oldest_relative`** _(string, optional)_ The oldest message to include, in 'DD:HH:MM' format.
-- **`latest_relative`** _(string, optional)_ The latest message to include, in 'DD:HH:MM' format.
-- **`oldest_datetime`** _(string, optional)_ The oldest message to include, in 'YYYY-MM-DD HH:MM:SS' format.
-- **`latest_datetime`** _(string, optional)_ The latest message to include, in 'YYYY-MM-DD HH:MM:SS' format.
+- **`oldest_relative`** _(string, optional)_ The oldest message to include in the results, specified as a time offset from the current time in the format 'DD:HH:MM'.
+- **`latest_relative`** _(string, optional)_ The latest message to include in the results, specified as a time offset from the current time in the format 'DD:HH:MM'.
+- **`oldest_datetime`** _(string, optional)_ The oldest message to include in the results, specified as a datetime string in the format 'YYYY-MM-DD HH:MM:SS'.
+- **`latest_datetime`** _(string, optional)_ The latest message to include in the results, specified as a datetime string in the format 'YYYY-MM-DD HH:MM:SS'.
 - **`limit`** _(int, optional)_ The maximum number of messages to return. Defaults to 200.
-- **`next_cursor`** _(string, optional)_ The cursor to use for pagination, if continuing from a previous search.
+- **`next_cursor`** _(string, optional)_ The cursor to use for pagination.
+
+---
+
+## GetMessagesInDirectMessageConversationByUsername
+
+<br />
+<TabbedCodeBlock
+  tabs={[
+    {
+      label: "Call the Tool with User Authorization",
+      content: {
+        Python: [
+          "/examples/integrations/toolkits/slack/get_messages_in_direct_message_conversation_by_username_example_call_tool.py",
+        ],
+        JavaScript: ["/examples/integrations/toolkits/slack/get_messages_in_direct_message_conversation_by_username_example_call_tool.js"],
+      },
+    },
+    {
+      label: "Execute the Tool with OpenAI",
+      content: {
+        Python: [
+          "/examples/integrations/toolkits/slack/get_messages_in_direct_message_conversation_by_username_example_llm_oai.py",
+        ],
+        JavaScript: ["/examples/integrations/toolkits/slack/get_messages_in_direct_message_conversation_by_username_example_llm_oai.js"],
+      },
+    },
+  ]}
+/>
+
+Get the messages in a channel in Slack.
+
+**Parameters**
+
+- **`channel_name`** _(string, required)_ The name of the channel to get messages for.
+- **`oldest_relative`** _(string, optional)_ The oldest message to include in the results, specified as a time offset from the current time in the format 'DD:HH:MM'.
+- **`latest_relative`** _(string, optional)_ The latest message to include in the results, specified as a time offset from the current time in the format 'DD:HH:MM'.
+- **`oldest_datetime`** _(string, optional)_ The oldest message to include in the results, specified as a datetime string in the format 'YYYY-MM-DD HH:MM:SS'.
+- **`latest_datetime`** _(string, optional)_ The latest message to include in the results, specified as a datetime string in the format 'YYYY-MM-DD HH:MM:SS'.
+- **`limit`** _(int, optional)_ The maximum number of messages to return. Defaults to 200.
+- **`next_cursor`** _(string, optional)_ The cursor to use for pagination.
 
 ---
 
@@ -347,7 +398,7 @@ Get the metadata of a conversation in Slack searching by its ID.
 
 ---
 
-## GetConversationMetadataByName
+## GetChannelMetadataByName
 
 <br />
 <TabbedCodeBlock
@@ -356,28 +407,63 @@ Get the metadata of a conversation in Slack searching by its ID.
       label: "Call the Tool with User Authorization",
       content: {
         Python: [
-          "/examples/integrations/toolkits/slack/get_conversation_metadata_by_name_example_call_tool.py",
+          "/examples/integrations/toolkits/slack/get_channel_metadata_by_name_example_call_tool.py",
         ],
-        JavaScript: ["/examples/integrations/toolkits/slack/get_conversation_metadata_by_name_example_call_tool.js"],
+        JavaScript: ["/examples/integrations/toolkits/slack/get_channel_metadata_by_name_example_call_tool.js"],
       },
     },
     {
       label: "Execute the Tool with OpenAI",
       content: {
         Python: [
-          "/examples/integrations/toolkits/slack/get_conversation_metadata_by_name_example_llm_oai.py",
+          "/examples/integrations/toolkits/slack/get_channel_metadata_by_name_example_llm_oai.py",
         ],
-        JavaScript: ["/examples/integrations/toolkits/slack/get_conversation_metadata_by_name_example_llm_oai.js"],
+        JavaScript: ["/examples/integrations/toolkits/slack/get_channel_metadata_by_name_example_llm_oai.js"],
       },
     },
   ]}
 />
 
-Get the metadata of a conversation in Slack searching by its name.
+Get the metadata of a channel in Slack searching by its name.
 
 **Parameters**
 
-- **`conversation_name`** _(string, required)_ The name of the conversation to get metadata for.
+- **`channel_name`** _(string, required)_ The name of the channel to get metadata for.
+- **`next_cursor`** _(string, optional)_ The cursor to use for pagination, if continuing from a previous search.
+
+---
+
+## GetDirectMessageConversationMetadataByUsername
+
+<br />
+<TabbedCodeBlock
+  tabs={[
+    {
+      label: "Call the Tool with User Authorization",
+      content: {
+        Python: [
+          "/examples/integrations/toolkits/slack/get_direct_message_conversation_metadata_by_username_example_call_tool.py",
+        ],
+        JavaScript: ["/examples/integrations/toolkits/slack/get_direct_message_conversation_metadata_by_username_example_call_tool.js"],
+      },
+    },
+    {
+      label: "Execute the Tool with OpenAI",
+      content: {
+        Python: [
+          "/examples/integrations/toolkits/slack/get_direct_message_conversation_metadata_by_username_example_llm_oai.py",
+        ],
+        JavaScript: ["/examples/integrations/toolkits/slack/get_direct_message_conversation_metadata_by_username_example_llm_oai.js"],
+      },
+    },
+  ]}
+/>
+
+Get the metadata of a direct message conversation in Slack searching by the username of the other participant.
+
+**Parameters**
+
+- **`username`** _(string, required)_ The username of the user/person to get messages with.
 - **`next_cursor`** _(string, optional)_ The cursor to use for pagination, if continuing from a previous search.
 
 ---

--- a/public/examples/integrations/toolkits/slack/get_channel_metadata_by_name_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_channel_metadata_by_name_example_call_tool.js
@@ -3,7 +3,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
 const USER_ID = "you@example.com";
-const TOOL_NAME = "Slack.GetMembersInConversationByName";
+const TOOL_NAME = "Slack.GetChannelMetadataByName";
 
 // Start the authorization process
 const authResponse = await client.tools.authorize({
@@ -19,8 +19,7 @@ if (authResponse.status !== "completed") {
 await client.auth.waitForCompletion(authResponse);
 
 const toolInput = {
-    conversation_name: "general",
-    limit: 100
+    channel_name: "general"
 };
 
 const response = await client.tools.execute({
@@ -29,4 +28,4 @@ const response = await client.tools.execute({
     user_id: USER_ID,
 });
 
-console.log(response); 
+console.log(response);

--- a/public/examples/integrations/toolkits/slack/get_channel_metadata_by_name_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_channel_metadata_by_name_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
 USER_ID = "you@example.com"
-TOOL_NAME = "Slack.GetConversationMetadataByName"
+TOOL_NAME = "Slack.GetChannelMetadataByName"
 
 auth_response = client.tools.authorize(
     tool_name=TOOL_NAME,
@@ -16,7 +16,7 @@ if auth_response.status != "completed":
 # Wait for the authorization to complete
 client.auth.wait_for_completion(auth_response)
 
-tool_input = {"conversation_name": "general"}
+tool_input = {"channel_name": "general"}
 
 response = client.tools.execute(
     tool_name=TOOL_NAME,

--- a/public/examples/integrations/toolkits/slack/get_channel_metadata_by_name_example_llm_oai.js
+++ b/public/examples/integrations/toolkits/slack/get_channel_metadata_by_name_example_llm_oai.js
@@ -1,8 +1,8 @@
 import OpenAI from 'openai';
 
 const USER_ID = 'you@example.com';
-const PROMPT = "Retrieve the metadata for the conversation named 'general'."
-const TOOL_NAME = 'Slack.GetConversationMetadataByName';
+const PROMPT = "Retrieve the metadata for the channel named 'general'."
+const TOOL_NAME = 'Slack.GetChannelMetadataByName';
 
 const client = new OpenAI({
     baseURL: 'https://api.arcade.dev',
@@ -19,4 +19,4 @@ const response = await client.chat.completions.create({
     tool_choice: 'generate'
 });
 
-console.log(response.choices[0].message.content); 
+console.log(response.choices[0].message.content);

--- a/public/examples/integrations/toolkits/slack/get_channel_metadata_by_name_example_llm_oai.py
+++ b/public/examples/integrations/toolkits/slack/get_channel_metadata_by_name_example_llm_oai.py
@@ -1,0 +1,21 @@
+import os
+from openai import OpenAI
+
+USER_ID = "you@example.com"
+PROMPT = "Retrieve the metadata for the channel named 'general'."
+TOOL_NAME = "Slack.GetChannelMetadataByName"
+
+client = OpenAI(
+    base_url="https://api.arcade.dev", api_key=os.environ.get("ARCADE_API_KEY")
+)
+
+response = client.chat.completions.create(
+    messages=[
+        {"role": "user", "content": PROMPT},
+    ],
+    model="gpt-4o-mini",
+    user=USER_ID,
+    tools=[TOOL_NAME],
+    tool_choice="generate",
+)
+print(response.choices[0].message.content)

--- a/public/examples/integrations/toolkits/slack/get_direct_message_conversation_metadata_by_username_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_direct_message_conversation_metadata_by_username_example_call_tool.js
@@ -3,7 +3,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
 const USER_ID = "you@example.com";
-const TOOL_NAME = "Slack.GetConversationMetadataByName";
+const TOOL_NAME = "Slack.GetDirectMessageConversationMetadataByUsername";
 
 // Start the authorization process
 const authResponse = await client.tools.authorize({
@@ -19,7 +19,7 @@ if (authResponse.status !== "completed") {
 await client.auth.waitForCompletion(authResponse);
 
 const toolInput = {
-    conversation_name: "general"
+    username: "john_doe"
 };
 
 const response = await client.tools.execute({
@@ -28,4 +28,4 @@ const response = await client.tools.execute({
     user_id: USER_ID,
 });
 
-console.log(response); 
+console.log(response);

--- a/public/examples/integrations/toolkits/slack/get_direct_message_conversation_metadata_by_username_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_direct_message_conversation_metadata_by_username_example_call_tool.py
@@ -1,0 +1,26 @@
+from arcadepy import Arcade
+
+client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
+
+USER_ID = "you@example.com"
+TOOL_NAME = "Slack.GetDirectMessageConversationMetadataByUsername"
+
+auth_response = client.tools.authorize(
+    tool_name=TOOL_NAME,
+    user_id=USER_ID,
+)
+
+if auth_response.status != "completed":
+    print(f"Click this link to authorize: {auth_response.url}")
+
+# Wait for the authorization to complete
+client.auth.wait_for_completion(auth_response)
+
+tool_input = {"username": "john_doe"}
+
+response = client.tools.execute(
+    tool_name=TOOL_NAME,
+    input=tool_input,
+    user_id=USER_ID,
+)
+print(response)

--- a/public/examples/integrations/toolkits/slack/get_direct_message_conversation_metadata_by_username_example_llm_oai.js
+++ b/public/examples/integrations/toolkits/slack/get_direct_message_conversation_metadata_by_username_example_llm_oai.js
@@ -1,8 +1,8 @@
 import OpenAI from 'openai';
 
 const USER_ID = 'you@example.com';
-const PROMPT = "Retrieve the members of the conversation named 'general'."
-const TOOL_NAME = 'Slack.GetMembersInConversationByName';
+const PROMPT = "Retrieve the metadata for the direct message conversation with the username 'john_doe'."
+const TOOL_NAME = 'Slack.GetDirectMessageConversationMetadataByUsername';
 
 const client = new OpenAI({
     baseURL: 'https://api.arcade.dev',
@@ -19,4 +19,4 @@ const response = await client.chat.completions.create({
     tool_choice: 'generate'
 });
 
-console.log(response.choices[0].message.content); 
+console.log(response.choices[0].message.content);

--- a/public/examples/integrations/toolkits/slack/get_direct_message_conversation_metadata_by_username_example_llm_oai.py
+++ b/public/examples/integrations/toolkits/slack/get_direct_message_conversation_metadata_by_username_example_llm_oai.py
@@ -2,8 +2,8 @@ import os
 from openai import OpenAI
 
 USER_ID = "you@example.com"
-PROMPT = "Retrieve the metadata for the conversation named 'general'."
-TOOL_NAME = "Slack.GetConversationMetadataByName"
+PROMPT = "Retrieve the metadata for the direct message conversation with the username 'john_doe'."
+TOOL_NAME = "Slack.GetDirectMessageConversationMetadataByUsername"
 
 client = OpenAI(
     base_url="https://api.arcade.dev", api_key=os.environ.get("ARCADE_API_KEY")

--- a/public/examples/integrations/toolkits/slack/get_members_in_channel_by_name_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_members_in_channel_by_name_example_call_tool.js
@@ -1,0 +1,32 @@
+import { Arcade } from "@arcadeai/arcadejs";
+
+const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
+
+const USER_ID = "you@example.com";
+const TOOL_NAME = "Slack.GetMembersInChannelByName";
+
+// Start the authorization process
+const authResponse = await client.tools.authorize({
+    tool_name: TOOL_NAME,
+    user_id: USER_ID,
+});
+
+if (authResponse.status !== "completed") {
+    console.log(`Click this link to authorize: ${authResponse.url}`);
+}
+
+// Wait for the authorization to complete
+await client.auth.waitForCompletion(authResponse);
+
+const toolInput = {
+    channel_name: "general",
+    limit: 100
+};
+
+const response = await client.tools.execute({
+    tool_name: TOOL_NAME,
+    input: toolInput,
+    user_id: USER_ID,
+});
+
+console.log(response);

--- a/public/examples/integrations/toolkits/slack/get_members_in_channel_by_name_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_members_in_channel_by_name_example_call_tool.py
@@ -1,0 +1,26 @@
+from arcadepy import Arcade
+
+client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
+
+USER_ID = "you@example.com"
+TOOL_NAME = "Slack.GetMembersInChannelByName"
+
+auth_response = client.tools.authorize(
+    tool_name=TOOL_NAME,
+    user_id=USER_ID,
+)
+
+if auth_response.status != "completed":
+    print(f"Click this link to authorize: {auth_response.url}")
+
+# Wait for the authorization to complete
+client.auth.wait_for_completion(auth_response)
+
+tool_input = {"channel_name": "general", "limit": 100}
+
+response = client.tools.execute(
+    tool_name=TOOL_NAME,
+    input=tool_input,
+    user_id=USER_ID,
+)
+print(response)

--- a/public/examples/integrations/toolkits/slack/get_members_in_channel_by_name_example_llm_oai.js
+++ b/public/examples/integrations/toolkits/slack/get_members_in_channel_by_name_example_llm_oai.js
@@ -1,0 +1,22 @@
+import OpenAI from 'openai';
+
+const USER_ID = 'you@example.com';
+const PROMPT = "Retrieve the members of the channel named 'general'."
+const TOOL_NAME = 'Slack.GetMembersInChannelByName';
+
+const client = new OpenAI({
+    baseURL: 'https://api.arcade.dev',
+    apiKey: process.env.ARCADE_API_KEY
+});
+
+const response = await client.chat.completions.create({
+    messages: [
+        { role: 'user', content: PROMPT }
+    ],
+    model: 'gpt-4o-mini',
+    user: USER_ID,
+    tools: [TOOL_NAME],
+    tool_choice: 'generate'
+});
+
+console.log(response.choices[0].message.content);

--- a/public/examples/integrations/toolkits/slack/get_members_in_channel_by_name_example_llm_oai.py
+++ b/public/examples/integrations/toolkits/slack/get_members_in_channel_by_name_example_llm_oai.py
@@ -1,0 +1,21 @@
+import os
+from openai import OpenAI
+
+USER_ID = "you@example.com"
+PROMPT = "Retrieve the members of the channel named 'general'."
+TOOL_NAME = "Slack.GetMembersInChannelByName"
+
+client = OpenAI(
+    base_url="https://api.arcade.dev", api_key=os.environ.get("ARCADE_API_KEY")
+)
+
+response = client.chat.completions.create(
+    messages=[
+        {"role": "user", "content": PROMPT},
+    ],
+    model="gpt-4o-mini",
+    user=USER_ID,
+    tools=[TOOL_NAME],
+    tool_choice="generate",
+)
+print(response.choices[0].message.content)

--- a/public/examples/integrations/toolkits/slack/get_messages_in_direct_message_conversation_by_username_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_messages_in_direct_message_conversation_by_username_example_call_tool.js
@@ -1,0 +1,34 @@
+import { Arcade } from "@arcadeai/arcadejs";
+
+const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
+
+const USER_ID = "you@example.com";
+const TOOL_NAME = "Slack.GetMessagesInDirectMessageConversationByUsername";
+
+// Start the authorization process
+const authResponse = await client.tools.authorize({
+    tool_name: TOOL_NAME,
+    user_id: USER_ID,
+});
+
+if (authResponse.status !== "completed") {
+    console.log(`Click this link to authorize: ${authResponse.url}`);
+}
+
+// Wait for the authorization to complete
+await client.auth.waitForCompletion(authResponse);
+
+const toolInput = {
+    username: "john_doe",
+    limit: 100,
+    oldest_datetime: "2023-01-01 00:00:00",
+    latest_datetime: "2023-01-31 23:59:59"
+};
+
+const response = await client.tools.execute({
+    tool_name: TOOL_NAME,
+    input: toolInput,
+    user_id: USER_ID,
+});
+
+console.log(response);

--- a/public/examples/integrations/toolkits/slack/get_messages_in_direct_message_conversation_by_username_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_messages_in_direct_message_conversation_by_username_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
 USER_ID = "you@example.com"
-TOOL_NAME = "Slack.GetMembersInConversationByName"
+TOOL_NAME = "Slack.GetMessagesInDirectMessageConversationByUsername"
 
 auth_response = client.tools.authorize(
     tool_name=TOOL_NAME,
@@ -16,7 +16,12 @@ if auth_response.status != "completed":
 # Wait for the authorization to complete
 client.auth.wait_for_completion(auth_response)
 
-tool_input = {"conversation_name": "general", "limit": 100}
+tool_input = {
+    "username": "john_doe",
+    "limit": 100,
+    "oldest_datetime": "2023-01-01 00:00:00",
+    "latest_datetime": "2023-01-31 23:59:59",
+}
 
 response = client.tools.execute(
     tool_name=TOOL_NAME,

--- a/public/examples/integrations/toolkits/slack/get_messages_in_direct_message_conversation_by_username_example_llm_oai.js
+++ b/public/examples/integrations/toolkits/slack/get_messages_in_direct_message_conversation_by_username_example_llm_oai.js
@@ -1,0 +1,22 @@
+import OpenAI from 'openai';
+
+const USER_ID = 'you@example.com';
+const PROMPT = "Fetch the messages in the direct message conversation with the username 'john_doe' between '2023-01-01 00:00:00' and '2023-01-31 23:59:59'."
+const TOOL_NAME = 'Slack.GetMessagesInDirectMessageConversationByUsername';
+
+const client = new OpenAI({
+    baseURL: 'https://api.arcade.dev',
+    apiKey: process.env.ARCADE_API_KEY
+});
+
+const response = await client.chat.completions.create({
+    messages: [
+        { role: 'user', content: PROMPT }
+    ],
+    model: 'gpt-4o-mini',
+    user: USER_ID,
+    tools: [TOOL_NAME],
+    tool_choice: 'generate'
+});
+
+console.log(response.choices[0].message.content);

--- a/public/examples/integrations/toolkits/slack/get_messages_in_direct_message_conversation_by_username_example_llm_oai.py
+++ b/public/examples/integrations/toolkits/slack/get_messages_in_direct_message_conversation_by_username_example_llm_oai.py
@@ -2,8 +2,8 @@ import os
 from openai import OpenAI
 
 USER_ID = "you@example.com"
-PROMPT = "Retrieve the members of the conversation named 'general'."
-TOOL_NAME = "Slack.GetMembersInConversationByName"
+PROMPT = "Fetch the messages in the direct message conversation with the username 'john_doe' between '2023-01-01 00:00:00' and '2023-01-31 23:59:59'."
+TOOL_NAME = "Slack.GetMessagesInDirectMessageConversationByUsername"
 
 client = OpenAI(
     base_url="https://api.arcade.dev", api_key=os.environ.get("ARCADE_API_KEY")


### PR DESCRIPTION
Tools added to retrieve metadata and messages from direct message conversation. Changed the name of tools referring to 'conversation by name' to 'channel by name', since the tools don't actually apply to IM or MPIM, only to public or private channels.