### PR TITLE
Simple "attach" mechanism leveraging tunnel providers

### DIFF
--- a/pages/home/build-tools/create-a-toolkit.mdx
+++ b/pages/home/build-tools/create-a-toolkit.mdx
@@ -13,13 +13,13 @@ This guide walks you through the complete process of creating a custom toolkit f
 
 Before starting, make sure you have:
 
-- Python 3.10 or higher (verify with `python --version`)
 - An [Arcade account](https://api.arcade.dev/signup?utm_source=docs&utm_medium=page&utm_campaign=custom-tools)
-- An active virtual environment for your shell(s).
+- An active virtual environment for your shell(s) (e.g. `uv venv --seed -p 3.13`)
     - We recommend using [uv](https://docs.astral.sh/uv/pip/environments/) or [miniconda](https://www.anaconda.com/docs/getting-started/miniconda/main).
     - Toolkits each have a poetry project with their own virtual environment, but toolkits are loaded into the top-level arcade environment based on the active  "parent" virtual environment.  **The local development commands will not work without an active virtual environment.**
+- `pip` installed within that virtual environment (verify with `pip --version`)
 - Arcade CLI installed within your python virtual environment: `pip install arcade-ai`
-- Poetry for package management (the generated Makefile uses Poetry)
+- Poetry for package management (the generated Makefile uses Poetry): `pip install poetry`
 
 <Steps>
 
@@ -28,6 +28,7 @@ Before starting, make sure you have:
 Run the following command to start creating your toolkit:
 
 ```bash
+git init
 arcade new
 ```
 
@@ -77,12 +78,16 @@ The Makefile provides several helpful commands:
 
 ### Define your tools
 
-Create a Python file for your tools in the `arcade_<toolkit_name>/tools` directory:
+Create a Python file for your tools in the `arcade_<toolkit_name>/tools` directory.
+
+The following example shows a simple math toolkit with three tools: `add`, `subtract`, and `multiply`:
 
 ```python
 # arcade_arithmetic/tools/operations.py
-from typing import Annotated, List
+from typing import Annotated
+
 from arcade.sdk import tool
+
 
 @tool
 def add(
@@ -131,16 +136,16 @@ Update the package initialization files to expose your tools:
 
 ```python
 # arcade_arithmetic/tools/__init__.py
-from .operations import add, subtract, multiply
+from .operations import add, multiply, subtract
 
-__all__ = ["add", "subtract", "multiply"]
+__all__ = ["add", "multiply", "subtract"]
 ```
 
 ```python
 # arcade_arithmetic/__init__.py
-from arcade_arithmetic.tools import add, subtract, multiply
+from arcade_arithmetic.tools import add, multiply, subtract
 
-__all__ = ["add", "subtract", "multiply"]
+__all__ = ["add", "multiply", "subtract"]
 ```
 
 ### Test your toolkit
@@ -150,7 +155,9 @@ Write tests for your tools in the `tests` directory:
 ```python
 # tests/test_operations.py
 import pytest
-from arcade_arithmetic.tools.operations import add, subtract, multiply
+
+from arcade_arithmetic.tools.operations import add, multiply, subtract
+
 
 def test_add():
     assert add(3, 4) == 7
@@ -196,32 +203,64 @@ arcade show --local
 
 You should see your toolkit listed in the output.
 
-### Test with a local worker
+### Test your tools locally
 
-Start a local worker to test your toolkit with the Arcade API:
+Serve your toolkit locally with the Arcade CLI:
 
 ```bash
 arcade serve
 ```
 
-Visit http://localhost:8002/docs to see your tools in the Swagger UI.
+Visit http://localhost:8002/worker/health to see that your worker is running.
+
+### Connect your local toolkit to Arcade Gateway
+
+In another terminal, use a service like [ngrok](https://ngrok.com/docs/), [tailscale](https://tailscale.com/kb/1223/funnel), or [cloudflare](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/local-management/create-local-tunnel/) to give your local worker a public URL.
+
+```bash
+ngrok http 8002
+```
+
+```bash
+tailscale funnel 8002
+```
+
+```bash
+cloudflared tunnel --url http://localhost:8002
+```
+
+Then in your Arcade dashboard:
+
+1. Navigate to the [Workers](https://api.arcade.dev/dashboard/workers) page.
+1. Click **Add Worker**.
+1. Fill in the form with the following values:
+    - **ID**: `my-arithmetic-worker`
+    - **Worker Type**: `Arcade`
+    - **URL**: your public URL from ngrok, tailscale, or cloudflare
+    - **Secret**: `dev`
+    - **Timeout** and **Retry**: can be left at default values
+1. Click **Create**.
+
+Now, in the [Playground](https://api.arcade.dev/playground/execute), you can see your tools in action.
 
 ### Deploy your toolkit to Arcade
 
-Create a `worker.toml` file in your toolkit's root directory:
+Find the `worker.toml` file in your toolkit's root directory (where you ran `arcade new`):
 
 ```toml
 [[worker]]
 
 [worker.config]
-id = "arithmetic-worker"  # Choose a unique ID
-secret = "<your-secret>"  # Replace with a secure secret
-
+id = "demo-worker"  # Choose a unique ID
+enabled = true
+timeout = 30
+retries = 3
+secret = "<your-secret>"  # This is randomly generated for you by `arcade new`
 [worker.local_source]
-packages = ["."]  # Path to your toolkit directory
+packages = ["./arithmetic"]  # Path to your toolkit directory
 ```
 
-Deploy your worker to Arcade:
+From the root of your toolkit, deploy your toolkit to Arcade's cloud with:
 
 ```bash
 arcade deploy

--- a/pages/home/build-tools/create-a-toolkit.mdx
+++ b/pages/home/build-tools/create-a-toolkit.mdx
@@ -245,6 +245,8 @@ Now, in the [Playground](https://api.arcade.dev/playground/execute), you can see
 
 ### Deploy your toolkit to Arcade
 
+Alternatively, you can deploy your toolkit to Arcade's cloud instead of tunneling to it locally.
+
 Find the `worker.toml` file in your toolkit's root directory (where you ran `arcade new`):
 
 ```toml

--- a/pages/home/build-tools/create-a-toolkit.mdx
+++ b/pages/home/build-tools/create-a-toolkit.mdx
@@ -3,7 +3,7 @@ title: "Creating a Toolkit"
 description: "Learn how to create, test, deploy, and publish a custom toolkit for Arcade"
 ---
 
-import { Steps } from "nextra/components";
+import { Steps, Tabs } from "nextra/components";
 
 # Creating a Toolkit
 
@@ -213,21 +213,36 @@ arcade serve
 
 Visit http://localhost:8002/worker/health to see that your worker is running.
 
-### Connect your local toolkit to Arcade Gateway
+### Connect your toolkit to Arcade
 
 In another terminal, use a service like [ngrok](https://ngrok.com/docs/), [tailscale](https://tailscale.com/kb/1223/funnel), or [cloudflare](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/local-management/create-local-tunnel/) to give your local worker a public URL.
+
+<Tabs items={["ngrok", "Tailscale", "Cloudflare"]}>
+<Tabs.Tab>
 
 ```bash
 ngrok http 8002
 ```
 
+</Tabs.Tab>
+
+<Tabs.Tab>
+
 ```bash
 tailscale funnel 8002
 ```
 
+</Tabs.Tab>
+
+<Tabs.Tab>
+
 ```bash
 cloudflared tunnel --url http://localhost:8002
 ```
+
+</Tabs.Tab>
+
+</Tabs>
 
 Then in your Arcade dashboard:
 

--- a/pages/home/hybrid-deployment/hybrid-worker.mdx
+++ b/pages/home/hybrid-deployment/hybrid-worker.mdx
@@ -1,3 +1,123 @@
+---
+title: "Hybrid Worker"
+description: "Learn how to deploy Arcade workers in a hybrid architecture"
+---
+
+import { Steps, Tabs } from "nextra/components";
+
 # Hybrid Worker
 
-TODO
+A hybrid deployment allows you to execute tools in your own environment while still leveraging Arcade's cloud Gateway infrastructure. This gives you the flexibility to access private resources, maintain data security, and customize your worker environment while leveraging Arcade's gateway and management capabilities.
+
+## How hybrid workers work
+
+The hybrid worker model uses a bidirectional connection between your local environment and Arcade's cloud gateway:
+
+1. You run the Arcade worker in your environment (on-premises, private cloud, etc.)
+2. Your worker is exposed to Arcade's cloud gateway using a public URL
+3. The Arcade cloud gateway routes tool calls to your worker
+4. Your worker processes the requests and returns responses to the gateway
+
+## Benefits of hybrid workers
+
+- **Resource access**: Access private databases, APIs, or other resources not accessible from Arcade's cloud
+- **Data control**: Keep sensitive data within your environment while still using Arcade's capabilities
+- **Custom environments**: Use specific dependencies or configurations required by your tools
+- **Compliance**: Meet regulatory requirements by keeping data processing within your infrastructure
+
+## Setting up a hybrid worker
+
+<Steps>
+
+### Setup your toolkits
+
+Follow the [Creating a Toolkit](/home/build-tools/create-a-toolkit) guide to create your toolkits.
+
+Alternatively, you can install an Arcade Toolkit:
+
+```sh
+pip install arcade-math
+```
+
+### Start your local worker
+
+Run your Arcade worker locally with a secret that you generate in some secure way:
+
+```sh
+export ARCADE_WORKER_SECRET=your-secret
+arcade serve
+```
+
+Verify your worker is running by visiting http://localhost:8002/worker/health.
+
+### Create a public URL
+
+To allow the Arcade cloud gateway to connect to your locally running worker, you need a public URL. Here are a few options:
+
+<Tabs items={["ngrok", "Cloudflare", "Tailscale"]}>
+<Tabs.Tab>
+
+```sh
+ngrok http 8002
+```
+
+</Tabs.Tab>
+
+<Tabs.Tab>
+
+```sh
+cloudflared tunnel --url http://localhost:8002
+```
+
+</Tabs.Tab>
+
+<Tabs.Tab>
+
+```sh
+tailscale funnel 8002
+```
+
+</Tabs.Tab>
+</Tabs>
+
+### Register your worker in Arcade
+
+1. Navigate to the [Workers](https://api.arcade.dev/dashboard/workers) page in your Arcade dashboard
+1. Click **Add Worker**
+1. Fill in the form:
+   - **ID**: Choose a unique identifier (e.g., `my-hybrid-worker`)
+   - **Worker Type**: Select `Arcade`
+   - **URL**: Enter your public URL from Step 3
+   - **Secret**: Enter the secret for your worker (or use `dev` for testing)
+   - **Timeout** and **Retry**: Configure as needed for your use case
+1. Click **Create**
+
+### Test the connection to your worker
+
+You can now test your  worker by making requests through the Arcade API or using the Playground:
+
+1. Go to the [Playground](https://api.arcade.dev/playground/execute)
+1. Select a tool from your toolkit and execute it
+1. Verify that the response is correct and you see request logs in your worker
+
+</Steps>
+
+## Best practices
+
+- **Persistent URLs**: For production use, set up a persistent public URL rather than ephemeral ones
+- **TLS**: Use a TLS-enabled URL for production use
+- **Security**: Use strong secrets for worker authentication
+- **Monitoring**: Set up monitoring for your hybrid workers to ensure availability
+- **Scaling**: For high-load scenarios, consider running multiple workers behind a load balancer
+
+## Troubleshooting
+
+- **Connection issues**: Ensure your public URL is accessible and that your local worker is running
+- **Authentication failures**: Verify that the worker secret matches what's configured in the Arcade dashboard
+- **Timeout errors**: If your worker takes too long to respond, increase the timeout value in the worker configuration
+
+## Next steps
+
+- [Create custom tools](/home/build-tools/create-a-toolkit) for your hybrid worker
+- [Set up authentication](/home/build-tools/create-a-tool-with-auth) for secure access to resources
+- [Configure secrets](/home/build-tools/create-a-tool-with-secrets) for your worker


### PR DESCRIPTION
Some instructions for attaching a local worker (`arcade serve`) to the cloud gateway.

Also cleaned up the doc as I walked through it with python 3.10 and 3.13