### PR TITLE
Fix agent-frameworks page displaying as raw code

### DIFF
--- a/app/en/guides/agent-frameworks/page.mdx
+++ b/app/en/guides/agent-frameworks/page.mdx
@@ -1,4 +1,3 @@
-```mdx
 import { PlatformCard } from "@/app/_components/platform-card";
 import { Tabs } from "nextra/components";
 
@@ -72,4 +71,3 @@ These guides are for developers building AI applications who need to connect Arc
     </div>
   </Tabs.Tab>
 </Tabs>
-```


### PR DESCRIPTION
## Summary
- Remove erroneous markdown code fence wrappers from the agent-frameworks page
- The page was displaying MDX content as a code block instead of rendering components

## Root Cause
This issue was introduced across two PRs:
1. **PR #660** - Added a trailing ` ``` ` at the end of the file
2. **PR #663** - Added an opening ` ```mdx ` at the start

Together these caused the entire page content to be wrapped in a code fence, displaying raw MDX instead of rendered components.

## Test plan
- [ ] Verify https://docs.arcade.dev/en/guides/agent-frameworks renders correctly with PlatformCard components and tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes docs rendering for the agent frameworks guide.
> 
> - Removes erroneous opening ````mdx` and closing ``` fences from `app/en/guides/agent-frameworks/page.mdx`, restoring normal rendering of `Tabs` and `PlatformCard` components
> - No content or layout changes beyond correcting the markdown fencing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f82ffefc027f963b9ae8bc10ebc92e459075a47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->