### PR TITLE
Add link to download OpenAPI spec

### DIFF
--- a/app/en/references/api/page.mdx
+++ b/app/en/references/api/page.mdx
@@ -3,9 +3,9 @@ title: "Arcade API Reference"
 description: "Learn about the Arcade API.  It's swagger time!"
 ---
 
-import SwaggerUI from "swagger-ui-react"
-import "swagger-ui-react/swagger-ui.css"
-import "./swaggerHacks.css"
+import SwaggerUI from "swagger-ui-react";
+import "swagger-ui-react/swagger-ui.css";
+import "./swaggerHacks.css";
 
 # Arcade API Reference
 
@@ -13,5 +13,6 @@ The base URL for all API requests is `https://api.arcade.dev`.
 
 The use of this API is subject to our [Terms of Service](https://arcade.dev/terms-of-service), and you are required to have an account in good standing.
 
-<SwaggerUI url="https://api.arcade.dev/v1/swagger"  />
+Our OpenAPI 3.0 specification is [available here](https://api.arcade.dev/v1/swagger).
 
+<SwaggerUI url="https://api.arcade.dev/v1/swagger" />


### PR DESCRIPTION
I find it annoying when services have an OpenAPI spec doc, use it in their docs, but simply hide it from developers. We cannot be that annoying.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a direct link to the OpenAPI 3.0 spec on the API reference page and tidies imports/SwaggerUI markup.
> 
> - **Docs**:
>   - Add explicit link to download the OpenAPI 3.0 spec in `app/en/references/api/page.mdx`.
>   - Keep embedded `SwaggerUI` viewer for `https://api.arcade.dev/v1/swagger`.
> - **Minor**:
>   - Clean up imports and formatting (semicolons, whitespace).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6012cf9091c8417b446109c653c30856f6b72832. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->