### PR TITLE
Arcade Gateway

### DIFF
--- a/AUTHORING.md
+++ b/AUTHORING.md
@@ -24,5 +24,5 @@ These are the guidelines for writing documentation for Arcade, to help keep the 
 ## Naming and terminology
 
 - **Arcade**: Always refer to the product as "Arcade" in both titles and body text. Do not abbreviate or shorten the product name. Do not append "AI" to the product name.
-- **Engine**: Refer to "the Arcade Engine" when the deployment option is irrelevant. Otherwise, refer to "the Arcade Cloud Engine" or "a self-hosted Arcade Engine."
+- **Gateway**: Refer to "the Arcade Gateway" when the deployment option is irrelevant. Otherwise, refer to "the Arcade Cloud Gateway" or "a self-hosted Arcade Gateway."
 - **Toolkits**: Toolkits are collections of tools, either built by Arcade or a third party developer. For toolkits built by Arcade, refer to "the Arcade [Toolkit name] toolkit." For example, "the Arcade GitHub toolkit."

--- a/examples/code/integrations/linkedin/custom_tool.py
+++ b/examples/code/integrations/linkedin/custom_tool.py
@@ -20,7 +20,7 @@ async def create_text_post(
     endpoint = "/ugcPosts"
 
     # The LinkedIn user ID is required to create a post, even though we're using the user's access token.
-    # Arcade Engine gets the current user's info from LinkedIn and automatically populates context.authorization.user_info.
+    # Arcade Gateway gets the current user's info from LinkedIn and automatically populates context.authorization.user_info.
     # LinkedIn calls the user ID "sub" in their user_info data payload. See:
     # https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2#api-request-to-retreive-member-details
     user_id = context.authorization.user_info.get("sub")

--- a/pages/home/arcade-cli.mdx
+++ b/pages/home/arcade-cli.mdx
@@ -111,16 +111,16 @@ You can learn more about any of the commands by running `arcade <command> --help
  Open the Arcade Dashboard in a web browser
 
 ╭─ Options ─────────────────────────────────────────────────────────────────────────╮
-│ --host    -h      TEXT     The Arcade Engine host that serves the dashboard.      │
+│ --host    -h      TEXT     The Arcade Gateway host that serves the dashboard.      │
 │                            [default: api.arcade.dev]                              │
-│ --port    -p      INTEGER  The port of the Arcade Engine.                         │
+│ --port    -p      INTEGER  The port of the Arcade Gateway.                         │
 │                            [default: None]                                        │
 │ --local   -l               Open the local dashboard instead of the default remote │
 │                            dashboard.                                             │
 │ --tls                      Whether to force TLS for the connection to the Arcade  │
 │                            Engine.                                                │
 │ --no-tls                   Whether to disable TLS for the connection to the       │
-│                            Arcade Engine.                                         │
+│                            Arcade Gateway.                                         │
 │ --help                     Show this message and exit.                            │
 ╰───────────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -151,18 +151,18 @@ You can learn more about any of the commands by running `arcade <command> --help
 │                             [default: None]                                       │
 │ --tool     -t      TEXT     The specific tool to show details for                 │
 │                             [default: None]                                       │
-│ --host     -h      TEXT     The Arcade Engine address to show the tools/toolkits  │
+│ --host     -h      TEXT     The Arcade Gateway address to show the tools/toolkits  │
 │                             of.                                                   │
 │                             [default: api.arcade.dev]                             │
 │ --local    -l               Show the local environment's catalog instead of an    │
-│                             Arcade Engine's catalog.                              │
-│ --port     -p      INTEGER  The port of the Arcade Engine.                        │
+│                             Arcade Gateway's catalog.                              │
+│ --port     -p      INTEGER  The port of the Arcade Gateway.                        │
 │                             [default: None]                                       │
 │ --tls                       Whether to force TLS for the connection to the Arcade │
 │                             Engine. If not specified, the connection will use TLS │
 │                             if the engine URL uses a 'https' scheme.              │
 │ --no-tls                    Whether to disable TLS for the connection to the      │
-│                             Arcade Engine.                                        │
+│                             Arcade Gateway.                                        │
 │ --debug    -d               Show debug information                                │
 │ --help                      Show this message and exit.                           │
 ╰───────────────────────────────────────────────────────────────────────────────────╯
@@ -182,9 +182,9 @@ You can learn more about any of the commands by running `arcade <command> --help
 │ --prompt          TEXT     The system prompt to use for the chat.                   │
 │                            [default: None]                                          │
 │ --debug   -d               Show debug information                                   │
-│ --host    -h      TEXT     The Arcade Engine address to send chat requests to.      │
+│ --host    -h      TEXT     The Arcade Gateway address to send chat requests to.      │
 │                            [default: api.arcade.dev]                                │
-│ --port    -p      INTEGER  The port of the Arcade Engine.                           │
+│ --port    -p      INTEGER  The port of the Arcade Gateway.                           │
 │                            [default: None]                                          │
 │ --tls                      Whether to force TLS for the connection to the Arcade    │
 │                            Engine. If not specified, the connection will use TLS if │
@@ -212,19 +212,19 @@ You can learn more about any of the commands by running `arcade <command> --help
 │ --models          -m      TEXT     The models to use for evaluation (default:       │
 │                                    gpt-4o). Use commas to separate multiple models. │
 │                                    [default: gpt-4o]                                │
-│ --host            -h      TEXT     The Arcade Engine address to send chat requests  │
+│ --host            -h      TEXT     The Arcade Gateway address to send chat requests  │
 │                                    to.                                              │
 │                                    [default: localhost]                             │
 │ --cloud                            Whether to run evaluations against the Arcade    │
 │                                    Cloud Engine. Overrides the 'host' option.       │
-│ --port            -p      INTEGER  The port of the Arcade Engine.                   │
+│ --port            -p      INTEGER  The port of the Arcade Gateway.                   │
 │                                    [default: None]                                  │
 │ --tls                              Whether to force TLS for the connection to the   │
-│                                    Arcade Engine. If not specified, the connection  │
+│                                    Arcade Gateway. If not specified, the connection  │
 │                                    will use TLS if the engine URL uses a 'https'    │
 │                                    scheme.                                          │
 │ --no-tls                           Whether to disable TLS for the connection to the │
-│                                    Arcade Engine.                                   │
+│                                    Arcade Gateway.                                   │
 │ --help                             Show this message and exit.                      │
 ╰─────────────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -281,17 +281,17 @@ You can learn more about any of the commands by running `arcade <command> --help
 ╭─ Options ───────────────────────────────────────────────────────────────────────────╮
 │ --deployment-file  -d      TEXT     The deployment file to deploy.                  │
 │                                     [default: worker.toml]                          │
-│ --host             -h      TEXT     The Arcade Engine host to register the worker   │
+│ --host             -h      TEXT     The Arcade Gateway host to register the worker   │
 │                                     to.                                             │
 │                                     [default: api.arcade.dev]                       │
-│ --port             -p      INTEGER  The port of the Arcade Engine host.             │
+│ --port             -p      INTEGER  The port of the Arcade Gateway host.             │
 │                                     [default: None]                                 │
 │ --tls                               Whether to force TLS for the connection to the  │
-│                                     Arcade Engine. If not specified, the connection │
+│                                     Arcade Gateway. If not specified, the connection │
 │                                     will use TLS if the engine URL uses a 'https'   │
 │                                     scheme.                                         │
 │ --no-tls                            Whether to disable TLS for the connection to    │
-│                                     the Arcade Engine.                              │
+│                                     the Arcade Gateway.                              │
 │ --help                              Show this message and exit.                     │
 ╰─────────────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -304,9 +304,9 @@ You can learn more about any of the commands by running `arcade <command> --help
  Manage deployments of tool servers (logs, list, etc)
 
 ╭─ Options ───────────────────────────────────────────────────────────────────────────╮
-│ --host    -h      TEXT     The Arcade Engine host.                                  │
+│ --host    -h      TEXT     The Arcade Gateway host.                                  │
 │                            [default: api.arcade.dev]                                │
-│ --port    -p      INTEGER  The port of the Arcade Engine host.                      │
+│ --port    -p      INTEGER  The port of the Arcade Gateway host.                      │
 │                            [default: None]                                          │
 │ --tls                      Whether to force TLS for the connection to the Arcade    │
 │                            Engine.                                                  │

--- a/pages/home/auth-providers/asana.mdx
+++ b/pages/home/auth-providers/asana.mdx
@@ -2,7 +2,7 @@ import { Tabs } from "nextra/components";
 
 # Asana auth provider
 
-The Asana auth provider enables tools and agents to call Asana APIs on behalf of a user. Behind the scenes, the Arcade Engine and the Asana auth provider seamlessly manage Asana OAuth 2.0 authorization for your users.
+The Asana auth provider enables tools and agents to call Asana APIs on behalf of a user. Behind the scenes, the Arcade Gateway and the Asana auth provider seamlessly manage Asana OAuth 2.0 authorization for your users.
 
 <Tip>
   Want to quickly get started with Asana services in your agent or AI app? The
@@ -30,7 +30,7 @@ If you choose to use Arcade's Asana auth, you don't need to configure anything. 
 
 In a production environment, you will most likely want to use your own Asana app credentials. This way, your users will see your application's name requesting permission.
 
-You can use your own Asana credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/install/local) instance.
+You can use your own Asana credentials in both the Arcade Cloud and in a [self-hosted Arcade Gateway](/home/install/local) instance.
 
 Before showing how to configure your Asana app credentials, let's go through the steps to create an Asana app.
 
@@ -58,7 +58,7 @@ When creating your app, use the following settings:
 There are two ways to configure your Asana app credentials in Arcade:
 
 1. From the Arcade Dashboard GUI
-2. By editing the `engine.yaml` file directly (only possible with a self-hosted Arcade Engine)
+2. By editing the `engine.yaml` file directly (only possible with a self-hosted Arcade Gateway)
 
 We show both options step-by-step below.
 
@@ -88,7 +88,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Create the provider
 
-Hit the **Create** button and the provider will be ready to be used in the Arcade Engine.
+Hit the **Create** button and the provider will be ready to be used in the Arcade Gateway.
 </Steps>
 
 </Tabs.Tab>
@@ -97,7 +97,7 @@ Hit the **Create** button and the provider will be ready to be used in the Arcad
 ### Configure Asana Auth Using the Engine Configuration YAML
 
 <Tip>
-  Refer to [Engine configuration](/home/configure/engine) for more information on how to set environment variables and configure the Arcade Engine.
+  Refer to [Engine configuration](/home/configure/engine) for more information on how to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 <Steps>
@@ -121,7 +121,7 @@ ASANA_CLIENT_SECRET="<your client secret>"
 #### Edit the Engine configuration
 
 <Tip>
-  To locate the `engine.yaml` file in your OS after installing the Arcade Engine, check the [Engine configuration file](/home/configure/overview#engine-configuration-file) documentation.
+  To locate the `engine.yaml` file in your OS after installing the Arcade Gateway, check the [Engine configuration file](/home/configure/overview#engine-configuration-file) documentation.
 </Tip>
 
 Edit the `engine.yaml` file and add an Asana item to the `auth.providers` section:
@@ -130,9 +130,9 @@ Edit the `engine.yaml` file and add an Asana item to the `auth.providers` sectio
 
 ```
 
-#### Restart the Arcade Engine
+#### Restart the Arcade Gateway
 
-If the Arcade Engine is already running, you will need to restart it for the changes to take effect.
+If the Arcade Gateway is already running, you will need to restart it for the changes to take effect.
 
 </Steps>
 
@@ -158,7 +158,7 @@ Use `client.auth.start()` to get a user token for the Asana API:
 <Tabs items={["Python", "JavaScript"]}>
 <Tabs.Tab>
 <Note>
-  If you are [self-hosting Arcade](/home/install/overview), change the `base_url` parameter in the `Arcade` constructor to match your Arcade Engine URL. By default, the Engine will be available at `http://localhost:9099`.
+  If you are [self-hosting Arcade](/home/install/overview), change the `base_url` parameter in the `Arcade` constructor to match your Arcade Gateway URL. By default, the Engine will be available at `http://localhost:9099`.
 </Note>
 
 ```python file=<rootDir>/examples/code/integrations/asana/custom_auth.py {21-22}
@@ -168,7 +168,7 @@ Use `client.auth.start()` to get a user token for the Asana API:
 
 <Tabs.Tab>
 <Note>
-  If you are [self-hosting Arcade](/home/install/overview), change the `baseURL` parameter in the `Arcade` constructor to match your Arcade Engine URL. By default, the Engine will be available at `http://localhost:9099`.
+  If you are [self-hosting Arcade](/home/install/overview), change the `baseURL` parameter in the `Arcade` constructor to match your Arcade Gateway URL. By default, the Engine will be available at `http://localhost:9099`.
 </Note>
 
 ```javascript file=<rootDir>/examples/code/integrations/asana/custom_auth.js {20-21}
@@ -193,14 +193,14 @@ Use the `Asana()` auth class to specify that a tool requires authorization with 
 
 ```
 
-If you are [self-hosting Arcade](/home/install/overview), you will need to restart the Arcade Worker and the Engine for the new tool to be available.
+If you are [self-hosting Arcade](/home/install/overview), you will need to restart the Arcade Worker and the Gateway for the new tool to be available.
 
 Your new tool can be called like demonstrated below:
 
 <Tabs items={["Python", "JavaScript"]}>
 <Tabs.Tab>
 <Note>
-  If you are self-hosting, change the `base_url` parameter in the `Arcade` constructor to match your Arcade Engine URL. By default, the Engine will be available at `http://localhost:9099`.
+  If you are self-hosting, change the `base_url` parameter in the `Arcade` constructor to match your Arcade Gateway URL. By default, the Engine will be available at `http://localhost:9099`.
 </Note>
 
 ```python file=<rootDir>/examples/code/integrations/asana/custom_tool_call.py
@@ -209,7 +209,7 @@ Your new tool can be called like demonstrated below:
 </Tabs.Tab>
 <Tabs.Tab>
 <Note>
-  If you are self-hosting, change the `baseURL` parameter in the `Arcade` constructor to match your Arcade Engine URL. By default, the Engine will be available at `http://localhost:9099`.
+  If you are self-hosting, change the `baseURL` parameter in the `Arcade` constructor to match your Arcade Gateway URL. By default, the Engine will be available at `http://localhost:9099`.
 </Note>
 
 ```javascript file=<rootDir>/examples/code/integrations/asana/custom_tool_call.js

--- a/pages/home/auth-providers/atlassian.mdx
+++ b/pages/home/auth-providers/atlassian.mdx
@@ -8,7 +8,7 @@ import {Tabs} from 'nextra/components'
   OAuth 2.0 credentials as described below.
 </Note>
 
-The Atlassian auth provider enables tools and agents to call the Atlassian API on behalf of a user. Behind the scenes, the Arcade Engine and the Atlassian auth provider seamlessly manage Atlassian OAuth 2.0 authorization for your users.
+The Atlassian auth provider enables tools and agents to call the Atlassian API on behalf of a user. Behind the scenes, the Arcade Gateway and the Atlassian auth provider seamlessly manage Atlassian OAuth 2.0 authorization for your users.
 
 ### What's documented here
 
@@ -28,7 +28,7 @@ This auth provider is used by:
 - In the Permissions tab, enable any permissions you need for your app
 - In the Settings tab, copy the Client ID and Secret to use below
 
-Next, add the Atlassian app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the Atlassian app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Atlassian auth with the Arcade Dashboard
 
@@ -38,9 +38,9 @@ Next, add the Atlassian app to your Arcade Engine configuration. You can do this
 4. Enter your **Client ID** and **Client Secret** from your Atlassian app.
 5. Click **Save**.
 
-When you use tools that require Atlassian auth using your Arcade account credentials, the Arcade Engine will automatically use this Atlassian OAuth provider.
+When you use tools that require Atlassian auth using your Arcade account credentials, the Arcade Gateway will automatically use this Atlassian OAuth provider.
 
-### Configuring Atlassian auth in self-hosted Arcade Engine configuration
+### Configuring Atlassian auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -62,7 +62,7 @@ ATLASSIAN_CLIENT_ID="<your client ID>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/home/auth-providers/discord.mdx
+++ b/pages/home/auth-providers/discord.mdx
@@ -8,7 +8,7 @@ import { Tabs } from "nextra/components";
   OAuth 2.0 credentials as described below.
 </Note>
 
-The Discord auth provider enables tools and agents to call the Discord API on behalf of a user. Behind the scenes, the Arcade Engine and the Discord auth provider seamlessly manage Discord OAuth 2.0 authorization for your users.
+The Discord auth provider enables tools and agents to call the Discord API on behalf of a user. Behind the scenes, the Arcade Gateway and the Discord auth provider seamlessly manage Discord OAuth 2.0 authorization for your users.
 
 ### What's documented here
 
@@ -27,7 +27,7 @@ This auth provider is used by:
 - In the OAuth2 tab, set the redirect URI to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the Client ID and Client Secret (you may need to reset the secret to see it)
 
-Next, add the Discord app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the Discord app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Discord auth with the Arcade Dashboard
 
@@ -37,9 +37,9 @@ Next, add the Discord app to your Arcade Engine configuration. You can do this i
 4. Enter your **Client ID** and **Client Secret** from your Discord app.
 5. Click **Save**.
 
-When you use tools that require Discord auth using your Arcade account credentials, the Arcade Engine will automatically use this Discord OAuth provider.
+When you use tools that require Discord auth using your Arcade account credentials, the Arcade Gateway will automatically use this Discord OAuth provider.
 
-### Configuring Discord auth in self-hosted Arcade Engine configuration
+### Configuring Discord auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -61,7 +61,7 @@ DISCORD_CLIENT_ID="<your client ID>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/home/auth-providers/dropbox.mdx
+++ b/pages/home/auth-providers/dropbox.mdx
@@ -8,7 +8,7 @@ import { Tabs } from "nextra/components";
   OAuth 2.0 credentials as described below.
 </Note>
 
-The Dropbox auth provider enables tools and agents to call the Dropbox API on behalf of a user. Behind the scenes, the Arcade Engine and the Dropbox auth provider seamlessly manage Dropbox OAuth 2.0 authorization for your users.
+The Dropbox auth provider enables tools and agents to call the Dropbox API on behalf of a user. Behind the scenes, the Arcade Gateway and the Dropbox auth provider seamlessly manage Dropbox OAuth 2.0 authorization for your users.
 
 ### What's documented here
 
@@ -28,7 +28,7 @@ This auth provider is used by:
 - In the Permissions tab, add any scopes that your app will need
 - In the Settings tab, copy the App key (Client ID) and App secret (Client Secret), which you'll need below
 
-Next, add the Dropbox app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the Dropbox app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Dropbox auth with the Arcade Dashboard
 
@@ -38,9 +38,9 @@ Next, add the Dropbox app to your Arcade Engine configuration. You can do this i
 4. Enter your **Client ID** and **Client Secret** from your Dropbox app.
 5. Click **Save**.
 
-When you use tools that require Dropbox auth using your Arcade account credentials, the Arcade Engine will automatically use this Dropbox OAuth provider.
+When you use tools that require Dropbox auth using your Arcade account credentials, the Arcade Gateway will automatically use this Dropbox OAuth provider.
 
-### Configuring Dropbox auth in self-hosted Arcade Engine configuration
+### Configuring Dropbox auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -67,7 +67,7 @@ DROPBOX_CLIENT_ID="<your client ID>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/home/auth-providers/github.mdx
+++ b/pages/home/auth-providers/github.mdx
@@ -2,7 +2,7 @@ import { Tabs } from "nextra/components";
 
 # GitHub auth provider
 
-The GitHub auth provider enables tools and agents to call [GitHub APIs](https://docs.github.com/en/rest/overview/resources-in-the-rest-api) on behalf of a user. Behind the scenes, the Arcade Engine and the GitHub auth provider seamlessly manage GitHub OAuth 2.0 authorization for your users.
+The GitHub auth provider enables tools and agents to call [GitHub APIs](https://docs.github.com/en/rest/overview/resources-in-the-rest-api) on behalf of a user. Behind the scenes, the Arcade Gateway and the GitHub auth provider seamlessly manage GitHub OAuth 2.0 authorization for your users.
 
 <Tip>
   Want to quickly get started with GitHub in your agent or AI app? The pre-built
@@ -21,9 +21,9 @@ This auth provider is used by:
 
 ## Configuring GitHub auth
 
-How you configure the GitHub auth provider depends on whether you use the Arcade Cloud Engine or a [self-hosted Engine](/home/install/overview).
+How you configure the GitHub auth provider depends on whether you use the Arcade Cloud Gateway or a [self-hosted Gateway](/home/install/overview).
 
-With the Arcade Cloud Engine, you can start building and testing GitHub auth without any configuration. Your users will see `Arcade.dev` as the name of the application that's requesting permission.
+With the Arcade Cloud Gateway, you can start building and testing GitHub auth without any configuration. Your users will see `Arcade.dev` as the name of the application that's requesting permission.
 
 When you are ready to go to production, you'll want to configure the GitHub auth provider with your own GitHub app credentials, so users see your app name when they authorize access.
 
@@ -43,7 +43,7 @@ If you need to access private repositories in an organization, you must also:
   1. Make the app public via Advanced > Make public
   2. Add the app to the organization via Install app
 
-Next, add the GitHub app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the GitHub app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring GitHub auth with the Arcade Dashboard
 
@@ -53,9 +53,9 @@ Next, add the GitHub app to your Arcade Engine configuration. You can do this in
 4. Enter your **Client ID** and **Client Secret** from your GitHub app.
 5. Click **Save**.
 
-When you use tools that require GitHub auth using your Arcade account credentials, the Arcade Engine will automatically use this GitHub OAuth provider.
+When you use tools that require GitHub auth using your Arcade account credentials, the Arcade Gateway will automatically use this GitHub OAuth provider.
 
-### Configuring GitHub auth in self-hosted Arcade Engine configuration
+### Configuring GitHub auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -77,7 +77,7 @@ GITHUB_CLIENT_SECRET="<your client secret>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/home/auth-providers/google.mdx
+++ b/pages/home/auth-providers/google.mdx
@@ -2,7 +2,7 @@ import { Tabs } from "nextra/components";
 
 # Google auth provider
 
-The Google auth provider enables tools and agents to call Google/Google Workspace APIs on behalf of a user. Behind the scenes, the Arcade Engine and the Google auth provider seamlessly manage Google OAuth 2.0 authorization for your users.
+The Google auth provider enables tools and agents to call Google/Google Workspace APIs on behalf of a user. Behind the scenes, the Arcade Gateway and the Google auth provider seamlessly manage Google OAuth 2.0 authorization for your users.
 
 <Tip>
   Want to quickly get started with Google services in your agent or AI app? The
@@ -22,9 +22,9 @@ This auth provider is used by:
 
 ## Configuring Google auth
 
-How you configure the Google auth provider depends on whether you use the Arcade Cloud Engine or a [self-hosted Engine](/home/install/overview).
+How you configure the Google auth provider depends on whether you use the Arcade Cloud Gateway or a [self-hosted Gateway](/home/install/overview).
 
-With the Arcade Cloud Engine, you can start building and testing Google auth without any configuration. Your users will see `Arcade (demo)` as the name of the application that's requesting permission.
+With the Arcade Cloud Gateway, you can start building and testing Google auth without any configuration. Your users will see `Arcade (demo)` as the name of the application that's requesting permission.
 
 When you are ready to go to production, you'll want to configure the Google auth provider with your own Google app credentials, so users see your app name when they authorize access.
 
@@ -38,7 +38,7 @@ When you are ready to go to production, you'll want to configure the Google auth
 - Set the redirect URL to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the client ID and client secret to use below
 
-Next, add the Google app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the Google app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Google auth with the Arcade Dashboard
 
@@ -48,9 +48,9 @@ Next, add the Google app to your Arcade Engine configuration. You can do this in
 4. Enter your **Client ID** and **Client Secret** from your Google app.
 5. Click **Save**.
 
-When you use tools that require Google auth using your Arcade account credentials, the Arcade Engine will automatically use this Google OAuth provider.
+When you use tools that require Google auth using your Arcade account credentials, the Arcade Gateway will automatically use this Google OAuth provider.
 
-### Configuring Google auth in self-hosted Arcade Engine configuration
+### Configuring Google auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -72,7 +72,7 @@ GOOGLE_CLIENT_SECRET="<your client secret>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/home/auth-providers/hubspot.mdx
+++ b/pages/home/auth-providers/hubspot.mdx
@@ -2,7 +2,7 @@ import { Tabs } from "nextra/components";
 
 # Hubspot auth provider
 
-The Hubspot auth provider enables tools and agents to call Hubspot APIs on behalf of a user. Behind the scenes, the Arcade Engine and the Hubspot auth provider seamlessly manage Hubspot OAuth 2.0 authorization for your users.
+The Hubspot auth provider enables tools and agents to call Hubspot APIs on behalf of a user. Behind the scenes, the Arcade Gateway and the Hubspot auth provider seamlessly manage Hubspot OAuth 2.0 authorization for your users.
 
 <Tip>
   Want to quickly get started with Hubspot services in your agent or AI app? The
@@ -30,7 +30,7 @@ If you choose to use Arcade's Hubspot auth, you don't need to configure anything
 
 In a production environment, you will most likely want to use your own Hubspot app credentials. This way, your users will see your application's name requesting permission.
 
-You can use your own Hubspot credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/install/local) instance.
+You can use your own Hubspot credentials in both the Arcade Cloud and in a [self-hosted Arcade Gateway](/home/install/local) instance.
 
 Before showing how to configure your Hubspot app credentials, let's go through the steps to create a Hubspot app.
 
@@ -62,7 +62,7 @@ Create the app and take note of the **Client ID** and **Client Secret**. You don
 There are two ways to configure your Hubspot app credentials in Arcade:
 
 1. From the Arcade Dashboard GUI
-2. By editing the `engine.yaml` file directly (only possible with a self-hosted Arcade Engine)
+2. By editing the `engine.yaml` file directly (only possible with a self-hosted Arcade Gateway)
 
 We show both options step-by-step below.
 
@@ -92,7 +92,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Create the provider
 
-Hit the **Create** button and the provider will be ready to be used in the Arcade Engine.
+Hit the **Create** button and the provider will be ready to be used in the Arcade Gateway.
 </Steps>
 
 </Tabs.Tab>
@@ -101,7 +101,7 @@ Hit the **Create** button and the provider will be ready to be used in the Arcad
 ### Configure Hubspot Auth Using the Engine Configuration YAML
 
 <Tip>
-  Refer to [Engine configuration](/home/configure/engine) for more information on how to set environment variables and configure the Arcade Engine.
+  Refer to [Engine configuration](/home/configure/engine) for more information on how to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 <Steps>
@@ -125,7 +125,7 @@ HUBSPOT_CLIENT_SECRET="<your client secret>"
 #### Edit the Engine configuration
 
 <Tip>
-  To locate the `engine.yaml` file in your OS after installing the Arcade Engine, check the [Engine configuration file](/home/configure/overview#engine-configuration-file) documentation.
+  To locate the `engine.yaml` file in your OS after installing the Arcade Gateway, check the [Engine configuration file](/home/configure/overview#engine-configuration-file) documentation.
 </Tip>
 
 Edit the `engine.yaml` file and add a Hubspot item to the `auth.providers` section:
@@ -134,9 +134,9 @@ Edit the `engine.yaml` file and add a Hubspot item to the `auth.providers` secti
 
 ```
 
-#### Restart the Arcade Engine
+#### Restart the Arcade Gateway
 
-If the Arcade Engine is already running, you will need to restart it for the changes to take effect.
+If the Arcade Gateway is already running, you will need to restart it for the changes to take effect.
 
 </Steps>
 
@@ -158,7 +158,7 @@ Use `client.auth.start()` to get a user token for the Hubspot API:
 <Tabs items={["Python", "JavaScript"]} storageKey="preferredLanguage">
 <Tabs.Tab>
 <Note>
-  If you are [self-hosting Arcade](/home/install/overview), change the `base_url` parameter in the `Arcade` constructor to match your Arcade Engine URL. By default, the Engine will be available at `http://localhost:9099`.
+  If you are [self-hosting Arcade](/home/install/overview), change the `base_url` parameter in the `Arcade` constructor to match your Arcade Gateway URL. By default, the Gateway will be available at `http://localhost:9099`.
 </Note>
 
 ```python file=<rootDir>/examples/code/integrations/hubspot/custom_auth.py {21}
@@ -168,7 +168,7 @@ Use `client.auth.start()` to get a user token for the Hubspot API:
 
 <Tabs.Tab>
 <Note>
-  If you are [self-hosting Arcade](/home/install/overview), change the `baseURL` parameter in the `Arcade` constructor to match your Arcade Engine URL. By default, the Engine will be available at `http://localhost:9099`.
+  If you are [self-hosting Arcade](/home/install/overview), change the `baseURL` parameter in the `Arcade` constructor to match your Arcade Gateway URL. By default, the Gateway will be available at `http://localhost:9099`.
 </Note>
 
 ```javascript file=<rootDir>/examples/code/integrations/hubspot/custom_auth.js {20}
@@ -191,14 +191,14 @@ Use the `Hubspot()` auth class to specify that a tool requires authorization wit
 
 ```
 
-If you are [self-hosting Arcade](/home/install/overview), you will need to restart the Arcade Worker and the Engine for the new tool to be available.
+If you are [self-hosting Arcade](/home/install/overview), you will need to restart the Arcade Worker and the Gateway for the new tool to be available.
 
 Your new tool can be called like demonstrated below:
 
 <Tabs items={["Python", "JavaScript"]} storageKey="preferredLanguage">
 <Tabs.Tab>
 <Note>
-  If you are self-hosting, change the `base_url` parameter in the `Arcade` constructor to match your Arcade Engine URL. By default, the Engine will be available at `http://localhost:9099`.
+  If you are self-hosting, change the `base_url` parameter in the `Arcade` constructor to match your Arcade Gateway URL. By default, the Gateway will be available at `http://localhost:9099`.
 </Note>
 
 ```python file=<rootDir>/examples/code/integrations/hubspot/custom_tool_call.py
@@ -207,7 +207,7 @@ Your new tool can be called like demonstrated below:
 </Tabs.Tab>
 <Tabs.Tab>
 <Note>
-  If you are self-hosting, change the `baseURL` parameter in the `Arcade` constructor to match your Arcade Engine URL. By default, the Engine will be available at `http://localhost:9099`.
+  If you are self-hosting, change the `baseURL` parameter in the `Arcade` constructor to match your Arcade Gateway URL. By default, the Gateway will be available at `http://localhost:9099`.
 </Note>
 
 ```javascript file=<rootDir>/examples/code/integrations/hubspot/custom_tool_call.js

--- a/pages/home/auth-providers/linkedin.mdx
+++ b/pages/home/auth-providers/linkedin.mdx
@@ -2,7 +2,7 @@ import { Tabs } from "nextra/components";
 
 # LinkedIn auth provider
 
-The LinkedIn auth provider enables tools and agents to call the LinkedIn API on behalf of a user. Behind the scenes, the Arcade Engine and the LinkedIn auth provider seamlessly manage LinkedIn OAuth 2.0 authorization for your users.
+The LinkedIn auth provider enables tools and agents to call the LinkedIn API on behalf of a user. Behind the scenes, the Arcade Gateway and the LinkedIn auth provider seamlessly manage LinkedIn OAuth 2.0 authorization for your users.
 
 ### What's documented here
 
@@ -15,9 +15,9 @@ This auth provider is used by:
 
 ## Configuring LinkedIn auth
 
-How you configure the LinkedIn auth provider depends on whether you use the Arcade Cloud Engine or a [self-hosted Engine](/home/install/overview).
+How you configure the LinkedIn auth provider depends on whether you use the Arcade Cloud Gateway or a [self-hosted Gateway](/home/install/overview).
 
-With the Arcade Cloud Engine, you can start building and testing LinkedIn auth without any configuration. Your users will see `Arcade (demo)` as the name of the application that's requesting permission.
+With the Arcade Cloud Gateway, you can start building and testing LinkedIn auth without any configuration. Your users will see `Arcade (demo)` as the name of the application that's requesting permission.
 
 When you are ready to go to production, you'll want to configure the LinkedIn auth provider with your own LinkedIn app credentials, so users see your app name when they authorize access.
 
@@ -29,7 +29,7 @@ When you are ready to go to production, you'll want to configure the LinkedIn au
 - On the Auth tab, set the redirect URL to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the client ID and client secret to use below
 
-Next, add the LinkedIn app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the LinkedIn app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring LinkedIn auth with the Arcade Dashboard
 
@@ -39,9 +39,9 @@ Next, add the LinkedIn app to your Arcade Engine configuration. You can do this 
 4. Enter your **Client ID** and **Client Secret** from your LinkedIn app.
 5. Click **Save**.
 
-When you use tools that require LinkedIn auth using your Arcade account credentials, the Arcade Engine will automatically use this LinkedIn OAuth provider.
+When you use tools that require LinkedIn auth using your Arcade account credentials, the Arcade Gateway will automatically use this LinkedIn OAuth provider.
 
-### Configuring LinkedIn auth in self-hosted Arcade Engine configuration
+### Configuring LinkedIn auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -63,7 +63,7 @@ LINKEDIN_CLIENT_SECRET="<your client secret>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/home/auth-providers/microsoft.mdx
+++ b/pages/home/auth-providers/microsoft.mdx
@@ -8,7 +8,7 @@ import { Tabs } from "nextra/components";
   OAuth 2.0 credentials as described below.
 </Note>
 
-The Microsoft auth provider enables tools and agents to call the Microsoft Graph API on behalf of a user. Behind the scenes, the Arcade Engine and the Microsoft auth provider seamlessly manage Microsoft OAuth 2.0 authorization for your users.
+The Microsoft auth provider enables tools and agents to call the Microsoft Graph API on behalf of a user. Behind the scenes, the Arcade Gateway and the Microsoft auth provider seamlessly manage Microsoft OAuth 2.0 authorization for your users.
 
 ### What's documented here
 
@@ -21,7 +21,7 @@ This auth provider is used by:
 
 ## Configuring Microsoft auth
 
-How you configure the Microsoft auth provider depends on whether you use the Arcade Cloud Engine or a [self-hosted Engine](/home/install/overview).
+How you configure the Microsoft auth provider depends on whether you use the Arcade Cloud Gateway or a [self-hosted Gateway](/home/install/overview).
 
 When you are ready to go to production, you'll want to configure the Microsoft auth provider with your own Microsoft app credentials, so users see your app name when they authorize access.
 
@@ -32,7 +32,7 @@ When you are ready to go to production, you'll want to configure the Microsoft a
 - Set the redirect URL to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the client ID and client secret to use below
 
-Next, add the Microsoft app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the Microsoft app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Microsoft auth with the Arcade Dashboard
 
@@ -42,9 +42,9 @@ Next, add the Microsoft app to your Arcade Engine configuration. You can do this
 4. Enter your **Client ID** and **Client Secret** from your Microsoft app.
 5. Click **Save**.
 
-When you use tools that require Microsoft auth using your Arcade account credentials, the Arcade Engine will automatically use this Microsoft OAuth provider.
+When you use tools that require Microsoft auth using your Arcade account credentials, the Arcade Gateway will automatically use this Microsoft OAuth provider.
 
-### Configuring Microsoft auth in self-hosted Arcade Engine configuration
+### Configuring Microsoft auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -66,7 +66,7 @@ MICROSOFT_CLIENT_SECRET="<your client secret>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/home/auth-providers/notion.mdx
+++ b/pages/home/auth-providers/notion.mdx
@@ -2,7 +2,7 @@ import { Tabs } from "nextra/components";
 
 # Notion auth provider
 
-The Notion auth provider enables tools and agents to call [Notion APIs](https://developers.notion.com/reference/intro) on behalf of a user. Behind the scenes, the Arcade Engine and the Notion auth provider seamlessly manage Notion OAuth 2.0 authorization for your users.
+The Notion auth provider enables tools and agents to call [Notion APIs](https://developers.notion.com/reference/intro) on behalf of a user. Behind the scenes, the Arcade Gateway and the Notion auth provider seamlessly manage Notion OAuth 2.0 authorization for your users.
 
 ### What's documented here
 
@@ -15,9 +15,9 @@ This auth provider is used by:
 
 ## Configuring Notion auth
 
-How you configure the Notion auth provider depends on whether you use the Arcade Cloud Engine or a [self-hosted Engine](/home/install/overview).
+How you configure the Notion auth provider depends on whether you use the Arcade Cloud Gateway or a [self-hosted Gateway](/home/install/overview).
 
-With the Arcade Cloud Engine, you can start building and testing Notion auth without any configuration. Your users will see `Arcade (demo)` as the name of the application that's requesting permission.
+With the Arcade Cloud Gateway, you can start building and testing Notion auth without any configuration. Your users will see `Arcade (demo)` as the name of the application that's requesting permission.
 
 When you are ready to go to production, you'll want to configure the Notion auth provider with your own Notion app credentials, so users see your app name when they authorize access.
 
@@ -27,7 +27,7 @@ When you are ready to go to production, you'll want to configure the Notion auth
 - Set the redirect URI to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Once you complete creating your integration, copy the client ID and client secret to use below
 
-Next, add the Notion app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the Notion app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Notion auth with the Arcade Dashboard
 
@@ -37,9 +37,9 @@ Next, add the Notion app to your Arcade Engine configuration. You can do this in
 4. Enter your **Client ID** and **Client Secret** from your Notion app.
 5. Click **Save**.
 
-When you use tools that require Notion auth using your Arcade account credentials, the Arcade Engine will automatically use this Notion OAuth provider.
+When you use tools that require Notion auth using your Arcade account credentials, the Arcade Gateway will automatically use this Notion OAuth provider.
 
-### Configuring Notion auth in self-hosted Arcade Engine configuration
+### Configuring Notion auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -61,7 +61,7 @@ NOTION_CLIENT_SECRET="<your client secret>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/home/auth-providers/oauth2.mdx
+++ b/pages/home/auth-providers/oauth2.mdx
@@ -7,7 +7,7 @@ import { Tabs } from "nextra/components";
 
 # OAuth 2.0 auth provider
 
-The OAuth 2.0 auth provider enables tools and agents to authorize with any OAuth 2.0-compatible API on behalf of a user. Behind the scenes, the Arcade Engine and this auth provider seamlessly manage OAuth 2.0 authorization for your users.
+The OAuth 2.0 auth provider enables tools and agents to authorize with any OAuth 2.0-compatible API on behalf of a user. Behind the scenes, the Arcade Gateway and this auth provider seamlessly manage OAuth 2.0 authorization for your users.
 
 <Tip>
   Arcade has [pre-built integrations](/home/auth-providers) with many popular
@@ -28,7 +28,7 @@ The only supported OAuth 2.0 flow is the authorization code grant flow (with or 
 
 ## Configuring OAuth 2.0
 
-How you configure the OAuth 2.0 provider depends on whether you use the Arcade Cloud Engine or a [self-hosted Engine](/home/install/overview). If you use the Cloud Engine, you must configure your provider in the Dashboard.
+How you configure the OAuth 2.0 provider depends on whether you use the Arcade Cloud Gateway or a [self-hosted Gateway](/home/install/overview). If you use the Cloud Gateway, you must configure your provider in the Dashboard.
 
 <Note>
 When configuring your app in the OAuth 2.0 enabled service, you must use `https://cloud.arcade.dev/api/v1/oauth/callback` as the redirect URL (sometimes called callback URL).
@@ -46,7 +46,7 @@ When configuring your app in the OAuth 2.0 enabled service, you must use `https:
 4. Enter your **Client ID** and **Client Secret** from your OAuth 2.0 provider.
 5. Click **Save**.
 
-When you use tools that require OAuth 2.0 authorization using your Arcade account credentials, the Arcade Engine will automatically use this OAuth 2.0 provider.
+When you use tools that require OAuth 2.0 authorization using your Arcade account credentials, the Arcade Gateway will automatically use this OAuth 2.0 provider.
 
 ### Using the `engine.yaml` configuration file
 
@@ -74,13 +74,13 @@ HOOLI_CLIENT_SECRET="<your client secret>"
 
 <Tip>
   See [configuration](/home/configure/engine) for more information on how to set
-  environment variables and configure the Arcade Engine.
+  environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration
 
 <Tip>
-  To locate the `engine.yaml` file in your OS after installing the Arcade Engine, check the [Engine configuration file](/home/configure/overview#engine-configuration-file) documentation.
+  To locate the `engine.yaml` file in your OS after installing the Arcade Gateway, check the [Gateway configuration file](/home/configure/overview#engine-configuration-file) documentation.
 </Tip>
 
 Edit the `engine.yaml` file and add a new item to the `auth.providers` section:
@@ -222,7 +222,7 @@ refresh_request:
 
 #### `user_info_request`
 
-Some OAuth 2.0 APIs provide a user info endpoint that returns information about the user. Arcade Engine can automatically request user info from servers that support it. If the `user_info_request` section is omitted, user info will not be requested.
+Some OAuth 2.0 APIs provide a user info endpoint that returns information about the user. Arcade Gateway can automatically request user info from servers that support it. If the `user_info_request` section is omitted, user info will not be requested.
 
 - `endpoint`: The user info endpoint for your OAuth 2.0 server, e.g. `/oauth2/userinfo`
 - `auth_method` _(optional, default `bearer_access_token`)_: The authentication method to use. The only supported value is `bearer_access_token`.

--- a/pages/home/auth-providers/reddit.mdx
+++ b/pages/home/auth-providers/reddit.mdx
@@ -8,7 +8,7 @@ import { Tabs } from "nextra/components";
   OAuth 2.0 credentials as described below.
 </Note>
 
-The Reddit auth provider enables tools and agents to call the Reddit API on behalf of a user. Behind the scenes, the Arcade Engine and the Reddit auth provider seamlessly manage Reddit OAuth 2.0 authorization for your users.
+The Reddit auth provider enables tools and agents to call the Reddit API on behalf of a user. Behind the scenes, the Arcade Gateway and the Reddit auth provider seamlessly manage Reddit OAuth 2.0 authorization for your users.
 
 ### What's documented here
 
@@ -27,7 +27,7 @@ This auth provider is used by:
 - Set the OAuth Redirect URL to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the App key (Client ID) and App secret (Client Secret), which you'll need below
 
-Next, add the Reddit app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the Reddit app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Reddit auth with the Arcade Dashboard
 
@@ -37,9 +37,9 @@ Next, add the Reddit app to your Arcade Engine configuration. You can do this in
 4. Enter your **Client ID** and **Client Secret** from your Reddit app.
 5. Click **Save**.
 
-When you use tools that require Reddit auth using your Arcade account credentials, the Arcade Engine will automatically use this Reddit OAuth provider.
+When you use tools that require Reddit auth using your Arcade account credentials, the Arcade Gateway will automatically use this Reddit OAuth provider.
 
-### Configuring Reddit auth in self-hosted Arcade Engine configuration
+### Configuring Reddit auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -66,7 +66,7 @@ REDDIT_CLIENT_ID="<your client ID>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/home/auth-providers/slack.mdx
+++ b/pages/home/auth-providers/slack.mdx
@@ -2,7 +2,7 @@ import { Tabs } from "nextra/components";
 
 # Slack auth provider
 
-The Slack auth provider enables tools and agents to call [Slack APIs](https://api.slack.com/docs) on behalf of a user. Behind the scenes, the Arcade Engine and the Slack auth provider seamlessly manage Slack OAuth 2.0 authorization for your users.
+The Slack auth provider enables tools and agents to call [Slack APIs](https://api.slack.com/docs) on behalf of a user. Behind the scenes, the Arcade Gateway and the Slack auth provider seamlessly manage Slack OAuth 2.0 authorization for your users.
 
 <Tip>
   Want to quickly get started with Slack in your agent or AI app? The pre-built
@@ -21,9 +21,9 @@ This auth provider is used by:
 
 ## Configuring Slack auth
 
-How you configure the Slack auth provider depends on whether you use the Arcade Cloud Engine or a [self-hosted Engine](/home/install/overview).
+How you configure the Slack auth provider depends on whether you use the Arcade Cloud Gateway or a [self-hosted Gateway](/home/install/overview).
 
-With the Arcade Cloud Engine, you can start building and testing Slack auth without any configuration. Your users will see `Arcade (demo)` as the name of the application that's requesting permission.
+With the Arcade Cloud Gateway, you can start building and testing Slack auth without any configuration. Your users will see `Arcade (demo)` as the name of the application that's requesting permission.
 
 When you are ready to go to production, you'll want to configure the Slack auth provider with your own Slack app credentials, so users see your app name when they authorize access.
 
@@ -34,7 +34,7 @@ When you are ready to go to production, you'll want to configure the Slack auth 
 - Set the redirect URL to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the client ID and client secret
 
-Next, add the Slack app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the Slack app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Slack auth with the Arcade Dashboard
 
@@ -44,9 +44,9 @@ Next, add the Slack app to your Arcade Engine configuration. You can do this in 
 4. Enter your **Client ID** and **Client Secret** from your Slack app.
 5. Click **Save**.
 
-When you use tools that require Slack auth using your Arcade account credentials, the Arcade Engine will automatically use this Slack OAuth provider.
+When you use tools that require Slack auth using your Arcade account credentials, the Arcade Gateway will automatically use this Slack OAuth provider.
 
-### Configuring Slack auth in self-hosted Arcade Engine configuration
+### Configuring Slack auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -68,7 +68,7 @@ SLACK_CLIENT_SECRET="<your client secret>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/home/auth-providers/spotify.mdx
+++ b/pages/home/auth-providers/spotify.mdx
@@ -8,7 +8,7 @@ import { Tabs } from "nextra/components";
   OAuth 2.0 credentials as described below.
 </Note>
 
-The Spotify auth provider enables tools and agents to call the Spotify API on behalf of a user. Behind the scenes, the Arcade Engine and the Spotify auth provider seamlessly manage Spotify OAuth 2.0 authorization for your users.
+The Spotify auth provider enables tools and agents to call the Spotify API on behalf of a user. Behind the scenes, the Arcade Gateway and the Spotify auth provider seamlessly manage Spotify OAuth 2.0 authorization for your users.
 
 ### What's documented here
 
@@ -21,7 +21,7 @@ This auth provider is used by:
 
 ## Configuring Spotify auth
 
-How you configure the Spotify auth provider depends on whether you use the Arcade Cloud Engine or a [self-hosted Engine](/home/install/overview).
+How you configure the Spotify auth provider depends on whether you use the Arcade Cloud Gateway or a [self-hosted Gateway](/home/install/overview).
 
 When you are ready to go to production, you'll want to configure the Spotify auth provider with your own Spotify app credentials, so users see your app name when they authorize access.
 
@@ -32,7 +32,7 @@ When you are ready to go to production, you'll want to configure the Spotify aut
 - Set the redirect URL to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the client ID and client secret to use below
 
-Next, add the Spotify app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the Spotify app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Spotify auth with the Arcade Dashboard
 
@@ -42,9 +42,9 @@ Next, add the Spotify app to your Arcade Engine configuration. You can do this i
 4. Enter your **Client ID** and **Client Secret** from your Spotify app.
 5. Click **Save**.
 
-When you use tools that require Spotify auth using your Arcade account credentials, the Arcade Engine will automatically use this Spotify OAuth provider.
+When you use tools that require Spotify auth using your Arcade account credentials, the Arcade Gateway will automatically use this Spotify OAuth provider.
 
-### Configuring Spotify auth in self-hosted Arcade Engine configuration
+### Configuring Spotify auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -66,7 +66,7 @@ SPOTIFY_CLIENT_SECRET="<your client secret>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/home/auth-providers/twitch.mdx
+++ b/pages/home/auth-providers/twitch.mdx
@@ -8,7 +8,7 @@ import { Tabs } from "nextra/components";
   OAuth 2.0 credentials as described below.
 </Note>
 
-The Twitch auth provider enables tools and agents to call the Twitch API on behalf of a user. Behind the scenes, the Arcade Engine and the Twitch auth provider seamlessly manage Twitch OAuth 2.0 authorization for your users.
+The Twitch auth provider enables tools and agents to call the Twitch API on behalf of a user. Behind the scenes, the Arcade Gateway and the Twitch auth provider seamlessly manage Twitch OAuth 2.0 authorization for your users.
 
 ### What's documented here
 
@@ -30,7 +30,7 @@ This auth provider is used by:
 - Select the 'Confidential' Client Type
 - Copy the App key (Client ID) and App secret (Client Secret), which you'll need below
 
-Next, add the Twitch app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the Twitch app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Twitch auth with the Arcade Dashboard
 
@@ -40,9 +40,9 @@ Next, add the Twitch app to your Arcade Engine configuration. You can do this in
 4. Enter your **Client ID** and **Client Secret** from your Twitch app.
 5. Click **Save**.
 
-When you use tools that require Twitch auth using your Arcade account credentials, the Arcade Engine will automatically use this Twitch OAuth provider.
+When you use tools that require Twitch auth using your Arcade account credentials, the Arcade Gateway will automatically use this Twitch OAuth provider.
 
-### Configuring Twitch auth in self-hosted Arcade Engine configuration
+### Configuring Twitch auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -69,7 +69,7 @@ TWITCH_CLIENT_ID="<your client ID>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/home/auth-providers/x.mdx
+++ b/pages/home/auth-providers/x.mdx
@@ -2,7 +2,7 @@ import { Tabs } from "nextra/components";
 
 # X auth provider
 
-The X auth provider enables tools and agents to call the X (Twitter) API on behalf of a user. Behind the scenes, the Arcade Engine and the X auth provider seamlessly manage X OAuth 2.0 authorization for your users.
+The X auth provider enables tools and agents to call the X (Twitter) API on behalf of a user. Behind the scenes, the Arcade Gateway and the X auth provider seamlessly manage X OAuth 2.0 authorization for your users.
 
 <Tip>
   Want to quickly get started with X services in your agent or AI app? The
@@ -22,9 +22,9 @@ This auth provider is used by:
 
 ## Configuring X auth
 
-How you configure the X auth provider depends on whether you use the Arcade Cloud Engine or a [self-hosted Engine](/home/install/overview).
+How you configure the X auth provider depends on whether you use the Arcade Cloud Gateway or a [self-hosted Gateway](/home/install/overview).
 
-With the Arcade Cloud Engine, you can start building and testing X auth without any configuration. Your users will see `Arcade (demo)` as the name of the application that's requesting permission.
+With the Arcade Cloud Gateway, you can start building and testing X auth without any configuration. Your users will see `Arcade (demo)` as the name of the application that's requesting permission.
 
 When you are ready to go to production, you'll want to configure the X auth provider with your own X app credentials, so users see your app name when they authorize access.
 
@@ -35,7 +35,7 @@ When you are ready to go to production, you'll want to configure the X auth prov
 - Set the redirect URL to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the client ID and client secret to use below
 
-Next, add the X app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the X app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring X auth with the Arcade Dashboard
 
@@ -45,9 +45,9 @@ Next, add the X app to your Arcade Engine configuration. You can do this in the 
 4. Enter your **Client ID** and **Client Secret** from your X app.
 5. Click **Save**.
 
-When you use tools that require X auth using your Arcade account credentials, the Arcade Engine will automatically use this X OAuth provider.
+When you use tools that require X auth using your Arcade account credentials, the Arcade Gateway will automatically use this X OAuth provider.
 
-### Configuring X auth in self-hosted Arcade Engine configuration
+### Configuring X auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -69,7 +69,7 @@ X_CLIENT_SECRET="<your client secret>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/home/auth-providers/zoom.mdx
+++ b/pages/home/auth-providers/zoom.mdx
@@ -8,7 +8,7 @@ import { Tabs } from "nextra/components";
   credentials as described below.
 </Note>
 
-The Zoom auth provider enables tools and agents to call the Zoom API on behalf of a user. Behind the scenes, the Arcade Engine and the Zoom auth provider seamlessly manage Zoom OAuth 2.0 authorization for your users.
+The Zoom auth provider enables tools and agents to call the Zoom API on behalf of a user. Behind the scenes, the Arcade Gateway and the Zoom auth provider seamlessly manage Zoom OAuth 2.0 authorization for your users.
 
 ### What's documented here
 
@@ -21,7 +21,7 @@ This auth provider is used by:
 
 ## Configuring Zoom auth
 
-How you configure the Zoom auth provider depends on whether you use the Arcade Cloud Engine or a [self-hosted Engine](/home/install/overview).
+How you configure the Zoom auth provider depends on whether you use the Arcade Cloud Gateway or a [self-hosted Gateway](/home/install/overview).
 
 When you are ready to go to production, you'll want to configure the Zoom auth provider with your own Zoom app credentials, so users see your app name when they authorize access.
 
@@ -32,7 +32,7 @@ When you are ready to go to production, you'll want to configure the Zoom auth p
 - Enable the Zoom features and permissions (scopes) that your app needs
 - Copy the client ID and client secret to use below
 
-Next, add the Zoom app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the Zoom app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Zoom auth with the Arcade Dashboard
 
@@ -42,9 +42,9 @@ Next, add the Zoom app to your Arcade Engine configuration. You can do this in t
 4. Enter your **Client ID** and **Client Secret** from your Zoom app.
 5. Click **Save**.
 
-When you use tools that require Zoom auth using your Arcade account credentials, the Arcade Engine will automatically use this Zoom OAuth provider.
+When you use tools that require Zoom auth using your Arcade account credentials, the Arcade Gateway will automatically use this Zoom OAuth provider.
 
-### Configuring Zoom auth in self-hosted Arcade Engine configuration
+### Configuring Zoom auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -66,7 +66,7 @@ ZOOM_CLIENT_SECRET="<your client secret>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/home/auth/how-arcade-helps.mdx
+++ b/pages/home/auth/how-arcade-helps.mdx
@@ -32,7 +32,7 @@ Each tool in Arcade's toolkits has a set of required permissions - or, more comm
 
 A scope is what the user has authorized someone else (in this case, the AI agent) to do on their behalf. In any OAuth2-compatible service, each kind of action requires a different set of permissions. This gives the user fine-grained control over what data third-party services can access and what actions can be executed in their accounts.
 
-When a tool is called, the Arcade Engine will check if the user has granted the required permissions. If not, it will automatically prompt the user to authorize the tool, coordinating the OAuth2 flow with the service provider.
+When a tool is called, the Arcade Gateway will check if the user has granted the required permissions. If not, it will automatically prompt the user to authorize the tool, coordinating the OAuth2 flow with the service provider.
 
 ### How to implement OAuth2-authorized tool calling
 

--- a/pages/home/build-tools/create-a-tool-with-auth.mdx
+++ b/pages/home/build-tools/create-a-tool-with-auth.mdx
@@ -88,7 +88,7 @@ Arcade offers a number of [built-in auth providers](/home/auth-providers), inclu
 ```
 
 <Note>
-  The `OAuth2` class requires an `id` parameter to identify the auth provider in the Arcade Engine. For built-in providers like `Slack`, you can skip the `id` - the Arcade Engine will find the right provider using your credentials. While you can specify an `id` for built-in providers, only do this for private tools that won't be shared.
+  The `OAuth2` class requires an `id` parameter to identify the auth provider in the Arcade Gateway. For built-in providers like `Slack`, you can skip the `id` - the Arcade Gateway will find the right provider using your credentials. While you can specify an `id` for built-in providers, only do this for private tools that won't be shared.
 </Note>
 
 ### Use your authorized tool with Arcade

--- a/pages/home/build-tools/create-a-tool-with-secrets.mdx
+++ b/pages/home/build-tools/create-a-tool-with-secrets.mdx
@@ -80,7 +80,7 @@ Sql_GetTableSchema: Get the schema of a table
 
 ### Supplying the Secret
 
-Note how in the example above we never provided a value for `DATABASE_CONNECTION_STRING`.  This is because we want the Arcade engine to manage this for us, keeping the sercets that the tool needs seperate from the environment that is exceuting the LLM calls (our application above).
+Note how in the example above we never provided a value for `DATABASE_CONNECTION_STRING`.  This is because we want the Arcade Gateway to manage this for us, keeping the sercets that the tool needs seperate from the environment that is exceuting the LLM calls (our application above).
 
 Using Arcade Cloud, after publishing your tool with [`arcade deploy`](https://docs.arcade.dev/home/serve-tools/arcade-deploy), you will see that your tool requires the `DATABASE_CONNECTION_STRING` secret:
 

--- a/pages/home/evaluate-tools/run-evaluations.mdx
+++ b/pages/home/evaluate-tools/run-evaluations.mdx
@@ -63,13 +63,13 @@ The `arcade evals` command supports several options to customize the evaluation 
   arcade evals . --max-concurrent 4
   ```
 
-- `--host`, `-h`: Specify the Arcade Engine address to send evaluation requests to.
+- `--host`, `-h`: Specify the Arcade Gateway address to send evaluation requests to.
 
-- `--port`, `-p`: Specify the port of the Arcade Engine.
+- `--port`, `-p`: Specify the port of the Arcade Gateway.
 
-- `--tls`: Force TLS for the connection to the Arcade Engine.
+- `--tls`: Force TLS for the connection to the Arcade Gateway.
 
-- `--no-tls`: Disable TLS for the connection to the Arcade Engine.
+- `--no-tls`: Disable TLS for the connection to the Arcade Gateway.
 
 #### Example Command
 
@@ -158,7 +158,7 @@ arcade evals . --models gpt-4o,gpt-3.5
 
 ### Considerations
 
-- **Engine Availability**: Ensure the Arcade Engine is running and accessible. You can specify the host and port if running the engine locally or on a different server.
+- **Gateway Availability**: Ensure the Arcade Gateway is running and accessible. You can specify the host and port if running the gateway locally or on a different server.
 
 - **Authentication**: Make sure you are logged in and have the necessary API keys configured.
 

--- a/pages/home/local-deployment/configure/arcade-deploy.mdx
+++ b/pages/home/local-deployment/configure/arcade-deploy.mdx
@@ -70,7 +70,7 @@ You can use a secret from the environment to configure the worker with the `${en
 secret = "${env: MY_ENVIRONMENT_SECRET}"
 ```
 
-## Using with a local engine
+## Using with a local gateway
 
 To register the worker with your local engine, you can use the host and port flags.
 

--- a/pages/home/local-deployment/configure/arcade-deploy.mdx
+++ b/pages/home/local-deployment/configure/arcade-deploy.mdx
@@ -70,9 +70,9 @@ You can use a secret from the environment to configure the worker with the `${en
 secret = "${env: MY_ENVIRONMENT_SECRET}"
 ```
 
-## Using with a local gateway
+## Using with a local Gateway
 
-To register the worker with your local engine, you can use the host and port flags.
+To register the worker with your local Arcade Gateway, you can use the host and port flags.
 
 ```bash
 arcade deploy -h localhost -p 9099 --no-tls

--- a/pages/home/local-deployment/configure/engine.mdx
+++ b/pages/home/local-deployment/configure/engine.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Configuration"
-description: "Arcade Engine Configuration"
+description: "Arcade Gateway Configuration"
 ---
 
 import TableOfContents from "@/components/TableOfContents";
 
-# Arcade Engine configuration
+# Arcade Gateway configuration
 
-Arcade Engine's configuration is a [YAML file](https://yaml.org/) with the following sections:
+Arcade Gateway's configuration is a [YAML file](https://yaml.org/) with the following sections:
 
 <TableOfContents
   headers={["Section", "Description"]}
@@ -24,7 +24,7 @@ Arcade Engine's configuration is a [YAML file](https://yaml.org/) with the follo
 
 ## Specify a config file
 
-To start the Arcade Engine, pass a config file with `-c` or `--config`:
+To start the Arcade Gateway, pass a config file with `-c` or `--config`:
 
 ```bash
 arcade-engine -c /path/to/config.yaml
@@ -38,7 +38,7 @@ arcade dev -c /path/to/config.yaml
 
 ## Dotenv files
 
-Arcade Engine automatically loads environment variables from `.env` files in the directory where it was called. Use the `-e` or`--env` flag to specify a path:
+Arcade Gateway automatically loads environment variables from `.env` files in the directory where it was called. Use the `-e` or`--env` flag to specify a path:
 
 ```bash
 arcade-engine -e .env.dev -c config.yaml
@@ -46,7 +46,7 @@ arcade-engine -e .env.dev -c config.yaml
 
 ## Secrets
 
-Arcade Engine supports two ways of passing sensitive information like API keys without storing them directly in the config file.
+Arcade Gateway supports two ways of passing sensitive information like API keys without storing them directly in the config file.
 
 Environment variables:
 
@@ -70,10 +70,10 @@ topic:
 
 ## API configuration
 
-HTTP is the supported protocol for Arcade Engine's API. The following configuration options are available:
+HTTP is the supported protocol for Arcade Gateway's API. The following configuration options are available:
 
 - `api.development` _(optional, default: `false`)_ - Enable development mode, with more logging and simple [worker authentication](/home/configure/engine#http-worker-configuration)
-- `api.http.host` _(default: `localhost`)_ - Address to which Arcade Engine binds its server (e.g., `localhost` or `0.0.0.0`)
+- `api.http.host` _(default: `localhost`)_ - Address to which Arcade Gateway binds its server (e.g., `localhost` or `0.0.0.0`)
 - `api.http.read_timeout` _(optional, default: `30s`)_ - Timeout for reading data from clients
 - `api.http.write_timeout` _(optional, default: `1m`)_ - Timeout for writing data to clients
 - `api.http.idle_timeout` _(optional, default: `30s`)_ - Timeout for idle connections
@@ -85,12 +85,12 @@ A typical configuration for production looks like:
 
 ```
 
-For local development, set `api.development = true`. In development mode, Arcade Engine does not require [worker authentication](/home/configure/engine#http-worker-configuration).
+For local development, set `api.development = true`. In development mode, Arcade Gateway does not require [worker authentication](/home/configure/engine#http-worker-configuration).
 
 
 ## Auth configuration
 
-Arcade Engine manages auth for [AI tools](/home/auth/auth-tool-calling) and [direct API calls](/home/auth/call-third-party-apis-directly). It supports many built-in [auth providers](/home/auth-providers), and can also connect to any [OAuth 2.0](/home/auth-providers/oauth2) authorization server.
+Arcade Gateway manages auth for [AI tools](/home/auth/auth-tool-calling) and [direct API calls](/home/auth/call-third-party-apis-directly). It supports many built-in [auth providers](/home/auth-providers), and can also connect to any [OAuth 2.0](/home/auth-providers/oauth2) authorization server.
 
 The `auth.providers` section defines the providers that users can authorize with. Each provider must have a unique `id` in the array. There are two ways to configure a provider:
 
@@ -110,7 +110,7 @@ You can specify a mix of built-in and custom providers.
 The `cache` section configures the short-lived cache.
 
 <Note>
-  Configuring the cache is optional. If not configured, the cache will default to an in-memory cache implementation suitable for a single-node Arcade Engine deployment.
+  Configuring the cache is optional. If not configured, the cache will default to an in-memory cache implementation suitable for a single-node Arcade Gateway deployment.
 </Note>
 
 The `cache` section has the following configuration options:
@@ -118,8 +118,8 @@ The `cache` section has the following configuration options:
 - `api_key_ttl` _(optional, default: `10s`)_ - The time-to-live for API keys in the cache
 
 Two cache implementations are available:
-- `in_memory` - _(default)_ An in-memory cache implementation suitable for a single-node Arcade Engine deployment.
-- `redis` - A Redis cache implementation suitable for a multi-node Arcade Engine deployment:
+- `in_memory` - _(default)_ An in-memory cache implementation suitable for a single-node Arcade Gateway deployment.
+- `redis` - A Redis cache implementation suitable for a multi-node Arcade Gateway deployment:
 
 ```yaml file=<rootDir>/examples/code/home/configuration/engine/full_config.1.0.yaml#L74-L79 {3-6}
 
@@ -127,7 +127,7 @@ Two cache implementations are available:
 
 ## Security configuration
 
-The `security` section configures the root encryption keys that the Arcade Engine uses to encrypt and decrypt data at rest. See the [storage configuration](#storage-configuration) section below to configure where data is stored.
+The `security` section configures the root encryption keys that the Arcade Gateway uses to encrypt and decrypt data at rest. See the [storage configuration](#storage-configuration) section below to configure where data is stored.
 
 A typical configuration looks like this:
 
@@ -143,7 +143,7 @@ openssl rand -base64 32
 
 ### Default root key
 
-When you [install Arcade Engine locally](/home/install/local), an `engine.env` file is created with a default root key:
+When you [install Arcade Gateway locally](/home/install/local), an `engine.env` file is created with a default root key:
 
 ```bash file=<rootDir>/examples/code/home/configuration/engine/engine.env#L7-L8 {2}
 
@@ -157,7 +157,7 @@ This default value can only be used in development mode (see [API configuration]
 
 ## Storage configuration
 
-The `storage` section configures the storage backend that the Arcade Engine uses to store persistent data.
+The `storage` section configures the storage backend that the Arcade Gateway uses to store persistent data.
 
 There are three storage implementations available:
 
@@ -181,7 +181,7 @@ storage:
 
 Arcade supports logs, metrics, and traces with [OpenTelemetry](https://opentelemetry.io/).
 
-If you are using the Arcade Engine locally, you can set the `environment` field to `local`. This will only output logs to the console:
+If you are using the Arcade Gateway locally, you can set the `environment` field to `local`. This will only output logs to the console:
 
 ```yaml
 telemetry:
@@ -208,7 +208,7 @@ To connect to OpenTelemetry compatible collectors, set the necessary [OpenTeleme
 
 ## Tools configuration
 
-Arcade Engine orchestrates [tools](/home/use-tools/tools-overview) that AI models can use. Tools are executed by distributed workers called **workers**, which are grouped into **directors**.
+Arcade Gateway orchestrates [tools](/home/use-tools/tools-overview) that AI models can use. Tools are executed by distributed workers called **workers**, which are grouped into **directors**.
 
 The `tools.directors` section configures the workers that are available to service tool calls:
 

--- a/pages/home/local-deployment/configure/overview.mdx
+++ b/pages/home/local-deployment/configure/overview.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Configuration Overview"
-description: "Arcade Engine Configuration Overview"
+description: "Arcade Gateway Configuration Overview"
 ---
 
 import { Tabs } from "nextra/components";
 
 # Configuration Overview
 
-Arcade uses configuration files to manage engine settings and default values. When you install the Arcade Engine, two files are created:
+Arcade uses configuration files to manage engine settings and default values. When you install the Arcade Gateway, two files are created:
 
 - The `engine.yaml` file for engine configuration.
 - The `engine.env` file for environment variables.
@@ -16,7 +16,7 @@ Let's explore each file to understand their purpose and how to locate them.
 
 ## Engine configuration file
 
-The `engine.yaml` file controls Arcade Engine settings. It supports variable expansion so you can integrate secrets and environment values seamlessly. You can customize this file to suit your setup. For more details, check the [Engine Configuration](/home/configure/engine) page.
+The `engine.yaml` file controls Arcade Gateway settings. It supports variable expansion so you can integrate secrets and environment values seamlessly. You can customize this file to suit your setup. For more details, check the [Engine Configuration](/home/configure/engine) page.
 
 Choose your installation method to view the default location of `engine.yaml`:
 
@@ -41,7 +41,7 @@ Choose your installation method to view the default location of `engine.yaml`:
 
 ## Engine environment file
 
-The `engine.env` file contains default environment variables that power Arcade Engine. You can override these defaults by exporting your own variables or by editing the file directly.
+The `engine.env` file contains default environment variables that power Arcade Gateway. You can override these defaults by exporting your own variables or by editing the file directly.
 
 Select your installation method below to see the default path for `engine.env`:
 

--- a/pages/home/local-deployment/configure/templates.mdx
+++ b/pages/home/local-deployment/configure/templates.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuration Templates"
-description: "Arcade Engine Configuration Templates"
+description: "Arcade Gateway Configuration Templates"
 ---
 
 

--- a/pages/home/local-deployment/install/docker.mdx
+++ b/pages/home/local-deployment/install/docker.mdx
@@ -9,9 +9,9 @@ description: Deploy Arcade with Docker
 
 ### Pulling the Gateway Image
 
-The Arcade Gateway is stateless and the docker image is designed to scale horizontally for production environments.
+Arcade Gateway is designed to scale horizontally for production environments.
 
-The docker image for the engine can be pulled with
+The Docker image for the Gateway can be pulled with:
 
 ```bash
 docker pull ghcr.io/arcadeai/engine:latest

--- a/pages/home/local-deployment/install/docker.mdx
+++ b/pages/home/local-deployment/install/docker.mdx
@@ -5,11 +5,11 @@ description: Deploy Arcade with Docker
 
 # Docker Installation
 
-## Engine
+## Gateway
 
-### Pulling the Engine Image
+### Pulling the Gateway Image
 
-The Arcade Engine is stateless and the docker image is designed to scale horizontally for production environments.
+The Arcade Gateway is stateless and the docker image is designed to scale horizontally for production environments.
 
 The docker image for the engine can be pulled with
 
@@ -17,9 +17,9 @@ The docker image for the engine can be pulled with
 docker pull ghcr.io/arcadeai/engine:latest
 ```
 
-### Running the Engine
+### Running the Gateway
 
-The engine can be run with:
+The gateway can be run with:
 
 ```bash
 docker run -d -p 9099:9099 -v ./engine.yaml:/bin/engine.yaml ghcr.io/arcadeai/engine:latest

--- a/pages/home/local-deployment/install/local.mdx
+++ b/pages/home/local-deployment/install/local.mdx
@@ -30,7 +30,7 @@ Verify your Python version by running `python --version` or `python3 --version` 
 
 <Steps>
 ### Install the Client
-To connect to the cloud or local Arcade Gateway, we need to install the Arcade SDK and CLI from the `arcade-ai` package.
+To connect to a cloud or local Arcade Gateway, we need to install the Arcade SDK and CLI from the `arcade-ai` package.
 
 ```bash
 pip install 'arcade-ai[evals]'

--- a/pages/home/local-deployment/install/local.mdx
+++ b/pages/home/local-deployment/install/local.mdx
@@ -30,7 +30,7 @@ Verify your Python version by running `python --version` or `python3 --version` 
 
 <Steps>
 ### Install the Client
-To connect to the cloud or local Arcade Engine, we need to install the Arcade SDK and CLI from the `arcade-ai` package.
+To connect to the cloud or local Arcade Gateway, we need to install the Arcade SDK and CLI from the `arcade-ai` package.
 
 ```bash
 pip install 'arcade-ai[evals]'
@@ -41,7 +41,7 @@ For a simple example on using the Arcade CLI, see the [quickstart on building to
 
 ### Install the Engine
 
-To run the Arcade Engine locally, you'll need to install `arcade-engine`. Choose the installation method that matches your operating system.
+To run the Arcade Gateway locally, you'll need to install `arcade-engine`. Choose the installation method that matches your operating system.
 
 This will install a template engine configuration.
 
@@ -90,7 +90,7 @@ Edit the `engine.env` file to set the `OPENAI_API_KEY` environment variable:
 OPENAI_API_KEY="<your_openai_api_key>"
 ```
 
-See the [configuration overview](/home/configure/overview) for more information on how to configure Arcade Engine and how to locate the `engine.env` file.
+See the [configuration overview](/home/configure/overview) for more information on how to configure Arcade Gateway and how to locate the `engine.env` file.
 
 ### Start the Engine and worker
 
@@ -141,7 +141,7 @@ or
 command not found: arcade-engine
 ```
 
-This means that the Arcade Engine cannot be found in your path. Brew and Apt will automatically add the binary to you path.
+This means that the Arcade Gateway cannot be found in your path. Brew and Apt will automatically add the binary to you path.
 
 Check that the binary has been properly installed (These are the common installation locations):
 
@@ -184,7 +184,7 @@ This means that there are no toolkits found in the same environment as the Arcad
 or
 
 ```bash
-Arcade Engine has finished with error: unable to read config file $HOME/.arcade/engine.yaml: open $HOME/.arcade/engine.yaml: no such file or directory
+Arcade Gateway has finished with error: unable to read config file $HOME/.arcade/engine.yaml: open $HOME/.arcade/engine.yaml: no such file or directory
 ```
 
 `arcade dev` will search for the engine config in known directories including:

--- a/pages/home/local-deployment/install/overview.mdx
+++ b/pages/home/local-deployment/install/overview.mdx
@@ -19,7 +19,7 @@ The Arcade Client can be installed with `pip` by following the [quickstart guide
 
 The Arcade CLI & SDK can be installed with `pip` by following the [CLI guide](/home/arcade-cli).
 
-## Engine
+## Gateway / Engine
 
 ### Brew and APT
 

--- a/pages/home/local-deployment/install/overview.mdx
+++ b/pages/home/local-deployment/install/overview.mdx
@@ -19,7 +19,7 @@ The Arcade Client can be installed with `pip` by following the [quickstart guide
 
 The Arcade CLI & SDK can be installed with `pip` by following the [CLI guide](/home/arcade-cli).
 
-## Gateway / Engine
+## Gateway
 
 ### Brew and APT
 

--- a/pages/home/local-deployment/install/toolkits.mdx
+++ b/pages/home/local-deployment/install/toolkits.mdx
@@ -7,7 +7,7 @@ description: "How to install Arcade Tools"
 
 ## Running a Local worker
 
-To run a local worker without the arcade engine, you can run the following command locally:
+To run a local worker without the Arcade Gateway, you can run the following command locally:
 
 ```bash
 arcade serve
@@ -107,4 +107,4 @@ arcade show -h <engine_host> -p <engine_port>
 
 ## Authenticated Tools
 
-Some Toolkits may need authentication through an API key or OAuth, which can be configured in the Arcade Engine. To see the specific configuration requirements, you can checkout our [Auth Providers](/home/auth-providers).
+Some Toolkits may need authentication through an API key or OAuth, which can be configured in the Arcade Gateway. To see the specific configuration requirements, you can checkout our [Auth Providers](/home/auth-providers).

--- a/pages/home/quickstart.mdx
+++ b/pages/home/quickstart.mdx
@@ -10,7 +10,7 @@ import { SignupLink } from "@/components/Analytics";
 
 This guide will walk you through the process of getting started with Arcade.dev.  First, we will go over Direct Tool Calling, a simple way to call tools directly from your agent.
 
-Direct tool calling is useful in situations where you already know what tool is needed or when there is no prompt for an LLM to interpret and decide on the tool calling. It also gives you full control over what is executed by the Arcade Engine and how.
+Direct tool calling is useful in situations where you already know what tool is needed or when there is no prompt for an LLM to interpret and decide on the tool calling. It also gives you full control over what is executed by the Arcade Gateway and how.
 
 <Steps>
 

--- a/pages/home/serve-tools/modal-worker.mdx
+++ b/pages/home/serve-tools/modal-worker.mdx
@@ -7,7 +7,7 @@ import { Steps } from "nextra/components";
 
 # Deploy a custom worker on Modal
 
-This guide shows you how to deploy a custom Arcade Worker using Modal. It takes you through setting up the environment, deploying the worker, and connecting it to the Arcade Engine.
+This guide shows you how to deploy a custom Arcade Worker using Modal. It takes you through setting up the environment, deploying the worker, and connecting it to the Arcade Gateway.
 
 <Steps>
 
@@ -68,11 +68,11 @@ def fastapi_app():
     return web_app
 ```
 
-### Connect to Arcade Engine
+### Connect to Arcade Gateway
 
-To connect the Arcade Engine to your worker, configure the worker URL in the engine's configuration file. Start the engine with the appropriate configuration.
+To connect the Arcade Gateway to your worker, configure the worker URL in the engine's configuration file. Start the engine with the appropriate configuration.
 
-For more details, refer to the [Arcade Engine configuration documentation](/home/configure/engine).
+For more details, refer to the [Arcade Gateway configuration documentation](/home/configure/engine).
 
 </Steps>
 

--- a/pages/toolkits/development/github/github.mdx
+++ b/pages/toolkits/development/github/github.mdx
@@ -569,7 +569,7 @@ List review comments in a GitHub repository.
 
 The Arcade GitHub toolkit uses the [GitHub auth provider](/home/auth-providers/github) to connect to users' GitHub accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the GitHub auth provider](/home/auth-providers/github#configuring-github-auth) with your own GitHub app credentials.
 

--- a/pages/toolkits/entertainment/twitch.mdx
+++ b/pages/toolkits/entertainment/twitch.mdx
@@ -9,7 +9,7 @@ import ToolFooter from "@/components/ToolFooter";
   OAuth 2.0 credentials as described below.
 </Note>
 
-The Twitch auth provider enables tools and agents to call the Twitch API on behalf of a user. Behind the scenes, the Arcade Engine and the Twitch auth provider seamlessly manage Twitch OAuth 2.0 authorization for your users.
+The Twitch auth provider enables tools and agents to call the Twitch API on behalf of a user. Behind the scenes, the Arcade Gateway and the Twitch auth provider seamlessly manage Twitch OAuth 2.0 authorization for your users.
 
 ### What's documented here
 
@@ -31,7 +31,7 @@ This auth provider is used by:
 - Select the 'Confidential' Client Type
 - Copy the App key (Client ID) and App secret (Client Secret), which you'll need below
 
-Next, add the Twitch app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the Twitch app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Twitch auth with the Arcade Dashboard
 
@@ -41,9 +41,9 @@ Next, add the Twitch app to your Arcade Engine configuration. You can do this in
 4. Enter your **Client ID** and **Client Secret** from your Twitch app.
 5. Click **Save**.
 
-When you use tools that require Twitch auth using your Arcade account credentials, the Arcade Engine will automatically use this Twitch OAuth provider.
+When you use tools that require Twitch auth using your Arcade account credentials, the Arcade Gateway will automatically use this Twitch OAuth provider.
 
-### Configuring Twitch auth in self-hosted Arcade Engine configuration
+### Configuring Twitch auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -70,7 +70,7 @@ TWITCH_CLIENT_ID="<your client ID>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/toolkits/productivity/asana.mdx
+++ b/pages/toolkits/productivity/asana.mdx
@@ -548,7 +548,7 @@ List the user workspaces.
 
 The Arcade Asana toolkit uses the [Asana auth provider](/home/auth-providers/asana) to connect to users' Asana accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Asana auth provider](/home/auth-providers/asana#configuring-asana-auth) with your own Asana app credentials.
 

--- a/pages/toolkits/productivity/confluence.mdx
+++ b/pages/toolkits/productivity/confluence.mdx
@@ -2,7 +2,7 @@ import {Tabs} from 'nextra/components'
 
 # Confluence
 
-The Atlassian auth provider enables tools and agents to call the Atlassian API on behalf of a user. Behind the scenes, the Arcade Engine and the Atlassian auth provider seamlessly manage Atlassian OAuth 2.0 authorization for your users.
+The Atlassian auth provider enables tools and agents to call the Atlassian API on behalf of a user. Behind the scenes, the Arcade Gateway and the Atlassian auth provider seamlessly manage Atlassian OAuth 2.0 authorization for your users.
 
 ### What's documented here
 
@@ -22,7 +22,7 @@ This auth provider is used by:
 - In the Permissions tab, enable any permissions you need for your app
 - In the Settings tab, copy the Client ID and Secret to use below
 
-Next, add the Atlassian app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the Atlassian app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Atlassian auth with the Arcade Dashboard
 
@@ -32,9 +32,9 @@ Next, add the Atlassian app to your Arcade Engine configuration. You can do this
 4. Enter your **Client ID** and **Client Secret** from your Atlassian app.
 5. Click **Save**.
 
-When you use tools that require Atlassian auth using your Arcade account credentials, the Arcade Engine will automatically use this Atlassian OAuth provider.
+When you use tools that require Atlassian auth using your Arcade account credentials, the Arcade Gateway will automatically use this Atlassian OAuth provider.
 
-### Configuring Atlassian auth in self-hosted Arcade Engine configuration
+### Configuring Atlassian auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -56,7 +56,7 @@ ATLASSIAN_CLIENT_ID="<your client ID>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/toolkits/productivity/dropbox.mdx
+++ b/pages/toolkits/productivity/dropbox.mdx
@@ -117,7 +117,7 @@ Note: to call this tool, you must provide either `file_path` or `file_id`.
 
 The Arcade Dropbox toolkit uses the [Dropbox auth provider](/home/auth-providers/dropbox) to connect to users' Dropbox accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Dropbox auth provider](/home/auth-providers/dropbox#configuring-dropbox-auth) with your own Dropbox app credentials.
 

--- a/pages/toolkits/productivity/google/calendar.mdx
+++ b/pages/toolkits/productivity/google/calendar.mdx
@@ -234,7 +234,7 @@ Provides time slots when everyone is free within a given date range and time bou
 
 The Arcade Calendar toolkit uses the [Google auth provider](/home/auth-providers/google) to connect to users' Google accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Google auth provider](/home/auth-providers/google#configuring-google-auth) with your own Google app credentials.
 

--- a/pages/toolkits/productivity/google/contacts.mdx
+++ b/pages/toolkits/productivity/google/contacts.mdx
@@ -129,7 +129,7 @@ Create a new contact record in Google Contacts.
 
 The Arcade Contacts toolkit uses the [Google auth provider](/home/auth-providers/google) to connect to users' Google accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Google auth provider](/home/auth-providers/google#configuring-google-auth) with your own Google app credentials.
 

--- a/pages/toolkits/productivity/google/docs.mdx
+++ b/pages/toolkits/productivity/google/docs.mdx
@@ -162,7 +162,7 @@ Create a Google Docs document with the specified title and text content.
 
 The Arcade Docs toolkit uses the [Google auth provider](/home/auth-providers/google) to connect to users' Google accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Google auth provider](/home/auth-providers/google#configuring-google-auth) with your own Google app credentials.
 

--- a/pages/toolkits/productivity/google/drive.mdx
+++ b/pages/toolkits/productivity/google/drive.mdx
@@ -164,7 +164,7 @@ picker flow, the prior tool can be retried.
 
 The Arcade Drive toolkit uses the [Google auth provider](/home/auth-providers/google) to connect to users' Google accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Google auth provider](/home/auth-providers/google#configuring-google-auth) with your own Google app credentials.
 

--- a/pages/toolkits/productivity/google/gmail.mdx
+++ b/pages/toolkits/productivity/google/gmail.mdx
@@ -195,7 +195,6 @@ Delete a draft email using the Gmail API.
 ## TrashEmail
 
 <Warning type="warning" emoji="⚠️">
-  The `TrashEmail` tool is currently only available on a self-hosted instance of the Arcade Gateway. To learn more about self-hosting, see the [self-hosting documentation](/home/install/local#install-the-engine).
 </Warning>
 
 <br />

--- a/pages/toolkits/productivity/google/gmail.mdx
+++ b/pages/toolkits/productivity/google/gmail.mdx
@@ -195,7 +195,7 @@ Delete a draft email using the Gmail API.
 ## TrashEmail
 
 <Warning type="warning" emoji="⚠️">
-  The `TrashEmail` tool is currently only available on a self-hosted instance of the Arcade Engine. To learn more about self-hosting, see the [self-hosting documentation](/home/install/local#install-the-engine).
+  The `TrashEmail` tool is currently only available on a self-hosted instance of the Arcade Gateway. To learn more about self-hosting, see the [self-hosting documentation](/home/install/local#install-the-engine).
 </Warning>
 
 <br />
@@ -390,7 +390,7 @@ Get the specified thread by ID.
 
 The Arcade Gmail toolkit uses the [Google auth provider](/home/auth-providers/google) to connect to users' Google accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Google auth provider](/home/auth-providers/google#configuring-google-auth) with your own Google app credentials.
 

--- a/pages/toolkits/productivity/google/sheets.mdx
+++ b/pages/toolkits/productivity/google/sheets.mdx
@@ -123,7 +123,7 @@ Write a value to a specific cell in a spreadsheet.
 
 The Arcade Sheets toolkit uses the [Google auth provider](/home/auth-providers/google) to connect to users' Google accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Google auth provider](/home/auth-providers/google#configuring-google-auth) with your own Google app credentials.
 

--- a/pages/toolkits/productivity/jira.mdx
+++ b/pages/toolkits/productivity/jira.mdx
@@ -2,7 +2,7 @@ import {Tabs} from 'nextra/components'
 
 # Atlassian auth provider
 
-The Atlassian auth provider enables tools and agents to call the Atlassian API on behalf of a user. Behind the scenes, the Arcade Engine and the Atlassian auth provider seamlessly manage Atlassian OAuth 2.0 authorization for your users.
+The Atlassian auth provider enables tools and agents to call the Atlassian API on behalf of a user. Behind the scenes, the Arcade Gateway and the Atlassian auth provider seamlessly manage Atlassian OAuth 2.0 authorization for your users.
 
 ### What's documented here
 
@@ -22,7 +22,7 @@ This auth provider is used by:
 - In the Permissions tab, enable any permissions you need for your app
 - In the Settings tab, copy the Client ID and Secret to use below
 
-Next, add the Atlassian app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the Atlassian app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Atlassian auth with the Arcade Dashboard
 
@@ -32,9 +32,9 @@ Next, add the Atlassian app to your Arcade Engine configuration. You can do this
 4. Enter your **Client ID** and **Client Secret** from your Atlassian app.
 5. Click **Save**.
 
-When you use tools that require Atlassian auth using your Arcade account credentials, the Arcade Engine will automatically use this Atlassian OAuth provider.
+When you use tools that require Atlassian auth using your Arcade account credentials, the Arcade Gateway will automatically use this Atlassian OAuth provider.
 
-### Configuring Atlassian auth in self-hosted Arcade Engine configuration
+### Configuring Atlassian auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -56,7 +56,7 @@ ATLASSIAN_CLIENT_ID="<your client ID>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/toolkits/productivity/microsoft/outlook_calendar.mdx
+++ b/pages/toolkits/productivity/microsoft/outlook_calendar.mdx
@@ -136,7 +136,7 @@ If the user has not set a timezone for their calendar, then the timezone will be
 
 The Arcade Outlook Calendar toolkit uses the [Microsoft auth provider](/home/auth-providers/microsoft) to connect to users' Microsoft accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Microsoft auth provider](/home/auth-providers/microsoft#configuring-microsoft-auth) with your own Microsoft app credentials.
 

--- a/pages/toolkits/productivity/microsoft/outlook_mail.mdx
+++ b/pages/toolkits/productivity/microsoft/outlook_mail.mdx
@@ -256,7 +256,7 @@ Exactly one of `well_known_folder_name` or `folder_id` MUST be provided.
 
 The Arcade Outlook Mail toolkit uses the [Microsoft auth provider](/home/auth-providers/microsoft) to connect to users' Microsoft accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Microsoft auth provider](/home/auth-providers/microsoft#configuring-microsoft-auth) with your own Microsoft app credentials.
 

--- a/pages/toolkits/productivity/notion.mdx
+++ b/pages/toolkits/productivity/notion.mdx
@@ -217,7 +217,7 @@ _None_
 
 The Arcade Notion toolkit uses the [Notion auth provider](/home/auth-providers/notion) to connect to users' Notion accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Notion auth provider](/home/auth-providers/notion#configuring-notion-auth) with your own Notion app credentials.
 

--- a/pages/toolkits/sales/hubspot.mdx
+++ b/pages/toolkits/sales/hubspot.mdx
@@ -124,7 +124,7 @@ The Arcade Cloud offers a default Hubspot auth provider. If you use it, there's 
 
 Alternatively, you can [configure a custom Hubspot auth provider](/home/auth-providers/hubspot#use-your-own-hubspot-app-credentials) with your own Hubspot app credentials. This way, your users will see your application's name requesting permission.
 
-### Self-hosted Arcade Engine
+### Self-hosted Arcade Gateway
 
 With a [self-hosted installation of Arcade](/home/install/local), you must [configure the Hubspot auth provider](/home/auth-providers/hubspot) with your own Hubspot app credentials.
 

--- a/pages/toolkits/social-communication/discord.mdx
+++ b/pages/toolkits/social-communication/discord.mdx
@@ -2,7 +2,7 @@ import { Tabs } from "nextra/components";
 
 # Discord auth provider
 
-The Discord auth provider enables tools and agents to call the Discord API on behalf of a user. Behind the scenes, the Arcade Engine and the Discord auth provider seamlessly manage Discord OAuth 2.0 authorization for your users.
+The Discord auth provider enables tools and agents to call the Discord API on behalf of a user. Behind the scenes, the Arcade Gateway and the Discord auth provider seamlessly manage Discord OAuth 2.0 authorization for your users.
 
 ### What's documented here
 
@@ -21,7 +21,7 @@ This auth provider is used by:
 - In the OAuth2 tab, set the redirect URI to: `https://cloud.arcade.dev/api/v1/oauth/callback`
 - Copy the Client ID and Client Secret (you may need to reset the secret to see it)
 
-Next, add the Discord app to your Arcade Engine configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
+Next, add the Discord app to your Arcade Gateway configuration. You can do this in the Arcade Dashboard, or by editing the `engine.yaml` file directly (for a self-hosted instance).
 
 ### Configuring Discord auth with the Arcade Dashboard
 
@@ -31,9 +31,9 @@ Next, add the Discord app to your Arcade Engine configuration. You can do this i
 4. Enter your **Client ID** and **Client Secret** from your Discord app.
 5. Click **Save**.
 
-When you use tools that require Discord auth using your Arcade account credentials, the Arcade Engine will automatically use this Discord OAuth provider.
+When you use tools that require Discord auth using your Arcade account credentials, the Arcade Gateway will automatically use this Discord OAuth provider.
 
-### Configuring Discord auth in self-hosted Arcade Engine configuration
+### Configuring Discord auth in self-hosted Arcade Gateway configuration
 
 <Steps>
 
@@ -55,7 +55,7 @@ DISCORD_CLIENT_ID="<your client ID>"
 
 <Tip>
   See [Engine configuration](/home/configure/engine) for more information on how
-  to set environment variables and configure the Arcade Engine.
+  to set environment variables and configure the Arcade Gateway.
 </Tip>
 
 ### Edit the Engine configuration

--- a/pages/toolkits/social-communication/linkedin.mdx
+++ b/pages/toolkits/social-communication/linkedin.mdx
@@ -66,7 +66,7 @@ Share a new text post to LinkedIn.
 
 The Arcade LinkedIn toolkit uses the [LinkedIn auth provider](/home/auth-providers/linkedin) to connect to users' LinkedIn accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the LinkedIn auth provider](/home/auth-providers/linkedin#configuring-linkedin-auth) with your own LinkedIn app credentials.
 

--- a/pages/toolkits/social-communication/reddit.mdx
+++ b/pages/toolkits/social-communication/reddit.mdx
@@ -346,7 +346,7 @@ Get posts that were created by the authenticated user sorted by newest first
 
 The Arcade Reddit toolkit uses the [Reddit auth provider](/home/auth-providers/reddit) to connect to users' Reddit accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Reddit auth provider](/home/auth-providers/reddit#configuring-reddit-auth) with your own Reddit app credentials.
 

--- a/pages/toolkits/social-communication/slack.mdx
+++ b/pages/toolkits/social-communication/slack.mdx
@@ -624,7 +624,7 @@ List all users in the authenticated user's Slack team.
 
 The Arcade Slack toolkit uses the [Slack auth provider](/home/auth-providers/slack) to connect to users' Slack accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the Slack auth provider](/home/auth-providers/slack#configuring-slack-auth) with your own Slack app credentials.
 

--- a/pages/toolkits/social-communication/x.mdx
+++ b/pages/toolkits/social-communication/x.mdx
@@ -211,7 +211,7 @@ Look up a user on X (Twitter) by their username.
 
 The Arcade X (Twitter) toolkit uses the [X auth provider](/home/auth-providers/x) to connect to users' X (formerly Twitter) accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade` as the name of the application that's requesting permission.
 
 With a self-hosted installation of Arcade, you need to [configure the X auth provider](/home/auth-providers/x#configuring-x-auth) with your own X (formerly Twitter) app credentials.
 

--- a/pages/toolkits/social-communication/zoom.mdx
+++ b/pages/toolkits/social-communication/zoom.mdx
@@ -65,7 +65,7 @@ Retrieve the invitation note for a specific Zoom meeting.
 
 The Arcade Zoom toolkit uses the [Zoom auth provider](/home/auth-providers/zoom) to connect to users' Zoom accounts.
 
-With the hosted Arcade Engine, there's nothing to configure. Your users will see `Arcade ` as the name of the application that's requesting permission.
+With the hosted Arcade Gateway, there's nothing to configure. Your users will see `Arcade ` as the name of the application that's requesting permission.
 
 
 With a self-hosted installation of Arcade, you need to [configure the Zoom auth provider](/home/auth-providers/zoom#configuring-zoom-auth) with your own Zoom app credentials.


### PR DESCRIPTION
This change was tricky.  In most places, I rebranded the "engine" to "gateway"... but all references to files (e.g. `engine.yaml`) stay the same for now.