### PR TITLE
Docs: Fix incorrect reference to Dashboard

### DIFF
--- a/app/en/home/auth-providers/asana/page.mdx
+++ b/app/en/home/auth-providers/asana/page.mdx
@@ -81,7 +81,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **Asana**.

--- a/app/en/home/auth-providers/atlassian/page.mdx
+++ b/app/en/home/auth-providers/atlassian/page.mdx
@@ -57,7 +57,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **Atlassian**.

--- a/app/en/home/auth-providers/calendly/page.mdx
+++ b/app/en/home/auth-providers/calendly/page.mdx
@@ -83,7 +83,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **OAuth 2.0** tab at the top.
 

--- a/app/en/home/auth-providers/clickup/page.mdx
+++ b/app/en/home/auth-providers/clickup/page.mdx
@@ -51,7 +51,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **ClickUp**.

--- a/app/en/home/auth-providers/discord/page.mdx
+++ b/app/en/home/auth-providers/discord/page.mdx
@@ -56,7 +56,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **Discord**.

--- a/app/en/home/auth-providers/dropbox/page.mdx
+++ b/app/en/home/auth-providers/dropbox/page.mdx
@@ -58,7 +58,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **Dropbox**.

--- a/app/en/home/auth-providers/figma/page.mdx
+++ b/app/en/home/auth-providers/figma/page.mdx
@@ -83,7 +83,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **OAuth 2.0** tab at the top.
 

--- a/app/en/home/auth-providers/github/page.mdx
+++ b/app/en/home/auth-providers/github/page.mdx
@@ -70,7 +70,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **GitHub**.

--- a/app/en/home/auth-providers/google/page.mdx
+++ b/app/en/home/auth-providers/google/page.mdx
@@ -63,7 +63,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **Google**.

--- a/app/en/home/auth-providers/hubspot/page.mdx
+++ b/app/en/home/auth-providers/hubspot/page.mdx
@@ -87,7 +87,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **Hubspot**.

--- a/app/en/home/auth-providers/linear/page.mdx
+++ b/app/en/home/auth-providers/linear/page.mdx
@@ -56,7 +56,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **Linear**.

--- a/app/en/home/auth-providers/mailchimp/page.mdx
+++ b/app/en/home/auth-providers/mailchimp/page.mdx
@@ -85,7 +85,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **OAuth 2.0** tab at the top.
 
@@ -253,7 +253,7 @@ async with httpx.AsyncClient() as client:
     )
     metadata = metadata_response.json()
     api_endpoint = metadata["api_endpoint"]
-    
+
 # Now use the api_endpoint for all API calls
 # Example: f"{api_endpoint}/3.0/lists"
 ```
@@ -313,7 +313,7 @@ async def get_mailchimp_lists(
             headers={"Authorization": f"Bearer {context.authorization.token}"}
         )
         api_endpoint = metadata_response.json()["api_endpoint"]
-        
+
         # Now get the lists
         response = await client.get(
             f"{api_endpoint}/3.0/lists",

--- a/app/en/home/auth-providers/microsoft/page.mdx
+++ b/app/en/home/auth-providers/microsoft/page.mdx
@@ -70,7 +70,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **Microsoft**.

--- a/app/en/home/auth-providers/miro/page.mdx
+++ b/app/en/home/auth-providers/miro/page.mdx
@@ -87,7 +87,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **OAuth 2.0** tab at the top.
 

--- a/app/en/home/auth-providers/notion/page.mdx
+++ b/app/en/home/auth-providers/notion/page.mdx
@@ -53,7 +53,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **Notion**.

--- a/app/en/home/auth-providers/pagerduty/page.mdx
+++ b/app/en/home/auth-providers/pagerduty/page.mdx
@@ -87,7 +87,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **OAuth 2.0** tab at the top.
 

--- a/app/en/home/auth-providers/reddit/page.mdx
+++ b/app/en/home/auth-providers/reddit/page.mdx
@@ -58,7 +58,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **Reddit**.

--- a/app/en/home/auth-providers/salesforce/page.mdx
+++ b/app/en/home/auth-providers/salesforce/page.mdx
@@ -126,7 +126,7 @@ By default, the Arcade Dashboard will be available at http://localhost:9099/dash
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Custom Provider** tab at the top.
 

--- a/app/en/home/auth-providers/slack/page.mdx
+++ b/app/en/home/auth-providers/slack/page.mdx
@@ -81,7 +81,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **Slack**.

--- a/app/en/home/auth-providers/spotify/page.mdx
+++ b/app/en/home/auth-providers/spotify/page.mdx
@@ -59,7 +59,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **Spotify**.

--- a/app/en/home/auth-providers/square/page.mdx
+++ b/app/en/home/auth-providers/square/page.mdx
@@ -89,7 +89,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **OAuth 2.0** tab at the top.
 

--- a/app/en/home/auth-providers/ticktick/page.mdx
+++ b/app/en/home/auth-providers/ticktick/page.mdx
@@ -82,7 +82,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **OAuth 2.0** tab at the top.
 

--- a/app/en/home/auth-providers/twitch/page.mdx
+++ b/app/en/home/auth-providers/twitch/page.mdx
@@ -62,7 +62,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **Twitch**.

--- a/app/en/home/auth-providers/x/page.mdx
+++ b/app/en/home/auth-providers/x/page.mdx
@@ -61,7 +61,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **X**.

--- a/app/en/home/auth-providers/zoho/page.mdx
+++ b/app/en/home/auth-providers/zoho/page.mdx
@@ -98,7 +98,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **OAuth 2.0** tab at the top.
 

--- a/app/en/home/auth-providers/zoom/page.mdx
+++ b/app/en/home/auth-providers/zoom/page.mdx
@@ -60,7 +60,7 @@ To access the Arcade Cloud dashboard, go to [api.arcade.dev/dashboard](https://a
 
 #### Navigate to the OAuth Providers page
 
-- Under the **OAuth** section of the Arcade Dashboard left-side menu, click **Providers**.
+- Under the **Connections** section of the Arcade Dashboard left-side menu, click **Connected Apps**.
 - Click **Add OAuth Provider** in the top right corner.
 - Select the **Included Providers** tab at the top.
 - In the **Provider** dropdown, select **Zoom**.


### PR DESCRIPTION
The docs were referencing a page on the Dashboard that doesn't exist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates auth provider docs to point to Connections > Connected Apps (instead of OAuth > Providers) and fixes minor whitespace.
> 
> - **Docs**
>   - **Dashboard navigation fix**: Replace `OAuth > Providers` with `Connections > Connected Apps` in `app/en/home/auth-providers/*/page.mdx` for providers:
>     - `asana`, `atlassian`, `calendly`, `clickup`, `discord`, `dropbox`, `figma`, `github`, `google`, `hubspot`, `linear`, `miro`, `notion`, `pagerduty`, `reddit`, `salesforce`, `slack`, `spotify`, `square`, `ticktick`, `twitch`, `x`, `zoho`, `zoom`.
>   - Minor whitespace cleanup in `mailchimp/page.mdx` examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8a158376f36cb644208fc6665a7fd5446563ff4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->