### PR TITLE
updated the google news MCP server docs to the new tool name

### DIFF
--- a/app/en/mcp-servers/search/google_news/page.mdx
+++ b/app/en/mcp-servers/search/google_news/page.mdx
@@ -25,7 +25,10 @@ The Arcade Google News MCP Server provides a pre-built set of tools for interact
 <TableOfContents
   headers={["Tool Name", "Description"]}
   data={[
-    ["GoogleNews.SearchNews", "Search for news stories with Google News."],
+    [
+      "GoogleNews.SearchNewsStories",
+      "Search for news stories with Google News.",
+    ],
   ]}
 />
 
@@ -35,7 +38,7 @@ The Arcade Google News MCP Server provides a pre-built set of tools for interact
   tools](/home/build-tools/create-a-mcp-server).
 </Callout>
 
-## GoogleNews.SearchNews
+## GoogleNews.SearchNewsStories
 
 <br />
 <TabbedCodeBlock
@@ -58,7 +61,7 @@ Search for news stories with Google News.
 
 **Parameters**
 
-- **`query`** _(string, required)_ Keywords to search for news articles. E.g. 'Apple launches new iPhone'.
+- **`keywords`** _(string, required)_ Keywords to search for news articles. E.g. 'Apple launches new iPhone'.
 - **`country_code`** _(string, optional, Defaults to `None`)_ 2-character country code to search for news articles. E.g. 'us' (United States). Defaults to `None` (search news globally).
 - **`language`** _(string, optional, Defaults to 'en' English)_ 2-character language code to search for news articles. E.g. 'en' (English). Defaults to 'en' (English).
 - **`limit`** _(int, optional, Defaults to `None`)_ Maximum number of news articles to return. Defaults to None (returns all results found by the API).

--- a/public/examples/integrations/mcp-servers/search/google_news/search_news_example_call_tool.js
+++ b/public/examples/integrations/mcp-servers/search/google_news/search_news_example_call_tool.js
@@ -3,10 +3,10 @@ import { Arcade } from "@arcadeai/arcadejs";
 const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
 
 const USER_ID = "{arcade_user_id}";
-const TOOL_NAME = "GoogleNews.SearchNews";
+const TOOL_NAME = "GoogleNews.SearchNewsStories";
 
 const toolInput = {
-	query: "Apple's new iPhone",
+	keywords: "Apple's new iPhone",
 };
 
 const response = await client.tools.execute({

--- a/public/examples/integrations/mcp-servers/search/google_news/search_news_example_call_tool.py
+++ b/public/examples/integrations/mcp-servers/search/google_news/search_news_example_call_tool.py
@@ -3,10 +3,10 @@ from arcadepy import Arcade
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 
 USER_ID = "{arcade_user_id}"
-TOOL_NAME = "GoogleNews.SearchNews"
+TOOL_NAME = "GoogleNews.SearchNewsStories"
 
 tool_input = {
-    "query": "Apple's new iPhone",
+    "keywords": "Apple's new iPhone",
 }
 
 response = client.tools.execute(


### PR DESCRIPTION
The tool works but docs were not in sync

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the Google News tool to `GoogleNews.SearchNewsStories` and updates the required parameter from `query` to `keywords`, reflecting changes in docs and JS/Python examples.
> 
> - **Docs (Google News MCP)**:
>   - Rename tool `GoogleNews.SearchNews` → `GoogleNews.SearchNewsStories` in `app/en/mcp-servers/search/google_news/page.mdx`.
>   - Update required parameter `query` → `keywords` in parameters section.
>   - Refresh Table of Contents entry and section header to new tool name.
> - **Examples**:
>   - JS: Update `TOOL_NAME` and tool input from `query` → `keywords` in `public/.../search_news_example_call_tool.js`.
>   - Python: Update `TOOL_NAME` and tool input from `query` → `keywords` in `public/.../search_news_example_call_tool.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be60cef1bd45952b5a295c26befbcc492777a711. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->