### PR TITLE
fix broken link in notion tool card

### DIFF
--- a/src/components/custom/Toolkits/toolkits-config.ts
+++ b/src/components/custom/Toolkits/toolkits-config.ts
@@ -220,7 +220,7 @@ const availableTools: Tool[] = [
     name: "Notion",
     image: "notion.png",
     summary: "Create, read, and search Notion pages",
-    link: "/toolkits/productivity/notion/readme",
+    link: "/toolkits/productivity/notion",
     category: "productivity",
     type: "arcade",
   },


### PR DESCRIPTION
The Notion Card is a broken link (all others work), this redirects it to the proper page in the docs.
