### PR TITLE
Fix pre-commit hook to not stage unrelated working directory changes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -74,18 +74,36 @@ if git diff --cached --name-only | grep -q "next.config.ts"; then
 
     # Only stage files that were NOT already modified (i.e., newly modified by update-links)
     STAGED_COUNT=0
+    SKIPPED_FILES=""
     if [ -n "$NOW_MODIFIED" ]; then
       for file in $NOW_MODIFIED; do
         # Check if this file was already modified before update-links ran
         if [ -z "$ALREADY_MODIFIED" ] || ! echo "$ALREADY_MODIFIED" | grep -qxF "$file"; then
           git add "$file"
           STAGED_COUNT=$((STAGED_COUNT + 1))
+        else
+          # File had both user's unstaged changes AND needed link updates
+          # We can't stage it without also staging user's unrelated changes
+          SKIPPED_FILES="$SKIPPED_FILES $file"
         fi
       done
     fi
 
     if [ "$STAGED_COUNT" -gt 0 ]; then
       echo "✅ Internal links updated and staged ($STAGED_COUNT file(s))"
+    fi
+
+    # Warn about files that needed link updates but couldn't be staged
+    if [ -n "$SKIPPED_FILES" ]; then
+      echo ""
+      echo "⚠️  Warning: The following files need link updates but have unstaged changes:"
+      for file in $SKIPPED_FILES; do
+        echo "   - $file"
+      done
+      echo ""
+      echo "   The link updates were applied but NOT staged to avoid mixing with your changes."
+      echo "   After this commit, review these files and stage the link updates separately,"
+      echo "   or run 'git checkout -- <file>' to discard all changes including link updates."
     fi
   fi
 fi


### PR DESCRIPTION
## Summary
- Fix update-links section to not accidentally stage unrelated working directory changes
- Captures already-modified files BEFORE running update-links, then only stages newly-modified files

## Problem
The update-links section was using `git diff --name-only` which captures ALL modified files in the working directory, not just files modified by the update-links script. This could accidentally stage files the user had modified but intentionally not staged for the current commit.

## Test plan
- [ ] Modify an mdx file but don't stage it
- [ ] Stage next.config.ts with a new redirect
- [ ] Run commit - verify the unstaged mdx file is NOT automatically staged
- [ ] Verify files actually modified by update-links ARE staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the `update-links` step in `.husky/pre-commit` does not stage unrelated working changes.
> 
> - Captures `ALREADY_MODIFIED` files before running `pnpm update-links`, then stages only newly modified `app/**/*.mdx|md|tsx` files
> - Adds count of staged files and warning output listing files skipped due to existing unstaged changes
> - Prevents mixing user unstaged work with automated link updates; updates messaging accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c5bf2088df71edc0ce14e17e69a15e30d93e5cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->