### PR TITLE
fix: Quickstart has confusing instructions around env vars

### DIFF
--- a/pages/home/quickstart.mdx
+++ b/pages/home/quickstart.mdx
@@ -12,7 +12,7 @@ import { Prerequisites } from "@components/pages/quickstart/Prerequisites/prereq
 
 ## Prerequisites
 
-First, make sure you have these pre-requisites installed on your system:
+First, make sure you have these prerequisites installed on your system:
 
 - **Arcade Account**: Sign up for an [Arcade account](https://api.arcade.dev/signup) if you haven't already.
 

--- a/src/components/pages/quickstart/Prerequisites/openai.mdx
+++ b/src/components/pages/quickstart/Prerequisites/openai.mdx
@@ -1,7 +1,7 @@
 import { Steps, Tabs } from "nextra/components"; import { Info } from "lucide-react";
 
-- OpenAI Client - Install the official OpenAI SDK for your preferred programming language. See the [OpenAI libraries documentation](https://platform.openai.com/docs/libraries) for installation instructions specific to your language.
-- Arcade API Key
+- OpenAI Client: Install the official OpenAI SDK for your preferred programming language. See the [OpenAI libraries documentation](https://platform.openai.com/docs/libraries) for installation instructions specific to your language.
+- Arcade API key
 
 <Tip>
   To obtain an API key, please refer to the [SDK
@@ -32,9 +32,9 @@ Below we show you Python and JavaScript installation commands, but you can find 
 
 ### Set up your OpenAI client
 
-To connect with Arcade's enhanced capabilities, configure your client with two essential pieces:
+To use the OpenAI client with Arcade's enhanced capabilities, configure your client with two essential values:
 
-1. Point your client to Arcade's endpoint
+1. Point your client to Arcade's endpoint (base URL)
 2. Use your Arcade API key
 
 First, set the `ARCADE_API_KEY` environment variable:
@@ -68,25 +68,9 @@ export const client = new OpenAI({
 
 </Tabs.Tab> </Tabs>
 
-<details className="rounded-lg border border-blue-100 bg-blue-50/30 p-4 my-4 dark:border-blue-900/50 dark:bg-blue-950/30 hover:bg-blue-100/50 dark:hover:bg-blue-950/40 transition-colors">
-  <summary className="flex items-center gap-2 text-sm font-medium dark:hover:bg-transparent">
-    <Info className="text-blue-500 dark:text-blue-400 w-4 h-4" />
-    <span>Keep your API key secure with environment variables</span>
-  </summary>
-
-  <div className="mt-4 text-sm text-neutral-700 dark:text-neutral-300">
-    We recommend storing your API key in a `.env` file:
-
-    1. Create a `.env` file:
-
-    ```
-    ARCADE_API_KEY=your_api_key_here
-    ```
-
-    2. Use a package like `dotenv` or `python-dotenv` to load the `.env` file in your code and populate the `ARCADE_API_KEY` environment variable.
-
-  </div>
-</details>
+<Note>
+  We recommend storing your API key in a `.env` file and using a package like `dotenv` or `python-dotenv` to load the `.env` file in your code.
+</Note>
 
 ### Call a tool
 

--- a/src/components/pages/quickstart/Prerequisites/openai.mdx
+++ b/src/components/pages/quickstart/Prerequisites/openai.mdx
@@ -37,6 +37,11 @@ To connect with Arcade's enhanced capabilities, configure your client with two e
 1. Point your client to Arcade's endpoint
 2. Use your Arcade API key
 
+First, set the `ARCADE_API_KEY` environment variable:
+```bash
+export ARCADE_API_KEY=your_api_key_here
+```
+
 <Tabs items={["Python", "JavaScript"]}> <Tabs.Tab>
 
 ```python
@@ -77,6 +82,8 @@ export const client = new OpenAI({
     ```
     ARCADE_API_KEY=your_api_key_here
     ```
+
+    2. Use a package like `dotenv` or `python-dotenv` to load the `.env` file in your code and populate the `ARCADE_API_KEY` environment variable.
 
   </div>
 </details>

--- a/src/components/pages/quickstart/Prerequisites/python.mdx
+++ b/src/components/pages/quickstart/Prerequisites/python.mdx
@@ -2,7 +2,7 @@ import { Steps } from "nextra/components";
 import { Info } from "lucide-react";
 
 - **Python 3.10+** & **pip**
-- Arcade API Key
+- Arcade API key
 
 <Tip>
   To obtain an API key, please refer to the [SDK
@@ -23,7 +23,7 @@ pip install arcadepy
 
 ### Set up your Arcade client
 
-In your python application, import the Arcade client and initialize it with your Arcade API key:
+In your Python application, import the Arcade client and initialize it with your Arcade API key:
 
 ```python
 from arcadepy import Arcade
@@ -40,7 +40,7 @@ client = Arcade(
   </summary>
 
   <div className="mt-4 text-sm text-neutral-700 dark:text-neutral-300">
-    We recommend storing your API key in a `.env` file using `python-dotenv`:
+    We recommend storing your API key in a `.env` file using `python-dotenv`.
 
     1. Install python-dotenv:
 
@@ -58,7 +58,6 @@ client = Arcade(
 
     ```python
     from dotenv import load_dotenv
-    import os
 
     load_dotenv()
     client = Arcade() # the env var ARCADE_API_KEY is loaded automatically

--- a/src/components/pages/quickstart/Prerequisites/python.mdx
+++ b/src/components/pages/quickstart/Prerequisites/python.mdx
@@ -23,13 +23,13 @@ pip install arcadepy
 
 ### Set up your Arcade client
 
-In your python application, import the Arcade client and initialize it with your API key:
+In your python application, import the Arcade client and initialize it with your Arcade API key:
 
 ```python
 from arcadepy import Arcade
 
 client = Arcade(
-    api_key=<ARCADE_API_KEY>
+    api_key="your_api_key_here"
 )
 ```
 
@@ -54,14 +54,14 @@ client = Arcade(
     ARCADE_API_KEY=your_api_key_here
     ```
 
-    3. Load the API key in your code:
+    3. Load the `.env` file in your code:
 
     ```python
     from dotenv import load_dotenv
     import os
 
     load_dotenv()
-    api_key = os.getenv("ARCADE_API_KEY")
+    client = Arcade() # the env var ARCADE_API_KEY is loaded automatically
     ```
 
   </div>

--- a/src/components/pages/quickstart/Prerequisites/typescript.mdx
+++ b/src/components/pages/quickstart/Prerequisites/typescript.mdx
@@ -2,7 +2,7 @@ import { Steps } from "nextra/components";
 import { Info } from "lucide-react";
 
 - **Node.js 18** & **npm**
-- Arcade API Key
+- Arcade API key
 
 <Tip>
   To obtain an API key, please refer to the [SDK
@@ -40,7 +40,7 @@ const client = new Arcade({
   </summary>
 
   <div className="mt-4 text-sm text-neutral-700 dark:text-neutral-300">
-    We recommend storing your API key in a `.env` file:
+    We recommend storing your API key in a `.env` file.
 
     1. Install the `dotenv` package:
 

--- a/src/components/pages/quickstart/Prerequisites/typescript.mdx
+++ b/src/components/pages/quickstart/Prerequisites/typescript.mdx
@@ -23,13 +23,13 @@ npm install @arcadeai/arcadejs
 
 ### Set up your Arcade client
 
-In your TypeScript application, import the Arcade client and initialize it with your API key:
+In your TypeScript application, import the Arcade client and initialize it with your Arcade API key:
 
 ```typescript
 import Arcade from "@arcadeai/arcadejs";
 
 const client = new Arcade({
-  apiKey: process.env["ARCADE_API_KEY"],
+  apiKey: "your_api_key_here",
 });
 ```
 
@@ -42,10 +42,25 @@ const client = new Arcade({
   <div className="mt-4 text-sm text-neutral-700 dark:text-neutral-300">
     We recommend storing your API key in a `.env` file:
 
-    1. Create a `.env` file:
+    1. Install the `dotenv` package:
+
+    ```bash
+    npm install dotenv
+    ```
+
+    2. Create a `.env` file:
 
     ```
     ARCADE_API_KEY=your_api_key_here
+    ```
+
+    3. Load the `.env` file in your code:
+
+    ```typescript
+    import dotenv from "dotenv";
+    dotenv.config();
+
+    const client = new Arcade(); // the env var ARCADE_API_KEY is loaded automatically
     ```
 
   </div>


### PR DESCRIPTION
Ticket: [Docs: Quickstart has confusing instructions around env vars](https://app.clickup.com/t/86b3xbhq6)