### PR TITLE
Prevent vale style review from removing code blocks

### DIFF
--- a/scripts/vale-style-review.ts
+++ b/scripts/vale-style-review.ts
@@ -394,12 +394,15 @@ function countLeadingWhitespace(line: string): number {
 
 // Count consecutive fence characters (backticks or tildes) at the start of a trimmed line
 // Returns both the count and the character type
-function countLeadingFenceChars(trimmedLine: string): { count: number; char: string } {
+function countLeadingFenceChars(trimmedLine: string): {
+  count: number;
+  char: string;
+} {
   const firstChar = trimmedLine[0];
   if (firstChar !== "`" && firstChar !== "~") {
     return { count: 0, char: "" };
   }
-  
+
   let count = 0;
   for (const char of trimmedLine) {
     if (char === firstChar) {
@@ -455,9 +458,7 @@ function getLinesInCodeBlocks(content: string): Set<number> {
 
       if (inCodeBlock) {
         linesInCodeBlocks.add(lineNum);
-        if (
-          isValidClosingFence(trimmedLine, fenceInfo, openingFenceInfo)
-        ) {
+        if (isValidClosingFence(trimmedLine, fenceInfo, openingFenceInfo)) {
           inCodeBlock = false;
           openingFenceInfo = { count: 0, char: "" };
         }


### PR DESCRIPTION
## Summary
- Adds safeguards to prevent the vale-style-review automation from removing code blocks from documentation
- The LLM was making overly aggressive suggestions that removed entire code examples (as seen in PR #700)

## Changes
- Add `getLinesInCodeBlocks()` function to detect lines inside fenced code blocks
- Skip any suggestion targeting lines inside code blocks
- Reject suggestions where suggested text is <70% of original length
- Strengthen LLM prompt with explicit "NEVER MODIFY CODE" instructions
- Extract validation helpers to reduce cognitive complexity

## Test plan
- [ ] Run `pnpm vale:review --pr <number>` on a PR with code blocks and verify no code is modified
- [ ] Verify suggestions are still generated for prose content outside code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hardens the vale-style-review script to avoid destructive edits and never touch code blocks.
> 
> - Detects fenced code blocks (```/~~~) per CommonMark (indent ≤3, tab stops of 4) via new helpers: `countLeadingWhitespace`, `countLeadingFenceChars`, `isFenceCandidate`, `isValidClosingFence`, `getLinesInCodeBlocks`; skips any suggestions on those lines
> - Strengthens LLM prompt with explicit “NEVER MODIFY CODE” and guidance to omit code-related issues
> - Adds validation helpers: `hasValidFields`, `wouldRemoveContent` (≥70% length), `isDestructiveChange` (>50% length change) and applies them in `formatReviewComments`
> - Introduces constants `MIN_SUGGESTED_LENGTH_RATIO`, `MAX_FENCE_INDENT`, `TAB_STOP_WIDTH`; adjusts logging and filtering but preserves overall workflow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 606e9b426e826ca960af2d617ee3b5cbf1184cd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->