### PR TITLE
replaced creating toolkit video with full tutorial

### DIFF
--- a/pages/home/build-tools/create-a-toolkit.mdx
+++ b/pages/home/build-tools/create-a-toolkit.mdx
@@ -13,7 +13,7 @@ import { Steps, Tabs } from "nextra/components";
   </div>
   <iframe
    className="aspect-video w-full max-w-[900px] rounded-xl shadow-2xl"
-   src="https://www.youtube.com/embed/EcCb_1W9Gb4?si=rCt30twDTEgoIVi2"
+   src="https://www.youtube.com/embed/q2V_P35KYCg?si=CYhKw-eYx1O98O9K"
    title="Create a Toolkit"
    frameborder="0"
    allow="fullscreen; accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"


### PR DESCRIPTION
This replaces the original "Create a Toolkit" video with the toolkit building video implementing Mastodon
