### PR TITLE
Add ASCII art Arcade logo at bottom of landing page

### DIFF
--- a/app/en/home/landing-page.tsx
+++ b/app/en/home/landing-page.tsx
@@ -681,6 +681,24 @@ export function LandingPage() {
         </div>
       </section>
 
+      {/* ASCII Art Logo */}
+      <section className="border-gray-200 border-t py-12 dark:border-gray-800">
+        <div className="container mx-auto px-4">
+          <pre
+            aria-hidden="true"
+            className="mx-auto select-none text-center font-mono text-[0.45rem] leading-[0.5rem] text-gray-300 sm:text-[0.55rem] sm:leading-[0.6rem] md:text-xs md:leading-[0.7rem] dark:text-gray-700"
+          >
+            {[
+              "           ___                          __",
+              "          /   |   _____  _____ ____ ___/ /__",
+              "         / /| |  / ___/ / ___// __ `// _  / _ \\",
+              "        / ___ | / /    / /__ / /_/ // /_/ /  __/",
+              "       /_/  |_|/_/     \\___/ \\__,_/ \\__,_/\\___/",
+            ].join("\n")}
+          </pre>
+        </div>
+      </section>
+
       {/* Background decoration at bottom */}
       <div
         aria-hidden="true"


### PR DESCRIPTION
## Summary
Displays a decorative FIGlet-style Arcade wordmark below the Quick Links section with responsive scaling and theme-aware coloring for both light and dark modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational change to the landing page (adds a decorative `<pre>` section) with no impact on data, auth, or routing logic.
> 
> **Overview**
> Adds a new bottom-of-page section on `app/en/home/landing-page.tsx` that renders an ASCII-art “Arcade” wordmark below the Quick Links.
> 
> The logo is displayed in a `<pre>` with responsive font/line-height sizing and light/dark theme-aware coloring, and is marked `aria-hidden` as decorative.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20e7a56c95ad4bdd9938a1657b3012a504c99cc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->