### PR TITLE
chore: automate design system dependency updates

### DIFF
--- a/.github/workflows/update-design-system-dependency.yml
+++ b/.github/workflows/update-design-system-dependency.yml
@@ -51,7 +51,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update @arcadeai/design-system to latest"
           title: "chore: update @arcadeai/design-system to latest"
-          team-reviewers: engineering
           body: |
             This PR updates `@arcadeai/design-system` to the latest published version.
 


### PR DESCRIPTION
Add a GitHub workflow that checks @arcadeai/design-system against the latest published version, updates only when needed, and opens a PR while skipping Husky hooks in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new manually triggered GitHub Actions workflow to bump a single dependency and open a PR; main risk is CI/automation behavior (permissions, PR creation) rather than runtime code changes.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/update-design-system-dependency.yml`) that can be manually triggered to update `@arcadeai/design-system` to the latest version via `pnpm`, detect whether `package.json`/`pnpm-lock.yaml` changed, and automatically open a PR (skipping Husky hooks) on a dedicated automation branch when updates are needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 726b76a4f4216351d02b8765658f97465da47b7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->