### PR TITLE
fix: pre commit was breaking merge state loclly when there were conflictscommit 

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,6 +2,16 @@
 # Exit on any error
 set -e
 
+# Detect merge/rebase state — used later to skip the stash+format block
+# which conflicts with merge state and corrupts it.
+GIT_DIR="$(git rev-parse --git-dir)"
+IS_MERGING=false
+if [ -f "$GIT_DIR/MERGE_HEAD" ] || \
+   [ -d "$GIT_DIR/rebase-merge" ] || \
+   [ -d "$GIT_DIR/rebase-apply" ]; then
+  IS_MERGING=true
+fi
+
 # Check if there are any staged files
 if [ -z "$(git diff --cached --name-only)" ]; then
   echo "No staged files to check"
@@ -123,6 +133,15 @@ fi
 
 # --- Lint Staged (formatting) ---
 pnpm dlx lint-staged
+
+# --- Stash + Format ---
+# Skip this block during merge/rebase: git stash --keep-index destroys
+# MERGE_HEAD and corrupts the merge state, causing repeated failures.
+# lint-staged (above) already handles formatting for staged files safely.
+if [ "$IS_MERGING" = true ]; then
+  echo "⏭️  Skipping stash+format (merge/rebase in progress)"
+  exit 0
+fi
 
 # Store the hash of staged changes to detect modifications
 STAGED_HASH=$(git diff --cached | sha256sum | cut -d' ' -f1)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Change is isolated to the local `pre-commit` hook and only affects developer workflow; main risk is unintentionally skipping formatting during merges/rebases.
> 
> **Overview**
> Prevents the `pre-commit` hook from breaking in-progress merges/rebases by detecting merge/rebase state (`MERGE_HEAD`, `rebase-merge`, `rebase-apply`) and **skipping the stash+format section** that uses `git stash --keep-index`.
> 
> `lint-staged` still runs as before, but during merge/rebase the hook now exits early after formatting staged files via `lint-staged`, avoiding stash operations that can corrupt the merge state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d70d7865d02e2a158969e60cef86e0d9b0f654c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->