### PR TITLE
revert claude desktop instructions to stdio

### DIFF
--- a/app/en/home/mcp-clients/claude-desktop/page.mdx
+++ b/app/en/home/mcp-clients/claude-desktop/page.mdx
@@ -17,21 +17,22 @@ In this guide, you'll learn how to connect Claude Desktop to a local Arcade serv
 
 1. Download and open [Claude Desktop](https://claude.ai/download)
 2. Claude Menu --> "Settings" --> "Developer" --> "Edit Config"
-3. Follow the guide [here](https://support.claude.com/en/articles/11175166-getting-started-with-custom-connectors-using-remote-mcp)
+3. This will create a configuration file at:
+   - On Mac: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - On Windows: `%APPDATA%\Claude\claude_desktop_config.json`
 4. Open the configuration file and replace the file contents with this:
-    * Give your MCP server a name, like `mcp-arcade`
-    * Use the the URL of your MCP Gateway.
-    * Add the API key as the bearer token within the `Authorization` header, and the email address that you used to sign up for the Arcade account as the `Arcade-User-ID` header
+
+Replace `YOUR_ARCADE_API_KEY_HERE` with your actual Arcade API key and `/path/to/python` with the path to your Python interpreter and `/path/to/arcade` with the path to the Arcade package.
 
 ```json
 {
   "mcpServers": {
-    "arcade-mcp": {
-      "url": "https://api.arcade.dev/mcp/<YOUR-GATEWAY-SLUG>",
-      "headers": {
-        "Authorization": "Bearer {arcade_api_key}",
-        "Arcade-User-ID": "{arcade_user_id}"
-      }
+    "arcade-stdio": {
+      "command": "bash",
+      "args": [
+        "-c",
+        "export ARCADE_API_KEY=YOUR_ARCADE_API_KEY_HERE && /path/to/python /path/to/arcade serve --mcp"
+      ]
     }
   }
 }


### PR DESCRIPTION
Preview: https://docs-git-mateo-dev-32-mcp-client-claude-desktop-arcade-ai.vercel.app/en/home/mcp-clients/claude-desktop

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Claude Desktop guide to use a local stdio MCP server configuration instead of HTTP gateway, adding OS-specific config paths and env-based API key usage.
> 
> - **Docs — Claude Desktop setup**:
>   - Replace HTTP gateway config with stdio-based `mcpServers.arcade-stdio` using `bash` command to run `arcade serve --mcp` and `ARCADE_API_KEY` env var.
>   - Add OS-specific locations for `claude_desktop_config.json` (Mac and Windows).
>   - Include note to replace API key and local paths for Python and Arcade package.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea61a224cfe34763bc8daca2cd1dab0168912b07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->