### PR TITLE
fixes broken integration links

### DIFF
--- a/app/en/resources/integrations/components/toolkits.tsx
+++ b/app/en/resources/integrations/components/toolkits.tsx
@@ -14,6 +14,21 @@ import { ToolCard } from "./tool-card";
 import { TYPE_CONFIG, TYPE_DESCRIPTIONS } from "./type-config";
 import { useFilterStore, useToolkitFilters } from "./use-toolkit-filters";
 
+// Map old MCP server paths to new integration paths
+function mapToNewIA(oldLink: string): string {
+  // Pattern: /en/mcp-servers/{category}/{tool} -> /en/resources/integrations/{category}/{tool}/reference
+  const mcpServerPattern = /^\/en\/mcp-servers\/([^/]+)\/([^/]+)$/;
+  const match = oldLink.match(mcpServerPattern);
+
+  if (match) {
+    const [, category, tool] = match;
+    return `/en/resources/integrations/${category}/${tool}/reference`;
+  }
+
+  // Return original link if it doesn't match the pattern
+  return oldLink;
+}
+
 export default function Toolkits() {
   const clearAllFilters = useFilterStore((state) => state.clearAllFilters);
 
@@ -123,7 +138,7 @@ export default function Toolkits() {
                       isComingSoon={toolkit.isComingSoon}
                       isPro={toolkit.isPro}
                       key={toolkit.id}
-                      link={toolkit.relativeDocsLink}
+                      link={mapToNewIA(toolkit.relativeDocsLink)}
                       name={toolkit.label}
                       type={toolkit.type}
                     />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures toolkit cards link to valid integration docs by rewriting legacy MCP server URLs.
> 
> - Adds `mapToNewIA` in `toolkits.tsx` to convert `/en/mcp-servers/{category}/{tool}` to `/en/resources/integrations/{category}/{tool}/reference`
> - Updates `ToolCard` `link` prop to use `mapToNewIA(toolkit.relativeDocsLink)`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ab87bcc6d2499b0a15a1f22ce2a64c8a2174b08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->