### PR TITLE
Fix GitHub integration links by removing /reference suffix

### DIFF
--- a/app/en/resources/integrations/components/toolkits.tsx
+++ b/app/en/resources/integrations/components/toolkits.tsx
@@ -16,13 +16,13 @@ import { useFilterStore, useToolkitFilters } from "./use-toolkit-filters";
 
 // Map old MCP server paths to new integration paths
 function mapToNewIA(oldLink: string): string {
-  // Pattern: /en/mcp-servers/{category}/{tool} -> /en/resources/integrations/{category}/{tool}/reference
+  // Pattern: /en/mcp-servers/{category}/{tool} -> /en/resources/integrations/{category}/{tool}
   const mcpServerPattern = /^\/en\/mcp-servers\/([^/]+)\/([^/]+)$/;
   const match = oldLink.match(mcpServerPattern);
 
   if (match) {
     const [, category, tool] = match;
-    return `/en/resources/integrations/${category}/${tool}/reference`;
+    return `/en/resources/integrations/${category}/${tool}`;
   }
 
   // Return original link if it doesn't match the pattern


### PR DESCRIPTION
## Summary
- Fixed GitHub integration link that was incorrectly pointing to a non-existent `/reference` page
- Modified `mapToNewIA` function to remove automatic `/reference` suffix for all integration paths
- GitHub integration now correctly links to `/en/resources/integrations/development/github` instead of `/en/resources/integrations/development/github/reference`

## Test plan
- [x] Verify GitHub integration page exists at correct path
- [x] Check that modified mapping function removes `/reference` suffix
- [x] Confirm landing page will now link to working GitHub page

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `/reference` suffix from mapped integration links to resolve broken pages.
> 
> - Updates `mapToNewIA` to convert `"/en/mcp-servers/{category}/{tool}"` to `"/en/resources/integrations/{category}/{tool}"` (was adding `/reference`).
> - Ensures Toolkit `ToolCard` links now point to existing integration pages (e.g., GitHub).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 438d5b5e339183789680bb62942537a701df97e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->