### PR TITLE
Add ASCII art Arcade logo to landing page footer

### DIFF
--- a/app/en/home/landing-page.tsx
+++ b/app/en/home/landing-page.tsx
@@ -681,6 +681,24 @@ export function LandingPage() {
         </div>
       </section>
 
+      {/* ASCII Art Logo */}
+      <section className="pb-8 pt-4">
+        <pre
+          aria-hidden="true"
+          className="mx-auto select-none text-center font-mono text-[0.45rem] leading-[1.1] text-gray-300 sm:text-[0.55rem] md:text-xs dark:text-gray-700"
+        >
+          {[
+            "     ██████╗                                              ██╗",
+            "    ██╔═══██╗                                             ██║",
+            "   ██║    ╚██╗  ██╗██╗  ██████╗  ██████╗   ████████╗  ██████║  ██████╗",
+            "  ████████████║ ███╔═╝ ██╔════╝ ██╔═══██║  ██╔═══██║ ██╔═══╝ ██╔═══██╗",
+            " ██╔═══════██║ ██╔╝   ██║      ████████╔╝  ██║   ██║ ██║     ████████╔╝",
+            "██╔╝       ██║ ██║    ╚██████╗ ██╔═════╝   ████████║ ╚██████╗╚██████╗",
+            "╚═╝       ╚══╝╚══╝    ╚══════╝╚══╝        ╚═══════╝  ╚══════╝ ╚═════╝",
+          ].join("\n")}
+        </pre>
+      </section>
+
       {/* Background decoration at bottom */}
       <div
         aria-hidden="true"


### PR DESCRIPTION
Adds a decorative Unicode box-drawing ASCII art rendering of the Arcade logo at the bottom of the landing page. Uses responsive font sizing and theme-aware colors (gray-300 in light mode, gray-700 in dark mode) for a subtle, elegant touch. The ASCII art is marked as decorative with aria-hidden to maintain accessibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational change to the landing page markup/styling with no data, auth, or logic changes; risk is limited to minor layout/visual regressions.
> 
> **Overview**
> Adds a decorative ASCII-art Arcade logo block to the bottom of the landing page (`landing-page.tsx`) between the quick links and the existing background decoration.
> 
> The logo is rendered in a `<pre>` with responsive mono font sizing, light/dark theme-aware coloring, and `aria-hidden` so it doesn’t affect accessibility or screen readers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d761f1df961d2e14e6cbbc8995f76f46f9b3312b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->