### PR TITLE
Clarify server type in On-prem MCP Server page

### DIFF
--- a/app/en/home/deployment/on-prem-mcp/page.mdx
+++ b/app/en/home/deployment/on-prem-mcp/page.mdx
@@ -110,7 +110,7 @@ tailscale funnel 8000
 1. Fill in the form:
    - **ID**: Choose a unique identifier (e.g., `my-server`)
    - **Server Type**:
-     - Select `Arcade` if you followed the [Creating a MCP Server](/home/build-tools/create-a-mcp-server) guide
+     - Select `Arcade` if you followed the [Creating a MCP Server](/home/build-tools/create-a-mcp-server) guide.  Some features like OAuth for users and secret injection require connecting to the server via the `Arcade` method. 
      - Select `MCP` if you have an MCP Server that was not created with Arcade
    - **URL**: Enter your public URL from Step 3, and add `/mcp` to the end
    - **Timeout** and **Retry**: Configure as needed for your use case


### PR DESCRIPTION
Clarify when to select server type Arcade and when to select MCP.

It was previously indicating to choose MCP, but since we tell the user to first follow the [Create a MCP Server](https://docs.arcade.dev/home/build-tools/create-a-mcp-server) doc, the correct server type is actually "Arcade".