### PR TITLE
Docs: Update Tool Error Handling

### DIFF
--- a/pages/home/build-tools/handle-tool-errors.mdx
+++ b/pages/home/build-tools/handle-tool-errors.mdx
@@ -38,7 +38,7 @@ ToolkitError                                  # (Abstract base class)
 
 ## Error adapters
 
-Error adapters automatically translate common exceptions (from `httpx`, `requests`, SDKs, etc.) into appropriate Arcade errors. This means zero boilerplate error handling code for you. To see which SDKs have error adapters, see [arcade_tdk/error_adapters/__init__.py](https://github.com/ArcadeAI/arcade-ai/blob/main/libs/arcade-tdk/arcade_tdk/error_adapters/__init__.py). You may want to create your own error adapter or contribute an error adapter to the TDK. If so, see the [HTTP Error Adapter](https://github.com/ArcadeAI/arcade-ai/blob/main/libs/arcade-tdk/arcade_tdk/providers/http/error_adapter.py) for an example.
+Error adapters automatically translate common exceptions (from `httpx`, `requests`, SDKs, etc.) into appropriate Arcade errors. This means zero boilerplate error handling code for you. To see which SDKs already have error adapters, see [arcade_tdk/error_adapters/__init__.py](https://github.com/ArcadeAI/arcade-ai/blob/main/libs/arcade-tdk/arcade_tdk/error_adapters/__init__.py). You may want to create your own error adapter or contribute an error adapter to the TDK. If so, see the [HTTP Error Adapter](https://github.com/ArcadeAI/arcade-ai/blob/main/libs/arcade-tdk/arcade_tdk/providers/http/error_adapter.py) for an example. Ensure your error adapter implements the [ErrorAdapter protocol](https://github.com/ArcadeAI/arcade-ai/blob/main/libs/arcade-tdk/arcade_tdk/error_adapters/base.py).
 
 ### Automatic error adaptation
 


### PR DESCRIPTION
This doc is targeted to tool developers and is about how and when to raise errors in your tools.

When writing this up I noticed that our documentation is missing a "Using Tools" section. Within that section we could talk about how to properly catch errors when calling tools via the client libraries.
