### PR TITLE
fixed broken internal links in the 'Hosting options' section

### DIFF
--- a/pages/home/hosting-overview.mdx
+++ b/pages/home/hosting-overview.mdx
@@ -25,4 +25,4 @@ See [Hybrid Deployment](/home/hybrid-deployment/hybrid-worker) for more informat
 
 Local deployments involve running all of the Arcade services locally.  This is more complex than a hybrid deployment, but it does give you the flexibility to run Arcade anywhere.
 
-See [Local Deployment](/home/local-deployment/overview) for more information.
+See [Local Deployment](home/local-deployment/install/overview) for more information.

--- a/pages/home/local-deployment/install/docker.mdx
+++ b/pages/home/local-deployment/install/docker.mdx
@@ -25,7 +25,7 @@ The engine can be run with:
 docker run -d -p 9099:9099 -v ./engine.yaml:/bin/engine.yaml ghcr.io/arcadeai/engine:latest
 ```
 
-where config.yaml is the path to the [configuration file](/home/configure/templates).
+where config.yaml is the path to the [configuration file](/home/local-deployment/configure/templates).
 
 ## Worker
 

--- a/pages/home/local-deployment/install/local.mdx
+++ b/pages/home/local-deployment/install/local.mdx
@@ -37,7 +37,7 @@ pip install 'arcade-ai[evals]'
 arcade login
 ```
 
-For a simple example on using the Arcade CLI, see the [quickstart on building tools](/home/custom-tools)
+For a simple example on using the Arcade CLI, see the [quickstart on building tools](/home/build-tools/create-a-toolkit)
 
 ### Install the Engine
 
@@ -76,7 +76,7 @@ In order to run the Arcade worker, you'll need to install at least one tool. For
 pip install arcade-math
 ```
 
-For more information on installing toolkits, see the [Toolkit Installation](/home/install/toolkits) page.
+For more information on installing toolkits, see the [Toolkit Installation](/home/local-deployment/install/toolkits) page.
 
 To see all available toolkits, view the [Toolkits Page](/toolkits).
 
@@ -90,7 +90,7 @@ Edit the `engine.env` file to set the `OPENAI_API_KEY` environment variable:
 OPENAI_API_KEY="<your_openai_api_key>"
 ```
 
-See the [configuration overview](/home/configure/overview) for more information on how to configure Arcade Engine and how to locate the `engine.env` file.
+See the [configuration overview](/home/local-deployment/configure/overview) for more information on how to configure Arcade Engine and how to locate the `engine.env` file.
 
 ### Start the Engine and worker
 
@@ -118,14 +118,14 @@ To chat with the running Engine, in a separate terminal instance, run:
 arcade chat -h localhost
 ```
 
-You are now chatting with Arcade locally! To see an example of chatting, view the [quickstart](/home/custom-tools).
+You are now chatting with Arcade locally!
 
 </Steps>
 
 ## Next Steps
 
 - **Building Tools**: Learn how to build tools with your local Arcade Instance in the [Creating a Toolkit](/home/build-tools/create-a-toolkit) guide.
-- **Hosting With Docker**: Learn how to run the [Engine in Docker](/home/install/docker).
+- **Hosting With Docker**: Learn how to run the [Engine in Docker](/home/local-deployment/install/docker).
 
 ## Troubleshooting
 
@@ -197,6 +197,6 @@ The engine config will be downloaded by and added to one of these locations when
 
 When running the engine without `arcade dev`, the config needs to be in the `$HOME/.arcade/` directory or explicitly located with `arcade-engine -c /path/to/engine.yaml`
 
-If you cannot find your engine config, you can save and use the [Configuration Templates](/home/configure/templates).
+If you cannot find your engine config, you can save and use the [Configuration Templates](/home/local-deployment/configure/templates).
 
 ---

--- a/pages/home/local-deployment/install/overview.mdx
+++ b/pages/home/local-deployment/install/overview.mdx
@@ -7,8 +7,8 @@ description: "Installation options for Arcade"
 
 Explore the different installation options for Arcade.
 
-- Set up Arcade [locally](/home/install/local)
-- Run Arcade in [Docker](/home/install/docker)
+- Set up Arcade [locally](/home/local-deployment/install/local)
+- Run Arcade in [Docker](/home/local-deployment/install/docker)
 - Kubernetes (coming soon)
 
 ## Client
@@ -23,7 +23,7 @@ The Arcade CLI & SDK can be installed with `pip` by following the [CLI guide](/h
 
 ### Brew and APT
 
-The `arcade-engine` binary can be downloaded through system package managers like `brew` or `apt` following the instructions [here](/home/install/local#install-the-engine)
+The `arcade-engine` binary can be downloaded through system package managers like `brew` or `apt` following the instructions [here](/home/local-deployment/install/local#install-the-engine)
 
 ### Binary
 


### PR DESCRIPTION
Some of the internal links on the "Hosting options" section are currently broken, this PR restores these links.