### PR TITLE
fixing the links in the framework overview

### DIFF
--- a/app/_components/agent-framework-tabs.tsx
+++ b/app/_components/agent-framework-tabs.tsx
@@ -7,35 +7,35 @@ export function AgentFrameworkTabs() {
       <Tabs.Tab>
         <div className="mt-6 grid gap-3 sm:grid-cols-2 sm:gap-4 md:gap-5 lg:grid-cols-3">
           <PlatformCard
-            icon="/images/icons/python.svg"
-            link="/get-started/agent-frameworks/setup-arcade-with-your-llm-python"
-            name="Vanilla Python"
-            type="MCP Client"
-          />
-          <PlatformCard
-            icon="/images/icons/langchain.svg"
-            invertInDark
-            link="/guides/agent-frameworks/langchain/use-arcade-tools"
-            name="LangChain"
-            type="Agent Framework"
-          />
-          <PlatformCard
             icon="https://avatars.githubusercontent.com/u/170677839?s=200&v=4"
-            link="/guides/agent-frameworks/crewai/use-arcade-tools"
+            link="/en/get-started/agent-frameworks/crewai/use-arcade-tools"
             name="CrewAI"
             type="Agent Framework"
           />
           <PlatformCard
+            icon="https://avatars.githubusercontent.com/u/1342004?s=200&v=4"
+            link="/en/get-started/agent-frameworks/google-adk/setup-python"
+            name="Google ADK"
+            type="Agent Framework"
+          />
+          <PlatformCard
+            icon="/images/icons/langchain.svg"
+            invertInDark
+            link="/en/get-started/agent-frameworks/langchain/use-arcade-with-langchain-py"
+            name="LangChain"
+            type="Agent Framework"
+          />
+          <PlatformCard
             icon="https://avatars.githubusercontent.com/u/14957082?s=200&v=4"
-            link="/guides/agent-frameworks/openai-agents/overview"
+            link="/en/get-started/agent-frameworks/openai-agents/setup-python"
             name="OpenAI Agents"
             type="Agent Framework"
           />
           <PlatformCard
-            icon="https://avatars.githubusercontent.com/u/1342004?s=200&v=4"
-            link="/guides/agent-frameworks/google-adk/overview"
-            name="Google ADK"
-            type="Agent Framework"
+            icon="/images/icons/python.svg"
+            link="/en/get-started/agent-frameworks/setup-arcade-with-your-llm-python"
+            name="Vanilla Python"
+            type="MCP Client"
           />
         </div>
       </Tabs.Tab>
@@ -44,27 +44,27 @@ export function AgentFrameworkTabs() {
           <PlatformCard
             icon="/images/icons/langchain.svg"
             invertInDark
-            link="/guides/agent-frameworks/langchain/use-arcade-tools"
+            link="/en/get-started/agent-frameworks/langchain/use-arcade-with-langchain-ts"
             name="LangChain"
             type="Agent Framework"
           />
           <PlatformCard
             icon="https://avatars.githubusercontent.com/u/1342004?s=200&v=4"
-            link="/guides/agent-frameworks/google-adk/overview"
+            link="/en/get-started/agent-frameworks/google-adk/setup-typescript"
             name="Google ADK"
             type="Agent Framework"
           />
           <PlatformCard
             icon="/images/icons/mastra.svg"
             invertInDark
-            link="/guides/agent-frameworks/mastra/overview"
+            link="/en/get-started/agent-frameworks/mastra"
             name="Mastra"
             type="Agent Framework"
           />
           <PlatformCard
             icon="/images/icons/vercel.svg"
             invertInDark
-            link="/guides/agent-frameworks/vercelai"
+            link="/en/get-started/agent-frameworks/vercelai"
             name="Vercel AI"
             type="Agent Framework"
           />


### PR DESCRIPTION
* Vanilla Python was borked
* They didn't link to the language pages, just overviews