### PR TITLE
changelog: 2026-01-23

### DIFF
--- a/app/en/references/changelog/page.mdx
+++ b/app/en/references/changelog/page.mdx
@@ -9,6 +9,21 @@ import { Callout } from "nextra/components";
 
 _Here's what's new at Arcade.dev!_
 
+## 2026-01-23
+
+**Arcade MCP Servers**
+- `[feature - 🚀]` Launched `https://ctl.arcade.dev/mcp` - Arcade's Gateway Assistant.  Connect your LLM to help build MCP Gateways and MCP Servers for any agent use case.  Learn more about it [here](/guides/mcp-gateways/create-via-ai)!
+
+**Platform and Engine**
+- `[maintenance - 🔧]`   Fixed a race condition in `arcade deploy`
+
+**Misc**
+- `[documentation - 📝]` Updated OpenAI agents guide in Python
+- `[documentation - 📝]` Fixed agent-frameworks page displaying as raw code
+- `[documentation - 📝]` Quickstart now walks through setting up a `uv` project
+- `[documentation - 📝]` Added connecting arcade tools to your llm page
+- `[documentation - 📝]` Added Copilot Studio docs
+
 ## 2026-01-16
 
 **Arcade MCP Servers**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new changelog section for `2026-01-23`.
> 
> - **Arcade MCP Servers**: Launches `https://ctl.arcade.dev/mcp` (Gateway Assistant) with link to setup guide
> - **Platform and Engine**: Notes maintenance fix for race condition in `arcade deploy`
> - **Misc/docs**: Updates OpenAI agents (Python) guide, fixes agent-frameworks page rendering, quickstart now uses `uv`, adds "connect arcade tools to your LLM" page, and Copilot Studio docs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33b44ec0b858019a017a17919f4743ab9629ec32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->