### PR TITLE
Fix security link on Contact page

### DIFF
--- a/app/en/resources/contact-us/contact-cards.tsx
+++ b/app/en/resources/contact-us/contact-cards.tsx
@@ -54,7 +54,7 @@ export function ContactCards() {
         />
         <QuickStartCard
           description="Report security vulnerabilities responsibly. Learn about our security research program and disclosure process."
-          href="/resources/security"
+          href="/guides/security/security-research-program"
           icon={Shield}
           title="Security Research"
         />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Fix link routing**
> 
> - In `contact-cards.tsx`, updates the `Security Research` QuickStartCard `href` from `/resources/security` to `
> `/guides/security/security-research-program` to direct users to the correct page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e44e77ae2f5ef4deba4b2d00ea13517e2fcfcb94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->