### PR TITLE
Add Authorizations billing metric definition

### DIFF
--- a/pages/home/glossary.mdx
+++ b/pages/home/glossary.mdx
@@ -16,7 +16,7 @@ graph TD
 
 ### Agent
 
-An 'agent' is the application you are building.  It can be a chatbot, a web application, a mobile app, or any other type of application that happens to use an LLM to as part of its functionality.  Agents interact with the world by calling tools.  Helping you build, test, authenticate, and deploy tools is what Arcade is all about.
+An 'agent' is the application you are building.  It can be a chatbot, a web application, a mobile app, or any other type of application that happens to use an LLM as part of its functionality.  Agents interact with the world by calling tools.  Helping you build, test, authenticate, and deploy tools is what Arcade is all about.
 
 ### Toolkit
 
@@ -62,7 +62,7 @@ graph TD
 
 ### Account
 
-The 'account' is you (or your teammates), the developer(s) whoare using Arcade to build an application or agent.  You can sign into the Arcade dashboard, manage projects, and more.
+The 'account' is you (or your teammates), the developer(s) who are using Arcade to build an application or agent.  You can sign into the Arcade dashboard, manage projects, and more.
 
 ### Tenant
 
@@ -94,7 +94,7 @@ Monthly Active Users are the unique end-users (counted by `user_id`) who have ex
 
 ### User Authentications (User Auths)
 
-User Authentications are the number of unique users (by `user_id`) who have started the authentication flow for a  authentication provider.  This is intended to be a proxy for the number of new users who are using your agent.  The same user authenticating to multiple toolkits will be counted multiple times (e.g. once for Slack and once for Google).  We also count the act of elevating permissions to a user who has already authenticated to a toolkit (e.g. adding a "write" scope when they previously only had a "read" scope).
+User Authentications are the number of unique users (by `user_id`) who have started the authentication flow for an  authentication provider.  This is intended to be a proxy for the number of new users who are using your agent.  The same user authenticating to multiple toolkits will be counted multiple times (e.g. once for Slack and once for Google).  We also count the act of elevating permissions to a user who has already authenticated to a toolkit (e.g. adding a "write" scope when they previously only had a "read" scope).
 
 ### Authentication Provider
 
@@ -111,7 +111,7 @@ Learn more about [authorized tool calling](/home/auth/auth-tool-calling).
 
 ### Tool Executions
 
-A 'tool execution' is a single call to a tool to interact with a remote system or service. The tool execution itself may fail (e.g. the user does not have permission to call the tool), but as long as the execution was able to be routed to a worker, the tool execution will be counted.
+A 'tool execution' is a single call to a tool to interact with a remote system or service. The tool execution itself may fail (e.g. the user does not have permission to call the tool), but as long as the execution was able to be routed to a worker, it will be counted.
 
 *Learn more about [tool executions](/home/use-tools/tools-overview).*
 

--- a/pages/home/glossary.mdx
+++ b/pages/home/glossary.mdx
@@ -87,9 +87,9 @@ A 'user' is your end-user, the person who is using your application or agent.  U
 
 Monthly Active Users are the unique end-users (counted by `user_id`) who have executed a tool in your app/agent within the past month.  If the same `user_id` calls a tool multiple times in the same month, or executes multiple tools, it is only counted once.
 
-### Authorizations
+### User Challenges
 
-Authorizations are the count of authorization events performed for any end-user or service account (both are specified by user_id in Arcade's SDKs and APIs). They occur when an end-user or service account needs a new permission or scope that they don't currently have, including previously-held scopes that were deleted or expired. The same user authenticating to multiple toolkits will have an Authorization for each toolkit (e.g. once for Slack and once for Google). We also count the act of elevating permissions for a user or service account who has already authenticated to a toolkit (e.g. adding a "write" scope when they previously only had a "read" scope).
+User Challenges are the count of authorizations performed for any user (specified by user_id in Arcade's SDKs and APIs). Authorization challenges occur when a user needs a new permission or scope that they don't currently have, including previously-held scopes that were deleted or expired. The same user authenticating to multiple toolkits will have a User Challenge for each toolkit  (e.g. once for Slack and once for Google). We also count the act of elevating permissions to a user who has already authenticated to a toolkit (e.g. adding a "write" scope when they previously only had a "read" scope).
 
 ### Authentication Provider
 

--- a/pages/home/glossary.mdx
+++ b/pages/home/glossary.mdx
@@ -89,7 +89,7 @@ Monthly Active Users are the unique end-users (counted by `user_id`) who have ex
 
 ### User Authentications (User Auths)
 
-User Authentications are the number of unique users (by `user_id`) who have started the authentication flow for an  authentication provider.  This is intended to be a proxy for the number of new users who are using your agent.  The same user authenticating to multiple toolkits will be counted multiple times (e.g. once for Slack and once for Google).  We also count the act of elevating permissions to a user who has already authenticated to a toolkit (e.g. adding a "write" scope when they previously only had a "read" scope).
+User Authentications are the count of permission-level scopes granted to a user or service account that have never been granted before on our platform, including previously held scopes that were deleted and re-granted. The same user authenticating to multiple toolkits will be counted multiple times (e.g. once for Slack and once for Google). We also count the act of elevating permissions to a user who has already authenticated to a toolkit (e.g. adding a "write" scope when they previously only had a "read" scope).
 
 ### Authentication Provider
 

--- a/pages/home/glossary.mdx
+++ b/pages/home/glossary.mdx
@@ -92,9 +92,9 @@ A 'user' is your end-user, the person who is using your application or agent.  U
 
 Monthly Active Users are the unique end-users (counted by `user_id`) who have executed a tool in your app/agent within the past month.  If the same `user_id` calls a tool multiple times in the same month, or executes multiple tools, it is only counted once.
 
-### Authentication Starts (Auth Starts)
+### User Authentications (User Auths)
 
-Authentication Starts are the number of unique users (by `user_id`) who have started the authentication flow for a  authentication provider.  This is intended to be a proxy for the number of new users who are using your agent.  The same user authenticating to multiple toolkits will be counted multiple times (e.g. once for Slack and once for Google).  We also count the act of elevating permissions to a user who has already authenticated to a toolkit (e.g. adding a "write" scope when they previously only had a "read" scope).
+User Authentications are the number of unique users (by `user_id`) who have started the authentication flow for a  authentication provider.  This is intended to be a proxy for the number of new users who are using your agent.  The same user authenticating to multiple toolkits will be counted multiple times (e.g. once for Slack and once for Google).  We also count the act of elevating permissions to a user who has already authenticated to a toolkit (e.g. adding a "write" scope when they previously only had a "read" scope).
 
 ### Authentication Provider
 

--- a/pages/home/glossary.mdx
+++ b/pages/home/glossary.mdx
@@ -87,9 +87,9 @@ A 'user' is your end-user, the person who is using your application or agent.  U
 
 Monthly Active Users are the unique end-users (counted by `user_id`) who have executed a tool in your app/agent within the past month.  If the same `user_id` calls a tool multiple times in the same month, or executes multiple tools, it is only counted once.
 
-### User Authentications (User Auths)
+### Authorizations
 
-User Authentications are the count of permission-level scopes granted to a user or service account that have never been granted before on our platform, including previously held scopes that were deleted and re-granted. The same user authenticating to multiple toolkits will be counted multiple times (e.g. once for Slack and once for Google). We also count the act of elevating permissions to a user who has already authenticated to a toolkit (e.g. adding a "write" scope when they previously only had a "read" scope).
+Authorizations are the count of authorization events performed for any end-user or service account (both are specified by user_id in Arcade's SDKs and APIs). They occur when an end-user or service account needs a new permission or scope that they don't currently have, including previously-held scopes that were deleted or expired. The same user authenticating to multiple toolkits will have an Authorization for each toolkit (e.g. once for Slack and once for Google). We also count the act of elevating permissions for a user or service account who has already authenticated to a toolkit (e.g. adding a "write" scope when they previously only had a "read" scope).
 
 ### Authentication Provider
 


### PR DESCRIPTION
## Add Authorizations billing metric definition

### Summary
Defines "Authorizations" as a new billing metric that counts authorization events when users request new permissions or scopes they don't currently have.

### Changes
- Added comprehensive definition covering all edge cases
- Included both short and detailed versions for different use cases
- Covers cross-toolkit authentication, permission elevation, and expired/deleted scope scenarios

### Key Details
- **Short definition**: "The number of times a user is challenged for new permissions"
- **Billing trigger**: Any new scope grant, including previously held scopes that were deleted/expired
- **Cross-toolkit**: Same user authenticating to Slack + Google = 2 authorizations
- **Permission elevation**: Adding "write" when user has "read" = 1 authorization
- **User identification**: Based on `user_id` in Arcade's SDKs and APIs

### Impact
- Provides clear billing model for authorization events
- Prevents implementation confusion and billing disputes
- Ready for use in documentation, contracts, and API specs
