### PR TITLE
Public data storage information

### DIFF
--- a/app/en/guides/deployment-hosting/arcade-cloud/page.mdx
+++ b/app/en/guides/deployment-hosting/arcade-cloud/page.mdx
@@ -88,7 +88,7 @@ Training consent does **not** apply to:
 Arcade follows a customer-governed consent model that prioritizes transparency and control:
 
 - **Opt-out is available anytime** through your organization or project settings—no review process, and it takes effect immediately.
-- **Consent is scoped to the organization or project level.** Consent for data training is controlled buy the Arcade customer, and not end-users. For enterprise accounts, an organization admin manages consent for the team.
+- **Consent is scoped to the organization level.** Consent for data training is controlled buy the Arcade customer, and not end-users. For enterprise accounts, an organization admin manages consent for the team.
 
 
 
@@ -109,7 +109,7 @@ Training data is retained for up to 5 years, which is sufficient for model devel
 
 | Layer | Standard |
 | ----- | -------- |
-| **At rest** | All production systems use encrypted storage volumes |
+| **At rest** | All production systems use AES-256 encrypted storage volumes |
 | **In transit** | TLS 1.2+ for all API communications |
 | **Application-level** | Sensitive fields (tokens, secrets) use additional AES-256 encryption before persisting to storage |
 


### PR DESCRIPTION
Closes TOO-372

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security behavior modifications, though accuracy matters for compliance expectations.
> 
> **Overview**
> Expands the `Arcade Cloud infrastructure` guide from a brief networking note into a broader compliance-focused page covering **US-only sovereignty**, VPC peering availability, and detailed descriptions of **data storage categories**.
> 
> Adds documentation for **monitoring/analytics retention**, **training data scope + org-level opt-out model + retention**, and **encryption standards** (at rest/in transit/app-level), plus a clearer callout distinguishing Arcade Cloud vs self-hosted deployments and updated contact guidance for compliance questions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 461591916eeeb5ca406ee900fd8c974483062d43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->