### PR TITLE
improved the quickstart output

### DIFF
--- a/app/en/get-started/quickstarts/call-tool-agent/page.mdx
+++ b/app/en/get-started/quickstarts/call-tool-agent/page.mdx
@@ -236,7 +236,7 @@ response_send_email = authorize_and_run_tool(
 )
 
 # Print the response from the tool call
-print(f"Congratulations! Here's what you just achieved:\n - A Google Docs containing the retrieved news was created\n - An email with a link to that document was just sent to {user_id}! Here's the metadata:")
+print(f"Success! Check your email at {user_id}\n\nYou just chained 3 tools together:\n  1. Searched Google News for stories about MCP URL mode elicitation\n  2. Created a Google Doc with the results\n  3. Sent yourself an email with the document link\n\nEmail metadata:")
 print(response_send_email.output.value)
 ```
 
@@ -295,7 +295,7 @@ const respose_send_email = await authorize_and_run_tool({
 
 // Print the response from the tool call
 console.log(
-  `Congratulations! Here's what you just achieved:\n - A Google Docs containing the retrieved news was created\n - An email with a link to that document was just sent to ${userId}! Here's the metadata:`
+  `Success! Check your email at ${userId}\n\nYou just chained 3 tools together:\n  1. Searched Google News for stories about MCP URL mode elicitation\n  2. Created a Google Doc with the results\n  3. Sent yourself an email with the document link\n\nEmail metadata:`
 );
 console.log(respose_send_email.output?.value);
 ```
@@ -314,9 +314,14 @@ console.log(respose_send_email.output?.value);
     uv run example.py
     ```
     ```text
-    Congratulations! Here's what you just achieved:
-     - A Google Docs containing the retrieved news was created
-     - An email with a link to that document was just sent to mateo@arcade.dev! Here's the metadata:
+    Success! Check your email at mateo@arcade.dev
+
+    You just chained 3 tools together:
+      1. Searched Google News for stories about MCP URL mode elicitation
+      2. Created a Google Doc with the results
+      3. Sent yourself an email with the document link
+
+    Email metadata:
     {'id': '19ba...', 'label_ids': ['UNREAD', 'SENT', 'INBOX'], 'thread_id': '19ba...', 'url': 'https://mail.google.com/mail/u/0/#sent/19ba...'}
     ```
 
@@ -328,9 +333,14 @@ console.log(respose_send_email.output?.value);
     ```
 
     ```text
-    Congratulations! Here's what you just achieved:
-     - A Google Docs containing the retrieved news was created
-     - An email with a link to that document was just sent to mateo@arcade.dev! Here's the metadata:
+    Success! Check your email at mateo@arcade.dev
+
+    You just chained 3 tools together:
+      1. Searched Google News for stories about MCP URL mode elicitation
+      2. Created a Google Doc with the results
+      3. Sent yourself an email with the document link
+
+    Email metadata:
     {
       id: "19ba...",
       label_ids: [ "UNREAD", "SENT", "INBOX" ],
@@ -535,7 +545,9 @@ const respose_send_email = await authorize_and_run_tool({
 });
 
 // Print the response from the tool call
-console.log("Success! Check your email at {user_id}\n\nYou just chained 3 tools together:\n  1. Searched Google News for stories about MCP URL mode elicitation\n  2. Created a Google Doc with the results\n  3. Sent yourself an email with the document link\n\nEmail metadata:")
+console.log(
+  `Success! Check your email at ${userId}\n\nYou just chained 3 tools together:\n  1. Searched Google News for stories about MCP URL mode elicitation\n  2. Created a Google Doc with the results\n  3. Sent yourself an email with the document link\n\nEmail metadata:`
+);
 console.log(respose_send_email.output?.value);
 ```
 


### PR DESCRIPTION
This PR simplifies and hopefully improves the output of the "Calling tools in your agent with Arcade" quickstart.

Preview: https://docs-git-mateo-dev-253-improve-quickstart-output-arcade-ai.vercel.app/en/get-started/quickstarts/call-tool-agent


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines the quickstart to focus on end results rather than raw news output.
> 
> - Adds a success message after `Gmail.SendEmail` in both Python and TypeScript (`print`/`console.log`) indicating the email was sent and summarizing the 3-step tool chain
> - Updates sample "Run the code" outputs to show concise confirmation plus email metadata instead of long news lists
> - Mirrors these changes in the "Example Code" section to keep Python/TypeScript examples consistent
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cc9a065b69b253401861443fb054cd630564bc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->