### PR TITLE
fix: Auth provider docs incorrectly state that Atlassian (etc) don't work with Arcade Cloud

### DIFF
--- a/pages/home/auth-providers/atlassian.mdx
+++ b/pages/home/auth-providers/atlassian.mdx
@@ -5,7 +5,7 @@ import {Tabs} from 'nextra/components'
 <Note>
   At this time, Arcade does not offer a default Atlassian Auth Provider. To use
   Atlassian auth, you must create a custom Auth Provider with your own Atlassian
-  OAuth 2.0 credentials.
+  OAuth 2.0 credentials as described below.
 </Note>
 
 The Atlassian auth provider enables tools and agents to call the Atlassian API on behalf of a user. Behind the scenes, the Arcade Engine and the Atlassian auth provider seamlessly manage Atlassian OAuth 2.0 authorization for your users.
@@ -21,14 +21,14 @@ This auth provider is used by:
 
 ## Configuring Atlassian auth
 
-At the moment, you can only configure Atlassian auth with a [self-hosted Engine](/home/install/overview).
-
-### Create a Atlassian app
+### Create an Atlassian app
 
 - Create a Atlassian app in the [Atlassian developer console](https://developer.atlassian.com/console/myapps/)
 - In the Authorization tab, click the "Add" action button and set the Callback URL to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - In the Permissions tab, enable any permissions you need for your app
 - In the Settings tab, copy the Client ID and Secret to use below
+
+Next, add the Atlassian app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Atlassian auth with the Arcade Dashboard
 

--- a/pages/home/auth-providers/discord.mdx
+++ b/pages/home/auth-providers/discord.mdx
@@ -5,7 +5,7 @@ import { Tabs } from "nextra/components";
 <Note>
   At this time, Arcade does not offer a default Discord Auth Provider. To use
   Discord auth, you must create a custom Auth Provider with your own Discord
-  OAuth 2.0 credentials.
+  OAuth 2.0 credentials as described below.
 </Note>
 
 The Discord auth provider enables tools and agents to call the Discord API on behalf of a user. Behind the scenes, the Arcade Engine and the Discord auth provider seamlessly manage Discord OAuth 2.0 authorization for your users.
@@ -21,13 +21,13 @@ This auth provider is used by:
 
 ## Configuring Discord auth
 
-At the moment, you can only configure Discord auth with a [self-hosted Engine](/home/install/overview).
-
 ### Create a Discord app
 
 - Create a Discord Application in the [Discord developer portal](https://discord.com/developers/applications)
 - In the OAuth2 tab, set the redirect URI to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the Client ID and Client Secret (you may need to reset the secret to see it)
+
+Next, add the Discord app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Discord auth with the Arcade Dashboard
 

--- a/pages/home/auth-providers/dropbox.mdx
+++ b/pages/home/auth-providers/dropbox.mdx
@@ -5,7 +5,7 @@ import { Tabs } from "nextra/components";
 <Note>
   At this time, Arcade does not offer a default Dropbox Auth Provider. To use
   Dropbox auth, you must create a custom Auth Provider with your own Dropbox
-  OAuth 2.0 credentials.
+  OAuth 2.0 credentials as described below.
 </Note>
 
 The Dropbox auth provider enables tools and agents to call the Dropbox API on behalf of a user. Behind the scenes, the Arcade Engine and the Dropbox auth provider seamlessly manage Dropbox OAuth 2.0 authorization for your users.
@@ -21,14 +21,14 @@ This auth provider is used by:
 
 ## Configuring Dropbox auth
 
-At the moment, you can only configure Dropbox auth with a [self-hosted Engine](/home/install/overview).
-
 ### Create a Dropbox app
 
 - Create a Dropbox Application in the [Dropbox App Console](https://www.dropbox.com/developers/apps)
 - In the Settings tab, under the "OAuth 2" section, set the redirect URI to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - In the Permissions tab, add any scopes that your app will need
 - In the Settings tab, copy the App key (Client ID) and App secret (Client Secret), which you'll need below
+
+Next, add the Dropbox app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Dropbox auth with the Arcade Dashboard
 

--- a/pages/home/auth-providers/github.mdx
+++ b/pages/home/auth-providers/github.mdx
@@ -35,6 +35,8 @@ When you are ready to go to production, you'll want to configure the GitHub auth
 - Set the redirect URL to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the client ID and client secret to use below
 
+Next, add the GitHub app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+
 ### Configuring GitHub auth with the Arcade Dashboard
 
 1. Navigate to the OAuth section of the Arcade Dashboard and click **Add OAuth Provider**.

--- a/pages/home/auth-providers/google.mdx
+++ b/pages/home/auth-providers/google.mdx
@@ -38,6 +38,8 @@ When you are ready to go to production, you'll want to configure the Google auth
 - Set the redirect URL to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the client ID and client secret to use below
 
+Next, add the Google app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+
 ### Configuring Google auth with the Arcade Dashboard
 
 1. Navigate to the OAuth section of the Arcade Dashboard and click **Add OAuth Provider**.

--- a/pages/home/auth-providers/linkedin.mdx
+++ b/pages/home/auth-providers/linkedin.mdx
@@ -29,6 +29,8 @@ When you are ready to go to production, you'll want to configure the LinkedIn au
 - On the Auth tab, set the redirect URL to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the client ID and client secret to use below
 
+Next, add the LinkedIn app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+
 ### Configuring LinkedIn auth with the Arcade Dashboard
 
 1. Navigate to the OAuth section of the Arcade Dashboard and click **Add OAuth Provider**.

--- a/pages/home/auth-providers/microsoft.mdx
+++ b/pages/home/auth-providers/microsoft.mdx
@@ -5,7 +5,7 @@ import { Tabs } from "nextra/components";
 <Note>
   At this time, Arcade does not offer a default Microsoft Auth Provider. To use
   Microsoft auth, you must create a custom Auth Provider with your own Microsoft
-  OAuth 2.0 credentials.
+  OAuth 2.0 credentials as described below.
 </Note>
 
 The Microsoft auth provider enables tools and agents to call the Microsoft Graph API on behalf of a user. Behind the scenes, the Arcade Engine and the Microsoft auth provider seamlessly manage Microsoft OAuth 2.0 authorization for your users.
@@ -31,6 +31,8 @@ When you are ready to go to production, you'll want to configure the Microsoft a
 - Choose the permissions (scopes) you need for your app
 - Set the redirect URL to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the client ID and client secret to use below
+
+Next, add the Microsoft app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Microsoft auth with the Arcade Dashboard
 

--- a/pages/home/auth-providers/slack.mdx
+++ b/pages/home/auth-providers/slack.mdx
@@ -34,6 +34,8 @@ When you are ready to go to production, you'll want to configure the Slack auth 
 - Set the redirect URL to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the client ID and client secret
 
+Next, add the Slack app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+
 ### Configuring Slack auth with the Arcade Dashboard
 
 1. Navigate to the OAuth section of the Arcade Dashboard and click **Add OAuth Provider**.

--- a/pages/home/auth-providers/spotify.mdx
+++ b/pages/home/auth-providers/spotify.mdx
@@ -5,7 +5,7 @@ import { Tabs } from "nextra/components";
 <Note>
   At this time, Arcade does not offer a default Spotify Auth Provider. To use
   Spotify auth, you must create a custom Auth Provider with your own Spotify
-  OAuth 2.0 credentials.
+  OAuth 2.0 credentials as described below.
 </Note>
 
 The Spotify auth provider enables tools and agents to call the Spotify API on behalf of a user. Behind the scenes, the Arcade Engine and the Spotify auth provider seamlessly manage Spotify OAuth 2.0 authorization for your users.
@@ -31,6 +31,8 @@ When you are ready to go to production, you'll want to configure the Spotify aut
 - Choose the "Web API" product (at a minimum)
 - Set the redirect URL to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the client ID and client secret to use below
+
+Next, add the Spotify app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Spotify auth with the Arcade Dashboard
 

--- a/pages/home/auth-providers/x.mdx
+++ b/pages/home/auth-providers/x.mdx
@@ -35,6 +35,8 @@ When you are ready to go to production, you'll want to configure the X auth prov
 - Set the redirect URL to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the client ID and client secret to use below
 
+Next, add the X app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+
 ### Configuring X auth with the Arcade Dashboard
 
 1. Navigate to the OAuth section of the Arcade Dashboard and click **Add OAuth Provider**.

--- a/pages/home/auth-providers/zoom.mdx
+++ b/pages/home/auth-providers/zoom.mdx
@@ -5,7 +5,7 @@ import { Tabs } from "nextra/components";
 <Note>
   At this time, Arcade does not offer a default Zoom Auth Provider. To use Zoom
   auth, you must create a custom Auth Provider with your own Zoom OAuth 2.0
-  credentials.
+  credentials as described below.
 </Note>
 
 The Zoom auth provider enables tools and agents to call the Zoom API on behalf of a user. Behind the scenes, the Arcade Engine and the Zoom auth provider seamlessly manage Zoom OAuth 2.0 authorization for your users.
@@ -31,6 +31,8 @@ When you are ready to go to production, you'll want to configure the Zoom auth p
 - Set the redirect URL to: `https://cloud.arcade.dev/api/v1/oauth/callback` and enable Strict Mode
 - Enable the Zoom features and permissions (scopes) that your app needs
 - Copy the client ID and client secret to use below
+
+Next, add the Zoom app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Zoom auth with the Arcade Dashboard
 


### PR DESCRIPTION
Ticket: [Auth provider docs incorrectly state that Atlassian (etc) don't work with Arcade Cloud](https://app.clickup.com/t/86b3wazef)