### PR TITLE
Remove context 7

### DIFF
--- a/app/en/get-started/setup/connect-arcade-docs/page.mdx
+++ b/app/en/get-started/setup/connect-arcade-docs/page.mdx
@@ -5,7 +5,7 @@ description: "Learn how to speed up your development with agents in your IDEs"
 
 # Agentic Development
 
-Give your AI IDE access to Arcade.dev's documentation using the [llms.txt](/llms.txt) file, or use [context7](https://context7.com/arcadeai/docs). This allows Claude Code, Cursor, and other AI IDEs to access the documentation and help you write code.
+Give your AI IDE access to Arcade.dev's documentation using the [llms.txt](/llms.txt) file. This allows Claude Code, Cursor, and other AI IDEs to access the documentation and help you write code.
 
 ## LLMs.txt
 
@@ -16,11 +16,3 @@ The LLMs.txt files are available at [`/llms.txt`](/llms.txt).
 ![LLMs.txt example](/images/agentic-development/cursor-llms-txt.png)
 
 Learn more about the LLMs.txt file format [here](https://llmstxt.org/).
-
-## Context7
-
-Context7 is an MCP server designed to provide Large Language Models (LLMs) and AI code editors with up-to-date, version-specific documentation and code examples. It helps prevent AI models from "hallucinating" or providing outdated code by fetching accurate information directly from its knowledge base and injecting it into the LLM's prompt, ensuring more reliable and accurate coding assistance
-
-To use Context7, you first need to add the [Context7 MCP server](https://github.com/upstash/context7) to your editor, and then select the [`arcadeai/docs` project](https://context7.com/arcadeai/docs).
-
-Learn more about Context7 [here](https://context7.com/).


### PR DESCRIPTION
re: https://arcade-ai.slack.com/archives/C07EXGYH91B/p1769440640892149

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines the "Agentic Development" docs to focus solely on `llms.txt` for IDE integration.
> 
> - Deletes the entire "Context7" section and all related links/instructions
> - Updates intro sentence to remove the alternative `context7` option, keeping only `llms.txt`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f773ee7eae5d34ef4b12ed1bf6754bf5b2bbdae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->