### PR TITLE
fix edit link

### DIFF
--- a/app/_layouts/shared-layout.tsx
+++ b/app/_layouts/shared-layout.tsx
@@ -105,7 +105,7 @@ export default async function SharedLayout({
         )}
         <Layout
           copyPageButton={true}
-          docsRepositoryBase="https://github.com/ArcadeAI/docs"
+          docsRepositoryBase="https://github.com/ArcadeAI/docs/tree/main/"
           editLink={dictionary.editPage}
           footer={
             <NextraFooter>


### PR DESCRIPTION
Update the edit link:

<img width="237" height="77" alt="Screenshot 2025-10-14 at 11 15 13 AM" src="https://github.com/user-attachments/assets/c1445cd9-bf22-4ff9-85e7-5c0c6d9b0e94" />

It was redirecting to a `Not Found` page.
