### PR TITLE
Guard referrer URL parsing

Co-authored-by: wils <wils@arcade-ai.com>

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -51,7 +51,14 @@ export default function NotFound() {
 
     const referrer =
       typeof document !== "undefined" ? document.referrer || "" : "";
-    const referringDomain = referrer ? new URL(referrer).hostname : "";
+    let referringDomain = "";
+    if (referrer) {
+      try {
+        referringDomain = new URL(referrer).hostname;
+      } catch {
+        referringDomain = "";
+      }
+    }
 
     posthog.capture("Page not found", {
       status_code: 404,


### PR DESCRIPTION
cursor blip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hardens analytics on the 404 page by making referrer parsing resilient to malformed URLs.
> 
> - Wraps `new URL(referrer).hostname` in a try/catch and defaults `referringDomain` to `""` in `app/not-found.tsx`
> - Preserves `$referrer` and `$referring_domain` properties in the PostHog `"Page not found"` capture
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1472595b2db636738ce0f9d30c446909643ffa7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->