### PR TITLE
Remove Last Updated Timestamp 

### DIFF
--- a/pages/home/supported-models/_meta.ts
+++ b/pages/home/supported-models/_meta.ts
@@ -1,3 +1,7 @@
 export default {
   index: "Overview",
+  anthropic: "Anthropic",
+  groq: "Groq",
+  ollama: "Ollama",
+  openai: "OpenAI",
 };

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -29,6 +29,7 @@ const config: DocsThemeConfig = {
     icon: <SiDiscord />,
   },
   docsRepositoryBase: "https://github.com/ArcadeAI/arcade-ai",
+  gitTimestamp: null,
   editLink: {
     content: null, // TODO: add edit link when our repo is public
   },


### PR DESCRIPTION
The last updated timestamp on docs is misleading. "Last updated on March 21, 2025" at the bottom of every page seems to apply to the whole site, not the particular page you're looking at.

Nextra needs the full git commit history in order to provide accurate 'Last updated on'. When we deploy, we're only providing a shallow clone, so only the most recent commit date is available to Nextra. This is why the issue only exists in production and not locally.


ClickUp ticket: https://app.clickup.com/t/86b4d4g2a