### PR TITLE
Update Slack docs with new rate-limiting and API usage terms

### DIFF
--- a/pages/home/auth-providers/slack.mdx
+++ b/pages/home/auth-providers/slack.mdx
@@ -29,6 +29,12 @@ Before showing how to configure your Slack app credentials, let's go through the
 
 ### Create a Slack app
 
+<Warning>
+  In May 29, 2025, [Slack announced](https://api.slack.com/changelog/2025-05-terms-rate-limit-update-and-faq) changes to their API rate-limits and terms of service for apps that are not approved for the Slack Marketplace.
+
+  The `conversations.history` and `conversations.replies` endpoints are now limited to 1 request/minute and up to 15 objects returned per request. This affects various tools in the [Arcade Slack toolkit](/toolkits/social-communication/slack). Additionally, the [API Terms of Service](https://slack.com/terms-of-service/api) now requires [Slack Marketplace](https://api.slack.com/slack-marketplace/using) approval for commercial distribution.
+</Warning>
+
 - Follow Slack's guide to [registering a Slack app](https://api.slack.com/quickstart)
 - Choose the scopes (permissions) you need for your app
 - Set the redirect URL to: `https://cloud.arcade.dev/api/v1/oauth/callback`

--- a/pages/toolkits/social-communication/slack.mdx
+++ b/pages/toolkits/social-communication/slack.mdx
@@ -30,6 +30,10 @@ The Arcade Slack toolkit provides a comprehensive set of tools for interacting w
 - Retrieve messages in a channel, direct or multi-person conversation
 - Retrieve conversation metadata
 
+<Warning>
+  If you intend to use this toolkit for commercial purposes, you must [create your own Slack App](/home/auth-providers/slack#create-a-slack-app) and seek [Marketplace approval](https://api.slack.com/slack-marketplace/using), according to Slack API [Terms of Service](https://slack.com/terms-of-service/api).
+</Warning>
+
 ## Available Tools
 
 These tools are currently available in the Arcade Slack toolkit.
@@ -231,6 +235,10 @@ Get the members of a channel in Slack by the channel's name.
   ]}
 />
 
+<Warning>
+  Slack Apps that are not [Marketplace](https://api.slack.com/slack-marketplace/using)-approved [will be limited](https://api.slack.com/changelog/2025-05-terms-rate-limit-update-and-faq) to 1 request/minute and up to 15 objects returned per request when using this tool.
+</Warning>
+
 Get the history of a conversation in Slack.
 
 **Parameters**
@@ -261,6 +269,10 @@ Get the history of a conversation in Slack.
     }
   ]}
 />
+
+<Warning>
+  Slack Apps that are not [Marketplace](https://api.slack.com/slack-marketplace/using)-approved [will be limited](https://api.slack.com/changelog/2025-05-terms-rate-limit-update-and-faq) to 1 request/minute and up to 15 objects returned per request when using this tool.
+</Warning>
 
 Get the messages in a channel in Slack.
 
@@ -293,6 +305,10 @@ Get the messages in a channel in Slack.
   ]}
 />
 
+<Warning>
+  Slack Apps that are not [Marketplace](https://api.slack.com/slack-marketplace/using)-approved [will be limited](https://api.slack.com/changelog/2025-05-terms-rate-limit-update-and-faq) to 1 request/minute and up to 15 objects returned per request when using this tool.
+</Warning>
+
 Get the messages in a Direct Message conversation with another user in Slack.
 
 **Parameters**
@@ -323,6 +339,10 @@ Get the messages in a Direct Message conversation with another user in Slack.
     }
   ]}
 />
+
+<Warning>
+  Slack Apps that are not [Marketplace](https://api.slack.com/slack-marketplace/using)-approved [will be limited](https://api.slack.com/changelog/2025-05-terms-rate-limit-update-and-faq) to 1 request/minute and up to 15 objects returned per request when using this tool.
+</Warning>
 
 Get the messages in a multi-person direct message conversation in Slack by the usernames of the participants (other than the currently authenticated user).
 


### PR DESCRIPTION
In May 29, [Slack announced](https://api.slack.com/changelog/2025-05-terms-rate-limit-update-and-faq) severe rate-limit reduction for the `conversations.history` endpoint, which many of our tools rely on. Additionally, it now requires all commercial applications to seek Marketplace approval in order to use the Slack API. This PR updates the Slack toolkit and auth provider docs about these changes.