### PR TITLE
Replace user ID in examples with Arcade account email (if logged in)

### DIFF
--- a/examples/code/guides/agentauth/auth_with_google.js
+++ b/examples/code/guides/agentauth/auth_with_google.js
@@ -13,8 +13,10 @@ import { google } from "googleapis";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-// Your app's internal ID for the user (an email, UUID, etc). It's used internally to identify your user in Arcade, not to identify with the Gmail service.
-const user_id = "user@example.com";
+// Your app's internal ID for the user (an email, UUID, etc).
+// It's used internally to identify your user in Arcade, not to identify with the Gmail service.
+// Use your Arcade account email for testing:
+const user_id = "{arcade_user_id}";
 
 // Start the authorization process
 let auth_response = await client.auth.start(user_id, "google", {

--- a/examples/code/guides/agentauth/auth_with_google.py
+++ b/examples/code/guides/agentauth/auth_with_google.py
@@ -15,7 +15,7 @@ Below we are just showing how to use Arcade as an auth provider, if you need to 
 """
 
 # This would be your app's internal ID for the user (an email, UUID, etc.)
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 # Start the authorization process
 auth_response = client.auth.start(

--- a/examples/code/home/crewai/custom_auth_flow.py
+++ b/examples/code/home/crewai/custom_auth_flow.py
@@ -4,7 +4,7 @@ from crewai import Agent, Crew, Task
 from crewai.llm import LLM
 from crewai_arcade import ArcadeToolManager
 
-USER_ID = "user@example.com"
+USER_ID = "{arcade_user_id}"
 
 def custom_auth_flow(
     manager: ArcadeToolManager, tool_name: str, **tool_input: dict[str, Any]

--- a/examples/code/home/crewai/custom_auth_flow_callback_section.py
+++ b/examples/code/home/crewai/custom_auth_flow_callback_section.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from crewai_arcade import ArcadeToolManager
 
-USER_ID = "user@example.com"
+USER_ID = "{arcade_user_id}"
 
 def custom_auth_flow(
     manager: ArcadeToolManager, tool_name: str, **tool_input: dict[str, Any]

--- a/examples/code/home/crewai/use_arcade_tools.py
+++ b/examples/code/home/crewai/use_arcade_tools.py
@@ -2,7 +2,7 @@ from crewai import Agent, Crew, Task
 from crewai.llm import LLM
 from crewai_arcade import ArcadeToolManager
 
-manager = ArcadeToolManager(default_user_id="user@example.com")
+manager = ArcadeToolManager(default_user_id="{arcade_user_id}")
 
 tools = manager.get_tools(tools=["Google.ListEmails"])
 

--- a/examples/code/home/mcp/streamable-http/typescript-client.ts.fake
+++ b/examples/code/home/mcp/streamable-http/typescript-client.ts.fake
@@ -9,7 +9,7 @@ import {
 
 // Replace with your actual API key and user ID
 const arcadeApiKey = "your_arcade_api_key";
-const userId = "your_email@example.com";
+const userId = "{arcade_user_id}";
 const arcadeURL = "https://api.arcade.dev/v1";
 const serverURL = `${arcadeURL}/mcp`;
 

--- a/examples/code/home/use-tools/call-tools-directly/github_directly.js
+++ b/examples/code/home/use-tools/call-tools-directly/github_directly.js
@@ -2,7 +2,7 @@ import Arcade from "@arcadeai/arcadejs";
 
 const client = new Arcade();
 
-let userId = "you@example.com";
+let userId = "{arcade_user_id}";
 
 const response = await client.tools.execute({
   tool_name: "GitHub.SetStarred",

--- a/examples/code/home/use-tools/call-tools-directly/github_directly.py
+++ b/examples/code/home/use-tools/call-tools-directly/github_directly.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 response = client.tools.execute(
     tool_name="GitHub.SetStarred",

--- a/examples/code/home/use-tools/call-tools-directly/quickstart.mjs
+++ b/examples/code/home/use-tools/call-tools-directly/quickstart.mjs
@@ -2,12 +2,12 @@ import Arcade from "@arcadeai/arcadejs";
 
 // You can also set the `ARCADE_API_KEY` environment variable instead of passing it as a parameter.
 const client = new Arcade({
-  apiKey: "arcade_api_key",
+  apiKey: "{arcade_api_key}",
 });
 
 // Arcade needs a unique identifier for your application user (this could be an email address, a UUID, etc).
-// In this example, simply use your email address as the user ID:
-let userId = "you@example.com";
+// In this example, use the email you used to sign up for Arcade.dev:
+let userId = "{arcade_user_id}";
 
 // Let's use the `Math.Sqrt` tool from the Arcade Math toolkit to get the square root of a number.
 const response_sqrt = await client.tools.execute({

--- a/examples/code/home/use-tools/call-tools-directly/quickstart.py
+++ b/examples/code/home/use-tools/call-tools-directly/quickstart.py
@@ -1,11 +1,11 @@
 from arcadepy import Arcade
 
 # You can also set the `ARCADE_API_KEY` environment variable instead of passing it as a parameter.
-client = Arcade(api_key="arcade_api_key")
+client = Arcade(api_key="{arcade_api_key}")
 
 # Arcade needs a unique identifier for your application user (this could be an email address, a UUID, etc).
-# In this example, simply use your email address as the user ID:
-user_id = "user@example.com"
+# In this example, use the email you used to sign up for Arcade.dev:
+user_id = "{arcade_user_id}"
 
 # Let's use the `Math.Sqrt` tool from the Arcade Math toolkit to get the square root of a number.
 response = client.tools.execute(

--- a/examples/code/integrations/asana/custom_auth.js
+++ b/examples/code/integrations/asana/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade({ baseURL: "https://api.arcade.dev" }); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 // Start the authorization process
 const authResponse = await client.auth.start(userId, "asana", {

--- a/examples/code/integrations/asana/custom_auth.py
+++ b/examples/code/integrations/asana/custom_auth.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade(base_url="https://api.arcade.dev")  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 # Start the authorization process
 auth_response = client.auth.start(

--- a/examples/code/integrations/asana/custom_tool_call.js
+++ b/examples/code/integrations/asana/custom_tool_call.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade({ baseURL: "https://api.arcade.dev" }); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Asana.DeleteTask";
 
 // Start the authorization process

--- a/examples/code/integrations/asana/custom_tool_call.py
+++ b/examples/code/integrations/asana/custom_tool_call.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade(base_url="https://api.arcade.dev")  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Asana.DeleteTask"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME, user_id=USER_ID)

--- a/examples/code/integrations/atlassian/custom_auth.js
+++ b/examples/code/integrations/atlassian/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 // Start the authorization process
 let authResponse = await client.auth.start(userId, "atlassian", {

--- a/examples/code/integrations/atlassian/custom_auth.py
+++ b/examples/code/integrations/atlassian/custom_auth.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 # Start the authorization process
 auth_response = client.auth.start(

--- a/examples/code/integrations/discord/custom_auth.js
+++ b/examples/code/integrations/discord/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade();
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 // Start the authorization process
 const authResponse = await client.auth.start(userId, "discord", {

--- a/examples/code/integrations/discord/custom_auth.py
+++ b/examples/code/integrations/discord/custom_auth.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 # Start the authorization process
 auth_response = client.auth.start(

--- a/examples/code/integrations/dropbox/custom_auth.js
+++ b/examples/code/integrations/dropbox/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade();
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 // Start the authorization process
 const authResponse = await client.auth.start(userId, "dropbox", {

--- a/examples/code/integrations/dropbox/custom_auth.py
+++ b/examples/code/integrations/dropbox/custom_auth.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 # Start the authorization process
 auth_response = client.auth.start(

--- a/examples/code/integrations/github/custom_auth.js
+++ b/examples/code/integrations/github/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 /*
 In this example, we will use Arcade to authenticate with GitHub and retrieve

--- a/examples/code/integrations/github/custom_auth.py
+++ b/examples/code/integrations/github/custom_auth.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 """
 In this example, we will use Arcade to authenticate with GitHub and retrieve

--- a/examples/code/integrations/google/custom_auth.js
+++ b/examples/code/integrations/google/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 /*
 In this example, we will use Arcade to authenticate with Google and

--- a/examples/code/integrations/google/custom_auth.py
+++ b/examples/code/integrations/google/custom_auth.py
@@ -4,7 +4,7 @@ from googleapiclient.discovery import build
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 """
 In this example, we will use Arcade to authenticate with Google and

--- a/examples/code/integrations/hubspot/custom_auth.js
+++ b/examples/code/integrations/hubspot/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade({ baseURL: "https://api.arcade.dev" }); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 // Start the authorization process
 const authResponse = await client.auth.start(userId, "hubspot", {

--- a/examples/code/integrations/hubspot/custom_auth.py
+++ b/examples/code/integrations/hubspot/custom_auth.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade(base_url="https://api.arcade.dev")  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 # Start the authorization process
 auth_response = client.auth.start(

--- a/examples/code/integrations/hubspot/custom_tool_call.js
+++ b/examples/code/integrations/hubspot/custom_tool_call.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade({ baseURL: "https://api.arcade.dev" }); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Hubspot.GetCompanyDetails";
 
 // Start the authorization process

--- a/examples/code/integrations/hubspot/custom_tool_call.py
+++ b/examples/code/integrations/hubspot/custom_tool_call.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade(base_url="https://api.arcade.dev")  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Hubspot.GetCompanyDetails"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME, user_id=USER_ID)

--- a/examples/code/integrations/linkedin/custom_auth.js
+++ b/examples/code/integrations/linkedin/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 /*
 In this example, we will use Arcade to authenticate with LinkedIn and post a

--- a/examples/code/integrations/linkedin/custom_auth.py
+++ b/examples/code/integrations/linkedin/custom_auth.py
@@ -5,7 +5,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 """
 In this example, we will use Arcade to authenticate with LinkedIn and post a

--- a/examples/code/integrations/microsoft/custom_auth.js
+++ b/examples/code/integrations/microsoft/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade();
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 // Start the authorization process
 let authResponse = await client.auth.start(userId, "microsoft", {

--- a/examples/code/integrations/microsoft/custom_auth.py
+++ b/examples/code/integrations/microsoft/custom_auth.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 # Start the authorization process
 auth_response = client.auth.start(

--- a/examples/code/integrations/notion/custom_auth.js
+++ b/examples/code/integrations/notion/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade();
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 // Start the authorization process
 const authResponse = await client.auth.start(userId, "notion");

--- a/examples/code/integrations/notion/custom_auth.py
+++ b/examples/code/integrations/notion/custom_auth.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 # Start the authorization process
 auth_response = client.auth.start(

--- a/examples/code/integrations/oauth2/custom_auth.js
+++ b/examples/code/integrations/oauth2/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 // Start the authorization process
 let authResponse = await client.auth.start(userId, "hooli", [

--- a/examples/code/integrations/oauth2/custom_auth.py
+++ b/examples/code/integrations/oauth2/custom_auth.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 # Start the authorization process
 auth_response = client.auth.start(

--- a/examples/code/integrations/reddit/custom_auth.js
+++ b/examples/code/integrations/reddit/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade();
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 // Start the authorization process
 const authResponse = await client.auth.start(userId, "reddit", {

--- a/examples/code/integrations/reddit/custom_auth.py
+++ b/examples/code/integrations/reddit/custom_auth.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 # Start the authorization process
 auth_response = client.auth.start(

--- a/examples/code/integrations/salesforce/custom_auth.js
+++ b/examples/code/integrations/salesforce/custom_auth.js
@@ -4,7 +4,7 @@ const client = new Arcade((baseURL = "http://localhost:9099")); // Automatically
 
 const salesforceProviderId = "salesforce";
 const salesforceOrgSubdomain = "salesforce-org-subdomain";
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 const scopes = ["read_account"];
 
 // Start the authorization process

--- a/examples/code/integrations/salesforce/custom_auth.py
+++ b/examples/code/integrations/salesforce/custom_auth.py
@@ -5,7 +5,7 @@ client = Arcade(base_url="http://localhost:9099")  # Automatically finds the `AR
 
 salesforce_provider_id = "salesforce"
 salesforce_org_subdomain = "salesforce-org-subdomain"
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 scopes = ["read_account"]
 
 # Start the authorization process

--- a/examples/code/integrations/slack/custom_auth.js
+++ b/examples/code/integrations/slack/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 // Start the authorization process
 let authResponse = await client.auth.start(userId, "slack", {

--- a/examples/code/integrations/slack/custom_auth.py
+++ b/examples/code/integrations/slack/custom_auth.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 # Start the authorization process
 auth_response = client.auth.start(

--- a/examples/code/integrations/spotify/custom_auth.js
+++ b/examples/code/integrations/spotify/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 // Start the authorization process
 let authResponse = await client.auth.start(userId, "spotify", [

--- a/examples/code/integrations/spotify/custom_auth.py
+++ b/examples/code/integrations/spotify/custom_auth.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 # Start the authorization process
 auth_response = client.auth.start(

--- a/examples/code/integrations/twitch/custom_auth.js
+++ b/examples/code/integrations/twitch/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade();
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 // Start the authorization process
 const authResponse = await client.auth.start(userId, "twitch", {

--- a/examples/code/integrations/twitch/custom_auth.py
+++ b/examples/code/integrations/twitch/custom_auth.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 # Start the authorization process
 auth_response = client.auth.start(

--- a/examples/code/integrations/x/custom_auth.js
+++ b/examples/code/integrations/x/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 // Start the authorization process
 let authResponse = await client.auth.start(userId, "x", [

--- a/examples/code/integrations/x/custom_auth.py
+++ b/examples/code/integrations/x/custom_auth.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 # Start the authorization process
 auth_response = client.auth.start(

--- a/examples/code/integrations/zoom/custom_auth.js
+++ b/examples/code/integrations/zoom/custom_auth.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const userId = "user@example.com";
+const userId = "{arcade_user_id}";
 
 // Start the authorization process
 let authResponse = await client.auth.start(userId, "zoom", [

--- a/examples/code/integrations/zoom/custom_auth.py
+++ b/examples/code/integrations/zoom/custom_auth.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 # Start the authorization process
 auth_response = client.auth.start(

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://arcade.dev/",
   "dependencies": {
     "@icons-pack/react-simple-icons": "^10.2.0",
+    "@ory/client": "^1.20.22",
     "@radix-ui/react-checkbox": "^1.2.3",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-label": "^2.1.4",

--- a/pages/home/auth/auth-tool-calling.mdx
+++ b/pages/home/auth/auth-tool-calling.mdx
@@ -53,7 +53,7 @@ This authorization must be approved by the user. By approving, the user allows y
 ```python
 # As the developer, you must identify the user you're authorizing
 # and pass a unique identifier for them (e.g. an email or user ID) to Arcade:
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 
 # Request access to the user's Gmail account
 auth_response = client.tools.authorize(
@@ -70,7 +70,7 @@ if auth_response.status != "completed":
 ```js
 // As the developer, you must identify the user you're authorizing
 // and pass a unique identifier for them (e.g. an email or user ID) to Arcade:
-const userId = "you@example.com";
+const userId = "{arcade_user_id}";
 
 // Request access to the user's Gmail account
 const authResponse = await client.tools.authorize({

--- a/pages/home/auth/call-third-party-apis-directly.mdx
+++ b/pages/home/auth/call-third-party-apis-directly.mdx
@@ -78,7 +78,7 @@ Create an instance of the Arcade client:
 
 ### Initiate an authorization request
 
-Use `client.auth.start` to initiate the authorization process:
+Use `client.auth.start()` to initiate the authorization process:
 
 <Tabs items={["Python", "JavaScript"]} storageKey="preferredLanguage">
 <Tabs.Tab>
@@ -87,7 +87,7 @@ Use `client.auth.start` to initiate the authorization process:
 ```
 </Tabs.Tab>
 <Tabs.Tab>
-```javascript file=<rootDir>/examples/code/guides/agentauth/auth_with_google.js#L16-L22
+```javascript file=<rootDir>/examples/code/guides/agentauth/auth_with_google.js#L16-L24
 
 ```
 </Tabs.Tab>
@@ -104,7 +104,7 @@ If authorization is not completed, prompt the user to visit the authorization UR
 ```
 </Tabs.Tab>
 <Tabs.Tab>
-```javascript file=<rootDir>/examples/code/guides/agentauth/auth_with_google.js#L24-L27
+```javascript file=<rootDir>/examples/code/guides/agentauth/auth_with_google.js#L26-L29
 
 ```
 </Tabs.Tab>
@@ -119,7 +119,7 @@ If authorization is not completed, prompt the user to visit the authorization UR
 ```
 </Tabs.Tab>
 <Tabs.Tab>
-```javascript file=<rootDir>/examples/code/guides/agentauth/auth_with_google.js#L30
+```javascript file=<rootDir>/examples/code/guides/agentauth/auth_with_google.js#L32
 
 ```
 </Tabs.Tab>
@@ -136,7 +136,7 @@ Once authorization is complete, you can use the obtained token to access the thi
 ```
 </Tabs.Tab>
 <Tabs.Tab>
-```javascript file=<rootDir>/examples/code/guides/agentauth/auth_with_google.js#L36-L47
+```javascript file=<rootDir>/examples/code/guides/agentauth/auth_with_google.js#L39-L49
 
 ```
 </Tabs.Tab>

--- a/pages/home/auth/tool-auth-status.mdx
+++ b/pages/home/auth/tool-auth-status.mdx
@@ -44,7 +44,7 @@ You can get a list of all available tools and check their authorization status f
 <Tabs items={["Python", "JavaScript"]} storageKey="preferredLanguage">
 <Tabs.Tab>
 ```python
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 
 # Get all tools for the user
 tools = client.tools.list(user_id=USER_ID)
@@ -73,7 +73,7 @@ for tool in tools:
 </Tabs.Tab>
 <Tabs.Tab>
 ```js
-const userId = "you@example.com";
+const userId = "{arcade_user_id}";
 
 // Get all tools for the user
 const tools = await client.tools.list({ user_id: userId });
@@ -119,7 +119,7 @@ You can also check the authorization status for a specific tool by name:
 <Tabs items={["Python", "JavaScript"]} storageKey="preferredLanguage">
 <Tabs.Tab>
 ```python
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.ListEmails"
 
 # Get specific tool details
@@ -149,7 +149,7 @@ if tool.requirements:
 </Tabs.Tab>
 <Tabs.Tab>
 ```js
-const userId = "you@example.com";
+const userId = "{arcade_user_id}";
 const toolName = "Google.ListEmails";
 
 // Get specific tool details

--- a/pages/home/build-tools/create-a-tool-with-auth.mdx
+++ b/pages/home/build-tools/create-a-tool-with-auth.mdx
@@ -113,7 +113,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 
 # Use the tool
 response = client.tools.execute(

--- a/pages/home/crewai/use-arcade-tools.mdx
+++ b/pages/home/crewai/use-arcade-tools.mdx
@@ -41,7 +41,7 @@ Use the `ArcadeToolManager` to initialize, add, and get Arcade tools:
 ```python
 from crewai_arcade import ArcadeToolManager
 
-manager = ArcadeToolManager(default_user_id="user@example.com")
+manager = ArcadeToolManager(default_user_id="{arcade_user_id}")
 
 """
 Retrieves the provided tools and/or toolkits as CrewAI StructuredTools.

--- a/pages/home/faq.mdx
+++ b/pages/home/faq.mdx
@@ -36,7 +36,7 @@ This is an important observation. Technically, both included and custom provider
 
 ### Can my users connect multiple accounts of the same provider?
 
-Today this is possible if you assign multiple Arcade `user_id`s to the same user on your system. You will need to manage the mapping between users in your system and the different Arcade `user_id`s assigned to them.
+Please [contact us](mailto:support@arcade.dev) if you need this feature.
 
 ### Can I authenticate multiple tools at once?
 
@@ -51,7 +51,7 @@ Tools](/home/auth-providers/google), you can use this code to authenticate once:
 from arcadepy import Arcade
 
 client = Arcade() # Automatically finds the `ARCADE_API_KEY` env variable
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 
 # get the list of tools
 tools = client.tools.list(toolkit="Google")
@@ -79,7 +79,7 @@ if auth_response.status != "complete":
 import Arcade from "@arcadeai/arcadejs";
 
 const client = new Arcade();
-const user_id = "user@example.com";
+const user_id = "{arcade_user_id}";
 
 // get the list of tools
 const googleToolkit = await client.tools.list({toolkit: "google"})

--- a/pages/home/google-adk/overview.mdx
+++ b/pages/home/google-adk/overview.mdx
@@ -44,7 +44,7 @@ from google_adk_arcade.tools import get_arcade_tools
 
 async def main():
     app_name = 'my_app'
-    user_id = 'user@example.com'
+    user_id = '{arcade_user_id}'
     session_service = InMemorySessionService()
     artifact_service = InMemoryArtifactService()
     client = AsyncArcade()

--- a/pages/home/langchain/auth-langchain-tools.mdx
+++ b/pages/home/langchain/auth-langchain-tools.mdx
@@ -82,7 +82,7 @@ const arcade = new Arcade();
 <Tabs items={["Python", "JavaScript"]} storageKey="preferredLanguage">
 <Tabs.Tab>
 ```python
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 auth_response = client.auth.start(
     user_id=user_id,
     provider="google",
@@ -92,7 +92,7 @@ auth_response = client.auth.start(
 </Tabs.Tab>
 <Tabs.Tab>
 ```javascript
-const USER_ID = "user@example.com";
+const USER_ID = "{arcade_user_id}";
 const authResponse = await arcade.auth.start(USER_ID, "google", {
 	scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
 });

--- a/pages/home/langchain/use-arcade-tools.mdx
+++ b/pages/home/langchain/use-arcade-tools.mdx
@@ -164,7 +164,7 @@ Supply a basic config dictionary and a user query. Notice that user_id is requir
 config = {
     "configurable": {
         "thread_id": "1",
-        "user_id": "user@example.coom"
+        "user_id": "{arcade_user_id}"
     }
 }
 user_input = {
@@ -179,7 +179,7 @@ user_input = {
 const config = {
 	configurable: {
 		thread_id: "1",
-		user_id: "user@example.com",
+		user_id: "{arcade_user_id}",
 	},
 	streamMode: "values" as const,
 };

--- a/pages/home/langchain/user-auth-interrupts.mdx
+++ b/pages/home/langchain/user-auth-interrupts.mdx
@@ -85,7 +85,7 @@ import { ChatOpenAI } from "@langchain/openai";
 const arcade = new Arcade();
 
 // Replace with your application's user ID (e.g. email address, UUID, etc.)
-const USER_ID = "user@example.com";
+const USER_ID = "{arcade_user_id}";
 
 // Initialize tools from Google toolkit
 const googleToolkit = await arcade.tools.list({ toolkit: "google", limit: 30 });
@@ -324,7 +324,7 @@ inputs = {
 }
 
 # Configuration with thread and user IDs for authorization purposes
-config = {"configurable": {"thread_id": "4", "user_id": "user@example.com"}}
+config = {"configurable": {"thread_id": "4", "user_id": "{arcade_user_id}"}}
 
 # Run the graph and stream the outputs
 for chunk in graph.stream(inputs, config=config, stream_mode="values"):

--- a/pages/home/oai-agents/overview.mdx
+++ b/pages/home/oai-agents/overview.mdx
@@ -76,7 +76,7 @@ async def main():
         result = await Runner.run(
             starting_agent=google_agent,
             input="What are my latest emails?",
-            context={"user_id": "user@example.com"},
+            context={"user_id": "{arcade_user_id}"},
         )
         print("Final output:\n\n", result.final_output)
     except AuthorizationError as e:

--- a/pages/home/oai-agents/use-arcade-tools.mdx
+++ b/pages/home/oai-agents/use-arcade-tools.mdx
@@ -191,7 +191,7 @@ try:
     result = await Runner.run(
         starting_agent=google_agent,
         input="What are my latest emails?",
-        context={"user_id": "user@example.com"},
+        context={"user_id": "{arcade_user_id}"},
     )
     print("Final output:\n\n", result.final_output)
 except AuthorizationError as e:
@@ -200,7 +200,7 @@ except AuthorizationError as e:
 
 </Tabs.Tab>
 
-<Tabs.Tab> 
+<Tabs.Tab>
 ```javascript
 const result = await run(googleAgent, "What are my latest emails?");
 ```
@@ -273,7 +273,7 @@ async def main():
         result = await Runner.run(
             starting_agent=google_agent,
             input="What are my latest emails?",
-            context={"user_id": "user@example.com"},
+            context={"user_id": "{arcade_user_id}"},
         )
         print("Final output:\n\n", result.final_output)
     except AuthorizationError as e:

--- a/pages/home/oai-agents/user-auth-interrupts.mdx
+++ b/pages/home/oai-agents/user-auth-interrupts.mdx
@@ -134,7 +134,7 @@ try:
         starting_agent=github_agent,
         input="Star the arcadeai/arcade-ai repo",
         # Pass a unique user_id for authentication
-        context={"user_id": "user@example.com"},
+        context={"user_id": "{arcade_user_id}"},
     )
     print("Final output:\n\n", result.final_output)
 except AuthorizationError as e:
@@ -240,7 +240,7 @@ except AuthorizationError as e:
         result = await Runner.run(
             starting_agent=github_agent,
             input="Star the arcadeai/arcade-ai repo",
-            context={"user_id": "user@example.com"},
+            context={"user_id": "{arcade_user_id}"},
         )
         print("Final output:\n\n", result.final_output)
 ```
@@ -278,7 +278,7 @@ while (true) {
         if (response.status !== "completed") {
           console.log(`Please complete the authorization challenge in your browser: ${response.url}`);
         }
-        
+
         // Wait for the authorization to complete
         await client.auth.waitForCompletion(response);
         console.log("Authorization completed, retrying...");
@@ -324,7 +324,7 @@ async def main():
         tools=tools,
     )
 
-    user_id = "user@example.com"  # Make sure to use a unique user ID
+    user_id = "{arcade_user_id}"  # Make sure to use a unique user ID
 
     while True:
         try:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@icons-pack/react-simple-icons':
         specifier: ^10.2.0
         version: 10.2.0(react@19.0.0)
+      '@ory/client':
+        specifier: ^1.20.22
+        version: 1.20.22
       '@radix-ui/react-checkbox':
         specifier: ^1.2.3
         version: 1.2.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -856,6 +859,9 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@ory/client@1.20.22':
+    resolution: {integrity: sha512-N0UixgrJ7Xi0O5bttaFbJrtQhZAi61z69d9p/3tn71/nfBPOVTb8mOJIOlPhQIECj/11A65ttzI2R0QhEIeQEw==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1912,6 +1918,9 @@ packages:
   async-sema@3.1.1:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   autoprefixer@10.4.20:
     resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1926,6 +1935,9 @@ packages:
   axe-core@4.10.2:
     resolution: {integrity: sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==}
     engines: {node: '>=4'}
+
+  axios@1.10.0:
+    resolution: {integrity: sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -2112,6 +2124,10 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   comma-separated-tokens@1.0.8:
     resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
@@ -2428,6 +2444,10 @@ packages:
 
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   depd@1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
@@ -2848,12 +2868,25 @@ packages:
   flexsearch@0.7.43:
     resolution: {integrity: sha512-c5o/+Um8aqCSOXGcZoqZOm+NqtVwNsvVpWv6lfmSclU954O3wvQKxxK8zj74fPaSJbXpSLTs4PRhh+wnoCXnKg==}
 
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
 
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
+
+  form-data@4.0.3:
+    resolution: {integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==}
+    engines: {node: '>= 6'}
 
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
@@ -3699,6 +3732,14 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
@@ -4282,6 +4323,9 @@ packages:
 
   property-information@6.5.0:
     resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
@@ -5972,6 +6016,12 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@ory/client@1.20.22':
+    dependencies:
+      axios: 1.10.0
+    transitivePeerDependencies:
+      - debug
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -7124,6 +7174,8 @@ snapshots:
 
   async-sema@3.1.1: {}
 
+  asynckit@0.4.0: {}
+
   autoprefixer@10.4.20(postcss@8.5.1):
     dependencies:
       browserslist: 4.24.4
@@ -7139,6 +7191,14 @@ snapshots:
       possible-typed-array-names: 1.0.0
 
   axe-core@4.10.2: {}
+
+  axios@1.10.0:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.3
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   axobject-query@4.1.0: {}
 
@@ -7327,6 +7387,10 @@ snapshots:
     optional: true
 
   colorette@2.0.20: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   comma-separated-tokens@1.0.8: {}
 
@@ -7629,6 +7693,8 @@ snapshots:
   delaunator@5.0.1:
     dependencies:
       robust-predicates: 3.0.2
+
+  delayed-stream@1.0.0: {}
 
   depd@1.1.2: {}
 
@@ -8222,6 +8288,8 @@ snapshots:
 
   flexsearch@0.7.43: {}
 
+  follow-redirects@1.15.9: {}
+
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
@@ -8230,6 +8298,14 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data@4.0.3:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
 
   format@0.2.2: {}
 
@@ -9502,6 +9578,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   mime@3.0.0: {}
 
   mimic-fn@2.1.0: {}
@@ -10055,6 +10137,8 @@ snapshots:
       xtend: 4.0.2
 
   property-information@6.5.0: {}
+
+  proxy-from-env@1.1.0: {}
 
   pump@3.0.2:
     dependencies:

--- a/public/examples/integrations/toolkits/code-sandbox/create_static_matplotlib_chart_example_call_tool.js
+++ b/public/examples/integrations/toolkits/code-sandbox/create_static_matplotlib_chart_example_call_tool.js
@@ -3,7 +3,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 // Initialize the Arcade client
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "CodeSandbox.CreateStaticMatplotlibChart";
 
 // Define the code to create a chart

--- a/public/examples/integrations/toolkits/code-sandbox/create_static_matplotlib_chart_example_call_tool.py
+++ b/public/examples/integrations/toolkits/code-sandbox/create_static_matplotlib_chart_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 # Initialize the Arcade client
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "CodeSandbox.CreateStaticMatplotlibChart"
 
 # Define the code to create a chart

--- a/public/examples/integrations/toolkits/code-sandbox/run_code_example_call_tool.js
+++ b/public/examples/integrations/toolkits/code-sandbox/run_code_example_call_tool.js
@@ -3,7 +3,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 // Initialize the Arcade client
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "CodeSandbox.RunCode";
 
 // Define the code to merge sort a list

--- a/public/examples/integrations/toolkits/code-sandbox/run_code_example_call_tool.py
+++ b/public/examples/integrations/toolkits/code-sandbox/run_code_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 # Initialize the Arcade client
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "CodeSandbox.RunCode"
 
 # Define the code to merge sort a list

--- a/public/examples/integrations/toolkits/confluence/create_page_example_call_tool.js
+++ b/public/examples/integrations/toolkits/confluence/create_page_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Confluence.CreatePage";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/confluence/create_page_example_call_tool.py
+++ b/public/examples/integrations/toolkits/confluence/create_page_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Confluence.CreatePage"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/confluence/get_attachments_for_page_example_call_tool.js
+++ b/public/examples/integrations/toolkits/confluence/get_attachments_for_page_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Confluence.GetAttachmentsForPage";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/confluence/get_attachments_for_page_example_call_tool.py
+++ b/public/examples/integrations/toolkits/confluence/get_attachments_for_page_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Confluence.GetAttachmentsForPage"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/confluence/get_page_example_call_tool.js
+++ b/public/examples/integrations/toolkits/confluence/get_page_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Confluence.GetPage";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/confluence/get_page_example_call_tool.py
+++ b/public/examples/integrations/toolkits/confluence/get_page_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Confluence.GetPage"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/confluence/get_pages_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/confluence/get_pages_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Confluence.GetPagesById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/confluence/get_pages_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/confluence/get_pages_by_id_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Confluence.GetPagesById"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/confluence/get_space_example_call_tool.js
+++ b/public/examples/integrations/toolkits/confluence/get_space_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Confluence.GetSpace";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/confluence/get_space_example_call_tool.py
+++ b/public/examples/integrations/toolkits/confluence/get_space_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Confluence.GetSpace"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/confluence/get_space_hierarchy_example_call_tool.js
+++ b/public/examples/integrations/toolkits/confluence/get_space_hierarchy_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Confluence.GetSpaceHierarchy";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/confluence/get_space_hierarchy_example_call_tool.py
+++ b/public/examples/integrations/toolkits/confluence/get_space_hierarchy_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Confluence.GetSpaceHierarchy"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/confluence/list_attachments_example_call_tool.js
+++ b/public/examples/integrations/toolkits/confluence/list_attachments_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Confluence.ListAttachments";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/confluence/list_attachments_example_call_tool.py
+++ b/public/examples/integrations/toolkits/confluence/list_attachments_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Confluence.ListAttachments"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/confluence/list_pages_example_call_tool.js
+++ b/public/examples/integrations/toolkits/confluence/list_pages_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Confluence.ListPages";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/confluence/list_pages_example_call_tool.py
+++ b/public/examples/integrations/toolkits/confluence/list_pages_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Confluence.ListPages"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/confluence/list_spaces_example_call_tool.js
+++ b/public/examples/integrations/toolkits/confluence/list_spaces_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Confluence.ListSpaces";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/confluence/list_spaces_example_call_tool.py
+++ b/public/examples/integrations/toolkits/confluence/list_spaces_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Confluence.ListSpaces"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/confluence/rename_page_example_call_tool.js
+++ b/public/examples/integrations/toolkits/confluence/rename_page_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Confluence.RenamePage";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/confluence/rename_page_example_call_tool.py
+++ b/public/examples/integrations/toolkits/confluence/rename_page_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Confluence.RenamePage"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/confluence/search_content_example_call_tool.js
+++ b/public/examples/integrations/toolkits/confluence/search_content_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Confluence.SearchContent";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/confluence/search_content_example_call_tool.py
+++ b/public/examples/integrations/toolkits/confluence/search_content_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Confluence.SearchContent"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/confluence/update_page_content_example_call_tool.js
+++ b/public/examples/integrations/toolkits/confluence/update_page_content_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Confluence.UpdatePageContent";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/confluence/update_page_content_example_call_tool.py
+++ b/public/examples/integrations/toolkits/confluence/update_page_content_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Confluence.UpdatePageContent"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/github/count_stargazers_example_call_tool.js
+++ b/public/examples/integrations/toolkits/github/count_stargazers_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Github.CountStargazers";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/github/count_stargazers_example_call_tool.py
+++ b/public/examples/integrations/toolkits/github/count_stargazers_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Github.CountStargazers"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/github/create_issue_comment_example_call_tool.js
+++ b/public/examples/integrations/toolkits/github/create_issue_comment_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Github.CreateIssueComment";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/github/create_issue_comment_example_call_tool.py
+++ b/public/examples/integrations/toolkits/github/create_issue_comment_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Github.CreateIssueComment"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/github/create_issue_example_call_tool.js
+++ b/public/examples/integrations/toolkits/github/create_issue_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Github.CreateIssue";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/github/create_issue_example_call_tool.py
+++ b/public/examples/integrations/toolkits/github/create_issue_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Github.CreateIssue"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/github/create_reply_for_review_comment_example_call_tool.js
+++ b/public/examples/integrations/toolkits/github/create_reply_for_review_comment_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Github.CreateReplyForReviewComment";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/github/create_reply_for_review_comment_example_call_tool.py
+++ b/public/examples/integrations/toolkits/github/create_reply_for_review_comment_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Github.CreateReplyForReviewComment"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/github/create_review_comment_example_call_tool.js
+++ b/public/examples/integrations/toolkits/github/create_review_comment_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Github.CreateReviewComment";
 
 // Start the authorization process
@@ -32,4 +32,4 @@ const response = await client.tools.execute({
     user_id: USER_ID,
 });
 
-console.log(response); 
+console.log(response);

--- a/public/examples/integrations/toolkits/github/create_review_comment_example_call_tool.py
+++ b/public/examples/integrations/toolkits/github/create_review_comment_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Github.CreateReviewComment"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/github/get_pull_request_example_call_tool.js
+++ b/public/examples/integrations/toolkits/github/get_pull_request_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Github.GetPullRequest";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/github/get_pull_request_example_call_tool.py
+++ b/public/examples/integrations/toolkits/github/get_pull_request_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}}"
 TOOL_NAME = "Github.GetPullRequest"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/github/get_repository_example_call_tool.js
+++ b/public/examples/integrations/toolkits/github/get_repository_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Github.GetRepository";
 
 // Start the authorization process
@@ -29,4 +29,4 @@ const response = await client.tools.execute({
     user_id: USER_ID,
 });
 
-console.log(response); 
+console.log(response);

--- a/public/examples/integrations/toolkits/github/get_repository_example_call_tool.py
+++ b/public/examples/integrations/toolkits/github/get_repository_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Github.GetRepository"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/github/list_org_repositories_example_call_tool.js
+++ b/public/examples/integrations/toolkits/github/list_org_repositories_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Github.ListOrgRepositories";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/github/list_org_repositories_example_call_tool.py
+++ b/public/examples/integrations/toolkits/github/list_org_repositories_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Github.ListOrgRepositories"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/github/list_pull_request_commits_example_call_tool.js
+++ b/public/examples/integrations/toolkits/github/list_pull_request_commits_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Github.ListPullRequestCommits";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/github/list_pull_request_commits_example_call_tool.py
+++ b/public/examples/integrations/toolkits/github/list_pull_request_commits_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Github.ListPullRequestCommits"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/github/list_pull_requests_example_call_tool.js
+++ b/public/examples/integrations/toolkits/github/list_pull_requests_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}}";
 const TOOL_NAME = "Github.ListPullRequests";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/github/list_pull_requests_example_call_tool.py
+++ b/public/examples/integrations/toolkits/github/list_pull_requests_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Github.ListPullRequests"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/github/list_repository_activities_example_call_tool.js
+++ b/public/examples/integrations/toolkits/github/list_repository_activities_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Github.ListRepositoryActivities";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/github/list_repository_activities_example_call_tool.py
+++ b/public/examples/integrations/toolkits/github/list_repository_activities_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Github.ListRepositoryActivities"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/github/list_review_comments_in_a_repository_example_call_tool.js
+++ b/public/examples/integrations/toolkits/github/list_review_comments_in_a_repository_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Github.ListReviewCommentsInARepository";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/github/list_review_comments_in_a_repository_example_call_tool.py
+++ b/public/examples/integrations/toolkits/github/list_review_comments_in_a_repository_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Github.ListReviewCommentsInARepository"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/github/list_review_comments_on_pull_request_example_call_tool.js
+++ b/public/examples/integrations/toolkits/github/list_review_comments_on_pull_request_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Github.ListReviewCommentsOnPullRequest";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/github/list_review_comments_on_pull_request_example_call_tool.py
+++ b/public/examples/integrations/toolkits/github/list_review_comments_on_pull_request_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Github.ListReviewCommentsOnPullRequest"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/github/list_stargazers_example_call_tool.js
+++ b/public/examples/integrations/toolkits/github/list_stargazers_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Github.ListStargazers";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/github/list_stargazers_example_call_tool.py
+++ b/public/examples/integrations/toolkits/github/list_stargazers_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Github.ListStargazers"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/github/set_starred_example_call_tool.js
+++ b/public/examples/integrations/toolkits/github/set_starred_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Github.SetStarred";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/github/set_starred_example_call_tool.py
+++ b/public/examples/integrations/toolkits/github/set_starred_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Github.SetStarred"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/github/update_pull_request_example_call_tool.js
+++ b/public/examples/integrations/toolkits/github/update_pull_request_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Github.UpdatePullRequest";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/github/update_pull_request_example_call_tool.py
+++ b/public/examples/integrations/toolkits/github/update_pull_request_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Github.UpdatePullRequest"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/calendar/create_event_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/calendar/create_event_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.CreateEvent";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/calendar/create_event_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/calendar/create_event_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.CreateEvent"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/calendar/delete_event_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/calendar/delete_event_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.DeleteEvent";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/calendar/delete_event_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/calendar/delete_event_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.DeleteEvent"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/calendar/find_free_slots_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/calendar/find_free_slots_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.FindTimeSlotsWhenEveryoneIsFree";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/calendar/find_free_slots_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/calendar/find_free_slots_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.FindTimeSlotsWhenEveryoneIsFree"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/calendar/list_calendars_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/calendar/list_calendars_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.ListCalendars";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/calendar/list_calendars_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/calendar/list_calendars_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.ListCalendars"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/calendar/list_events_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/calendar/list_events_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.ListEvents";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/calendar/list_events_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/calendar/list_events_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.ListEvents"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/calendar/update_event_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/calendar/update_event_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.UpdateEvent";
 
 // Start the authorization process
@@ -33,4 +33,4 @@ const response = await client.tools.execute({
   user_id: USER_ID,
 });
 
-console.log(response); 
+console.log(response);

--- a/public/examples/integrations/toolkits/google/calendar/update_event_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/calendar/update_event_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.UpdateEvent"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/contacts/create_contact_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/contacts/create_contact_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.CreateContact";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/contacts/create_contact_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/contacts/create_contact_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.CreateContact"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/contacts/search_contacts_by_email_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/contacts/search_contacts_by_email_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.SearchContactsByEmail";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/contacts/search_contacts_by_email_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/contacts/search_contacts_by_email_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.SearchContactsByEmail"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/contacts/search_contacts_by_name_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/contacts/search_contacts_by_name_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.SearchContactsByName";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/contacts/search_contacts_by_name_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/contacts/search_contacts_by_name_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.SearchContactsByName"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/docs/create_blank_document_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/docs/create_blank_document_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.CreateBlankDocument";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/docs/create_blank_document_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/docs/create_blank_document_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.CreateBlankDocument"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/docs/create_document_from_text_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/docs/create_document_from_text_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.CreateDocumentFromText";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/docs/create_document_from_text_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/docs/create_document_from_text_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.CreateDocumentFromText"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/docs/get_document_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/docs/get_document_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.GetDocumentById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/docs/get_document_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/docs/get_document_by_id_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}}"
 TOOL_NAME = "Google.GetDocumentById"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/docs/insert_text_at_end_of_document_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/docs/insert_text_at_end_of_document_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}}";
 const TOOL_NAME = "Google.InsertTextAtEndOfDocument";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/docs/insert_text_at_end_of_document_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/docs/insert_text_at_end_of_document_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.InsertTextAtEndOfDocument"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/drive/generate_google_file_picker_url_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/drive/generate_google_file_picker_url_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.GenerateGoogleFilePickerUrl";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/drive/generate_google_file_picker_url_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/drive/generate_google_file_picker_url_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.GenerateGoogleFilePickerUrl"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/drive/get_file_tree_structure_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/drive/get_file_tree_structure_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.GetFileTreeStructure";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/drive/get_file_tree_structure_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/drive/get_file_tree_structure_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.GetFileTreeStructure"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/drive/search_and_retrieve_documents_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/drive/search_and_retrieve_documents_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.SearchAndRetrieveDocuments";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/drive/search_and_retrieve_documents_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/drive/search_and_retrieve_documents_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.SearchAndRetrieveDocuments"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/drive/search_documents_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/drive/search_documents_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.SearchDocuments";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/drive/search_documents_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/drive/search_documents_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.SearchDocuments"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/gmail/delete_draft_email_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/gmail/delete_draft_email_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.DeleteDraftEmail";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/gmail/delete_draft_email_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/gmail/delete_draft_email_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.DeleteDraftEmail"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/gmail/get_thread_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/gmail/get_thread_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.GetThread";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/gmail/get_thread_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/gmail/get_thread_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.GetThread"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/gmail/list_draft_emails_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/gmail/list_draft_emails_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.ListDraftEmails";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/gmail/list_draft_emails_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/gmail/list_draft_emails_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.ListDraftEmails"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/gmail/list_emails_by_header_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/gmail/list_emails_by_header_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.ListEmailsByHeader";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/gmail/list_emails_by_header_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/gmail/list_emails_by_header_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.ListEmailsByHeader"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/gmail/list_emails_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/gmail/list_emails_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.ListEmails";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/gmail/list_emails_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/gmail/list_emails_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.ListEmails"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/gmail/list_threads_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/gmail/list_threads_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.ListThreads";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/gmail/list_threads_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/gmail/list_threads_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.ListThreads"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/gmail/search_threads_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/gmail/search_threads_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.SearchThreads";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/gmail/search_threads_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/gmail/search_threads_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.SearchThreads"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/gmail/send_draft_email_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/gmail/send_draft_email_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.SendDraftEmail";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/gmail/send_draft_email_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/gmail/send_draft_email_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.SendDraftEmail"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/gmail/send_email_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/gmail/send_email_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.SendEmail";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/gmail/send_email_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/gmail/send_email_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.SendEmail"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/gmail/trash_email_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/gmail/trash_email_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.TrashEmail";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/gmail/trash_email_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/gmail/trash_email_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.TrashEmail"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/gmail/update_draft_email_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/gmail/update_draft_email_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.UpdateDraftEmail";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/gmail/update_draft_email_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/gmail/update_draft_email_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.UpdateDraftEmail"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/gmail/write_draft_email_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/gmail/write_draft_email_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.WriteDraftEmail";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/gmail/write_draft_email_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/gmail/write_draft_email_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.WriteDraftEmail"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/sheets/create_spreadsheet_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/sheets/create_spreadsheet_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.CreateSpreadsheet";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/sheets/create_spreadsheet_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/sheets/create_spreadsheet_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.CreateSpreadsheet"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/sheets/get_spreadsheet_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/sheets/get_spreadsheet_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.GetSpreadsheet";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/sheets/get_spreadsheet_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/sheets/get_spreadsheet_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.GetSpreadsheet"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/google/sheets/write_to_cell_example_call_tool.js
+++ b/public/examples/integrations/toolkits/google/sheets/write_to_cell_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Google.WriteToCell";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/google/sheets/write_to_cell_example_call_tool.py
+++ b/public/examples/integrations/toolkits/google/sheets/write_to_cell_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Google.WriteToCell"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/hubspot/create_contact_example_call_tool.js
+++ b/public/examples/integrations/toolkits/hubspot/create_contact_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Hubspot.CreateContact";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/hubspot/create_contact_example_call_tool.py
+++ b/public/examples/integrations/toolkits/hubspot/create_contact_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Hubspot.CreateContact"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME, user_id=USER_ID)

--- a/public/examples/integrations/toolkits/hubspot/get_company_data_by_keywords_example_call_tool.js
+++ b/public/examples/integrations/toolkits/hubspot/get_company_data_by_keywords_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Hubspot.GetCompanyDataByKeywords";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/hubspot/get_company_data_by_keywords_example_call_tool.py
+++ b/public/examples/integrations/toolkits/hubspot/get_company_data_by_keywords_example_call_tool.py
@@ -4,7 +4,7 @@ client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
 TOOL_NAME = "Hubspot.GetCompanyDataByKeywords"
 
-user_id = "user@example.com"
+user_id = "{arcade_user_id}"
 auth_response = client.tools.authorize(tool_name=TOOL_NAME, user_id=user_id)
 
 if auth_response.status != "completed":

--- a/public/examples/integrations/toolkits/hubspot/get_contact_data_by_keywords_example_call_tool.js
+++ b/public/examples/integrations/toolkits/hubspot/get_contact_data_by_keywords_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Hubspot.GetContactDataByKeywords";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/hubspot/get_contact_data_by_keywords_example_call_tool.py
+++ b/public/examples/integrations/toolkits/hubspot/get_contact_data_by_keywords_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Hubspot.GetContactDataByKeywords"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME, user_id=USER_ID)

--- a/public/examples/integrations/toolkits/jira/add_comment_to_issue_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/add_comment_to_issue_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.AddCommentToIssue";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/add_comment_to_issue_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/add_comment_to_issue_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.AddCommentToIssue"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/add_labels_to_issue_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/add_labels_to_issue_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.AddLabelsToIssue";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/add_labels_to_issue_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/add_labels_to_issue_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.AddLabelsToIssue"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/attach_file_to_issue_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/attach_file_to_issue_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.AttachFileToIssue";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/attach_file_to_issue_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/attach_file_to_issue_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.AttachFileToIssue"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/create_issue_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/create_issue_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.CreateIssue";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/create_issue_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/create_issue_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.CreateIssue"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/download_attachment_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/download_attachment_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.DownloadAttachment";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/download_attachment_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/download_attachment_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.DownloadAttachment"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/get_attachment_metadata_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/get_attachment_metadata_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.GetAttachmentMetadata";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/get_attachment_metadata_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/get_attachment_metadata_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.GetAttachmentMetadata"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/get_comment_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/get_comment_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.GetCommentById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/get_comment_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/get_comment_by_id_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.GetCommentById"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/get_issue_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/get_issue_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.GetIssueById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/get_issue_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/get_issue_by_id_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.GetIssueById"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/get_issue_comments_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/get_issue_comments_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.GetIssueComments";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/get_issue_comments_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/get_issue_comments_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.GetIssueComments"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/get_issue_type_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/get_issue_type_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.GetIssueTypeById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/get_issue_type_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/get_issue_type_by_id_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.GetIssueTypeById"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/get_issues_without_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/get_issues_without_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.GetIssuesWithoutId";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/get_issues_without_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/get_issues_without_id_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.GetIssuesWithoutId"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/get_priority_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/get_priority_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.GetPriorityById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/get_priority_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/get_priority_by_id_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.GetPriorityById"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/get_project_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/get_project_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.GetProjectById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/get_project_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/get_project_by_id_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.GetProjectById"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/get_transition_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/get_transition_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.GetTransitionById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/get_transition_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/get_transition_by_id_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.GetTransitionById"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/get_transition_by_status_name_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/get_transition_by_status_name_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.GetTransitionByStatusName";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/get_transition_by_status_name_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/get_transition_by_status_name_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.GetTransitionByStatusName"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/get_transitions_available_for_issue_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/get_transitions_available_for_issue_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.GetTransitionsAvailableForIssue";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/get_transitions_available_for_issue_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/get_transitions_available_for_issue_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.GetTransitionsAvailableForIssue"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/get_user_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/get_user_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.GetUserById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/get_user_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/get_user_by_id_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.GetUserById"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/get_users_without_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/get_users_without_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.GetUsersWithoutId";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/get_users_without_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/get_users_without_id_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.GetUsersWithoutId"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/list_issue_attachments_metadata_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/list_issue_attachments_metadata_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.ListIssueAttachmentsMetadata";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/list_issue_attachments_metadata_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/list_issue_attachments_metadata_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.ListIssueAttachmentsMetadata"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/list_issue_types_by_project_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/list_issue_types_by_project_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.ListIssueTypesByProject";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/list_issue_types_by_project_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/list_issue_types_by_project_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.ListIssueTypesByProject"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/list_issues_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/list_issues_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.ListIssues";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/list_issues_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/list_issues_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.ListIssues"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/list_labels_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/list_labels_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.ListLabels";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/list_labels_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/list_labels_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.ListLabels"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/list_priorities_associated_with_a_priority_scheme_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/list_priorities_associated_with_a_priority_scheme_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.ListPrioritiesAssociatedWithAPriorityScheme";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/list_priorities_associated_with_a_priority_scheme_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/list_priorities_associated_with_a_priority_scheme_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.ListPrioritiesAssociatedWithAPriorityScheme"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/list_priorities_available_to_a_project_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/list_priorities_available_to_a_project_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.ListPrioritiesAvailableToAProject";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/list_priorities_available_to_a_project_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/list_priorities_available_to_a_project_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.ListPrioritiesAvailableToAProject"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/list_priorities_available_to_an_issue_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/list_priorities_available_to_an_issue_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.ListPrioritiesAvailableToAnIssue";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/list_priorities_available_to_an_issue_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/list_priorities_available_to_an_issue_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.ListPrioritiesAvailableToAnIssue"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/list_priority_schemes_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/list_priority_schemes_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.ListPrioritySchemes";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/list_priority_schemes_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/list_priority_schemes_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.ListPrioritySchemes"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/list_projects_associated_with_a_priority_scheme_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/list_projects_associated_with_a_priority_scheme_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.ListProjectsAssociatedWithAPriorityScheme";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/list_projects_associated_with_a_priority_scheme_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/list_projects_associated_with_a_priority_scheme_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.ListProjectsAssociatedWithAPriorityScheme"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/list_projects_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/list_projects_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.ListProjects";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/list_projects_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/list_projects_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.ListProjects"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/list_users_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/list_users_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.ListUsers";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/list_users_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/list_users_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.ListUsers"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/remove_labels_from_issue_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/remove_labels_from_issue_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.RemoveLabelsFromIssue";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/remove_labels_from_issue_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/remove_labels_from_issue_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.RemoveLabelsFromIssue"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/search_issues_with_jql_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/search_issues_with_jql_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.SearchIssuesWithJql";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/search_issues_with_jql_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/search_issues_with_jql_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.SearchIssuesWithJql"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/search_issues_without_jql_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/search_issues_without_jql_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.SearchIssuesWithoutJql";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/search_issues_without_jql_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/search_issues_without_jql_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.SearchIssuesWithoutJql"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/search_projects_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/search_projects_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.SearchProjects";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/search_projects_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/search_projects_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.SearchProjects"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/transition_issue_to_new_status_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/transition_issue_to_new_status_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.TransitionIssueToNewStatus";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/transition_issue_to_new_status_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/transition_issue_to_new_status_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.TransitionIssueToNewStatus"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/jira/update_issue_example_call_tool.js
+++ b/public/examples/integrations/toolkits/jira/update_issue_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";  // Unique identifier for your user (email, UUID, etc.)
+const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
 const TOOL_NAME = "Jira.UpdateIssue";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/jira/update_issue_example_call_tool.py
+++ b/public/examples/integrations/toolkits/jira/update_issue_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"  # Unique identifier for your user (email, UUID, etc.)
+USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
 TOOL_NAME = "Jira.UpdateIssue"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME)

--- a/public/examples/integrations/toolkits/linkedin/create_text_post_example_call_tool.js
+++ b/public/examples/integrations/toolkits/linkedin/create_text_post_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "LinkedIn.CreateTextPost";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/linkedin/create_text_post_example_call_tool.py
+++ b/public/examples/integrations/toolkits/linkedin/create_text_post_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "LinkedIn.CreateTextPost"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/microsoft/outlook_calendar/create_event_example_call_tool.js
+++ b/public/examples/integrations/toolkits/microsoft/outlook_calendar/create_event_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Microsoft.CreateEvent";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/microsoft/outlook_calendar/create_event_example_call_tool.py
+++ b/public/examples/integrations/toolkits/microsoft/outlook_calendar/create_event_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Microsoft.CreateEvent"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/microsoft/outlook_calendar/get_event_example_call_tool.js
+++ b/public/examples/integrations/toolkits/microsoft/outlook_calendar/get_event_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Microsoft.GetEvent";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/microsoft/outlook_calendar/get_event_example_call_tool.py
+++ b/public/examples/integrations/toolkits/microsoft/outlook_calendar/get_event_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Microsoft.GetEvent"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/microsoft/outlook_calendar/list_events_in_time_range_example_call_tool.js
+++ b/public/examples/integrations/toolkits/microsoft/outlook_calendar/list_events_in_time_range_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Microsoft.ListEventsInTimeRange";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/microsoft/outlook_calendar/list_events_in_time_range_example_call_tool.py
+++ b/public/examples/integrations/toolkits/microsoft/outlook_calendar/list_events_in_time_range_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Microsoft.ListEventsInTimeRange"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/microsoft/outlook_mail/create_and_send_email_example_call_tool.js
+++ b/public/examples/integrations/toolkits/microsoft/outlook_mail/create_and_send_email_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Microsoft.CreateAndSendEmail";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/microsoft/outlook_mail/create_and_send_email_example_call_tool.py
+++ b/public/examples/integrations/toolkits/microsoft/outlook_mail/create_and_send_email_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Microsoft.CreateAndSendEmail"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/microsoft/outlook_mail/create_draft_email_example_call_tool.js
+++ b/public/examples/integrations/toolkits/microsoft/outlook_mail/create_draft_email_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Microsoft.CreateDraftEmail";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/microsoft/outlook_mail/create_draft_email_example_call_tool.py
+++ b/public/examples/integrations/toolkits/microsoft/outlook_mail/create_draft_email_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Microsoft.CreateDraftEmail"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/microsoft/outlook_mail/list_emails_by_property_example_call_tool.js
+++ b/public/examples/integrations/toolkits/microsoft/outlook_mail/list_emails_by_property_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Microsoft.ListEmailsByProperty";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/microsoft/outlook_mail/list_emails_by_property_example_call_tool.py
+++ b/public/examples/integrations/toolkits/microsoft/outlook_mail/list_emails_by_property_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Microsoft.ListEmailsByProperty"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/microsoft/outlook_mail/list_emails_example_call_tool.js
+++ b/public/examples/integrations/toolkits/microsoft/outlook_mail/list_emails_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Microsoft.ListEmails";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/microsoft/outlook_mail/list_emails_example_call_tool.py
+++ b/public/examples/integrations/toolkits/microsoft/outlook_mail/list_emails_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Microsoft.ListEmails"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/microsoft/outlook_mail/list_emails_in_folder_example_call_tool.js
+++ b/public/examples/integrations/toolkits/microsoft/outlook_mail/list_emails_in_folder_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Microsoft.ListEmailsInFolder";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/microsoft/outlook_mail/list_emails_in_folder_example_call_tool.py
+++ b/public/examples/integrations/toolkits/microsoft/outlook_mail/list_emails_in_folder_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Microsoft.ListEmailsInFolder"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/microsoft/outlook_mail/reply_to_email_example_call_tool.js
+++ b/public/examples/integrations/toolkits/microsoft/outlook_mail/reply_to_email_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Microsoft.ReplyToEmail";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/microsoft/outlook_mail/reply_to_email_example_call_tool.py
+++ b/public/examples/integrations/toolkits/microsoft/outlook_mail/reply_to_email_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Microsoft.ReplyToEmail"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/microsoft/outlook_mail/send_draft_email_example_call_tool.js
+++ b/public/examples/integrations/toolkits/microsoft/outlook_mail/send_draft_email_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Microsoft.SendDraftEmail";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/microsoft/outlook_mail/send_draft_email_example_call_tool.py
+++ b/public/examples/integrations/toolkits/microsoft/outlook_mail/send_draft_email_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Microsoft.SendDraftEmail"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/microsoft/outlook_mail/update_draft_email_example_call_tool.js
+++ b/public/examples/integrations/toolkits/microsoft/outlook_mail/update_draft_email_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Microsoft.UpdateDraftEmail";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/microsoft/outlook_mail/update_draft_email_example_call_tool.py
+++ b/public/examples/integrations/toolkits/microsoft/outlook_mail/update_draft_email_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Microsoft.UpdateDraftEmail"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/notion/create_page_example_call_tool.js
+++ b/public/examples/integrations/toolkits/notion/create_page_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "NotionToolkit.CreatePage";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/notion/create_page_example_call_tool.py
+++ b/public/examples/integrations/toolkits/notion/create_page_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "NotionToolkit.CreatePage"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/notion/get_object_metadata_example_call_tool.js
+++ b/public/examples/integrations/toolkits/notion/get_object_metadata_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "NotionToolkit.GetObjectMetadata";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/notion/get_object_metadata_example_call_tool.py
+++ b/public/examples/integrations/toolkits/notion/get_object_metadata_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "NotionToolkit.GetObjectMetadata"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/notion/get_page_content_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/notion/get_page_content_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "NotionToolkit.GetPageContentById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/notion/get_page_content_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/notion/get_page_content_by_id_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "NotionToolkit.GetPageContentById"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/notion/get_page_content_by_title_example_call_tool.js
+++ b/public/examples/integrations/toolkits/notion/get_page_content_by_title_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "NotionToolkit.GetPageContentByTitle";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/notion/get_page_content_by_title_example_call_tool.py
+++ b/public/examples/integrations/toolkits/notion/get_page_content_by_title_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "NotionToolkit.GetPageContentByTitle"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/notion/get_workspace_structure_example_call_tool.js
+++ b/public/examples/integrations/toolkits/notion/get_workspace_structure_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "NotionToolkit.GetWorkspaceStructure";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/notion/get_workspace_structure_example_call_tool.py
+++ b/public/examples/integrations/toolkits/notion/get_workspace_structure_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "NotionToolkit.GetWorkspaceStructure"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/notion/search_by_title_example_call_tool.js
+++ b/public/examples/integrations/toolkits/notion/search_by_title_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "NotionToolkit.SearchByTitle";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/notion/search_by_title_example_call_tool.py
+++ b/public/examples/integrations/toolkits/notion/search_by_title_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "NotionToolkit.SearchByTitle"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/reddit/check_subreddit_access_example_call_tool.js
+++ b/public/examples/integrations/toolkits/reddit/check_subreddit_access_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Reddit.CheckSubredditAccess";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/reddit/check_subreddit_access_example_call_tool.py
+++ b/public/examples/integrations/toolkits/reddit/check_subreddit_access_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Reddit.CheckSubredditAccess"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/reddit/comment_on_post_example_call_tool.js
+++ b/public/examples/integrations/toolkits/reddit/comment_on_post_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Reddit.CommentOnPost";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/reddit/comment_on_post_example_call_tool.py
+++ b/public/examples/integrations/toolkits/reddit/comment_on_post_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Reddit.CommentOnPost"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/reddit/get_content_of_multiple_posts_example_call_tool.js
+++ b/public/examples/integrations/toolkits/reddit/get_content_of_multiple_posts_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Reddit.GetContentOfMultiplePosts";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/reddit/get_content_of_multiple_posts_example_call_tool.py
+++ b/public/examples/integrations/toolkits/reddit/get_content_of_multiple_posts_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Reddit.GetContentOfMultiplePosts"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/reddit/get_content_of_post_example_call_tool.js
+++ b/public/examples/integrations/toolkits/reddit/get_content_of_post_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Reddit.GetContentOfPost";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/reddit/get_content_of_post_example_call_tool.py
+++ b/public/examples/integrations/toolkits/reddit/get_content_of_post_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Reddit.GetContentOfPost"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/reddit/get_my_posts_example_call_tool.js
+++ b/public/examples/integrations/toolkits/reddit/get_my_posts_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Reddit.GetMyPosts";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/reddit/get_my_posts_example_call_tool.py
+++ b/public/examples/integrations/toolkits/reddit/get_my_posts_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Reddit.GetMyPosts"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/reddit/get_my_username_example_call_tool.js
+++ b/public/examples/integrations/toolkits/reddit/get_my_username_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Reddit.GetMyUsername";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/reddit/get_my_username_example_call_tool.py
+++ b/public/examples/integrations/toolkits/reddit/get_my_username_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Reddit.GetMyUsername"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/reddit/get_posts_in_subreddit_example_call_tool.js
+++ b/public/examples/integrations/toolkits/reddit/get_posts_in_subreddit_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Reddit.GetPostsInSubreddit";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/reddit/get_posts_in_subreddit_example_call_tool.py
+++ b/public/examples/integrations/toolkits/reddit/get_posts_in_subreddit_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Reddit.GetPostsInSubreddit"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/reddit/get_subreddit_rules_example_call_tool.js
+++ b/public/examples/integrations/toolkits/reddit/get_subreddit_rules_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Reddit.GetSubredditRules";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/reddit/get_subreddit_rules_example_call_tool.py
+++ b/public/examples/integrations/toolkits/reddit/get_subreddit_rules_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Reddit.GetSubredditRules"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/reddit/get_top_level_comments_of_post_example_call_tool.js
+++ b/public/examples/integrations/toolkits/reddit/get_top_level_comments_of_post_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Reddit.GetTopLevelCommentsOfPost";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/reddit/get_top_level_comments_of_post_example_call_tool.py
+++ b/public/examples/integrations/toolkits/reddit/get_top_level_comments_of_post_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Reddit.GetTopLevelCommentsOfPost"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/reddit/reply_to_comment_example_call_tool.js
+++ b/public/examples/integrations/toolkits/reddit/reply_to_comment_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Reddit.ReplyToComment";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/reddit/reply_to_comment_example_call_tool.py
+++ b/public/examples/integrations/toolkits/reddit/reply_to_comment_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Reddit.ReplyToComment"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/reddit/submit_text_post_example_call_tool.js
+++ b/public/examples/integrations/toolkits/reddit/submit_text_post_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Reddit.SubmitTextPost";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/reddit/submit_text_post_example_call_tool.py
+++ b/public/examples/integrations/toolkits/reddit/submit_text_post_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Reddit.SubmitTextPost"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/salesforce/create_contact_example_call_tool.js
+++ b/public/examples/integrations/toolkits/salesforce/create_contact_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade({ baseURL: "http://localhost:9099" }); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Salesforce.CreateContact";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/salesforce/create_contact_example_call_tool.py
+++ b/public/examples/integrations/toolkits/salesforce/create_contact_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade(base_url="http://localhost:9099")  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Salesforce.CreateContact"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME, user_id=USER_ID)

--- a/public/examples/integrations/toolkits/salesforce/get_account_data_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/salesforce/get_account_data_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade({ baseURL: "http://localhost:9099" }); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "user@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Salesforce.GetAccountDataById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/salesforce/get_account_data_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/salesforce/get_account_data_by_id_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade(base_url="http://localhost:9099")  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "user@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Salesforce.GetAccountDataById"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME, user_id=USER_ID)

--- a/public/examples/integrations/toolkits/salesforce/get_account_data_by_keywords_example_call_tool.js
+++ b/public/examples/integrations/toolkits/salesforce/get_account_data_by_keywords_example_call_tool.js
@@ -3,7 +3,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 const client = new Arcade({ baseURL: "http://localhost:9099" }); // Automatically finds the `ARCADE_API_KEY` env variable
 
 const TOOL_NAME = "Salesforce.GetAccountDataByKeywords";
-const USER_ID = "user@example.com";
+const USER_ID = "{arcade_user_id}";
 
 // Start the authorization process
 const authResponse = await client.tools.authorize({tool_name: TOOL_NAME, user_id: USER_ID});

--- a/public/examples/integrations/toolkits/salesforce/get_account_data_by_keywords_example_call_tool.py
+++ b/public/examples/integrations/toolkits/salesforce/get_account_data_by_keywords_example_call_tool.py
@@ -3,7 +3,7 @@ from arcadepy import Arcade
 client = Arcade(base_url="http://localhost:9099")  # Automatically finds the `ARCADE_API_KEY` env variable
 
 TOOL_NAME = "Salesforce.GetAccountDataByKeywords"
-USER_ID = "user@example.com"
+USER_ID = "{arcade_user_id}"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME, user_id=USER_ID)
 

--- a/public/examples/integrations/toolkits/search/google_finance/get_stock_historical_data_example_call_tool.js
+++ b/public/examples/integrations/toolkits/search/google_finance/get_stock_historical_data_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Search.GetStockHistoricalData";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/search/google_finance/get_stock_historical_data_example_call_tool.py
+++ b/public/examples/integrations/toolkits/search/google_finance/get_stock_historical_data_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Search.GetStockHistoricalData"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/search/google_finance/get_stock_summary_example_call_tool.js
+++ b/public/examples/integrations/toolkits/search/google_finance/get_stock_summary_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Search.GetStockSummary";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/search/google_finance/get_stock_summary_example_call_tool.py
+++ b/public/examples/integrations/toolkits/search/google_finance/get_stock_summary_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Search.GetStockSummary"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/search/google_flights/search_one_way_flights_example_call_tool.js
+++ b/public/examples/integrations/toolkits/search/google_flights/search_one_way_flights_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Search.SearchOneWayFlights";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/search/google_flights/search_one_way_flights_example_call_tool.py
+++ b/public/examples/integrations/toolkits/search/google_flights/search_one_way_flights_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Search.SearchOneWayFlights"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/search/google_flights/search_roundtrip_flights_example_call_tool.js
+++ b/public/examples/integrations/toolkits/search/google_flights/search_roundtrip_flights_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Search.SearchRoundtripFlights";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/search/google_flights/search_roundtrip_flights_example_call_tool.py
+++ b/public/examples/integrations/toolkits/search/google_flights/search_roundtrip_flights_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Search.SearchRoundtripFlights"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/search/google_hotels/search_hotels_example_call_tool.js
+++ b/public/examples/integrations/toolkits/search/google_hotels/search_hotels_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Search.SearchHotels";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/search/google_hotels/search_hotels_example_call_tool.py
+++ b/public/examples/integrations/toolkits/search/google_hotels/search_hotels_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Search.SearchHotels"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/search/google_jobs/search_jobs_example_call_tool.js
+++ b/public/examples/integrations/toolkits/search/google_jobs/search_jobs_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Search.SearchJobs";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/search/google_jobs/search_jobs_example_call_tool.py
+++ b/public/examples/integrations/toolkits/search/google_jobs/search_jobs_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Search.SearchJobs"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/search/google_maps/get_directions_between_addresses_example_call_tool.js
+++ b/public/examples/integrations/toolkits/search/google_maps/get_directions_between_addresses_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Search.GetDirectionsBetweenAddresses";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/search/google_maps/get_directions_between_addresses_example_call_tool.py
+++ b/public/examples/integrations/toolkits/search/google_maps/get_directions_between_addresses_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Search.GetDirectionsBetweenAddresses"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/search/google_maps/get_directions_between_coordinates_example_call_tool.js
+++ b/public/examples/integrations/toolkits/search/google_maps/get_directions_between_coordinates_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Search.GetDirectionsBetweenCoordinates";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/search/google_maps/get_directions_between_coordinates_example_call_tool.py
+++ b/public/examples/integrations/toolkits/search/google_maps/get_directions_between_coordinates_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Search.GetDirectionsBetweenCoordinates"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/search/google_news/search_news_example_call_tool.js
+++ b/public/examples/integrations/toolkits/search/google_news/search_news_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Search.SearchNews";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/search/google_news/search_news_example_call_tool.py
+++ b/public/examples/integrations/toolkits/search/google_news/search_news_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Search.SearchNews"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/search/google_search/search_google_example_call_tool.js
+++ b/public/examples/integrations/toolkits/search/google_search/search_google_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Search.SearchGoogle";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/search/google_search/search_google_example_call_tool.py
+++ b/public/examples/integrations/toolkits/search/google_search/search_google_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Search.SearchGoogle"
 
 tool_input = {"query": "Arcade documentation", "n_results": 5}

--- a/public/examples/integrations/toolkits/slack/get_channel_metadata_by_name_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_channel_metadata_by_name_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.GetChannelMetadataByName";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/get_channel_metadata_by_name_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_channel_metadata_by_name_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.GetChannelMetadataByName"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/get_conversation_history_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_conversation_history_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.GetConversationHistoryById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/get_conversation_history_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_conversation_history_by_id_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.GetConversationHistoryById"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/get_conversation_history_by_name_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_conversation_history_by_name_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.GetConversationHistoryByName";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/get_conversation_history_by_name_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_conversation_history_by_name_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.GetConversationHistoryByName"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/get_conversation_metadata_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_conversation_metadata_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.GetConversationMetadataById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/get_conversation_metadata_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_conversation_metadata_by_id_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.GetConversationMetadataById"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/get_direct_message_conversation_metadata_by_username_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_direct_message_conversation_metadata_by_username_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.GetDirectMessageConversationMetadataByUsername";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/get_direct_message_conversation_metadata_by_username_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_direct_message_conversation_metadata_by_username_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.GetDirectMessageConversationMetadataByUsername"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/get_members_in_channel_by_name_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_members_in_channel_by_name_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.GetMembersInChannelByName";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/get_members_in_channel_by_name_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_members_in_channel_by_name_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.GetMembersInChannelByName"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/get_members_in_conversation_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_members_in_conversation_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.GetMembersInConversationById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/get_members_in_conversation_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_members_in_conversation_by_id_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.GetMembersInConversationById"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/get_messages_in_channel_by_name_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_messages_in_channel_by_name_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.GetMessagesInChannelByName";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/get_messages_in_channel_by_name_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_messages_in_channel_by_name_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.GetMessagesInChannelByName"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/get_messages_in_conversation_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_messages_in_conversation_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.GetMessagesInConversationById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/get_messages_in_conversation_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_messages_in_conversation_by_id_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.GetMessagesInConversationById"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/get_messages_in_direct_message_conversation_by_username_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_messages_in_direct_message_conversation_by_username_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.GetMessagesInDirectMessageConversationByUsername";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/get_messages_in_direct_message_conversation_by_username_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_messages_in_direct_message_conversation_by_username_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.GetMessagesInDirectMessageConversationByUsername"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/get_messages_in_multi_person_dm_conversation_by_username_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_messages_in_multi_person_dm_conversation_by_username_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.GetMessagesInMultiPersonDmConversationByUsername";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/get_messages_in_multi_person_dm_conversation_by_username_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_messages_in_multi_person_dm_conversation_by_username_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.GetMessagesInMultiPersonDmConversationByUsername"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/get_multi_person_dm_conversation_metadata_by_usernames_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_multi_person_dm_conversation_metadata_by_usernames_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.GetMultiPersonDmConversationMetadataByUsername";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/get_multi_person_dm_conversation_metadata_by_usernames_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_multi_person_dm_conversation_metadata_by_usernames_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.GetMultiPersonDmConversationMetadataByUsername"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/get_user_info_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/get_user_info_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.GetUserInfoById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/get_user_info_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/get_user_info_by_id_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.GetUserInfoById"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/list_conversations_metadata_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/list_conversations_metadata_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.ListConversationsMetadata";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/list_conversations_metadata_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/list_conversations_metadata_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.ListConversationsMetadata"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/list_direct_message_channels_metadata_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/list_direct_message_channels_metadata_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.ListDirectMessageChannelsMetadata";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/list_direct_message_channels_metadata_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/list_direct_message_channels_metadata_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.ListDirectMessageChannelsMetadata"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/list_direct_message_conversations_metadata_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/list_direct_message_conversations_metadata_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.ListDirectMessageConversationsMetadata";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/list_direct_message_conversations_metadata_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/list_direct_message_conversations_metadata_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.ListDirectMessageConversationsMetadata"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/list_group_direct_message_channels_metadata_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/list_group_direct_message_channels_metadata_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.ListGroupDirectMessageChannelsMetadata";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/list_group_direct_message_channels_metadata_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/list_group_direct_message_channels_metadata_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.ListGroupDirectMessageChannelsMetadata"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/list_group_direct_message_conversations_metadata_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/list_group_direct_message_conversations_metadata_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.ListGroupDirectMessageConversationsMetadata";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/list_group_direct_message_conversations_metadata_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/list_group_direct_message_conversations_metadata_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.ListGroupDirectMessageConversationsMetadata"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/list_private_channels_metadata_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/list_private_channels_metadata_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.ListPrivateChannelsMetadata";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/list_private_channels_metadata_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/list_private_channels_metadata_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.ListPrivateChannelsMetadata"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/list_public_channels_metadata_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/list_public_channels_metadata_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.ListPublicChannelsMetadata";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/list_public_channels_metadata_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/list_public_channels_metadata_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.ListPublicChannelsMetadata"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/list_users_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/list_users_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.ListUsers";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/list_users_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/list_users_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.ListUsers"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/send_dm_to_user_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/send_dm_to_user_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.SendDmToUser";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/send_dm_to_user_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/send_dm_to_user_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.SendDmToUser"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/slack/send_message_to_channel_example_call_tool.js
+++ b/public/examples/integrations/toolkits/slack/send_message_to_channel_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Slack.SendMessageToChannel";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/slack/send_message_to_channel_example_call_tool.py
+++ b/public/examples/integrations/toolkits/slack/send_message_to_channel_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Slack.SendMessageToChannel"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/spotify/adjust_playback_position_example_call_tool.js
+++ b/public/examples/integrations/toolkits/spotify/adjust_playback_position_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Spotify.AdjustPlaybackPosition";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/spotify/adjust_playback_position_example_call_tool.py
+++ b/public/examples/integrations/toolkits/spotify/adjust_playback_position_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Spotify.AdjustPlaybackPosition"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/spotify/get_available_devices_example_call_tool.js
+++ b/public/examples/integrations/toolkits/spotify/get_available_devices_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Spotify.GetAvailableDevices";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/spotify/get_available_devices_example_call_tool.py
+++ b/public/examples/integrations/toolkits/spotify/get_available_devices_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Spotify.GetAvailableDevices"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/spotify/get_currently_playing_example_call_tool.js
+++ b/public/examples/integrations/toolkits/spotify/get_currently_playing_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Spotify.GetCurrentlyPlaying";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/spotify/get_currently_playing_example_call_tool.py
+++ b/public/examples/integrations/toolkits/spotify/get_currently_playing_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Spotify.GetCurrentlyPlaying"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/spotify/get_playback_state_example_call_tool.js
+++ b/public/examples/integrations/toolkits/spotify/get_playback_state_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Spotify.GetPlaybackState";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/spotify/get_playback_state_example_call_tool.py
+++ b/public/examples/integrations/toolkits/spotify/get_playback_state_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Spotify.GetPlaybackState"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/spotify/get_track_from_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/spotify/get_track_from_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Spotify.GetTrackFromId";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/spotify/get_track_from_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/spotify/get_track_from_id_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Spotify.GetTrackFromId"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/spotify/pause_playback_example_call_tool.js
+++ b/public/examples/integrations/toolkits/spotify/pause_playback_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Spotify.PausePlayback";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/spotify/pause_playback_example_call_tool.py
+++ b/public/examples/integrations/toolkits/spotify/pause_playback_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Spotify.PausePlayback"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/spotify/play_artist_by_name_example_call_tool.js
+++ b/public/examples/integrations/toolkits/spotify/play_artist_by_name_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Spotify.PlayArtistByName";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/spotify/play_artist_by_name_example_call_tool.py
+++ b/public/examples/integrations/toolkits/spotify/play_artist_by_name_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Spotify.PlayArtistByName"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/spotify/play_track_by_name_example_call_tool.js
+++ b/public/examples/integrations/toolkits/spotify/play_track_by_name_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Spotify.PlayTrackByName";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/spotify/play_track_by_name_example_call_tool.py
+++ b/public/examples/integrations/toolkits/spotify/play_track_by_name_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Spotify.PlayTrackByName"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/spotify/resume_playback_example_call_tool.js
+++ b/public/examples/integrations/toolkits/spotify/resume_playback_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Spotify.ResumePlayback";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/spotify/resume_playback_example_call_tool.py
+++ b/public/examples/integrations/toolkits/spotify/resume_playback_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Spotify.ResumePlayback"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/spotify/search_example_call_tool.js
+++ b/public/examples/integrations/toolkits/spotify/search_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Spotify.Search";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/spotify/search_example_call_tool.py
+++ b/public/examples/integrations/toolkits/spotify/search_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Spotify.Search"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/spotify/skip_to_next_track_example_call_tool.js
+++ b/public/examples/integrations/toolkits/spotify/skip_to_next_track_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Spotify.SkipToNextTrack";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/spotify/skip_to_next_track_example_call_tool.py
+++ b/public/examples/integrations/toolkits/spotify/skip_to_next_track_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Spotify.SkipToNextTrack"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/spotify/skip_to_previous_track_example_call_tool.js
+++ b/public/examples/integrations/toolkits/spotify/skip_to_previous_track_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Spotify.SkipToPreviousTrack";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/spotify/skip_to_previous_track_example_call_tool.py
+++ b/public/examples/integrations/toolkits/spotify/skip_to_previous_track_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Spotify.SkipToPreviousTrack"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/spotify/start_tracks_playback_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/spotify/start_tracks_playback_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Spotify.StartTracksPlaybackById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/spotify/start_tracks_playback_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/spotify/start_tracks_playback_by_id_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Spotify.StartTracksPlaybackById"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/stripe/create_billing_portal_session_example_call_tool.js
+++ b/public/examples/integrations/toolkits/stripe/create_billing_portal_session_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Stripe.CreateBillingPortalSession";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/stripe/create_billing_portal_session_example_call_tool.py
+++ b/public/examples/integrations/toolkits/stripe/create_billing_portal_session_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Stripe.CreateBillingPortalSession"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/stripe/create_customer_example_call_tool.js
+++ b/public/examples/integrations/toolkits/stripe/create_customer_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Stripe.CreateCustomer";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/stripe/create_customer_example_call_tool.py
+++ b/public/examples/integrations/toolkits/stripe/create_customer_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Stripe.CreateCustomer"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/stripe/create_invoice_example_call_tool.js
+++ b/public/examples/integrations/toolkits/stripe/create_invoice_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Stripe.CreateInvoice";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/stripe/create_invoice_example_call_tool.py
+++ b/public/examples/integrations/toolkits/stripe/create_invoice_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Stripe.CreateInvoice"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/stripe/create_invoice_item_example_call_tool.js
+++ b/public/examples/integrations/toolkits/stripe/create_invoice_item_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Stripe.CreateInvoiceItem";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/stripe/create_invoice_item_example_call_tool.py
+++ b/public/examples/integrations/toolkits/stripe/create_invoice_item_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Stripe.CreateInvoiceItem"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/stripe/create_payment_link_example_call_tool.js
+++ b/public/examples/integrations/toolkits/stripe/create_payment_link_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Stripe.CreatePaymentLink";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/stripe/create_payment_link_example_call_tool.py
+++ b/public/examples/integrations/toolkits/stripe/create_payment_link_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Stripe.CreatePaymentLink"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/stripe/create_price_example_call_tool.js
+++ b/public/examples/integrations/toolkits/stripe/create_price_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Stripe.CreatePrice";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/stripe/create_price_example_call_tool.py
+++ b/public/examples/integrations/toolkits/stripe/create_price_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Stripe.CreatePrice"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/stripe/create_product_example_call_tool.js
+++ b/public/examples/integrations/toolkits/stripe/create_product_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Stripe.CreateProduct";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/stripe/create_product_example_call_tool.py
+++ b/public/examples/integrations/toolkits/stripe/create_product_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Stripe.CreateProduct"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/stripe/create_refund_example_call_tool.js
+++ b/public/examples/integrations/toolkits/stripe/create_refund_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Stripe.CreateRefund";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/stripe/create_refund_example_call_tool.py
+++ b/public/examples/integrations/toolkits/stripe/create_refund_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Stripe.CreateRefund"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/stripe/finalize_invoice_example_call_tool.js
+++ b/public/examples/integrations/toolkits/stripe/finalize_invoice_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Stripe.FinalizeInvoice";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/stripe/finalize_invoice_example_call_tool.py
+++ b/public/examples/integrations/toolkits/stripe/finalize_invoice_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Stripe.FinalizeInvoice"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/stripe/list_customers_example_call_tool.js
+++ b/public/examples/integrations/toolkits/stripe/list_customers_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Stripe.ListCustomers";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/stripe/list_customers_example_call_tool.py
+++ b/public/examples/integrations/toolkits/stripe/list_customers_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Stripe.ListCustomers"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/stripe/list_invoices_example_call_tool.js
+++ b/public/examples/integrations/toolkits/stripe/list_invoices_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Stripe.ListInvoices";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/stripe/list_invoices_example_call_tool.py
+++ b/public/examples/integrations/toolkits/stripe/list_invoices_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Stripe.ListInvoices"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/stripe/list_payment_intents_example_call_tool.js
+++ b/public/examples/integrations/toolkits/stripe/list_payment_intents_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Stripe.ListPaymentIntents";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/stripe/list_payment_intents_example_call_tool.py
+++ b/public/examples/integrations/toolkits/stripe/list_payment_intents_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Stripe.ListPaymentIntents"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/stripe/list_prices_example_call_tool.js
+++ b/public/examples/integrations/toolkits/stripe/list_prices_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Stripe.ListPrices";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/stripe/list_prices_example_call_tool.py
+++ b/public/examples/integrations/toolkits/stripe/list_prices_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Stripe.ListPrices"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/stripe/list_products_example_call_tool.js
+++ b/public/examples/integrations/toolkits/stripe/list_products_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Stripe.ListProducts";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/stripe/list_products_example_call_tool.py
+++ b/public/examples/integrations/toolkits/stripe/list_products_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Stripe.ListProducts"
 
 tool_input = {

--- a/public/examples/integrations/toolkits/stripe/retrieve_balance_example_call_tool.js
+++ b/public/examples/integrations/toolkits/stripe/retrieve_balance_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Stripe.RetrieveBalance";
 
 const toolInput = {};  // No input required for this tool

--- a/public/examples/integrations/toolkits/stripe/retrieve_balance_example_call_tool.py
+++ b/public/examples/integrations/toolkits/stripe/retrieve_balance_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Stripe.RetrieveBalance"
 
 tool_input = {}  # No input required for this tool

--- a/public/examples/integrations/toolkits/web/cancel_crawl_example_call_tool.js
+++ b/public/examples/integrations/toolkits/web/cancel_crawl_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Web.CancelCrawl";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/web/cancel_crawl_example_call_tool.py
+++ b/public/examples/integrations/toolkits/web/cancel_crawl_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Web.CancelCrawl"
 
 tool_input = {"crawl_id": "your_crawl_id"}

--- a/public/examples/integrations/toolkits/web/crawl_website_example_call_tool.js
+++ b/public/examples/integrations/toolkits/web/crawl_website_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Web.CrawlWebsite";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/web/crawl_website_example_call_tool.py
+++ b/public/examples/integrations/toolkits/web/crawl_website_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Web.CrawlWebsite"
 
 tool_input = {"url": "https://example.com", "max_depth": 2}

--- a/public/examples/integrations/toolkits/web/get_crawl_data_example_call_tool.js
+++ b/public/examples/integrations/toolkits/web/get_crawl_data_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Web.GetCrawlData";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/web/get_crawl_data_example_call_tool.py
+++ b/public/examples/integrations/toolkits/web/get_crawl_data_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Web.GetCrawlData"
 
 tool_input = {"crawl_id": "your_crawl_id"}

--- a/public/examples/integrations/toolkits/web/get_crawl_status_example_call_tool.js
+++ b/public/examples/integrations/toolkits/web/get_crawl_status_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Web.GetCrawlStatus";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/web/get_crawl_status_example_call_tool.py
+++ b/public/examples/integrations/toolkits/web/get_crawl_status_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Web.GetCrawlStatus"
 
 tool_input = {"crawl_id": "your_crawl_id"}

--- a/public/examples/integrations/toolkits/web/map_website_example_call_tool.js
+++ b/public/examples/integrations/toolkits/web/map_website_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Web.MapWebsite";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/web/map_website_example_call_tool.py
+++ b/public/examples/integrations/toolkits/web/map_website_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Web.MapWebsite"
 
 tool_input = {"url": "https://example.com"}

--- a/public/examples/integrations/toolkits/web/scrape_url_example_call_tool.js
+++ b/public/examples/integrations/toolkits/web/scrape_url_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "Web.ScrapeUrl";
 
 const toolInput = {

--- a/public/examples/integrations/toolkits/web/scrape_url_example_call_tool.py
+++ b/public/examples/integrations/toolkits/web/scrape_url_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "Web.ScrapeUrl"
 
 tool_input = {"url": "https://example.com", "formats": "Formats.MARKDOWN"}

--- a/public/examples/integrations/toolkits/x/delete_tweet_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/x/delete_tweet_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "X.DeleteTweetById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/x/delete_tweet_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/x/delete_tweet_by_id_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "X.DeleteTweetById"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/x/lookup_single_user_by_username_example_call_tool.js
+++ b/public/examples/integrations/toolkits/x/lookup_single_user_by_username_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "X.LookupSingleUserByUsername";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/x/lookup_single_user_by_username_example_call_tool.py
+++ b/public/examples/integrations/toolkits/x/lookup_single_user_by_username_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "X.LookupSingleUserByUsername"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/x/lookup_tweet_by_id_example_call_tool.js
+++ b/public/examples/integrations/toolkits/x/lookup_tweet_by_id_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "X.LookupTweetById";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/x/lookup_tweet_by_id_example_call_tool.py
+++ b/public/examples/integrations/toolkits/x/lookup_tweet_by_id_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "X.LookupTweetById"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/x/post_tweet_example_call_tool.js
+++ b/public/examples/integrations/toolkits/x/post_tweet_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "X.PostTweet";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/x/post_tweet_example_call_tool.py
+++ b/public/examples/integrations/toolkits/x/post_tweet_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "X.PostTweet"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/x/search_recent_tweets_by_keywords_example_call_tool.js
+++ b/public/examples/integrations/toolkits/x/search_recent_tweets_by_keywords_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "X.SearchRecentTweetsByKeywords";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/x/search_recent_tweets_by_keywords_example_call_tool.py
+++ b/public/examples/integrations/toolkits/x/search_recent_tweets_by_keywords_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "X.SearchRecentTweetsByKeywords"
 
 auth_response = client.tools.authorize(

--- a/public/examples/integrations/toolkits/x/search_recent_tweets_by_username_example_call_tool.js
+++ b/public/examples/integrations/toolkits/x/search_recent_tweets_by_username_example_call_tool.js
@@ -2,7 +2,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
-const USER_ID = "you@example.com";
+const USER_ID = "{arcade_user_id}";
 const TOOL_NAME = "X.SearchRecentTweetsByUsername";
 
 // Start the authorization process

--- a/public/examples/integrations/toolkits/x/search_recent_tweets_by_username_example_call_tool.py
+++ b/public/examples/integrations/toolkits/x/search_recent_tweets_by_username_example_call_tool.py
@@ -2,7 +2,7 @@ from arcadepy import Arcade
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
-USER_ID = "you@example.com"
+USER_ID = "{arcade_user_id}"
 TOOL_NAME = "X.SearchRecentTweetsByUsername"
 
 auth_response = client.tools.authorize(

--- a/src/components/CustomLayout.tsx
+++ b/src/components/CustomLayout.tsx
@@ -1,9 +1,16 @@
 import React from "react";
+import { OrySessionProvider } from "@/lib/OrySessionContext";
+import { PlaceholderReplacer } from "@/components/PlaceholderReplacer";
 
 const CustomLayout: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  return <main className="custom-main">{children}</main>;
+  return (
+    <OrySessionProvider>
+      <PlaceholderReplacer />
+      <main className="custom-main">{children}</main>
+    </OrySessionProvider>
+  );
 };
 
 export default CustomLayout;

--- a/src/components/PlaceholderReplacer.tsx
+++ b/src/components/PlaceholderReplacer.tsx
@@ -1,14 +1,21 @@
 import { useEffect } from "react";
 import { useOrySession } from "@/lib/OrySessionContext";
+import { getCookie } from "@/lib/utils";
 
 export function PlaceholderReplacer() {
   const { email, loading } = useOrySession();
 
   useEffect(() => {
-    // Determine the replacement value
+    // Determine the replacement value with fallback priority:
+    // 1. If loading, keep original placeholder
+    // 2. If Ory email is available, use that (highest priority)
+    // 3. If no Ory email but cookie exists, use cookie value
+    // 4. Otherwise, use original placeholder
+    const getCookieEmail = () => getCookie("last_arcadedev_account_email");
+
     const replacement = loading
       ? "{arcade_user_id}" // Keep original while loading
-      : email || "{arcade_user_id}";
+      : email || getCookieEmail() || "{arcade_user_id}";
 
     // Function to replace text in a text node
     const replaceInTextNode = (node: Text) => {

--- a/src/components/PlaceholderReplacer.tsx
+++ b/src/components/PlaceholderReplacer.tsx
@@ -1,0 +1,92 @@
+import { useEffect } from "react";
+import { useOrySession } from "@/lib/OrySessionContext";
+
+export function PlaceholderReplacer() {
+  const { email, loading } = useOrySession();
+
+  useEffect(() => {
+    // Determine the replacement value
+    const replacement = loading
+      ? "{arcade_user_id}" // Keep original while loading
+      : email || "{arcade_user_id}";
+
+    // Function to replace text in a text node
+    const replaceInTextNode = (node: Text) => {
+      if (node.nodeValue && node.nodeValue.includes("{arcade_user_id}")) {
+        const newValue = node.nodeValue.replace(
+          /\{arcade_user_id\}/g,
+          replacement,
+        );
+        if (node.nodeValue !== newValue) {
+          node.nodeValue = newValue;
+        }
+      }
+    };
+
+    // Function to process all text nodes in an element
+    const processElement = (element: Element) => {
+      // Skip script and style elements
+      if (element.tagName === "SCRIPT" || element.tagName === "STYLE") {
+        return;
+      }
+
+      // Walk through all text nodes
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT, {
+        acceptNode: (node) => {
+          // Only process text nodes that might contain our placeholder
+          if (node.nodeValue && node.nodeValue.includes("arcade_user_id")) {
+            return NodeFilter.FILTER_ACCEPT;
+          }
+          return NodeFilter.FILTER_SKIP;
+        },
+      });
+
+      let node;
+      while ((node = walker.nextNode())) {
+        replaceInTextNode(node as Text);
+      }
+    };
+
+    // Initial replacement on mount
+    const timeoutId = setTimeout(() => {
+      processElement(document.body);
+    }, 100); // Small delay to ensure content is rendered
+
+    // Set up MutationObserver for dynamic content
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === "childList") {
+          mutation.addedNodes.forEach((node) => {
+            if (node.nodeType === Node.ELEMENT_NODE) {
+              processElement(node as Element);
+            } else if (node.nodeType === Node.TEXT_NODE) {
+              replaceInTextNode(node as Text);
+            }
+          });
+        } else if (
+          mutation.type === "characterData" &&
+          mutation.target.nodeType === Node.TEXT_NODE
+        ) {
+          replaceInTextNode(mutation.target as Text);
+        }
+      });
+    });
+
+    // Start observing
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+      characterDataOldValue: true,
+    });
+
+    // Cleanup
+    return () => {
+      clearTimeout(timeoutId);
+      observer.disconnect();
+    };
+  }, [email, loading]);
+
+  // This component doesn't render anything
+  return null;
+}

--- a/src/lib/OrySessionContext.tsx
+++ b/src/lib/OrySessionContext.tsx
@@ -1,0 +1,74 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { Configuration, FrontendApi } from "@ory/client";
+
+interface OrySessionContextType {
+  email: string | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+const OrySessionContext = createContext<OrySessionContextType>({
+  email: null,
+  loading: true,
+  error: null,
+});
+
+// Initialize Ory client - you'll need to update this with your actual Ory domain
+const ory = new FrontendApi(
+  new Configuration({
+    basePath: process.env.NEXT_PUBLIC_ORY_SDK_URL || "https://auth.arcade.dev",
+    baseOptions: {
+      withCredentials: true,
+    },
+  }),
+);
+
+export function OrySessionProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [email, setEmail] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const checkSession = async () => {
+      try {
+        const { data: session } = await ory.toSession();
+
+        // Extract email from session identity traits
+        const userEmail = session?.identity?.traits?.email as
+          | string
+          | undefined;
+
+        if (userEmail) {
+          setEmail(userEmail);
+        } else {
+          setEmail(null);
+        }
+      } catch (err) {
+        // Session not found or expired
+        setEmail(null);
+        setError(
+          err instanceof Error ? err : new Error("Failed to fetch session"),
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    checkSession();
+  }, []);
+
+  return (
+    <OrySessionContext.Provider value={{ email, loading, error }}>
+      {children}
+    </OrySessionContext.Provider>
+  );
+}
+
+export function useOrySession() {
+  const context = useContext(OrySessionContext);
+  return context;
+}

--- a/src/lib/OrySessionContext.tsx
+++ b/src/lib/OrySessionContext.tsx
@@ -13,7 +13,6 @@ const OrySessionContext = createContext<OrySessionContextType>({
   error: null,
 });
 
-// Initialize Ory client - you'll need to update this with your actual Ory domain
 const ory = new FrontendApi(
   new Configuration({
     basePath: process.env.NEXT_PUBLIC_ORY_SDK_URL || "https://auth.arcade.dev",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,17 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Read a cookie value by name from document.cookie
+ * @param name - The name of the cookie to read
+ * @returns The cookie value or null if not found
+ */
+export function getCookie(name: string): string | null {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) {
+    return parts.pop()?.split(";").shift() || null;
+  }
+  return null;
+}

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -10,7 +10,7 @@ import { Check, Important, Info, Note, Tip, Warning } from "@markdown/Callouts";
 import { Card, Cards } from "@markdown/Cards";
 import { DarkOnly, LightOnly } from "@markdown/ThemeContent";
 import { DocsThemeConfig } from "nextra-theme-docs";
-import { Button, Cards as NavCards, Steps } from "nextra/components";
+import { Cards as NavCards, Steps } from "nextra/components";
 import { SignupLink } from "@/components/Analytics";
 import Link from "next/link";
 


### PR DESCRIPTION
To make the quickstart and code examples easier to follow, this PR replaces all sample user IDs like `you@example.com` with a placeholder with either:
- Your Arcade account email (if you are logged in)
- A clear placeholder `"{arcade_user_id"}` if not

This change will help reduce confusion especially when #341 is merged.