### PR TITLE
DEV-277 Add redirects for agent framework documentation paths

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -49,6 +49,11 @@ const nextConfig: NextConfig = withLlmsTxt({
           permanent: true,
         },
         {
+          source: "/:locale/home/build-tools/server-level-vs-tool-level-auth",
+          destination: "/:locale/learn/server-level-vs-tool-level-auth",
+          permanent: true,
+        },
+        {
           source: "/:locale/home/build-tools/secure-your-mcp-server",
           destination: "/:locale/guides/security/secure-your-mcp-server",
           permanent: true,


### PR DESCRIPTION
## Summary
- Add redirects for old `/home/*` paths to new `/guides/agent-frameworks/*` structure
- Covers LangChain, OpenAI Agents, and Mastra documentation paths

## Test plan
- [ ] Verify redirects work correctly in local/staging environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `next.config.ts` redirects to reflect the new agent framework docs structure.
> 
> - Adds redirects for `/:locale/home/langchain/user-auth-interrupts`, `/:locale/home/oai-agents/user-auth-interrupts`, and `/:locale/home/mastra/user-auth-interrupts` to corresponding `/:locale/guides/agent-frameworks/*` paths
> - Ensures `/:locale/home/langchain/use-arcade-tools` redirects to `/:locale/guides/agent-frameworks/langchain/use-arcade-tools` (and removes a duplicate entry)
> - No other app logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ad7251888b1168c1513d31488f0f9f16bc44a1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->