### PR TITLE
Document Slack tools to retrieve messages and metadata from MPIM conversations

### DIFF
--- a/pages/toolkits/social-communication/slack.mdx
+++ b/pages/toolkits/social-communication/slack.mdx
@@ -26,6 +26,7 @@ The Arcade Slack toolkit provides a comprehensive set of tools for interacting w
 - Retrieve user information
 - List users
 - List conversations
+- Retrieve messages in a channel, direct or multi-person conversation
 - Retrieve conversation metadata
 
 ## Install
@@ -62,6 +63,10 @@ pip install arcade_slack
       "Fetch the messages in a direct message conversation using the username of the other participant.",
     ],
     [
+      "GetMessagesInMultiPersonDmConversationByUsername",
+      "Fetch the messages in a multi-person direct message conversation using the usernames of the other participants.",
+    ],
+    [
       "GetConversationMetadataById",
       "Retrieve metadata of a conversation using its ID.",
     ],
@@ -72,6 +77,10 @@ pip install arcade_slack
     [
       "GetDirectMessageConversationMetadataByUsername",
       "Retrieve metadata of a direct message conversation using the username of the other participant.",
+    ],
+    [
+      "GetMultiPersonDmConversationMetadataByUsername",
+      "Retrieve metadata of a multi-person direct message conversation using the usernames of the other participants.",
     ],
     ["ListConversationsMetadata", "List metadata for Slack conversations."],
     [
@@ -350,11 +359,51 @@ Get the messages in a channel in Slack.
   ]}
 />
 
-Get the messages in a channel in Slack.
+Get the messages in a Direct Message conversation with another user in Slack.
 
 **Parameters**
 
-- **`channel_name`** _(string, required)_ The name of the channel to get messages for.
+- **`username`** _(string, required)_ The username of the user to get messages with.
+- **`oldest_relative`** _(string, optional)_ The oldest message to include in the results, specified as a time offset from the current time in the format 'DD:HH:MM'.
+- **`latest_relative`** _(string, optional)_ The latest message to include in the results, specified as a time offset from the current time in the format 'DD:HH:MM'.
+- **`oldest_datetime`** _(string, optional)_ The oldest message to include in the results, specified as a datetime string in the format 'YYYY-MM-DD HH:MM:SS'.
+- **`latest_datetime`** _(string, optional)_ The latest message to include in the results, specified as a datetime string in the format 'YYYY-MM-DD HH:MM:SS'.
+- **`limit`** _(int, optional)_ The maximum number of messages to return. Defaults to 200.
+- **`next_cursor`** _(string, optional)_ The cursor to use for pagination.
+
+---
+
+## GetMessagesInMultiPersonDmConversationByUsername
+
+<br />
+<TabbedCodeBlock
+  tabs={[
+    {
+      label: "Call the Tool with User Authorization",
+      content: {
+        Python: [
+          "/examples/integrations/toolkits/slack/get_messages_in_multi_person_dm_conversation_by_username_example_call_tool.py",
+        ],
+        JavaScript: ["/examples/integrations/toolkits/slack/get_messages_in_multi_person_dm_conversation_by_username_example_call_tool.js"],
+      },
+    },
+    {
+      label: "Execute the Tool with OpenAI",
+      content: {
+        Python: [
+          "/examples/integrations/toolkits/slack/get_messages_in_multi_person_dm_conversation_by_username_example_llm_oai.py",
+        ],
+        JavaScript: ["/examples/integrations/toolkits/slack/get_messages_in_multi_person_dm_conversation_by_username_example_llm_oai.js"],
+      },
+    },
+  ]}
+/>
+
+Get the messages in a multi-person direct message conversation in Slack by the usernames of the participants (other than the currently authenticated user).
+
+**Parameters**
+
+- **`usernames`** _(list of strings, required)_ The usernames of the users to get messages with.
 - **`oldest_relative`** _(string, optional)_ The oldest message to include in the results, specified as a time offset from the current time in the format 'DD:HH:MM'.
 - **`latest_relative`** _(string, optional)_ The latest message to include in the results, specified as a time offset from the current time in the format 'DD:HH:MM'.
 - **`oldest_datetime`** _(string, optional)_ The oldest message to include in the results, specified as a datetime string in the format 'YYYY-MM-DD HH:MM:SS'.
@@ -464,6 +513,41 @@ Get the metadata of a direct message conversation in Slack searching by the user
 **Parameters**
 
 - **`username`** _(string, required)_ The username of the user/person to get messages with.
+- **`next_cursor`** _(string, optional)_ The cursor to use for pagination, if continuing from a previous search.
+
+---
+
+## GetMultiPersonDmConversationMetadataByUsername
+
+<br />
+<TabbedCodeBlock
+  tabs={[
+    {
+      label: "Call the Tool with User Authorization",
+      content: {
+        Python: [
+          "/examples/integrations/toolkits/slack/get_multi_person_dm_conversation_metadata_by_username_example_call_tool.py",
+        ],
+        JavaScript: ["/examples/integrations/toolkits/slack/get_multi_person_dm_conversation_metadata_by_username_example_call_tool.js"],
+      },
+    },
+    {
+      label: "Execute the Tool with OpenAI",
+      content: {
+        Python: [
+          "/examples/integrations/toolkits/slack/get_multi_person_dm_conversation_metadata_by_username_example_llm_oai.py",
+        ],
+        JavaScript: ["/examples/integrations/toolkits/slack/get_multi_person_dm_conversation_metadata_by_username_example_llm_oai.js"],
+      },
+    },
+  ]}
+/>
+
+Get the metadata of a multi-person direct message conversation in Slack searching by the usernames of the participants (other than the currently authenticated user).
+
+**Parameters**
+
+- **`usernames`** _(list of strings, required)_ The usernames of the users to get messages with.
 - **`next_cursor`** _(string, optional)_ The cursor to use for pagination, if continuing from a previous search.
 
 ---

--- a/public/examples/integrations/toolkits/slack/get_messages_in_multi_person_dm_conversation_by_username_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_messages_in_multi_person_dm_conversation_by_username_example_call_tool.js
@@ -1,0 +1,34 @@
+import { Arcade } from "@arcadeai/arcadejs";
+
+const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
+
+const USER_ID = "you@example.com";
+const TOOL_NAME = "Slack.GetMessagesInMultiPersonDmConversationByUsername";
+
+// Start the authorization process
+const authResponse = await client.tools.authorize({
+    tool_name: TOOL_NAME,
+    user_id: USER_ID,
+});
+
+if (authResponse.status !== "completed") {
+    console.log(`Click this link to authorize: ${authResponse.url}`);
+}
+
+// Wait for the authorization to complete
+await client.auth.waitForCompletion(authResponse);
+
+const toolInput = {
+    usernames: ["john_doe", "jane_doe"],
+    limit: 100,
+    oldest_datetime: "2023-01-01 00:00:00",
+    latest_datetime: "2023-01-31 23:59:59"
+};
+
+const response = await client.tools.execute({
+    tool_name: TOOL_NAME,
+    input: toolInput,
+    user_id: USER_ID,
+});
+
+console.log(response);

--- a/public/examples/integrations/toolkits/slack/get_messages_in_multi_person_dm_conversation_by_username_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_messages_in_multi_person_dm_conversation_by_username_example_call_tool.py
@@ -1,0 +1,31 @@
+from arcadepy import Arcade
+
+client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
+
+USER_ID = "you@example.com"
+TOOL_NAME = "Slack.GetMessagesInMultiPersonDmConversationByUsername"
+
+auth_response = client.tools.authorize(
+    tool_name=TOOL_NAME,
+    user_id=USER_ID,
+)
+
+if auth_response.status != "completed":
+    print(f"Click this link to authorize: {auth_response.url}")
+
+# Wait for the authorization to complete
+client.auth.wait_for_completion(auth_response)
+
+tool_input = {
+    "usernames": ["john_doe", "jane_doe"],
+    "limit": 100,
+    "oldest_datetime": "2023-01-01 00:00:00",
+    "latest_datetime": "2023-01-31 23:59:59",
+}
+
+response = client.tools.execute(
+    tool_name=TOOL_NAME,
+    input=tool_input,
+    user_id=USER_ID,
+)
+print(response)

--- a/public/examples/integrations/toolkits/slack/get_messages_in_multi_person_dm_conversation_by_username_example_llm_oai.js
+++ b/public/examples/integrations/toolkits/slack/get_messages_in_multi_person_dm_conversation_by_username_example_llm_oai.js
@@ -1,0 +1,22 @@
+import OpenAI from 'openai';
+
+const USER_ID = 'you@example.com';
+const PROMPT = "Fetch the messages in the multi-person direct message conversation with the usernames 'john_doe' and 'jane_doe' between '2023-01-01 00:00:00' and '2023-01-31 23:59:59'."
+const TOOL_NAME = 'Slack.GetMessagesInMultiPersonDmConversationByUsername';
+
+const client = new OpenAI({
+    baseURL: 'https://api.arcade.dev',
+    apiKey: process.env.ARCADE_API_KEY
+});
+
+const response = await client.chat.completions.create({
+    messages: [
+        { role: 'user', content: PROMPT }
+    ],
+    model: 'gpt-4o-mini',
+    user: USER_ID,
+    tools: [TOOL_NAME],
+    tool_choice: 'generate'
+});
+
+console.log(response.choices[0].message.content);

--- a/public/examples/integrations/toolkits/slack/get_messages_in_multi_person_dm_conversation_by_username_example_llm_oai.py
+++ b/public/examples/integrations/toolkits/slack/get_messages_in_multi_person_dm_conversation_by_username_example_llm_oai.py
@@ -1,0 +1,21 @@
+import os
+from openai import OpenAI
+
+USER_ID = "you@example.com"
+PROMPT = "Fetch the messages in the multi-person direct message conversation with the usernames 'john_doe' and 'jane_doe' between '2023-01-01 00:00:00' and '2023-01-31 23:59:59'."
+TOOL_NAME = "Slack.GetMessagesInMultiPersonDmConversationByUsername"
+
+client = OpenAI(
+    base_url="https://api.arcade.dev", api_key=os.environ.get("ARCADE_API_KEY")
+)
+
+response = client.chat.completions.create(
+    messages=[
+        {"role": "user", "content": PROMPT},
+    ],
+    model="gpt-4o-mini",
+    user=USER_ID,
+    tools=[TOOL_NAME],
+    tool_choice="generate",
+)
+print(response.choices[0].message.content)

--- a/public/examples/integrations/toolkits/slack/get_multi_person_dm_conversation_metadata_by_usernames_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_multi_person_dm_conversation_metadata_by_usernames_example_call_tool.js
@@ -1,0 +1,31 @@
+import { Arcade } from "@arcadeai/arcadejs";
+
+const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
+
+const USER_ID = "you@example.com";
+const TOOL_NAME = "Slack.GetMultiPersonDmConversationMetadataByUsername";
+
+// Start the authorization process
+const authResponse = await client.tools.authorize({
+    tool_name: TOOL_NAME,
+    user_id: USER_ID,
+});
+
+if (authResponse.status !== "completed") {
+    console.log(`Click this link to authorize: ${authResponse.url}`);
+}
+
+// Wait for the authorization to complete
+await client.auth.waitForCompletion(authResponse);
+
+const toolInput = {
+    usernames: ["john_doe", "jane_doe"]
+};
+
+const response = await client.tools.execute({
+    tool_name: TOOL_NAME,
+    input: toolInput,
+    user_id: USER_ID,
+});
+
+console.log(response);

--- a/public/examples/integrations/toolkits/slack/get_multi_person_dm_conversation_metadata_by_usernames_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_multi_person_dm_conversation_metadata_by_usernames_example_call_tool.py
@@ -1,0 +1,26 @@
+from arcadepy import Arcade
+
+client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
+
+USER_ID = "you@example.com"
+TOOL_NAME = "Slack.GetMultiPersonDmConversationMetadataByUsername"
+
+auth_response = client.tools.authorize(
+    tool_name=TOOL_NAME,
+    user_id=USER_ID,
+)
+
+if auth_response.status != "completed":
+    print(f"Click this link to authorize: {auth_response.url}")
+
+# Wait for the authorization to complete
+client.auth.wait_for_completion(auth_response)
+
+tool_input = {"usernames": ["john_doe", "jane_doe"]}
+
+response = client.tools.execute(
+    tool_name=TOOL_NAME,
+    input=tool_input,
+    user_id=USER_ID,
+)
+print(response)

--- a/public/examples/integrations/toolkits/slack/get_multi_person_dm_conversation_metadata_by_usernames_example_llm_oai.js
+++ b/public/examples/integrations/toolkits/slack/get_multi_person_dm_conversation_metadata_by_usernames_example_llm_oai.js
@@ -1,0 +1,22 @@
+import OpenAI from 'openai';
+
+const USER_ID = 'you@example.com';
+const PROMPT = "Retrieve the metadata for the multi-person direct message conversation with the usernames 'john_doe' and 'jane_doe'."
+const TOOL_NAME = 'Slack.GetMultiPersonDmConversationMetadataByUsername';
+
+const client = new OpenAI({
+    baseURL: 'https://api.arcade.dev',
+    apiKey: process.env.ARCADE_API_KEY
+});
+
+const response = await client.chat.completions.create({
+    messages: [
+        { role: 'user', content: PROMPT }
+    ],
+    model: 'gpt-4o-mini',
+    user: USER_ID,
+    tools: [TOOL_NAME],
+    tool_choice: 'generate'
+});
+
+console.log(response.choices[0].message.content);

--- a/public/examples/integrations/toolkits/slack/get_multi_person_dm_conversation_metadata_by_usernames_example_llm_oai.py
+++ b/public/examples/integrations/toolkits/slack/get_multi_person_dm_conversation_metadata_by_usernames_example_llm_oai.py
@@ -1,0 +1,21 @@
+import os
+from openai import OpenAI
+
+USER_ID = "you@example.com"
+PROMPT = "Retrieve the metadata for the multi-person direct message conversation with the usernames 'john_doe' and 'jane_doe'."
+TOOL_NAME = "Slack.GetMultiPersonDmConversationMetadataByUsername"
+
+client = OpenAI(
+    base_url="https://api.arcade.dev", api_key=os.environ.get("ARCADE_API_KEY")
+)
+
+response = client.chat.completions.create(
+    messages=[
+        {"role": "user", "content": PROMPT},
+    ],
+    model="gpt-4o-mini",
+    user=USER_ID,
+    tools=[TOOL_NAME],
+    tool_choice="generate",
+)
+print(response.choices[0].message.content)


### PR DESCRIPTION
This PR also fixes a few errors in the documentation of get-messages and get-metadata from direct message conversation tools.