### PR TITLE
Enable full git history for accurate page timestamps

### DIFF
--- a/.github/workflows/generate-markdown.yml
+++ b/.github/workflows/generate-markdown.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           token: ${{ secrets.DOCS_PUBLISHABLE_GH_TOKEN }}
+          # Fetch full git history so Nextra can get accurate timestamps
+          fetch-depth: 0
 
       - name: Install pnpm
         run: npm install -g pnpm


### PR DESCRIPTION
## Summary
- Added `fetch-depth: 0` to the checkout step in `generate-markdown.yml` workflow

## Problem
Every time the markdown generation workflow ran, all "Last updated on" dates were being reset to the current build date. This happened because GitHub Actions defaults to shallow clones (`fetch-depth: 1`), which means git history isn't available.

Nextra uses git history to determine when each file was last modified. Without full history, it falls back to the build date.

## Solution
Set `fetch-depth: 0` to fetch the complete git history, allowing Nextra to accurately determine when each MDX file was last modified.

## Test plan
- [ ] Trigger the generate-markdown workflow on a PR
- [ ] Verify that "Last updated on" dates reflect actual file modification dates, not the build date

## References
- [actions/checkout - Fetch all history](https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches)
- Nextra's warning: "The repository is shallow cloned, so the latest modified time will not be presented"

🤖 Generated with [Claude Code](https://claude.com/claude-code)