### PR TITLE
MCPfied the retry tools page

### DIFF
--- a/app/en/home/build-tools/retry-tools-with-improved-prompt/page.mdx
+++ b/app/en/home/build-tools/retry-tools-with-improved-prompt/page.mdx
@@ -28,9 +28,9 @@ from typing import Annotated
 
 from slack_sdk import WebClient
 
-from arcade_tdk.errors import RetryableToolError
-from arcade_tdk import ToolContext, tool
-from arcade_tdk.auth import Slack
+from arcade_core.errors import RetryableToolError
+from arcade_mcp_server import Context, tool
+from arcade_mcp_server.auth import Slack
 
 
 @tool(
@@ -44,7 +44,7 @@ from arcade_tdk.auth import Slack
     )
 )
 def send_dm_to_user(
-    context: ToolContext,
+    context: Context,
     user_name: Annotated[
         str,
         "The Slack username of the person you want to message. Slack usernames are ALWAYS lowercase.",


### PR DESCRIPTION
removed mentions of the TDK in favor of `arcade_mcp_server` and `arcade_core`