### PR TITLE
Preferred locale english only

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -63,6 +63,24 @@ function getPreferredLocale(_request: NextRequest): string {
   return "en";
 }
 
+function getEnglishLocaleRedirectPath(pathname: string): string | null {
+  for (const locale of SUPPORTED_LOCALES) {
+    if (locale === "en") {
+      continue;
+    }
+
+    if (pathname === `/${locale}` || pathname === `/${locale}/`) {
+      return "/en/home";
+    }
+
+    if (pathname.startsWith(`/${locale}/`)) {
+      return `/en${pathname.slice(locale.length + 1)}`;
+    }
+  }
+
+  return null;
+}
+
 function pathnameIsMissingLocale(pathname: string): boolean {
   return SUPPORTED_LOCALES.every(
     (locale) => !pathname.startsWith(`/${locale}/`) && pathname !== `/${locale}`
@@ -149,6 +167,13 @@ function handleContentNegotiation(
 
 export function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
+
+  const englishLocaleRedirectPath = getEnglishLocaleRedirectPath(pathname);
+  if (englishLocaleRedirectPath) {
+    const url = request.nextUrl.clone();
+    url.pathname = englishLocaleRedirectPath;
+    return NextResponse.redirect(url);
+  }
 
   const contentNegotiationResponse = handleContentNegotiation(
     request,


### PR DESCRIPTION
Force `getPreferredLocale` to return "en" as other translations are not yet supported, and remove unused locale parsing logic.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-4675bdca-76ee-48ef-8e14-5c4db7ed5c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4675bdca-76ee-48ef-8e14-5c4db7ed5c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request routing/redirect behavior for locale-prefixed URLs, which could affect SEO and any existing links or bookmarks to `/es` or `/pt-BR` paths.
> 
> **Overview**
> Forces locale selection to **always use English** by simplifying `getPreferredLocale` to return `"en"` and removing Accept-Language/cookie-based locale parsing.
> 
> Adds early middleware redirects that map any `/es` or `/pt-BR` locale-prefixed routes (including bare locale roots) to the equivalent `/en/...` paths (with `/es`/`/pt-BR` roots going to `/en/home`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b5704ebb5c64700c1ad19a42eebd49f162de8dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->