### PR TITLE
Add instructions about the redirect url when configuring custom Oauth providers

### DIFF
--- a/pages/home/auth-providers/oauth2.mdx
+++ b/pages/home/auth-providers/oauth2.mdx
@@ -30,9 +30,15 @@ The only supported OAuth 2.0 flow is the authorization code grant flow (with or 
 
 How you configure the OAuth 2.0 provider depends on whether you use the Arcade Cloud Engine or a [self-hosted Engine](/home/install/overview).
 
-### Configuring OAuth 2.0 with the Arcade Dashboard
+### Arcade Cloud Engine
 
-1. Navigate to the OAuth section of the Arcade Dashboard and click **Add OAuth Provider**.
+#### Redirect URL
+
+The service you're configuring will require a redirect URL for the authorization flow. When using the Arcade Cloud, you should enter this URL: `https://cloud.arcade.dev/api/v1/oauth/callback`
+
+#### Add the OAuth Provider
+
+1. Navigate to the OAuth section of the [Arcade Dashboard](https://api.arcade.dev/dashboard/home) and click **Add OAuth Provider**.
 2. Select **OAuth 2.0** as the provider.
 3. Choose a unique **ID** for your provider (e.g. "my-oauth2-provider") with an optional **Description**.
 4. Enter your **Client ID** and **Client Secret** from your OAuth 2.0 provider.
@@ -40,7 +46,13 @@ How you configure the OAuth 2.0 provider depends on whether you use the Arcade C
 
 When you use tools that require OAuth 2.0 authorization using your Arcade account credentials, the Arcade Engine will automatically use this OAuth 2.0 provider.
 
-### Configuring OAuth 2.0 in self-hosted Arcade Engine configuration
+### Self-hosted Arcade Engine
+
+#### Redirect URL
+
+The service you're configuring will require a redirect URL for the authorization flow. When using a self-hosted Arcade Engine, you should enter this URL: `https://{your-engine-domain}/api/v1/oauth/callback`.
+
+> Replace `{your-engine-domain}` with the domain (or IP address) pointing to the server/cluster running the Arcade Engine.
 
 <Steps>
 


### PR DESCRIPTION
Our docs did not explain which redirect URL should be used when configuring a custom OAuth provider. Added that for cloud & self-hosted engine instructions.