### PR TITLE
update custom verifier code snippet to show redirect

### DIFF
--- a/app/en/guides/user-facing-agents/secure-auth-production/page.mdx
+++ b/app/en/guides/user-facing-agents/secure-auth-production/page.mdx
@@ -161,6 +161,7 @@ If the user's ID matches the ID specified at the start of the authorization flow
 const authResponse = await client.auth.waitForCompletion(result.auth_id);
 
 if (authResponse.status === "completed") {
+  // Either redirect to a URL, or render your own success page:
   return new Response(null, {
     status: 303,
     headers: {


### PR DESCRIPTION
Our example verifier app uses nextjs, which has its own redirect function ([which is what that uses](https://github.com/ArcadeAI/arcade-custom-verifier-next/blob/main/app/verify/route.ts#L47))

I opted for generic redirects from the server here to keep the examples from getting bloated or specific to some particular framework. Open to other approaches!

Alas, I did not remember to copy the branch name from Linear, but this should resolve https://linear.app/arcadedev/issue/PLT-354/allow-customers-to-set-next-uri-in-dashboard (though in a different way)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines the "Valid Response" examples in `app/en/guides/user-facing-agents/secure-auth-production/page.mdx` to emphasize server-driven redirects after the auth flow completes.
> 
> - JavaScript: use `client.auth.waitForCompletion(result.auth_id)` and return a `303` with `Location` header instead of a simple success string
> - Python: add `from starlette.responses import Response`, use `client.auth.wait_for_completion(result.auth_id)`, and return a `303` with `Location` header
> - Removes prior placeholder success messages and clarifies redirect handling post-completion
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f7156fb84487b3630ef9c6b30221a47367a40ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->