### PR TITLE
Fix GitHub integration link by removing /reference suffix

### DIFF
--- a/app/en/resources/integrations/components/toolkits.tsx
+++ b/app/en/resources/integrations/components/toolkits.tsx
@@ -16,13 +16,13 @@ import { useFilterStore, useToolkitFilters } from "./use-toolkit-filters";
 
 // Map old MCP server paths to new integration paths
 function mapToNewIA(oldLink: string): string {
-  // Pattern: /en/mcp-servers/{category}/{tool} -> /en/resources/integrations/{category}/{tool}/reference
+  // Pattern: /en/mcp-servers/{category}/{tool} -> /en/resources/integrations/{category}/{tool}
   const mcpServerPattern = /^\/en\/mcp-servers\/([^/]+)\/([^/]+)$/;
   const match = oldLink.match(mcpServerPattern);
 
   if (match) {
     const [, category, tool] = match;
-    return `/en/resources/integrations/${category}/${tool}/reference`;
+    return `/en/resources/integrations/${category}/${tool}`;
   }
 
   // Return original link if it doesn't match the pattern


### PR DESCRIPTION
The mapToNewIA function was incorrectly appending /reference to all integration paths, causing GitHub to link to a non-existent reference page instead of the main integration page. This fix removes the automatic /reference suffix so GitHub links to the correct path.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes broken integration links generated from MCP server entries.
> 
> - Updates `mapToNewIA` in `app/en/resources/integrations/components/toolkits.tsx` to map `/en/mcp-servers/{category}/{tool}` to `/en/resources/integrations/{category}/{tool}` (removes `/reference` suffix) so `ToolCard` links point to valid main integration pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 438d5b5e339183789680bb62942537a701df97e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->