### PR TITLE
Add Bun support and sticky package manager tabs

### DIFF
--- a/app/en/get-started/agent-frameworks/mastra/page.mdx
+++ b/app/en/get-started/agent-frameworks/mastra/page.mdx
@@ -60,7 +60,7 @@ Select your preferred model provider when prompted (we recommend OpenAI). Enter 
 
 Then navigate to the project directory and install the Arcade client:
 
-<Tabs items={["npm", "pnpm", "yarn"]}>
+<Tabs items={["npm", "pnpm", "yarn", "bun"]} storageKey="package-manager">
 
 <Tabs.Tab>
 
@@ -85,6 +85,15 @@ pnpm add @arcadeai/arcadejs @ai-sdk/openai zod@3
 ```bash
 cd arcade-agent
 yarn add @arcadeai/arcadejs @ai-sdk/openai zod@3
+```
+
+</Tabs.Tab>
+
+<Tabs.Tab>
+
+```bash
+cd arcade-agent
+bun add @arcadeai/arcadejs @ai-sdk/openai zod@3
 ```
 
 </Tabs.Tab>
@@ -311,7 +320,7 @@ export const mastra = new Mastra({
 
 Start the development server:
 
-<Tabs items={["npm", "pnpm", "yarn"]}>
+<Tabs items={["npm", "pnpm", "yarn", "bun"]} storageKey="package-manager">
 
 <Tabs.Tab>
 
@@ -333,6 +342,14 @@ pnpm dev
 
 ```bash
 yarn dev
+```
+
+</Tabs.Tab>
+
+<Tabs.Tab>
+
+```bash
+bun dev
 ```
 
 </Tabs.Tab>

--- a/app/en/get-started/agent-frameworks/vercelai/page.mdx
+++ b/app/en/get-started/agent-frameworks/vercelai/page.mdx
@@ -61,7 +61,7 @@ Use the default settings for the project.
 
 Install the required dependencies and [AI Elements](https://ai-sdk.dev/elements) (pre-built React components for chat interfaces):
 
-<Tabs items={["npm", "pnpm", "yarn"]}>
+<Tabs items={["npm", "pnpm", "yarn", "bun"]} storageKey="package-manager">
 
 <Tabs.Tab>
 
@@ -86,6 +86,15 @@ pnpm dlx ai-elements@latest
 ```bash
 yarn add ai @ai-sdk/openai @ai-sdk/react @arcadeai/arcadejs zod
 yarn dlx ai-elements@latest
+```
+
+</Tabs.Tab>
+
+<Tabs.Tab>
+
+```bash
+bun add ai @ai-sdk/openai @ai-sdk/react @arcadeai/arcadejs zod
+bunx ai-elements@latest
 ```
 
 </Tabs.Tab>
@@ -531,7 +540,7 @@ export default function Chat() {
 
 ### Run the chatbot
 
-<Tabs items={["npm", "pnpm", "yarn"]}>
+<Tabs items={["npm", "pnpm", "yarn", "bun"]} storageKey="package-manager">
 
 <Tabs.Tab>
 
@@ -553,6 +562,14 @@ pnpm dev
 
 ```bash
 yarn dev
+```
+
+</Tabs.Tab>
+
+<Tabs.Tab>
+
+```bash
+bun dev
 ```
 
 </Tabs.Tab>


### PR DESCRIPTION
## Summary
- Add Bun as a package manager option in Mastra and Vercel AI tutorials
- Add `storageKey="package-manager"` to all package manager tabs so selection persists across pages
- Users only need to select their preferred package manager once

## Files changed
- `app/en/get-started/agent-frameworks/mastra/page.mdx`
- `app/en/get-started/agent-frameworks/vercelai/page.mdx`

## Test plan
- [ ] Verify tabs show npm, pnpm, yarn, bun options
- [ ] Select a package manager on one page, navigate to another, confirm selection persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Bun as a first-class package manager option and makes package manager tab selection persist across tutorial pages.
> 
> - Updates `Tabs` in Mastra and Vercel AI guides to include `"bun"` and sets `storageKey="package-manager"`
> - Adds corresponding Bun install and dev commands in both guides’ install/run sections
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8290981a8804d98aa2e3d6aad314fd0f99ad05a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->