### PR TITLE
fix: Typo in OAuth 2.0 config example

### DIFF
--- a/examples/code/home/configuration/engine/full_config.1.0.yaml
+++ b/examples/code/home/configuration/engine/full_config.1.0.yaml
@@ -30,7 +30,7 @@ auth:
           code_challenge_method: S256
         authorize_request:
           endpoint: 'https://example.com/oauth/authorize'
-          parameters:
+          params:
             response_type: code
             client_id: '{{client_id}}'
             redirect_uri: '{{redirect_uri}}'
@@ -38,7 +38,7 @@ auth:
         token_request:
           endpoint: 'https://example.com/oauth/token'
           auth_method: client_secret_basic # Optional
-          parameters:
+          params:
             grant_type: authorization_code
             client_id: '{{client_id}}'
             client_secret: '{{client_secret}}'
@@ -52,7 +52,7 @@ auth:
         refresh_request: # Optional
           endpoint: 'https://example.com/oauth/token'
           auth_method: client_secret_basic # Optional
-          parameters:
+          params:
             grant_type: refresh_token
             client_id: '{{client_id}}'
             client_secret: '{{client_secret}}'


### PR DESCRIPTION
The correct name for the prop is `params` - see https://github.com/ArcadeAI/schemas/blob/main/engine/config/1.0/schema.json#L68