### PR TITLE
Fix broken links from Ahrefs 404 audit

### DIFF
--- a/app/_components/footer.tsx
+++ b/app/_components/footer.tsx
@@ -137,7 +137,7 @@ const Footer: React.FC = () => {
 
   const feedbackResources: Resource[] = [
     {
-      url: "/discord",
+      url: urlConfig.company.discord,
       title: "Discord",
       external: true,
     },

--- a/app/en/home/landing-page.tsx
+++ b/app/en/home/landing-page.tsx
@@ -70,7 +70,7 @@ const POPULAR_INTEGRATIONS_ROW1 = [
   {
     name: "HubSpot",
     icon: "/images/icons/hubspot.png",
-    href: "/resources/integrations/crm/hubspot",
+    href: "/resources/integrations/sales/hubspot",
   },
   {
     name: "Linear",

--- a/next.config.ts
+++ b/next.config.ts
@@ -631,6 +631,17 @@ const nextConfig: NextConfig = withLlmsTxt({
           destination: "/:locale/get-started/agent-frameworks/vercelai",
           permanent: true,
         },
+        // Legacy /integrations path
+        {
+          source: "/:locale/integrations",
+          destination: "/:locale/resources/integrations",
+          permanent: true,
+        },
+        {
+          source: "/:locale/integrations/:path*",
+          destination: "/:locale/resources/integrations/:path*",
+          permanent: true,
+        },
         // MCP servers to integrations
         {
           source: "/:locale/mcp-servers",


### PR DESCRIPTION
Fix Discord footer link, HubSpot category path, add missing _meta sidebar entries (weaviate-api, zoho-creator-api, sharepoint), and add redirect for /integrations legacy path.

Related to: https://linear.app/arcadedev/issue/MAR-202/fix-18-broken-pages-404s-6-broken-redirect-chains-across-arcadedev-and

Related PRs:
- https://github.com/ArcadeAI/arcade-ui/pull/62
- https://github.com/ArcadeAI/monorepo/pull/310


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates internal/external URLs and adds redirects; risk is limited to potential misrouting if redirect patterns or targets are incorrect.
> 
> **Overview**
> Fixes several broken navigation URLs by pointing the footer’s Discord link at `urlConfig.company.discord` and correcting the HubSpot landing-page integration link to the `/resources/integrations/sales/hubspot` path.
> 
> Adds permanent redirects in `next.config.ts` to map the legacy `/:locale/integrations` (and subpaths) to the current `/:locale/resources/integrations` routes, reducing 404s from old backlinks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b04e6c2e473b38cfb065fce98133cada782e2d47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->