### PR TITLE
Fix examples names

### DIFF
--- a/app/en/resources/examples/page.mdx
+++ b/app/en/resources/examples/page.mdx
@@ -27,8 +27,8 @@ import { SampleAppCard } from "../../../_components/sample-app-card";
     blank
   />
   <SampleAppCard
-    title="OpenAI SDK MCP Gateway"
-    description="Gateway implementation connecting OpenAI SDK with MCP (Model Context Protocol) servers."
+    title="OpenAI Agents SDK + Arcade MCP Gateway"
+    description="Gateway implementation connecting OpenAI Agents SDK with Arcade MCP servers."
     href="https://github.com/ArcadeAI/openaisdk-mcpgateway"
     image="/images/logo/arcade.png"
     tags={["TypeScript", "OpenAI"]}
@@ -45,7 +45,7 @@ import { SampleAppCard } from "../../../_components/sample-app-card";
     blank
   />
   <SampleAppCard
-    title="Arcade Custom Verifier Next"
+    title="Arcade Custom Verifier for Next.js apps"
     description="Custom user verification implementation for Next.js applications using Arcade."
     href="https://github.com/ArcadeAI/arcade-custom-verifier-next"
     image="/images/logo/arcade.png"
@@ -63,7 +63,7 @@ import { SampleAppCard } from "../../../_components/sample-app-card";
     blank
   />
   <SampleAppCard
-    title="CLI Agent Template"
+    title="Arcade CLI Agent Template"
     description="Command-line interface template for building agents with terminal interactions."
     href="https://github.com/ArcadeAI/cli-agent-template"
     image="/images/logo/arcade.png"
@@ -73,7 +73,7 @@ import { SampleAppCard } from "../../../_components/sample-app-card";
   />
   <SampleAppCard
     title="Megaforce"
-    description="Powerful multi-agent coordination system for complex task orchestration."
+    description="A tool for adapting your content for different (social media) platforms."
     href="https://github.com/ArcadeAI/megaforce"
     image="/images/logo/arcade.png"
     tags={["TypeScript"]}
@@ -81,8 +81,8 @@ import { SampleAppCard } from "../../../_components/sample-app-card";
     blank
   />
   <SampleAppCard
-    title="Framework Showdown"
-    description="Comparison and examples of different AI agent frameworks and their capabilities."
+    title="Human-in-the-loop (HITL) Agent Frameworks Showdown"
+    description="Comparison of human-in-the-loop approaches from Langgraph, OpenAI Agents SDK, and Google ADK."
     href="https://github.com/ArcadeAI/framework-showdown"
     image="/images/logo/arcade.png"
     tags={["TypeScript"]}
@@ -90,8 +90,8 @@ import { SampleAppCard } from "../../../_components/sample-app-card";
     blank
   />
   <SampleAppCard
-    title="Summarize YouTube Podcasts in Slack"
-    description="A Slack bot that extracts and summarizes YouTube transcripts in Weaviate, perfect for AI podcasts."
+    title="YouTube Transcript Bot"
+    description="A Slack bot that extracts and summarizes YouTube transcripts in Weaviate."
     href="https://github.com/dforwardfeed/slack-AIpodcast-summaries"
     image="/images/logo/arcade.png"
     tags={["Python", "Langchain", "Slack", "Weaviate"]}
@@ -99,8 +99,8 @@ import { SampleAppCard } from "../../../_components/sample-app-card";
     blank
   />
   <SampleAppCard
-    title="Archer"
-    description="A bot that can act on your behalf."
+    title="Archer: Agentic Slack Assistant"
+    description="An assistant for Slack built with Arcade and Langgraph. Interact with Google Calendar, Mail, Github, Search Engines, Firecrawl and more all from within Slack."
     href="https://github.com/ArcadeAI/ArcadeSlackAgent"
     image="/images/logo/arcade.png"
     tags={["JavaScript", "Slack"]}
@@ -108,7 +108,6 @@ import { SampleAppCard } from "../../../_components/sample-app-card";
     blank
   />
 </div>
-
 ## Submit your app
 
 Built something awesome with Arcade? We'd love to feature it! Submit your app by creating a pull request to our documentation site.
@@ -124,7 +123,7 @@ Built something awesome with Arcade? We'd love to feature it! Submit your app by
 ### How to submit
 
 1. Fork the [Arcade docs repository](https://github.com/ArcadeAI/docs)
-2. Add your app to `/app/en/home/examples/page.mdx` following the existing pattern
+2. Add your app to `/app/en/resources/examples/page.mdx` following the existing pattern
 3. Include a descriptive title, clear description, and appropriate tags
 4. Create a pull request with details about your app and its Arcade integration
 5. Our team will review and potentially feature your app!
@@ -132,4 +131,3 @@ Built something awesome with Arcade? We'd love to feature it! Submit your app by
 ### Need help?
 
 If you have questions about submitting your app, feel free to [contact us](/resources/contact-us) or open an issue in the docs repository.
-


### PR DESCRIPTION
Refines example app listings and fixes the submission path reference.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
\> - Updates titles/descriptions for multiple cards: `OpenAI Agents SDK + Arcade MCP Gateway`, `Arcade Custom Verifier for Next.js apps`, `Arcade CLI Agent Template`, `Megaforce`, `Human-in-the-loop (HITL) Agent Frameworks Showdown`, `YouTube Transcript Bot`, and `Archer: Agentic Slack Assistant`
> - Corrects submission guideline path from `/app/en/home/examples/page.mdx` to `/app/en/resources/examples/page.mdx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31413d94cf83ba0b40a717791b66de1cbec6ed96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->