### PR TITLE
Docs npm-tar vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,5 +101,10 @@
       "pnpm dlx ultracite fix "
     ]
   },
-  "packageManager": "pnpm@10.11.0"
+  "packageManager": "pnpm@10.11.0",
+  "pnpm": {
+    "overrides": {
+      "tar": ">=7.5.3"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  tar: '>=7.5.3'
+
 importers:
 
   .:
@@ -4458,8 +4461,8 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
-  tar@7.5.2:
-    resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
+  tar@7.5.4:
+    resolution: {integrity: sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==}
     engines: {node: '>=18'}
 
   third-party-capital@1.0.20:
@@ -6888,7 +6891,7 @@ snapshots:
   '@tailwindcss/oxide@4.1.14':
     dependencies:
       detect-libc: 2.1.2
-      tar: 7.5.2
+      tar: 7.5.4
     optionalDependencies:
       '@tailwindcss/oxide-android-arm64': 4.1.14
       '@tailwindcss/oxide-darwin-arm64': 4.1.14
@@ -9962,7 +9965,7 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  tar@7.5.2:
+  tar@7.5.4:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
Update `tar` package to version 7.5.4 to remediate CVE-2026-23745, a high-severity vulnerability in `npm-tar <= 7.5.2`.

The vulnerability was in the `tar` package, a transitive dependency of `@tailwindcss/oxide`. A `pnpm` override was added to `package.json` and `pnpm-lock.yaml` to force the use of `tar >= 7.5.3`, which updated it to 7.5.4.

---
Linear Issue: [TOO-351](https://linear.app/arcadedev/issue/TOO-351/vanta-remediate-high-vulnerabilities-identified-in-packages-are)

<a href="https://cursor.com/background-agent?bcId=bc-ed4fcb68-aed8-4e8a-8ac9-519a5ad12d4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ed4fcb68-aed8-4e8a-8ac9-519a5ad12d4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns transitive dependency resolution to a secure `tar` version.
> 
> - Adds `pnpm.overrides.tar: ">=7.5.3"` in `package.json`
> - Updates `pnpm-lock.yaml` to resolve `tar` to `7.5.4` and adjusts related entries (e.g., `@tailwindcss/oxide` now referencing `tar@7.5.4`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c9ce008b6b5abe71d005f40e19e1ef689919d16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->