### PR TITLE
Shorten Jira tool names exceeding Cursor limit

### DIFF
--- a/app/en/mcp-servers/productivity/jira/page.mdx
+++ b/app/en/mcp-servers/productivity/jira/page.mdx
@@ -154,11 +154,11 @@ When the user selects an Atlassian Cloud, it may be appropriate to keep this inf
       "Browse the priority schemes available in Jira.",
     ],
     [
-      "Jira.ListPrioritiesAssociatedWithAPriorityScheme",
+      "Jira.ListPrioritiesByScheme",
       "Browse the priorities associated with a priority scheme.",
     ],
     [
-      "Jira.ListProjectsAssociatedWithAPriorityScheme",
+      "Jira.ListProjectsByScheme",
       "Browse the projects associated with a priority scheme.",
     ],
     [
@@ -1202,7 +1202,7 @@ Browse the priority schemes available in Jira.
 - **order_by** (`Enum` [PrioritySchemeOrderBy](/mcp-servers/productivity/jira/reference#PrioritySchemeOrderBy), optional) The order in which to return the priority schemes. Defaults to name ascending.
 - **atlassian_cloud_id** (`string`, optional) The ID of the Atlassian Cloud to use (defaults to None). If not provided and the user has a single cloud authorized, the tool will use that. Otherwise, an error will be raised.
 
-## Jira.ListPrioritiesAssociatedWithAPriorityScheme
+## Jira.ListPrioritiesByScheme
 
 <br />
 <TabbedCodeBlock
@@ -1211,10 +1211,10 @@ Browse the priority schemes available in Jira.
       label: "Call the Tool Directly",
       content: {
         Python: [
-          "/examples/integrations/mcp-servers/jira/list_priorities_associated_with_a_priority_scheme_example_call_tool.py",
+          "/examples/integrations/mcp-servers/jira/list_priorities_by_scheme_example_call_tool.py",
         ],
         JavaScript: [
-          "/examples/integrations/mcp-servers/jira/list_priorities_associated_with_a_priority_scheme_example_call_tool.js",
+          "/examples/integrations/mcp-servers/jira/list_priorities_by_scheme_example_call_tool.js",
         ],
       },
     },
@@ -1230,7 +1230,7 @@ Browse the priorities associated with a priority scheme.
 - **offset** (`integer`, optional) The number of priority schemes to skip. Defaults to 0 (start from the first scheme).
 - **atlassian_cloud_id** (`string`, optional) The ID of the Atlassian Cloud to use (defaults to None). If not provided and the user has a single cloud authorized, the tool will use that. Otherwise, an error will be raised.
 
-## Jira.ListProjectsAssociatedWithAPriorityScheme
+## Jira.ListProjectsByScheme
 
 <br />
 <TabbedCodeBlock
@@ -1239,10 +1239,10 @@ Browse the priorities associated with a priority scheme.
       label: "Call the Tool Directly",
       content: {
         Python: [
-          "/examples/integrations/mcp-servers/jira/list_projects_associated_with_a_priority_scheme_example_call_tool.py",
+          "/examples/integrations/mcp-servers/jira/list_projects_by_scheme_example_call_tool.py",
         ],
         JavaScript: [
-          "/examples/integrations/mcp-servers/jira/list_projects_associated_with_a_priority_scheme_example_call_tool.js",
+          "/examples/integrations/mcp-servers/jira/list_projects_by_scheme_example_call_tool.js",
         ],
       },
     },

--- a/public/examples/integrations/mcp-servers/jira/list_priorities_by_scheme_example_call_tool.js
+++ b/public/examples/integrations/mcp-servers/jira/list_priorities_by_scheme_example_call_tool.js
@@ -3,7 +3,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
 const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
-const TOOL_NAME = "Jira.ListPrioritiesAssociatedWithAPriorityScheme";
+const TOOL_NAME = "Jira.ListPrioritiesByScheme";
 
 // Start the authorization process
 const authResponse = await client.tools.authorize({tool_name: TOOL_NAME, user_id: USER_ID});

--- a/public/examples/integrations/mcp-servers/jira/list_priorities_by_scheme_example_call_tool.py
+++ b/public/examples/integrations/mcp-servers/jira/list_priorities_by_scheme_example_call_tool.py
@@ -4,7 +4,7 @@ from arcadepy import Arcade
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
 USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
-TOOL_NAME = "Jira.ListProjectsAssociatedWithAPriorityScheme"
+TOOL_NAME = "Jira.ListPrioritiesByScheme"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME, user_id=USER_ID)
 
@@ -16,9 +16,7 @@ client.auth.wait_for_completion(auth_response)
 
 tool_input = {
     "scheme_id": "12345",
-    "project": "proj-001",
     "limit": 10,
-    "offset": 0,
     # Important: about the atlassian_cloud_id argument, please refer to the documentation at
     # https://docs.arcade.dev/mcp-servers/productivity/jira#handling-multiple-atlassian-clouds
     "atlassian_cloud_id": "13516a07-1725-4dc0-9ae7-13b5749dd747"

--- a/public/examples/integrations/mcp-servers/jira/list_projects_by_scheme_example_call_tool.js
+++ b/public/examples/integrations/mcp-servers/jira/list_projects_by_scheme_example_call_tool.js
@@ -3,7 +3,7 @@ import { Arcade } from "@arcadeai/arcadejs";
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
 const USER_ID = "{arcade_user_id}";  // Unique identifier for your user (email, UUID, etc.)
-const TOOL_NAME = "Jira.ListProjectsAssociatedWithAPriorityScheme";
+const TOOL_NAME = "Jira.ListProjectsByScheme";
 
 // Start the authorization process
 const authResponse = await client.tools.authorize({tool_name: TOOL_NAME, user_id: USER_ID});

--- a/public/examples/integrations/mcp-servers/jira/list_projects_by_scheme_example_call_tool.py
+++ b/public/examples/integrations/mcp-servers/jira/list_projects_by_scheme_example_call_tool.py
@@ -4,7 +4,7 @@ from arcadepy import Arcade
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
 USER_ID = "{arcade_user_id}"  # Unique identifier for your user (email, UUID, etc.)
-TOOL_NAME = "Jira.ListPrioritiesAssociatedWithAPriorityScheme"
+TOOL_NAME = "Jira.ListProjectsByScheme"
 
 auth_response = client.tools.authorize(tool_name=TOOL_NAME, user_id=USER_ID)
 
@@ -16,7 +16,9 @@ client.auth.wait_for_completion(auth_response)
 
 tool_input = {
     "scheme_id": "12345",
+    "project": "proj-001",
     "limit": 10,
+    "offset": 0,
     # Important: about the atlassian_cloud_id argument, please refer to the documentation at
     # https://docs.arcade.dev/mcp-servers/productivity/jira#handling-multiple-atlassian-clouds
     "atlassian_cloud_id": "13516a07-1725-4dc0-9ae7-13b5749dd747"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Shortens two Jira tool names and updates documentation and example scripts to use the new names.
> 
> - **Docs (`app/en/mcp-servers/productivity/jira/page.mdx`)**
>   - Rename `Jira.ListPrioritiesAssociatedWithAPriorityScheme` -> `Jira.ListPrioritiesByScheme`.
>   - Rename `Jira.ListProjectsAssociatedWithAPriorityScheme` -> `Jira.ListProjectsByScheme`.
>   - Update table entries, section headings, and example file paths accordingly.
> - **Examples (`public/examples/integrations/mcp-servers/jira/`)**
>   - Add `list_priorities_by_scheme_example_call_tool.{js,py}` using `Jira.ListPrioritiesByScheme`.
>   - Add `list_projects_by_scheme_example_call_tool.{js,py}` using `Jira.ListProjectsByScheme`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a334fc6506b04b69255151f08093c57933ea45fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->