### PR TITLE
Redirect to arcade-mcp repo instead of our docs repo

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -131,7 +131,7 @@ export default async function RootLayout({
               projectIcon={
                 <Github className="size-5.5 transition-colors duration-150 ease-in-out [&>path]:fill-current" />
               }
-              projectLink="https://github.com/ArcadeAI/docs"
+              projectLink="https://github.com/ArcadeAI/arcade-mcp"
             >
               <SignupLink linkLocation="docs:navbar">
                 <NavBarButton


### PR DESCRIPTION
<img width="569" height="62" alt="Screenshot 2025-11-07 at 11 45 56 AM" src="https://github.com/user-attachments/assets/31423b7e-c6f5-443e-9944-513b6f78ee8e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the navbar GitHub project link from `ArcadeAI/docs` to `ArcadeAI/arcade-mcp` in `app/layout.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34faef9f0e6b7a14a08b6cd8ac24c8a7f538f98f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->