### PR TITLE
Changelog: 2026-01-16

### DIFF
--- a/agents/changelog/agents/changelog.ts
+++ b/agents/changelog/agents/changelog.ts
@@ -53,7 +53,7 @@ When updating the changelog, follow these rules:
     privateRepositories: string[],
   ) {
     this.logger.startSpan(
-      `Generating changelog from changes in ${repositories.join(", ")}...`,
+      `Generating changelog from changes in ${repositories.join(", ")} and ${privateRepositories.join(", ")}...`,
     );
 
     const result = await this.run(
@@ -61,6 +61,7 @@ When updating the changelog, follow these rules:
       Today is ${new Date().toISOString().split("T")[0]}.
       The full path to the changelog.md that you will be appending to is \`${changelogPath}\`.
       The Github repositories to load commits from are: ${repositories.join(", ")}
+      The Github private repositories to load commits from are: ${privateRepositories.join(", ")}
       When appending to the changelog, do not include links for the private repositories, which are: ${privateRepositories.join(", ")}
       `,
     );

--- a/agents/changelog/index.ts
+++ b/agents/changelog/index.ts
@@ -65,12 +65,12 @@ program
   .argument(
     "[repos]",
     "A comma separated list of repositories to load the changelogs from",
-    "ArcadeAI/docs,ArcadeAI/arcade-mcp,ArcadeAI/Cloud,ArcadeAI/Engine,ArcadeAI/dashboard,ArcadeAI/toolkits",
+    "ArcadeAI/docs,ArcadeAI/arcade-mcp",
   )
   .argument(
     "[private_repos]",
     "A comma separated list of private repositories to load the changelogs from",
-    "ArcadeAI/Cloud,ArcadeAI/Engine,ArcadeAI/dashboard,ArcadeAI/toolkits",
+    "ArcadeAI/monorepo",
   )
   .action(
     async (

--- a/app/en/references/changelog/page.mdx
+++ b/app/en/references/changelog/page.mdx
@@ -9,6 +9,18 @@ import { Callout } from "nextra/components";
 
 _Here's what's new at Arcade.dev!_
 
+## 2026-01-16
+
+**Arcade MCP Servers**
+- `[feature - 🚀]` [`arcade-mcp`](https://github.com/ArcadeAI/arcade-mcp) Support Ed25519 Algorithm
+- `[bugfix - 🐛]` [`arcade-mcp`](https://github.com/ArcadeAI/arcade-mcp) Fix dateutil dependency issue
+- `[bugfix - 🐛]` [`arcade-mcp`](https://github.com/ArcadeAI/arcade-mcp) Fix PostHog dependency issue
+
+**Platform and Engine**
+- `[bugfix - 🐛]` fix: Allow long custom verifier URLs
+- `[feature - 🚀]` Add Dashboard support for expiring API keys
+
+
 ## 2026-01-09
 
 <Callout type="important">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Changelog content**
> - Append `2026-01-16` entries covering `arcade-mcp` fixes/features and Platform/Dashboard updates in `app/en/references/changelog/page.mdx`.
> 
> **Generator updates**
> - `ChangelogAgent.generate` now logs and prompts with private repositories, adding `"The Github private repositories to load commits from are: ..."`.
> - CLI defaults in `agents/changelog/index.ts` updated: public `repos` trimmed to `ArcadeAI/docs,ArcadeAI/arcade-mcp`; `private_repos` default set to `ArcadeAI/monorepo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8254d547f40899d2f2c6c288ca83325b17f1eb1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->