### PR TITLE
Remove tool instalation header from docs

### DIFF
--- a/pages/home/oai-agents/overview.mdx
+++ b/pages/home/oai-agents/overview.mdx
@@ -91,7 +91,7 @@ Arcade provides a variety of toolkits you can use with your agents:
 - **Web**: Web search, content extraction
 - **And more**: Weather, financial data, etc.
 
-For a full list of available toolkits, visit the [Arcade Integrations](https://docs.arcade.dev/toolkits) documentation.
+For a full list of available toolkits, visit the [Arcade Integrations](/toolkits) documentation.
 
 ## Next steps
 

--- a/pages/toolkits/development/code-sandbox.mdx
+++ b/pages/toolkits/development/code-sandbox.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to run code in a sandboxed environment."
@@ -19,16 +20,6 @@ The Arcade Code Sandbox toolkit provides a pre-built set of tools for running co
 
 - Run code in a sandboxed environment
 - Create a static matplotlib chart
-
-## Install
-
-```bash
-pip install arcade-code-sandbox
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -132,3 +123,5 @@ The Arcade Code Sandbox toolkit uses [E2B](https://e2b.dev/) to run code in a sa
 **Global Environment Variables:**
 
 - `E2B_API_KEY`: Your [E2B](https://e2b.dev/) API key.
+
+<ToolFooter pipPackageName="arcade-code-sandbox" />

--- a/pages/toolkits/development/github/github.mdx
+++ b/pages/toolkits/development/github/github.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to interact with GitHub repositories, issues, and pull requests."
@@ -21,16 +22,6 @@ The Arcade GitHub toolkit provides a pre-built set of tools for interacting with
 - Access private repositories (with the user's permission)
 - Get info about repositories, issues, pull requests, and more
 - Post issues, comments, and replies as the user
-
-## Install
-
-```bash
-pip install arcade_github
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -725,3 +716,5 @@ The Arcade GitHub toolkit uses the [GitHub auth provider](/home/auth-providers/g
 With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the GitHub auth provider](/home/auth-providers/github#configuring-github-auth) with your own GitHub app credentials.
+
+<ToolFooter pipPackageName="arcade_github" />

--- a/pages/toolkits/development/web/web.mdx
+++ b/pages/toolkits/development/web/web.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to scrape, crawl, and map websites."
@@ -22,16 +23,6 @@ The Arcade Web toolkit provides a pre-built set of tools for interacting with we
 - Map website structures
 - Retrieve crawl status and data
 - Cancel ongoing crawls
-
-## Install
-
-```bash
-pip install arcade_web
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -340,3 +331,5 @@ The Arcade Web toolkit uses [Firecrawl](https://www.firecrawl.dev/) to scrape, c
 **Global Environment Variables:**
 
 - `FIRECRAWL_API_KEY`: Your [Firecrawl](https://www.firecrawl.dev/) API key.
+
+<ToolFooter pipPackageName="arcade_web" />

--- a/pages/toolkits/entertainment/spotify.mdx
+++ b/pages/toolkits/entertainment/spotify.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to interact with Spotify tracks."
@@ -25,12 +26,6 @@ The Arcade Spotify toolkit provides a pre-built set of tools for interacting wit
 - Get information about tracks
 - Search for tracks
 - Control playback
-
-## Install
-
-```bash
-pip install arcade_spotify
-```
 
 ## Available Tools
 
@@ -585,3 +580,5 @@ Explanation of the q parameter: You can narrow down your search using field filt
 - `types` _(array, required)_ The types of results to return, Valid values are 'album', 'artist', 'playlist', 'track', 'show', 'episode', 'audiobook'
 
 - `limit` _(integer, optional)_ The maximum number of results to return. Defaults to `1`.
+
+<ToolFooter pipPackageName="arcade_spotify" />

--- a/pages/toolkits/entertainment/twitch.mdx
+++ b/pages/toolkits/entertainment/twitch.mdx
@@ -1,4 +1,5 @@
 import { Tabs } from "nextra/components";
+import ToolFooter from "@/components/ToolFooter";
 
 # Twitch auth provider
 
@@ -116,3 +117,5 @@ Use the `Twitch()` auth class to specify that a tool requires authorization with
 ```python file=<rootDir>/examples/code/integrations/twitch/custom_tool.py {5-6,9-13,36}
 
 ```
+
+<ToolFooter pipPackageName="arcade_twitch" />

--- a/pages/toolkits/payments/stripe.mdx
+++ b/pages/toolkits/payments/stripe.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Empower your agents to interact with the Stripe API."
@@ -16,16 +17,6 @@ import TableOfContents from "@/components/TableOfContents";
 <Badges repo="arcadeai/arcade-stripe" />
 
 The Arcade Stripe toolkit lets you interact with the Stripe API. Use these tools to build intelligent agents and applications that process payments, create invoices, and more.
-
-## Install
-
-```bash
-pip install arcade_stripe
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -591,3 +582,5 @@ The Arcade Stripe toolkit uses the [Stripe Agent Toolkit](https://github.com/str
 
 - **Required Secret:**
   - `STRIPE_SECRET_KEY`: Your Stripe API key.
+
+<ToolFooter pipPackageName="arcade_stripe" />

--- a/pages/toolkits/productivity/dropbox.mdx
+++ b/pages/toolkits/productivity/dropbox.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to interact with files and folders in Dropbox."
@@ -20,16 +21,6 @@ The Arcade Dropbox toolkit provides a pre-built set of tools for interacting wit
 - Browse files and folders
 - Search for files and folders
 - Download files
-
-## Install
-
-```bash
-pip install arcade_dropbox
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -150,3 +141,5 @@ The Arcade Dropbox toolkit uses the [Dropbox auth provider](/home/auth-providers
 With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Dropbox auth provider](/home/auth-providers/dropbox#configuring-dropbox-auth) with your own Dropbox app credentials.
+
+<ToolFooter pipPackageName="arcade_dropbox" />

--- a/pages/toolkits/productivity/google/calendar.mdx
+++ b/pages/toolkits/productivity/google/calendar.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to interact with Google Calendar events."
@@ -19,16 +20,6 @@ import TableOfContents from "@/components/TableOfContents";
 The Arcade Calendar toolkit provides a pre-built set of tools for interacting with Google Calendar. These tools make it easy to build agents and AI apps that can:
 
 - Create, update, list, and delete events
-
-## Install
-
-```bash
-pip install arcade_google
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -304,3 +295,5 @@ The Arcade Calendar toolkit uses the [Google auth provider](/home/auth-providers
 With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Google auth provider](/home/auth-providers/google#configuring-google-auth) with your own Google app credentials.
+
+<ToolFooter pipPackageName="arcade_google" />

--- a/pages/toolkits/productivity/google/contacts.mdx
+++ b/pages/toolkits/productivity/google/contacts.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to interact with Google Contacts."
@@ -20,16 +21,6 @@ The Arcade Contacts toolkit provides a pre-built set of tools for interacting wi
 
 - Create new contacts
 - Search for contacts by name or email
-
-## Install
-
-```bash
-pip install arcade_google
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -174,3 +165,5 @@ The Arcade Contacts toolkit uses the [Google auth provider](/home/auth-providers
 With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Google auth provider](/home/auth-providers/google#configuring-google-auth) with your own Google app credentials.
+
+<ToolFooter pipPackageName="arcade_google" />

--- a/pages/toolkits/productivity/google/docs.mdx
+++ b/pages/toolkits/productivity/google/docs.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to interact with Google Docs documents."
@@ -23,12 +24,6 @@ import TableOfContents from "@/components/TableOfContents";
 The Arcade Docs toolkit provides a pre-built set of tools for interacting with Google Docs. These tools make it easy to build agents and AI apps that can:
 
 - Create, update, list, and delete documents
-
-## Install
-
-```bash
-pip install arcade_google
-```
 
 ## Available Tools
 
@@ -206,3 +201,5 @@ The Arcade Docs toolkit uses the [Google auth provider](/home/auth-providers/goo
 With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Google auth provider](/home/auth-providers/google#configuring-google-auth) with your own Google app credentials.
+
+<ToolFooter pipPackageName="arcade_google" />

--- a/pages/toolkits/productivity/google/drive.mdx
+++ b/pages/toolkits/productivity/google/drive.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to interact with Google Drive."
@@ -21,12 +22,6 @@ The Arcade Drive toolkit provides a pre-built set of tools for interacting with 
 
 - Search Google documents in the user's Google Drive
 - Search and retrieve the contents of Google documents in the user's Google Drive
-
-## Install
-
-```bash
-pip install arcade_google
-```
 
 ## Available Tools
 
@@ -208,3 +203,5 @@ The Arcade Drive toolkit uses the [Google auth provider](/home/auth-providers/go
 With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Google auth provider](/home/auth-providers/google#configuring-google-auth) with your own Google app credentials.
+
+<ToolFooter pipPackageName="arcade_google" />

--- a/pages/toolkits/productivity/google/gmail.mdx
+++ b/pages/toolkits/productivity/google/gmail.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to send, read, and manage emails in Gmail."
@@ -23,16 +24,6 @@ The Arcade Gmail toolkit provides a pre-built set of tools for interacting with 
 - Delete emails
 - Search for emails by header
 - List emails in the user's mailbox
-
-## Install
-
-```bash
-pip install arcade_google
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -510,3 +501,5 @@ The Arcade Gmail toolkit uses the [Google auth provider](/home/auth-providers/go
 With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Google auth provider](/home/auth-providers/google#configuring-google-auth) with your own Google app credentials.
+
+<ToolFooter pipPackageName="arcade_google" />

--- a/pages/toolkits/productivity/google/sheets.mdx
+++ b/pages/toolkits/productivity/google/sheets.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to create, read, and update spreadsheets in Google Sheets."
@@ -21,16 +22,6 @@ The Arcade Google Sheets toolkit provides pre-built tools for working with sprea
 - Create new spreadsheets
 - Retrieve spreadsheet data
 - Update cell values
-
-## Install
-
-```bash
-pip install arcade_google
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -162,3 +153,5 @@ The Arcade Sheets toolkit uses the [Google auth provider](/home/auth-providers/g
 With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Google auth provider](/home/auth-providers/google#configuring-google-auth) with your own Google app credentials.
+
+<ToolFooter pipPackageName="arcade_google" />

--- a/pages/toolkits/productivity/notion.mdx
+++ b/pages/toolkits/productivity/notion.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to interact with Notion."
@@ -23,16 +24,6 @@ The Arcade Notion toolkit provides a pre-built set of tools for interacting with
 - Search for pages or databases by title
 - Get the metadata of a Notion object (page or database)
 - Get a workspace's folder structure
-
-## Install
-
-```bash
-pip install arcade_notion_toolkit
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available tools
 
@@ -289,3 +280,5 @@ The Arcade Notion toolkit uses the [Notion auth provider](/home/auth-providers/n
 With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Notion auth provider](/home/auth-providers/notion#configuring-notion-auth) with your own Notion app credentials.
+
+<ToolFooter pipPackageName="arcade_notion_toolkit" />

--- a/pages/toolkits/sales/hubspot.mdx
+++ b/pages/toolkits/sales/hubspot.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to interact with the Hubspot CRM."
@@ -20,16 +21,6 @@ The Arcade Hubspot toolkit provides a pre-built set of tools for interacting wit
 - Search and retrieve company data and associated objects (deals, calls, email messages, etc)
 - Search and retrieve contact data and associated objects (calls, email messages, notes, tasks, etc)
 - Create contacts
-
-## Install
-
-```bash
-pip install arcade_hubspot
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -157,3 +148,5 @@ Alternatively, you can [configure a custom Hubspot auth provider](/home/auth-pro
 ### Self-hosted Arcade Engine
 
 With a [self-hosted installation of Arcade](/home/install/local), you must [configure the Hubspot auth provider](/home/auth-providers/hubspot) with your own Hubspot app credentials.
+
+<ToolFooter pipPackageName="arcade_hubspot" />

--- a/pages/toolkits/search/google_finance.mdx
+++ b/pages/toolkits/search/google_finance.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Empower your agents to retrieve stock data using Arcade."
@@ -19,16 +20,6 @@ The Arcade Google Finance toolkit lets you fetch real-time and historical stock 
 
 - Stock summary data.
 - Historical stock data.
-
-## Install
-
-```bash
-pip install arcade_search
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -122,3 +113,5 @@ The Arcade Google Finance toolkit uses the [SerpAPI](https://serpapi.com/) to ge
 <Note>
   Setting the `SERP_API_KEY` secret is only required if you are [self-hosting](/home/install/overview) Arcade. If you're using Arcade Cloud, the secret is already set for you. To manage your secrets, go to the [Secrets page](https://api.arcade.dev/dashboard/auth/secrets) in the Arcade Dashboard.
 </Note>
+
+<ToolFooter pipPackageName="arcade_search" />

--- a/pages/toolkits/search/google_flights.mdx
+++ b/pages/toolkits/search/google_flights.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Empower your agents to search for flights using Arcade."
@@ -19,17 +20,7 @@ The Arcade Google Flights toolkit lets you search for flights with ease. Use the
 
 - Search for round-trip flights.
 - Search for one-way flights.
-
-## Install
-
-```bash
-pip install arcade_search
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
-
+  
 ## Available Tools
 
 <TableOfContents
@@ -133,3 +124,5 @@ The Arcade Google Flights toolkit uses the [SerpAPI](https://serpapi.com/) to se
 <Note>
   Setting the `SERP_API_KEY` secret is only required if you are [self-hosting](/home/install/overview) Arcade. If you're using Arcade Cloud, the secret is already set for you. To manage your secrets, go to the [Secrets page](https://api.arcade.dev/dashboard/auth/secrets) in the Arcade Dashboard.
 </Note>
+
+<ToolFooter pipPackageName="arcade_search" />

--- a/pages/toolkits/search/google_hotels.mdx
+++ b/pages/toolkits/search/google_hotels.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Empower your agents to search for hotels using Arcade."
@@ -16,16 +17,6 @@ import TableOfContents from "@/components/TableOfContents";
 <Badges repo="arcadeai/arcade-search" />
 
 The Arcade Google Hotels toolkit lets you search for hotels with ease. Use this tool to build intelligent agents and applications that search for hotels worldwide.
-
-## Install
-
-```bash
-pip install arcade_search
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -90,3 +81,5 @@ The Arcade Google Hotels toolkit uses the [SerpAPI](https://serpapi.com/) to sea
 <Note>
   Setting the `SERP_API_KEY` secret is only required if you are [self-hosting](/home/install/overview) Arcade. If you're using Arcade Cloud, the secret is already set for you. To manage your secrets, go to the [Secrets page](https://api.arcade.dev/dashboard/auth/secrets) in the Arcade Dashboard.
 </Note>
+
+<ToolFooter pipPackageName="arcade_search" />

--- a/pages/toolkits/search/google_jobs.mdx
+++ b/pages/toolkits/search/google_jobs.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to search for job openings with Google Jobs."
@@ -18,16 +19,6 @@ import TableOfContents from "@/components/TableOfContents";
 The Arcade Google Jobs toolkit provides a pre-built set of tools for interacting with Google Jobs. These tools make it easy to build agents and AI apps that can:
 
 - Search for job openings with Google Jobs.
-
-## Install
-
-```bash
-pip install arcade_search
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -102,3 +93,5 @@ The language code is a 2-character code that determines the language in which th
 - `ARCADE_GOOGLE_JOBS_LANGUAGE`: a default value for the jobs search tools. If not set, defaults to `ARCADE_GOOGLE_LANGUAGE`.
 
 A list of supported language codes can be found [here](/toolkits/search/reference#languagecodes).
+
+<ToolFooter pipPackageName="arcade_search" />

--- a/pages/toolkits/search/google_maps.mdx
+++ b/pages/toolkits/search/google_maps.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to get directions between two locations with Google Maps."
@@ -18,16 +19,6 @@ import TableOfContents from "@/components/TableOfContents";
 The Arcade Google Maps toolkit provides a pre-built set of tools for interacting with Google Maps. These tools make it easy to build agents and AI apps that can:
 
 - Get directions to a location using an address or latitude/longitude.
-
-## Install
-
-```bash
-pip install arcade_search
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -176,3 +167,5 @@ A list of supported travel modes can be found [here](/toolkits/search/reference#
 <Note>
   Setting the `SERP_API_KEY` secret is only required if you are [self-hosting](/home/install/overview) Arcade. If you're using Arcade Cloud, the secret is already set for you. To manage your secrets, go to the [Secrets page](https://api.arcade.dev/dashboard/auth/secrets) in the Arcade Dashboard.
 </Note>
+
+<ToolFooter pipPackageName="arcade_search" />

--- a/pages/toolkits/search/google_news.mdx
+++ b/pages/toolkits/search/google_news.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to search for news stories with Google News."
@@ -18,16 +19,6 @@ import TableOfContents from "@/components/TableOfContents";
 The Arcade Google News toolkit provides a pre-built set of tools for interacting with Google News. These tools make it easy to build agents and AI apps that can:
 
 - Search for news stories with Google News.
-
-## Install
-
-```bash
-pip install arcade_search
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -113,3 +104,5 @@ The country code is a 2-character code that determines the country in which the 
 - `ARCADE_GOOGLE_NEWS_COUNTRY`: a default value for the `SearchNews` tool. If not set, defaults to `None` (search news globally).
 
 A list of supported country codes can be found [here](/toolkits/search/reference#countrycodes).
+
+<ToolFooter pipPackageName="arcade_search" />

--- a/pages/toolkits/search/google_search.mdx
+++ b/pages/toolkits/search/google_search.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to perform Google searches using SerpAPI."
@@ -18,16 +19,6 @@ import TableOfContents from "@/components/TableOfContents";
 The Arcade Search toolkit provides a pre-built set of tools for interacting with Google search results. These tools make it easy to build agents and AI apps that can:
 
 - Search Google and return results.
-
-## Install
-
-```bash
-pip install arcade_search
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -84,3 +75,5 @@ The Arcade Google Search toolkit uses the [SerpAPI](https://serpapi.com/) to get
 <Note>
   Setting the `SERP_API_KEY` secret is only required if you are [self-hosting](/home/install/overview) Arcade. If you're using Arcade Cloud, the secret is already set for you. To manage your secrets, go to the [Secrets page](https://api.arcade.dev/dashboard/auth/secrets) in the Arcade Dashboard.
 </Note>
+
+<ToolFooter pipPackageName="arcade_search" />

--- a/pages/toolkits/search/google_shopping.mdx
+++ b/pages/toolkits/search/google_shopping.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to search for products with Google Shopping."
@@ -18,16 +19,6 @@ import TableOfContents from "@/components/TableOfContents";
 The Arcade Google Shopping Search toolkit provides a pre-built set of tools for interacting with Google Shopping. These tools make it easy to build agents and AI apps that can:
 
 - Search for products on Google Shopping;
-
-## Install
-
-```bash
-pip install arcade_search
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -111,3 +102,5 @@ The country code is a 2-character code that determines the country in which the 
 - `ARCADE_GOOGLE_SHOPPING_COUNTRY`: a default value for the Google Shopping Search tools. If not set, defaults to `ARCADE_GOOGLE_COUNTRY`. If `ARCADE_GOOGLE_COUNTRY` is not set, the default country for Google Shopping tools will be `us` (United States).
 
 A list of supported country codes can be found [here](/toolkits/search/reference#countrycodes).
+
+<ToolFooter pipPackageName="arcade_search" />

--- a/pages/toolkits/search/walmart.mdx
+++ b/pages/toolkits/search/walmart.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to search for products with Walmart."
@@ -19,16 +20,6 @@ The Arcade Walmart Search toolkit provides a pre-built set of tools for interact
 
 - Search for products listed on Walmart stores;
 - Get details about a product.
-
-## Install
-
-```bash
-pip install arcade_search
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -119,3 +110,5 @@ The Arcade Walmart Search toolkit uses the [SerpAPI](https://serpapi.com/) to ge
 <Note>
   Setting the `SERP_API_KEY` secret is only required if you are [self-hosting](/home/install/overview) Arcade. If you're using Arcade Cloud, the secret is already set for you. To manage your secrets, go to the [Secrets page](https://api.arcade.dev/dashboard/auth/secrets) in the Arcade Dashboard.
 </Note>
+
+<ToolFooter pipPackageName="arcade_search" />

--- a/pages/toolkits/search/youtube.mdx
+++ b/pages/toolkits/search/youtube.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to search for videos on YouTube."
@@ -19,16 +20,6 @@ The Arcade YouTube Search toolkit provides a pre-built set of tools for interact
 
 - Search for videos on YouTube;
 - Get details about a video.
-
-## Install
-
-```bash
-pip install arcade_search
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -144,3 +135,5 @@ The country code is a 2-character code that determines the country in which the 
 - `ARCADE_YOUTUBE_SEARCH_COUNTRY`: a default value for the YouTube Search tools. If not set, defaults to `ARCADE_GOOGLE_COUNTRY`. If `ARCADE_GOOGLE_COUNTRY` is not set, the default country for YouTube tools will be `us` (United States).
 
 A list of supported country codes can be found [here](/toolkits/search/reference#countrycodes).
+
+<ToolFooter pipPackageName="arcade_search" />

--- a/pages/toolkits/social-communication/linkedin.mdx
+++ b/pages/toolkits/social-communication/linkedin.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to interact with LinkedIn."
@@ -19,16 +20,6 @@ import TableOfContents from "@/components/TableOfContents";
 The Arcade LinkedIn toolkit provides a pre-built set of tools for interacting with LinkedIn. These tools make it easy to build agents and AI apps that can:
 
 - Create a post
-
-## Install
-
-```bash
-pip install arcade_linkedin
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -87,3 +78,5 @@ The Arcade LinkedIn toolkit uses the [LinkedIn auth provider](/home/auth-provide
 With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the LinkedIn auth provider](/home/auth-providers/linkedin#configuring-linkedin-auth) with your own LinkedIn app credentials.
+
+<ToolFooter pipPackageName="arcade_linkedin" />

--- a/pages/toolkits/social-communication/reddit.mdx
+++ b/pages/toolkits/social-communication/reddit.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to interact with Reddit."
@@ -28,16 +29,6 @@ The Arcade Reddit toolkit provides a pre-built set of tools for interacting with
 - Get rules of a subreddit
 - Get the authenticated user's username
 - Get posts by the authenticated user
-
-## Install
-
-```bash
-pip install arcade_reddit
-```
-
-<Note>
-  pip installing the toolkit is not needed if you're using the tools hosted on Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -480,3 +471,5 @@ The time range for filtering posts.
 - **`THIS_MONTH`** _(string: "THIS_MONTH")_
 - **`THIS_YEAR`** _(string: "THIS_YEAR")_
 - **`ALL_TIME`** _(string: "ALL_TIME")_
+
+<ToolFooter pipPackageName="arcade_reddit" />

--- a/pages/toolkits/social-communication/slack.mdx
+++ b/pages/toolkits/social-communication/slack.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to interact with Slack by sending messages, retrieving user and conversation information."
@@ -28,16 +29,6 @@ The Arcade Slack toolkit provides a comprehensive set of tools for interacting w
 - List conversations
 - Retrieve messages in a channel, direct or multi-person conversation
 - Retrieve conversation metadata
-
-## Install
-
-```bash
-pip install arcade_slack
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -807,3 +798,5 @@ The Arcade Slack toolkit uses the [Slack auth provider](/home/auth-providers/sla
 With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Slack auth provider](/home/auth-providers/slack#configuring-slack-auth) with your own Slack app credentials.
+
+<ToolFooter pipPackageName="arcade_slack" />

--- a/pages/toolkits/social-communication/x.mdx
+++ b/pages/toolkits/social-communication/x.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to interact with X (formerly Twitter)."
@@ -23,16 +24,6 @@ The Arcade X (Twitter) toolkit provides a pre-built set of tools for interacting
 - Search for tweets by username
 - Search for tweets by keywords
 - Look up a user by username
-
-## Install
-
-```bash
-pip install arcade_x
-```
-
-<Note>
-  pip installing the toolkit is only needed if you are [self-hosting](/home/install/overview) Arcade. You do not need to install the toolkit if you're using Arcade Cloud.
-</Note>
 
 ## Available Tools
 
@@ -277,3 +268,5 @@ The Arcade X (Twitter) toolkit uses the [X auth provider](/home/auth-providers/x
 With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the X auth provider](/home/auth-providers/x#configuring-x-auth) with your own X (formerly Twitter) app credentials.
+
+<ToolFooter pipPackageName="arcade_x" />

--- a/pages/toolkits/social-communication/zoom.mdx
+++ b/pages/toolkits/social-communication/zoom.mdx
@@ -4,6 +4,7 @@ import ToolInfo from "@/components/ToolInfo";
 import Badges from "@/components/Badges";
 import TabbedCodeBlock from "@/components/TabbedCodeBlock";
 import TableOfContents from "@/components/TableOfContents";
+import ToolFooter from "@/components/ToolFooter";
 
 <ToolInfo
   description="Enable agents to interact with Zoom by retrieving meeting information and invitations."
@@ -20,12 +21,6 @@ The Arcade Zoom toolkit provides tools for interacting with Zoom. With these too
 
 - List upcoming meetings
 - Retrieve meeting invitation details
-
-## Install
-
-```bash
-pip install arcade_zoom
-```
 
 ## Available Tools
 
@@ -74,3 +69,5 @@ With the hosted Arcade Engine, there's nothing to configure. Your users will see
 
 
 With a self-hosted installation of Arcade, you need to [configure the Zoom auth provider](/home/auth-providers/zoom#configuring-zoom-auth) with your own Zoom app credentials.
+
+<ToolFooter pipPackageName="arcade_zoom" />

--- a/src/components/QuickStartCard.tsx
+++ b/src/components/QuickStartCard.tsx
@@ -7,6 +7,7 @@ interface QuickStartCardProps {
   title: string;
   description: string;
   href: string;
+  code?: string;
 }
 
 export function QuickStartCard({
@@ -14,6 +15,7 @@ export function QuickStartCard({
   title,
   description,
   href,
+  code,
 }: QuickStartCardProps) {
   return (
     <motion.div
@@ -37,6 +39,11 @@ export function QuickStartCard({
             <p className="text-sm leading-relaxed text-gray-300">
               {description}
             </p>
+            {code && (
+              <pre className="mt-1 rounded-md bg-gray-900 p-1 text-sm text-gray-300">
+                <code>{code}</code>
+              </pre>
+            )}
           </CardContent>
         </Link>
       </Card>

--- a/src/components/ToolFooter.module.css
+++ b/src/components/ToolFooter.module.css
@@ -1,0 +1,5 @@
+.toolFooter {
+  margin-top: 2rem;
+  border-top: 1px solid var(--neutral-dark-medium);
+  padding-top: 1rem;
+}

--- a/src/components/ToolFooter.tsx
+++ b/src/components/ToolFooter.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import styles from "./ToolFooter.module.css";
+import { Cloud } from "lucide-react";
+import { Puzzle } from "lucide-react";
+import { QuickStartCard } from "./QuickStartCard";
+
+interface ToolFooterProps {
+  pipPackageName: string;
+}
+
+const ToolFooter: React.FC<ToolFooterProps> = ({ pipPackageName }) => {
+  return (
+    <div className={styles.toolFooter}>
+      <h2 className="mb-4 text-2xl font-bold tracking-tight text-white md:text-2xl">
+        Get Building
+      </h2>
+      <div className="mt-16 grid gap-8 md:grid-cols-2">
+        <QuickStartCard
+          icon={Cloud}
+          title="Use tools hosted on Arcade Cloud"
+          description="Arcade tools are hosted by our cloud platform and ready to be used in your agents.  Learn how."
+          href="/home/quickstart"
+        />
+        <QuickStartCard
+          icon={Puzzle}
+          title="Self Host Arcade tools"
+          description={`Arcade tools can be self-hosted on your own infrastructure.  Learn more about self-hosting.`}
+          href="/home/install/overview"
+          code={`pip install ${pipPackageName}`}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ToolFooter;


### PR DESCRIPTION
The persona we want to focus on is the agent developer, using the cloud product.  This means we should remove the 'install' step from the docs.  Instead, I added a footer with an 'escape hatch' that takes you either to the cloud docs or the self-hosting docs.  Folks /shouldn't/ be installing the pip packages 

<table>
  <tr>
    <td>
<img width="1771" alt="Screenshot 2025-04-24 at 3 27 45 PM" src="https://github.com/user-attachments/assets/2aab9599-d7a5-482d-b134-184451473689" />
 </td>
    <td>
<img width="1599" alt="Screenshot 2025-04-24 at 3 27 22 PM" src="https://github.com/user-attachments/assets/9b2a6bf1-7c08-4dc4-a7e4-b76e8483a20f" />
</td>
  </tr>
</table>