### PR TITLE
quickstart now walks through setting up a uv project

### DIFF
--- a/app/en/get-started/quickstarts/call-tool-agent/page.mdx
+++ b/app/en/get-started/quickstarts/call-tool-agent/page.mdx
@@ -332,7 +332,7 @@ console.log(respose_send_email.output?.value);
     ```
 
     ```text
-    Success! Check your email at mateo@arcade.dev
+    Success! Check your email at {arcade_user_id}
 
     You just chained 3 tools together:
       1. Searched Google News for stories about MCP URL mode elicitation
@@ -351,7 +351,7 @@ console.log(respose_send_email.output?.value);
     ```
 
     ```text
-    Success! Check your email at mateo@arcade.dev
+    Success! Check your email at {arcade_user_id}
 
     You just chained 3 tools together:
       1. Searched Google News for stories about MCP URL mode elicitation


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Modernizes the call-tool-agent quickstart and clarifies examples.
> 
> - Python path now uses `uv` project workflow: init project, create/activate venv, and `uv add arcadepy`; code lives in `main.py` and run via `uv run main.py`
> - Updated helper output to print authorization URLs on separate lines in both Python and TypeScript
> - Replaced hardcoded email with `{arcade_user_id}` in sample outputs
> - Added collapsible full-file examples for Python (`main.py`) and TypeScript (`example.ts`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54a6e82cd18086ddfbcf6a94333e2fb3381868cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->