### PR TITLE
Add redirect from /toolkits to /mcp-servers

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -93,10 +93,10 @@ export function middleware(request: NextRequest) {
     });
   }
 
-  // Redirect /toolkit routes to /mcp-server routes
-  if (pathname.includes("/toolkits/")) {
+  // Redirect /toolkits to /mcp-servers
+  if (pathname.includes("/toolkits")) {
     return NextResponse.redirect(
-      new URL(pathname.replace("/toolkits/", "/mcp-servers/"), request.url)
+      new URL(pathname.replace("/toolkits", "/mcp-servers"), request.url)
     );
   }
 


### PR DESCRIPTION
- Redirects /toolkits to /mcp-servers
- Redirects /en/toolkits to /en/mcp-servers
- Handles sub-paths like /en/toolkits/some-page