### PR TITLE
Add docs for the Vercel AI SDK

### DIFF
--- a/pages/home/use-tools/get-tool-definitions.mdx
+++ b/pages/home/use-tools/get-tool-definitions.mdx
@@ -75,3 +75,149 @@ To get all tools formatted for OpenAI, you can use the `client.tools.formatted.l
 ```
 </Tabs.Tab>
 </Tabs>
+
+## Get Zod Tool Definitions
+
+[Zod](https://zod.dev) is a TypeScript-first schema validation library that helps you define and validate data structures. The [Arcade JS](https://github.com/ArcadeAI/arcade-js) client offers methods to convert Arcade tool definitions into Zod schemas, providing type safety and validation while enabling seamless integration with AI frameworks like LangChain, Vercel AI SDK, and Mastra AI. Using Zod with Arcade provides:
+
+1. **Type Safety**: Runtime validation of tool inputs and outputs against their defined types
+2. **TypeScript Integration**: Provides excellent TypeScript support with automatic type inference
+3. **Framework Compatibility**: Direct integration with LangChain, Vercel AI SDK, and Mastra AI
+
+### Convert to Zod Format
+
+Arcade offers three ways to convert your tools into Zod schemas, each for different use cases:
+
+#### 1. Convert to array of Zod tools
+
+This method returns an array of tools with Zod validation.
+
+```ts
+import { toZod } from "@arcadeai/arcadejs/lib"
+
+const googleToolkit = await arcade.tools.list({
+    limit: 20,
+    toolkit: "google",
+});
+
+const tools = toZod({
+    tools: googleToolkit.items,
+    client: arcade,
+    userId: "<YOUR_USER_ID>",
+})
+```
+
+#### 2. Convert to object of Zod tools 
+
+This method returns an object with tool names as keys, allowing direct access to tools by name:
+
+```ts
+import { toZodToolSet } from "@arcadeai/arcadejs/lib"
+
+const googleToolkit = await arcade.tools.list({
+    limit: 20,
+    toolkit: "google",
+});
+
+const tools = toZodToolSet({
+    tools: googleToolkit.items,
+    client: arcade,
+    userId: "<YOUR_USER_ID>",
+})
+
+const emails = await tools.Google_ListEmails.execute({
+  limit: 10,
+});
+```
+
+#### 3. Convert a single tool
+
+When you only need to work with a specific tool, use this method to convert just that tool to a Zod schema:
+
+```ts
+import { createZodTool } from "@arcadeai/arcadejs/lib"
+
+const listEmails = await arcade.tools.get("Google_ListEmails");
+
+const listEmailsTool = createZodTool({
+    tool: listEmails,
+    client: arcade,
+    userId: "<YOUR_USER_ID>",
+});
+
+const emails = await listEmailsTool.execute({
+  limit: 10,
+});
+```
+
+### Handle Authorization
+When working with tools that require user authorization (like Gmail, GitHub, Slack, etc.), Arcade provides two approaches to handle the authorization flow when using Zod-converted tools:
+
+#### Option 1: Manual handling
+
+When you convert Arcade tools to Zod without adding an `executeFactory`, Arcade will try to run tools directly. For tools that need permission (like Google or Slack), you'll see a `PermissionDeniedError` if the user hasn't given access yet.
+
+This approach gives you complete control over the authorization flow, making it perfect for custom UI implementations or complex workflows. You'll have full flexibility to design your own user experience, but you'll need to handle authorization flows and error states manually in your code.
+
+```ts
+import { PermissionDeniedError } from "@arcadeai/arcadejs"
+
+const tools = toZodToolSet({
+  tools: googleToolkit.items,
+  client: arcade,
+  userId: "<YOUR_USER_ID>",
+})
+
+try {
+	const result = await tools.Google_ListEmails.execute({
+		limit: 10,
+	});
+	console.log(result);
+} catch (error) {
+	if (error instanceof PermissionDeniedError) {
+		// You can use the `arcade.tools.authorize` method to get an authorization URL for the user
+		const authorizationResponse = await arcade.tools.authorize({
+			tool_name: "Google.ListEmails",
+			user_id: "<YOUR_USER_ID>",
+		});
+		console.log(authorizationResponse.url);
+	} else {
+		console.error("Error executing tool:", error);
+	}
+}
+```
+
+#### Option 2: Execute and authorize tool
+
+Arcade offers a more convenient way to handle tool execution and initial authorization steps. When converting tools to Zod, you can add the `executeOrAuthorizeZodTool` helper to the `executeFactory`. With this helper, your code no longer needs to catch a `PermissionDeniedError` for tools requiring permissions (as shown in Option 1). Instead, if the user hasn't yet granted access, the `execute` method will return an `ToolAuthorizationResponse` object that contains the authorization URL.
+
+This approach simplifies your code by:
+
+1. Attempting to execute the tool.
+2. If permissions are missing, it returns an object containing the authorization URL. This eliminates the need for both a `try...catch` block for `PermissionDeniedError` and a separate call (like `arcade.tools.authorize`) just to retrieve this URL.
+3. If the tool is already authorized, it executes directly. Arcade remembers user authorizations, so once a user approves access, subsequent calls using this helper will execute the tool without prompting for authorization again.
+
+While this helper streamlines obtaining the authorization URL, you are still responsible for presenting this URL to the user. It's particularly useful for straightforward implementations where you want to reduce boilerplate.
+
+```ts
+import { executeOrAuthorizeZodTool } from "@arcadeai/arcadejs"
+
+const tools = toZodToolSet({
+	tools: googleToolkit.items,
+	client: arcade,
+	userId: "<YOUR_USER_ID>",
+	executeFactory: executeOrAuthorizeZodTool, // Automatically handles tool authorization flows, including generating auth URLs
+});
+
+const result = await tools.Google_ListEmails.execute({
+	limit: 10,
+});
+
+if ("authorization_required" in result && result.authorization_required) {
+	console.log(
+		`Please visit ${result.authorization_response.url} to authorize the tool`,
+	);
+} else {
+	console.log(result);
+} 
+```

--- a/pages/home/vercelai/use-arcade-tools.mdx
+++ b/pages/home/vercelai/use-arcade-tools.mdx
@@ -150,4 +150,4 @@ You just need to change the toolkit parameter in the `list` method. For example,
 const slackToolkit = await arcade.tools.list({ toolkit: "slack", limit: 30 })
 ```
 
-Browse our [complete toolkit catalog](https://docs.arcade.dev/toolkits) to see all available toolkits and their capabilities. Each toolkit comes with pre-built tools that are ready to use with your AI applications.
+Browse our [complete toolkit catalog](https://docs.arcade.dev/toolkits) to see all available toolkits and their capabilities. Each toolkit comes with pre-built tools that are ready to use with your AI applications.  Arcade also is the best way to create your own custom tools and toolkits - learn more [here](/home/custom-tools).

--- a/pages/home/vercelai/use-arcade-tools.mdx
+++ b/pages/home/vercelai/use-arcade-tools.mdx
@@ -7,10 +7,10 @@ import { Steps, Tabs } from "nextra/components";
 
 ## Use Arcade with Vercel AI SDK
 
-The [Vercel AI SDK](https://sdk.vercel.ai/) is an open-source library that makes it easier to build AI-powered applications. It gives you a consistent way to work with different AI providers and comes with several useful features:
+The [Vercel AI SDK](https://sdk.vercel.ai/) is an open-source library that simplifies the process of building AI-powered applications. It provides a consistent interface for working with various AI providers and includes several useful features:
 
 - Streaming AI responses for real-time interactions
-- Framework-agnostic support for React, Next.js, Vue, Nuxt, and SvelteKit
+- Framework-agnostic support for React, Next.js, Vue, Nuxt, and SvelteKit.
 - Easy switching between AI providers with a single line of code
 
 Let's supercharge your Vercel AI SDK applications with Arcade's tools. You'll get instant access to production-ready tools for working with Google, Slack, GitHub, LinkedIn, and many other popular services, all with built-in authentication. Browse our [complete toolkit catalog](https://docs.arcade.dev/toolkits) to discover what you can build.

--- a/pages/home/vercelai/use-arcade-tools.mdx
+++ b/pages/home/vercelai/use-arcade-tools.mdx
@@ -1,9 +1,153 @@
 ---
-title: "Use Arcade tools with Vercel AI"
+title: "Use Arcade tools with Vercel AI SDK"
 description: "Integrate Arcade tools into your Vercel AI applications"
 ---
 
-## Use Arcade tools with Vercel AI
+import { Steps, Tabs } from "nextra/components";
 
-TODO
+## Use Arcade with Vercel AI SDK
 
+The [Vercel AI SDK](https://sdk.vercel.ai/) is an open-source library that makes it easier to build AI-powered applications. It gives you a consistent way to work with different AI providers and comes with several useful features:
+
+- Streaming AI responses for real-time interactions
+- Framework-agnostic support for React, Next.js, Vue, Nuxt, and SvelteKit
+- Easy switching between AI providers with a single line of code
+
+Let's supercharge your Vercel AI SDK applications with Arcade's tools. You'll get instant access to production-ready tools for working with Google, Slack, GitHub, LinkedIn, and many other popular services, all with built-in authentication. Browse our [complete toolkit catalog](https://docs.arcade.dev/toolkits) to discover what you can build.
+
+In this guide, we'll show you how to use Arcade's Google toolkit to create an AI agent that can read and summarize emails. You can find the complete code in our [GitHub repository](https://github.com/ArcadeAI/arcade-ai/tree/main/examples/ai-sdk) or follow along below.
+
+## Getting started
+
+
+<Steps>
+
+### Install the required dependencies
+
+
+We'll use the `@ai-sdk/openai` package in this example, but you can use any AI provider supported by the Vercel AI SDK. See the [full list of providers](https://ai-sdk.dev/docs/foundations/providers-and-models#ai-sdk-providers).
+
+<Tabs items={["pnpm", "npm", "yarn"]}>
+
+<Tabs.Tab>
+
+```bash
+pnpm add ai @ai-sdk/openai @arcadeai/arcadejs
+```
+
+</Tabs.Tab>
+
+<Tabs.Tab>
+
+```bash
+npm install 
+```
+
+</Tabs.Tab>
+
+<Tabs.Tab>
+
+```bash
+yarn install 
+```
+
+</Tabs.Tab>
+
+</Tabs>
+
+### Get your API keys and set up environment variables
+
+You'll need two API keys:
+- **OpenAI API key** from [OpenAI dashboard](https://platform.openai.com/api-keys)
+- **Arcade API key** from our [Getting your API key guide](https://docs.arcade.dev/home/api-keys)
+
+Add them to your environment:
+
+```bash
+OPENAI_API_KEY=<YOUR_OPENAI_API_KEY>
+ARCADE_API_KEY=<YOUR_ARCADE_API_KEY>
+```
+
+
+### Import Libraries and Initialize Arcade
+
+```ts
+import { openai } from "@ai-sdk/openai"
+import { generateText } from "ai"
+import { Arcade } from "@arcadeai/arcadejs"
+import { toZodToolSet, executeOrAuthorizeZodTool } from "@arcadeai/arcadejs/lib"
+
+const arcade = new Arcade()
+```
+
+### Get tools from Arcade's Google toolkit and convert them to Zod
+
+```ts
+// Get Arcade's google toolkit
+const googleToolkit = await arcade.tools.list({ toolkit: "google", limit: 30 })
+const googleTools = toZodToolSet({
+    tools: googleToolkit.items,
+    client: arcade,
+    userId: "<YOUR_USER_ID>", // Your app's internal ID for the user (an email, UUID, etc). It's used internally to identify your user in Arcade
+    executeFactory: executeOrAuthorizeZodTool, // Checks if tool is authorized and executes it, or returns authorization URL if needed
+})
+```
+
+
+### Generate text with the tools
+
+```ts
+const result = await generateText({
+    model: openai("gpt-4o-mini"),
+    prompt: "Read my last email and summarize it in a few sentences",
+    tools: googleTools,
+    maxSteps: 5,
+})
+
+console.log(result.text)
+```
+
+<Note>
+On your first run, you'll get an authorization message with a link to connect your Google account. Open it in your browser to complete the setup. That's all you need to do! Arcade will remember your approval for future requests.
+</Note>
+</Steps>
+
+You can see the full code in our [GitHub repository](https://github.com/ArcadeAI/arcade-ai/blob/main/examples/ai-sdk/generateText.js).
+
+
+## Stream the response
+
+Vercel AI SDK supports streaming responses. This creates a more engaging, chat-like experience as the responses appear progressively instead of waiting for the complete answer.
+
+To enable streaming, make these key changes:
+
+1. Import `streamText` instead of `generateText`
+2. Use `streamText` to create a streamable response
+3. Process the response chunk by chunk
+
+```ts
+import { streamText } from "ai"
+
+const { textStream } = streamText({
+    model: openai("gpt-4o-mini"),
+    prompt: "Read my last email and summarize it in a few sentences",
+    tools: googleTools,
+    maxSteps: 5,
+})
+
+for await (const chunk of textStream) {
+    process.stdout.write(chunk)
+}
+```
+
+You can see the full code in our [GitHub repository](https://github.com/ArcadeAI/arcade-ai/blob/main/examples/ai-sdk/index.js).
+
+## How to use other toolkits
+
+You just need to change the toolkit parameter in the `list` method. For example, to use Slack tools:
+
+```ts
+const slackToolkit = await arcade.tools.list({ toolkit: "slack", limit: 30 })
+```
+
+Browse our [complete toolkit catalog](https://docs.arcade.dev/toolkits) to see all available toolkits and their capabilities. Each toolkit comes with pre-built tools that are ready to use with your AI applications.

--- a/pages/home/vercelai/use-arcade-tools.mdx
+++ b/pages/home/vercelai/use-arcade-tools.mdx
@@ -82,6 +82,8 @@ const arcade = new Arcade()
 
 ### Get tools from Arcade's Google toolkit and convert them to Zod
 
+Arcade offers methods to convert tools into Zod schemas, which is essential since the Vercel AI SDK defines tools using Zod. The `toZodToolSet` method is particularly useful, as it simplifies this integration and makes it easier to use Arcade's tools with the Vercel AI SDK. Learn more about Arcade's Zod integration options [here](/home/use-tools/get-tool-definitions#get-zod-tool-definitions).
+
 ```ts
 // Get Arcade's google toolkit
 const googleToolkit = await arcade.tools.list({ toolkit: "google", limit: 30 })
@@ -150,4 +152,4 @@ You just need to change the toolkit parameter in the `list` method. For example,
 const slackToolkit = await arcade.tools.list({ toolkit: "slack", limit: 30 })
 ```
 
-Browse our [complete toolkit catalog](https://docs.arcade.dev/toolkits) to see all available toolkits and their capabilities. Each toolkit comes with pre-built tools that are ready to use with your AI applications.  Arcade also is the best way to create your own custom tools and toolkits - learn more [here](/home/custom-tools).
+Browse our [complete toolkit catalog](https://docs.arcade.dev/toolkits) to see all available toolkits and their capabilities. Each toolkit comes with pre-built tools that are ready to use with your AI applications.  Arcade also is the best way to create your own custom tools and toolkits - learn more [here](/home/build-tools/create-a-toolkit).


### PR DESCRIPTION
A step-by-step guide on how to add Arcade tools to the Vercel AI SDK. This example uses some utility functions that are not yet available in `arcade-js`, but the final version would look something like this.

> [!WARNING]
> Don't merge until this [PR](https://github.com/ArcadeAI/arcade-js/pull/127) is merged. 