### PR TITLE
fix object Object showing on tools pages

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -50,7 +50,6 @@
   "files": {
     "ignoreUnknown": false,
     "includes": [
-      "**",
       "!dist",
       "!build",
       "!node_modules",


### PR DESCRIPTION
We were passing the entire meta file when generating `SubPagesList`, but a root page is inherently not a subpage, and also does not follow the same structure.  I looked at where this is used and I do not believe we want root pages listed there.

LINK: https://docs.arcade.dev/en/guides/create-tools/tool-basics

BEFORE:
<img width="940" height="559" alt="Screenshot 2026-01-12 at 11 55 52 AM" src="https://github.com/user-attachments/assets/a676bcc8-4eab-42b0-aa49-ca2c7224f416" />

<img width="976" height="519" alt="Screenshot 2026-01-12 at 11 57 55 AM" src="https://github.com/user-attachments/assets/1e6ee567-fbe9-4099-9b77-bdd7f8675188" />

etc.

AFTER: note that the Overview page IS still in the sidebar as it should be
<img width="1207" height="607" alt="Screenshot 2026-01-12 at 12 33 41 PM" src="https://github.com/user-attachments/assets/1de10632-97b9-415e-8841-f70d2eb54ab4" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents non-subpages and wildcard entries from appearing in the subpage list.
> 
> - Updates `SubpageList` to filter out `index` and `*` keys from `meta`, avoiding invalid link labels (e.g., `[object Object]`) and ensuring only real subpages are linked
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f65c643fc8fc0571f3086c4d388ddfcabc0bfc17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->