### PR TITLE
added link to custom user verifiers from the Auth customization pages

### DIFF
--- a/pages/home/auth-providers/asana.mdx
+++ b/pages/home/auth-providers/asana.mdx
@@ -28,6 +28,10 @@ If you choose to use Arcade's Asana auth, you don't need to configure anything. 
 
 ## Use Your Own Asana App Credentials
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own Asana app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own Asana credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.

--- a/pages/home/auth-providers/asana.mdx
+++ b/pages/home/auth-providers/asana.mdx
@@ -29,7 +29,7 @@ If you choose to use Arcade's Asana auth, you don't need to configure anything. 
 ## Use Your Own Asana App Credentials
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own Asana app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/atlassian.mdx
+++ b/pages/home/auth-providers/atlassian.mdx
@@ -22,7 +22,7 @@ This auth provider is used by:
 ## Configuring Atlassian auth
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own Atlassian app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/atlassian.mdx
+++ b/pages/home/auth-providers/atlassian.mdx
@@ -21,6 +21,10 @@ This auth provider is used by:
 
 ## Configuring Atlassian auth
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own Atlassian app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own Atlassian credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.

--- a/pages/home/auth-providers/discord.mdx
+++ b/pages/home/auth-providers/discord.mdx
@@ -21,6 +21,10 @@ This auth provider is used by:
 
 ## Configuring Discord auth
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own Discord app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own Discord credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.

--- a/pages/home/auth-providers/discord.mdx
+++ b/pages/home/auth-providers/discord.mdx
@@ -22,7 +22,7 @@ This auth provider is used by:
 ## Configuring Discord auth
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own Discord app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/dropbox.mdx
+++ b/pages/home/auth-providers/dropbox.mdx
@@ -21,6 +21,10 @@ This auth provider is used by:
 
 ## Configuring Dropbox auth
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own Dropbox app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own Dropbox credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.

--- a/pages/home/auth-providers/dropbox.mdx
+++ b/pages/home/auth-providers/dropbox.mdx
@@ -22,7 +22,7 @@ This auth provider is used by:
 ## Configuring Dropbox auth
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own Dropbox app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/github.mdx
+++ b/pages/home/auth-providers/github.mdx
@@ -21,6 +21,10 @@ This auth provider is used by:
 
 ## Configuring GitHub auth
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own GitHub app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own GitHub credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.

--- a/pages/home/auth-providers/github.mdx
+++ b/pages/home/auth-providers/github.mdx
@@ -22,7 +22,7 @@ This auth provider is used by:
 ## Configuring GitHub auth
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own GitHub app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/google.mdx
+++ b/pages/home/auth-providers/google.mdx
@@ -23,7 +23,7 @@ This auth provider is used by:
 ## Configuring Google auth
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own Google app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/google.mdx
+++ b/pages/home/auth-providers/google.mdx
@@ -22,6 +22,10 @@ This auth provider is used by:
 
 ## Configuring Google auth
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own Google app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own Google credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.

--- a/pages/home/auth-providers/hubspot.mdx
+++ b/pages/home/auth-providers/hubspot.mdx
@@ -27,6 +27,10 @@ If you choose to use Arcade's Hubspot auth, you don't need to configure anything
 
 ## Use Your Own Hubspot App Credentials
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own Hubspot app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own Hubspot credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.

--- a/pages/home/auth-providers/hubspot.mdx
+++ b/pages/home/auth-providers/hubspot.mdx
@@ -28,7 +28,7 @@ If you choose to use Arcade's Hubspot auth, you don't need to configure anything
 ## Use Your Own Hubspot App Credentials
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own Hubspot app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/linear.mdx
+++ b/pages/home/auth-providers/linear.mdx
@@ -15,6 +15,10 @@ This auth provider is used by:
 
 ## Configuring Linear auth
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own Linear app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own Linear credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.

--- a/pages/home/auth-providers/linear.mdx
+++ b/pages/home/auth-providers/linear.mdx
@@ -16,7 +16,7 @@ This auth provider is used by:
 ## Configuring Linear auth
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own Linear app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/linkedin.mdx
+++ b/pages/home/auth-providers/linkedin.mdx
@@ -15,6 +15,10 @@ This auth provider is used by:
 
 ## Configuring LinkedIn auth
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own LinkedIn app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own LinkedIn credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.

--- a/pages/home/auth-providers/linkedin.mdx
+++ b/pages/home/auth-providers/linkedin.mdx
@@ -16,7 +16,7 @@ This auth provider is used by:
 ## Configuring LinkedIn auth
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own LinkedIn app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/microsoft.mdx
+++ b/pages/home/auth-providers/microsoft.mdx
@@ -22,7 +22,7 @@ This auth provider is used by:
 ## Configuring Microsoft auth
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own Microsoft app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/microsoft.mdx
+++ b/pages/home/auth-providers/microsoft.mdx
@@ -21,6 +21,10 @@ This auth provider is used by:
 
 ## Configuring Microsoft auth
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own Microsoft app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own Microsoft credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.

--- a/pages/home/auth-providers/notion.mdx
+++ b/pages/home/auth-providers/notion.mdx
@@ -15,6 +15,10 @@ This auth provider is used by:
 
 ## Configuring Notion auth
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own Notion app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own Notion credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.

--- a/pages/home/auth-providers/notion.mdx
+++ b/pages/home/auth-providers/notion.mdx
@@ -16,7 +16,7 @@ This auth provider is used by:
 ## Configuring Notion auth
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own Notion app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/reddit.mdx
+++ b/pages/home/auth-providers/reddit.mdx
@@ -21,6 +21,10 @@ This auth provider is used by:
 
 ## Configuring Reddit auth
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own Reddit app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own Reddit credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.

--- a/pages/home/auth-providers/reddit.mdx
+++ b/pages/home/auth-providers/reddit.mdx
@@ -22,7 +22,7 @@ This auth provider is used by:
 ## Configuring Reddit auth
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own Reddit app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/salesforce.mdx
+++ b/pages/home/auth-providers/salesforce.mdx
@@ -21,6 +21,10 @@ This auth provider is used by:
 
 ## Create a Salesforce app
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 Salesforce has two types of apps: **Connected App** and **Lightning App**. For this guide, we'll create a **Connected App**. Make sure to follow the instructions below while you [create your Connected App](https://help.salesforce.com/s/articleView?id=xcloud.connected_app_create.htm&type=5).
 
 When creating your app, make sure to:

--- a/pages/home/auth-providers/salesforce.mdx
+++ b/pages/home/auth-providers/salesforce.mdx
@@ -22,7 +22,7 @@ This auth provider is used by:
 ## Create a Salesforce app
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 Salesforce has two types of apps: **Connected App** and **Lightning App**. For this guide, we'll create a **Connected App**. Make sure to follow the instructions below while you [create your Connected App](https://help.salesforce.com/s/articleView?id=xcloud.connected_app_create.htm&type=5).

--- a/pages/home/auth-providers/slack.mdx
+++ b/pages/home/auth-providers/slack.mdx
@@ -21,6 +21,10 @@ This auth provider is used by:
 
 ## Configuring Slack auth
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own Slack app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own Slack credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.

--- a/pages/home/auth-providers/slack.mdx
+++ b/pages/home/auth-providers/slack.mdx
@@ -22,7 +22,7 @@ This auth provider is used by:
 ## Configuring Slack auth
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own Slack app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/spotify.mdx
+++ b/pages/home/auth-providers/spotify.mdx
@@ -22,7 +22,7 @@ This auth provider is used by:
 ## Configuring Spotify auth
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own Spotify app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/spotify.mdx
+++ b/pages/home/auth-providers/spotify.mdx
@@ -21,6 +21,10 @@ This auth provider is used by:
 
 ## Configuring Spotify auth
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own Spotify app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own Spotify credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.

--- a/pages/home/auth-providers/twitch.mdx
+++ b/pages/home/auth-providers/twitch.mdx
@@ -21,6 +21,10 @@ This auth provider is used by:
 
 ## Configuring Twitch auth
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own Twitch app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own Twitch credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.

--- a/pages/home/auth-providers/twitch.mdx
+++ b/pages/home/auth-providers/twitch.mdx
@@ -22,7 +22,7 @@ This auth provider is used by:
 ## Configuring Twitch auth
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own Twitch app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/x.mdx
+++ b/pages/home/auth-providers/x.mdx
@@ -23,7 +23,7 @@ This auth provider is used by:
 ## Configuring X auth
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own X app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/x.mdx
+++ b/pages/home/auth-providers/x.mdx
@@ -22,6 +22,10 @@ This auth provider is used by:
 
 ## Configuring X auth
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own X app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own X credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.

--- a/pages/home/auth-providers/zendesk.mdx
+++ b/pages/home/auth-providers/zendesk.mdx
@@ -23,7 +23,7 @@ This auth provider is used by:
 ## Create a Zendesk app
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 ### Additional guides

--- a/pages/home/auth-providers/zendesk.mdx
+++ b/pages/home/auth-providers/zendesk.mdx
@@ -22,6 +22,10 @@ This auth provider is used by:
 
 ## Create a Zendesk app
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 ### Additional guides
 The following three guides from Zendesk will be helpful additional information as you progress through this guide:
 1. [Using OAuth authentication with your application](https://support.zendesk.com/hc/en-us/articles/4408845965210-Using-OAuth-authentication-with-your-application)

--- a/pages/home/auth-providers/zoom.mdx
+++ b/pages/home/auth-providers/zoom.mdx
@@ -22,7 +22,7 @@ This auth provider is used by:
 ## Configuring Zoom auth
 
 <Note>
-  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). Without this, your end-users will not be able to use your app or agent in production.
 </Note>
 
 In a production environment, you will most likely want to use your own Zoom app credentials. This way, your users will see your application's name requesting permission.

--- a/pages/home/auth-providers/zoom.mdx
+++ b/pages/home/auth-providers/zoom.mdx
@@ -21,6 +21,10 @@ This auth provider is used by:
 
 ## Configuring Zoom auth
 
+<Note>
+  When using your own app credentials, make sure you configure your project to use a [custom user verifier](/home/auth/secure-auth-production#build-a-custom-user-verifier). This enables your app to verify the user's identity when they authorize a tool.
+</Note>
+
 In a production environment, you will most likely want to use your own Zoom app credentials. This way, your users will see your application's name requesting permission.
 
 You can use your own Zoom credentials in both the Arcade Cloud and in a [self-hosted Arcade Engine](/home/local-deployment/install/local) instance.


### PR DESCRIPTION
This links to the instructions on how to build a custom user verifier from all the custom auth provider pages. 