### PR TITLE
moved quickstart example from JS to TS and Bun

### DIFF
--- a/app/en/home/quickstart/page.mdx
+++ b/app/en/home/quickstart/page.mdx
@@ -87,7 +87,7 @@ user_id = "{arcade_user_id}"
 
 <Tabs.Tab>
 
-Create a new script called `example.mjs`:
+Create a new script called `example.ts`:
 
 ```typescript filename="example.ts"
 import Arcade from "@arcadeai/arcadejs";
@@ -308,21 +308,23 @@ console.log(respose_send_email.output?.value);
 
     ```bash
     uv run example.py
-    > latest news about MCP URL mode elicitation:
-    > ----------------------------
-    > InfoWorld - Visual Studio Code adds multi-agent orchestration
-    > https://www.infoworld.com/article/4105879/visual-studio-code-adds-multi-agent-orchestration.html
-    > ----------------------------
-    > Visual Studio Magazine - VS Code 1.107 (November 2025 Update) Expands Multi-Agent Orchestration, Model Management
-    > https://visualstudiomagazine.com/articles/2025/12/12/vs-code-1-107-november-2025-update-expands-multi-agent-orchestration-model-management.aspx
-    > ----------------------------
-    > SD Times - Several new updates make their way into the MCP specification
-    > https://sdtimes.com/ai/several-new-updates-make-their-way-into-the-mcp-specification/
-    > ----------------------------
-    > AI News - How the MCP spec update boosts security as infrastructure scales
-    > https://www.artificialintelligence-news.com/news/how-the-mcp-spec-update-boosts-security-as-infrastructure-scales/
-    >
-    > {'body': '', 'cc': '', 'date': '', 'from': '', 'header_message_id': '', 'history_id': '', 'id': '19b....', 'in_reply_to': '', 'label_ids': ['UNREAD', 'SENT', 'INBOX'], 'references': '', 'reply_to': '', 'snippet': '', 'subject': '', 'thread_id': '19b....', 'to': '', 'url': 'https://mail.google.com/mail/u/0/#sent/19b....'}
+    ```
+    ```text
+    latest news about MCP URL mode elicitation:
+    ----------------------------
+    InfoWorld - Visual Studio Code adds multi-agent orchestration
+    https://www.infoworld.com/article/4105879/visual-studio-code-adds-multi-agent-orchestration.html
+    ----------------------------
+    Visual Studio Magazine - VS Code 1.107 (November 2025 Update) Expands Multi-Agent Orchestration, Model Management
+    https://visualstudiomagazine.com/articles/2025/12/12/vs-code-1-107-november-2025-update-expands-multi-agent-orchestration-model-management.aspx
+    ----------------------------
+    SD Times - Several new updates make their way into the MCP specification
+    https://sdtimes.com/ai/several-new-updates-make-their-way-into-the-mcp-specification/
+    ----------------------------
+    AI News - How the MCP spec update boosts security as infrastructure scales
+    https://www.artificialintelligence-news.com/news/how-the-mcp-spec-update-boosts-security-as-infrastructure-scales/
+
+    {'body': '', 'cc': '', 'date': '', 'from': '', 'header_message_id': '', 'history_id': '', 'id': '19b....', 'in_reply_to': '', 'label_ids': ['UNREAD', 'SENT', 'INBOX'], 'references': '', 'reply_to': '', 'snippet': '', 'subject': '', 'thread_id': '19b....', 'to': '', 'url': 'https://mail.google.com/mail/u/0/#sent/19b....'}
     ```
 
   </Tabs.Tab>
@@ -330,38 +332,41 @@ console.log(respose_send_email.output?.value);
 
     ```bash
     bun run example.ts
-    > latest news about MCP URL mode elicitation:
-    > --------------------------------
-    > InfoWorld - Visual Studio Code adds multi-agent orchestration
-    > https://www.infoworld.com/article/4105879/visual-studio-code-adds-multi-agent-orchestration.html
-    > --------------------------------
-    > Visual Studio Magazine - VS Code 1.107 (November 2025 Update) Expands Multi-Agent Orchestration, Model Management
-    > https://visualstudiomagazine.com/articles/2025/12/12/vs-code-1-107-november-2025-update-expands-multi-agent-orchestration-model-management.aspx
-    > --------------------------------
-    > SD Times - Several new updates make their way into the MCP specification
-    > https://sdtimes.com/ai/several-new-updates-make-their-way-into-the-mcp-specification/
-    > --------------------------------
-    > AI News - How the MCP spec update boosts security as infrastructure scales
-    > https://www.artificialintelligence-news.com/news/how-the-mcp-spec-update-boosts-security-as-infrastructure-scales/
-    >
-    > {
-    >   body: "",
-    >   cc: "",
-    >   date: "",
-    >   from: "",
-    >   header_message_id: "",
-    >   history_id: "",
-    >   id: "19b...",
-    >   in_reply_to: "",
-    >   label_ids: [ "UNREAD", "SENT", "INBOX" ],
-    >   references: "",
-    >   reply_to: "",
-    >   snippet: "",
-    >   subject: "",
-    >   thread_id: "19b...",
-    >   to: "",
-    >   url: "https://mail.google.com/mail/u/0/#sent/19b...",
-    > }
+    ```
+
+    ```text
+    latest news about MCP URL mode elicitation:
+    --------------------------------
+    InfoWorld - Visual Studio Code adds multi-agent orchestration
+    https://www.infoworld.com/article/4105879/visual-studio-code-adds-multi-agent-orchestration.html
+    --------------------------------
+    Visual Studio Magazine - VS Code 1.107 (November 2025 Update) Expands Multi-Agent Orchestration, Model Management
+    https://visualstudiomagazine.com/articles/2025/12/12/vs-code-1-107-november-2025-update-expands-multi-agent-orchestration-model-management.aspx
+    --------------------------------
+    SD Times - Several new updates make their way into the MCP specification
+    https://sdtimes.com/ai/several-new-updates-make-their-way-into-the-mcp-specification/
+    --------------------------------
+    AI News - How the MCP spec update boosts security as infrastructure scales
+    https://www.artificialintelligence-news.com/news/how-the-mcp-spec-update-boosts-security-as-infrastructure-scales/
+
+    {
+      body: "",
+      cc: "",
+      date: "",
+      from: "",
+      header_message_id: "",
+      history_id: "",
+      id: "19b...",
+      in_reply_to: "",
+      label_ids: [ "UNREAD", "SENT", "INBOX" ],
+      references: "",
+      reply_to: "",
+      snippet: "",
+      subject: "",
+      thread_id: "19b...",
+      to: "",
+      url: "https://mail.google.com/mail/u/0/#sent/19b...",
+    }
     ```
 
   </Tabs.Tab>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches quickstart from JavaScript/npm to TypeScript/Bun with updated code samples, commands, and outputs.
> 
> - **Docs** (`app/en/home/quickstart/page.mdx`):
>   - **Language/runtime migration**:
>     - Replace JavaScript with TypeScript across tabs, filenames (`.mjs` -> `.ts`), and code fences (`javascript` -> `typescript`).
>     - Swap npm/Node commands for Bun (`bun install`, `bun run example.ts`).
>     - Update prerequisites to require `bun` for TypeScript.
>   - **Code sample updates**:
>     - Adjust TS typings and formatting (e.g., use semicolons; annotate types).
>     - Use `client.auth.waitForCompletion(...)` in TS example.
>   - **Output and run sections**:
>     - Split run commands and sample outputs into separate code blocks.
>     - Refresh printed/output examples to match new TS/Bun flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1533fff7ca1e3dba9e7b5bb11b98cbbca3be75f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->