### PR TITLE
skip glossary for MCMP servers

### DIFF
--- a/lib/remark-glossary.ts
+++ b/lib/remark-glossary.ts
@@ -29,6 +29,11 @@ export function remarkGlossary(options: RemarkGlossaryOptions) {
       return;
     }
 
+    // don't process the many MCP tool pages
+    if (file.history?.[0]?.includes("/mcp-servers/")) {
+      return;
+    }
+
     // Lazy-load and cache glossary terms
     if (!cachedTerms || cachedGlossaryPath !== glossaryPath) {
       cachedTerms = sortTermsByLength(parseGlossary(glossaryPath));


### PR DESCRIPTION
```
rm -rf .next && time pnpm build
...
pnpm build  161.67s user 23.87s system 171% cpu 1:48.26 total
```

After

```
rm -rf .next && time pnpm build
...
pnpm build  150.42s user 18.48s system 172% cpu 1:37.94 total
```