### PR TITLE
Remove outdated 'coming soon'

### DIFF
--- a/app/en/guides/create-tools/tool-basics/compare-server-types/page.mdx
+++ b/app/en/guides/create-tools/tool-basics/compare-server-types/page.mdx
@@ -12,6 +12,6 @@ Depending on the transport you use and where you want to run your MCP server, Ar
 | stdio     | local                                                                        |             ✅             |         ✅         |              ✅               |              ❌              |
 | http      | local ([unprotected](/resources/glossary#unprotected-mcp-servers))           |             ✅             |         ❌         |              ❌               |              ❌              |
 | http      | remote ([unprotected](/resources/glossary#unprotected-mcp-servers))          |             ✅             |         ❌         |              ❌               |              ❌              |
-| http      | local ([protected](/resources/glossary#protected-mcp-servers)) `coming soon` |             ✅             |         ✅         |              ✅               |              ✅              |
+| http      | local ([protected](/resources/glossary#protected-mcp-servers))               |             ✅             |         ✅         |              ✅               |              ✅              |
 | http      | remote ([protected](/resources/glossary#protected-mcp-servers))              |             ✅             |         ✅         |              ✅               |              ✅              |
 | http      | Arcade Cloud                                                                 |             ✅             |         ✅         |              ✅               |              ✅              |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `app/en/guides/create-tools/tool-basics/compare-server-types/page.mdx` to mark protected local `http` MCP servers as available in the comparison table (removed “coming soon”).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b253ab519b785b961b6428885c4f77c356ab6000. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->