### PR TITLE
docs: reorganize MCP clients under Tool Calling section and improve Cursor guide

### DIFF
--- a/app/en/home/_meta.tsx
+++ b/app/en/home/_meta.tsx
@@ -61,12 +61,16 @@ export const meta: MetaRecord = {
   "serve-tools": {
     title: "Serve tools",
   },
-  "-- Agent Frameworks and MCP": {
+  "-- Tool Calling in Apps": {
     type: "separator",
-    title: "Agent Frameworks and MCP",
+    title: "Tool Calling in Apps",
   },
   "mcp-clients": {
     title: "MCP Clients",
+  },
+  "-- Agent Frameworks": {
+    type: "separator",
+    title: "Agent Frameworks",
   },
   langchain: {
     title: "LangChain",

--- a/app/en/home/mcp-clients/_meta.tsx
+++ b/app/en/home/mcp-clients/_meta.tsx
@@ -1,5 +1,5 @@
 export default {
   cursor: "Cursor",
-  "claude-desktop": "Claude Desktop",
   "visual-studio-code": "Visual Studio Code",
+  "claude-desktop": "Claude Desktop",
 };

--- a/app/en/home/mcp-clients/cursor/page.mdx
+++ b/app/en/home/mcp-clients/cursor/page.mdx
@@ -1,48 +1,88 @@
 import { Steps, Callout } from "nextra/components";
 import { SignupLink } from "@/app/_components/analytics";
 
+# Use Arcade tools in Cursor
 
-# Use Arcade in Cursor
+Connect Cursor to Arcade and give your AI coding assistant access to powerful tools like GitHub, Linear, Slack, Google Drive, and more.
 
-In this guide, you'll learn how to connect Cursor to an Arcade MCP Gateway.
+With this integration, you can ask Cursor's agent to:
+- Create GitHub issues and pull requests
+- Search and update Linear tickets
+- Send Slack messages
+- Read and write Google Docs
+- And much more
 
 <Steps>
 
-### Prerequisites
+### Get your Arcade credentials
 
-1. Create an <SignupLink linkLocation="docs:claude-desktop-client">Arcade account</SignupLink>
+1. <SignupLink linkLocation="docs:cursor-mcp-client">Create an Arcade account</SignupLink> if you don't have one
 2. Get an [Arcade API key](/home/api-keys)
-3. Create an [Arcade MCP Gateway](/home/mcp-gateways) and select the tools you want to use
+3. Create an [Arcade MCP Gateway](/home/mcp-gateways) and select the tools you want to use in Cursor
 
-### Set up Cursor
+<Callout type="info">
+Save your MCP Gateway URL—you'll need it in the next step. It looks like: `https://api.arcade.dev/mcp/your-gateway-slug`
+</Callout>
 
-3. Download and open [Cursor](https://cursor.com/download)
-4. Open the command palette and select **Open MCP Settings...**
-5. Choose **HTTP**
-6. Paste the URL of your MCP Gateway
-7. Give your MCP server a name, like `mcp-arcade`
-8. Add the API key as the bearer token within the `Authorization` header, and the email address that you used to sign up for the Arcade account as the `Arcade-User-ID` header
+### Configure Cursor
 
-Cursor will update your `settings.json` file with the following
+1. Open [Cursor](https://cursor.com/download) (version 0.50 or higher)
+2. Open the command palette (`Cmd+Shift+P` on Mac, `Ctrl+Shift+P` on Windows/Linux)
+3. Type **MCP** and select **Open MCP Settings...**
+4. Select **HTTP** as the server type
+5. Paste your MCP Gateway URL
+6. Name your server (e.g., `arcade`)
+7. Add your authentication headers:
+   - `Authorization`: `Bearer YOUR_API_KEY`
+   - `Arcade-User-ID`: Your Arcade account email
+
+Cursor updates your `settings.json` file. The configuration looks like this:
 
 ```json
 {
   "mcpServers": {
-    "mcp-arcade": {
-      "url": "https://api.arcade.dev/mcp/<YOUR-GATEWAY-SLUG>",
+    "arcade": {
+      "url": "https://api.arcade.dev/mcp/your-gateway-slug",
       "headers": {
-        "Authorization": "Bearer {arcade_api_key}",
-        "Arcade-User-ID": "{arcade_user_id}"
+        "Authorization": "Bearer your_api_key",
+        "Arcade-User-ID": "you@example.com"
       }
     }
   }
 }
 ```
 
-### Try it out
+### Start using tools
 
-1. Open the chat pane (typically command-l)
-1. Make sure you are in **Agent** mode
-1. Ask the agent to use a tool!
+1. Open the chat pane (`Cmd+L` on Mac, `Ctrl+L` on Windows/Linux)
+2. Switch to **Agent** mode using the dropdown at the bottom of the chat
+3. Ask the agent to use a tool!
+
+Try these example prompts:
+- "List my open GitHub issues"
+- "Create a Linear ticket for this bug"
+- "Send a Slack message to #general"
 
 </Steps>
+
+## Authorize tools
+
+Some tools require you to authorize access to your accounts (like GitHub or Google). When you use a tool for the first time, Arcade prompts you to authorize. Click the link and follow the OAuth flow—you only need to do this once per service.
+
+## Troubleshooting
+
+<Callout type="warning">
+**Tools not appearing?** Make sure you're in **Agent** mode, not Ask or Edit mode. Only Agent mode can use MCP tools.
+</Callout>
+
+**Common issues:**
+
+- **"Server not connected"**: Check that your MCP Gateway URL is correct and your API key is valid
+- **"Unauthorized" errors**: Verify your `Authorization` header includes `Bearer ` before your API key
+- **Tools not working**: Ensure the tool is enabled in your [MCP Gateway configuration](/home/mcp-gateways)
+
+## Next steps
+
+- Browse available [MCP Servers](/mcp-servers) to add more tools
+- Learn about [MCP Gateways](/home/mcp-gateways) to customize your tool selection
+- Build your own [custom MCP Server](/home/build-tools/create-a-mcp-server)


### PR DESCRIPTION
## Summary

This PR reorganizes the documentation structure and improves the Cursor MCP client guide for better discoverability and ease of use.

## Changes

### Navigation restructure
- **New section**: \"Tool Calling in Apps\" - dedicated section for MCP clients (Cursor, VS Code, Claude Desktop)
- **Separated**: \"Agent Frameworks\" now has its own section for SDK integrations (LangChain, CrewAI, etc.)
- This makes it clearer that MCP clients are for *using* tools in apps, while agent frameworks are for *building* agents

### Improved Cursor documentation
- Added clearer introduction explaining what users can achieve
- Example use cases (GitHub, Linear, Slack, Google Drive)
- More detailed step-by-step setup instructions
- Keyboard shortcuts for Mac/Windows/Linux
- Example prompts to get started
- Authorization flow explanation
- Troubleshooting section for common issues
- Next steps with links to related docs

## Testing
- [ ] Verify navigation renders correctly
- [ ] Test all links in Cursor guide
- [ ] Review on mobile

Closes DEV-33"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorganizes docs to separate MCP clients from agent frameworks and expands the Cursor guide with clearer setup, examples, and troubleshooting.
> 
> - **Navigation**:
>   - Add `-- Tool Calling in Apps` section and place `mcp-clients` under it.
>   - Add separate `-- Agent Frameworks` section for SDK integrations.
> - **Cursor MCP client guide** (`app/en/home/mcp-clients/cursor/page.mdx`):
>   - Rewrite with clearer intro and concrete use cases.
>   - Step-by-step setup split into credentials and Cursor configuration (with headers, shortcuts, and updated JSON sample using `arcade`).
>   - Add example prompts, authorization flow, troubleshooting tips, and next steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02a2e5217fd6aa6312b9aca7f24c35dbe2c60de0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->