### PR TITLE
Fix glossary: change 'Authentication Scope' to 'Authorization Scope'

### DIFF
--- a/pages/home/glossary.mdx
+++ b/pages/home/glossary.mdx
@@ -97,9 +97,9 @@ An 'authentication provider' is a service that your users can authenticate to gr
 
 *Learn more about [authentication providers](/home/auth-providers).*
 
-### Authentication Scope
+### Authorization Scope
 
-An 'authentication scope' is a permission that a user can grant to an agent.  This is used to control what the agent can do with the user's data.  Available authentication scopes are defined by the authentication provider, and each tool defines the scopes it requires.
+An 'authorization scope' is a permission that a user can grant to an agent.  This is used to control what the agent can do with the user's data.  Available authorization scopes are defined by the authentication provider, and each tool defines the scopes it requires.
 
 Learn more about [authorized tool calling](/home/auth/auth-tool-calling).
 


### PR DESCRIPTION
A permission you grant that defines what someone (or some thing) can do? That is the literal definition of authorization!


