### PR TITLE
updated cursor instructions for MCP gateways

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,5 +42,6 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.biome": "explicit",
     "source.organizeImports.biome": "explicit"
-  }
+  },
+  "makefile.configureOnOpen": false
 }

--- a/app/en/guides/tool-calling/mcp-clients/cursor/page.mdx
+++ b/app/en/guides/tool-calling/mcp-clients/cursor/page.mdx
@@ -1,4 +1,4 @@
-import { Steps, Callout } from "nextra/components";
+import { Steps, Callout, Tabs } from "nextra/components";
 import { SignupLink } from "@/app/_components/analytics";
 
 # Use Arcade in Cursor
@@ -20,12 +20,34 @@ Connect Cursor to an Arcade MCP Gateway.
 
 </GuideOverview>
 
+<Callout type="info">
+  Cursor currently does not refresh the MCP OAuth tokens automatically. To set a
+  persistent connection between Cursor and your MCP Gateway, you should set the
+  `Authorization` field to "Arcade Headers" in the dashboard.
+</Callout>
+
 ### Set up Cursor
 
 1. Open the Command Palette (`Cmd + Shift + P` on macOS, `Ctrl + Shift + P` on Windows/Linux) and select **Open MCP Settings**
 1. Click on the "New MCP Server" button
 
 Cursor will open the MCP settings file, and you can add a new entry to the `mcpServers` object:
+
+<Tabs items={["Arcade Auth", "Arcade Headers"]} storageKey="preferredMCPAuthMode">
+<Tabs.Tab>
+
+```json
+{
+  "mcpServers": {
+    "mcp-arcade": {
+      "url": "https://api.arcade.dev/mcp/<YOUR-GATEWAY-SLUG>"
+    }
+  }
+}
+```
+
+</Tabs.Tab>
+<Tabs.Tab>
 
 ```json
 {
@@ -40,6 +62,9 @@ Cursor will open the MCP settings file, and you can add a new entry to the `mcpS
   }
 }
 ```
+
+</Tabs.Tab>
+</Tabs>
 
 ### Try it out
 


### PR DESCRIPTION
This adds tabs to the cursor instructions with respect to the `Authorization` field in the MCP gateway, with a callout that using "Arcade Headers" is recommended for cursor for persistent connections to the MCP gateway

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Cursor MCP setup docs to clarify auth modes and improve usability.
> 
> - In `app/en/guides/tool-calling/mcp-clients/cursor/page.mdx`, adds an info callout noting Cursor doesn't auto-refresh MCP OAuth tokens and recommends setting `Authorization` to "Arcade Headers" for persistent connections
> - Introduces `Tabs` with two config options: "Arcade Auth" (basic URL) and "Arcade Headers" (includes `Authorization` and `Arcade-User-ID` headers) for the `mcpServers` entry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 783f4fdda942ef3297130445d07f6078c3f33504. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->