### PR TITLE
fix: constrain locale param in legacy redirect rules to prevent path duplication

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -673,24 +673,28 @@ const nextConfig: NextConfig = withLlmsTxt({
           permanent: true,
         },
         // Legacy /integrations path
+        // NOTE: :locale is constrained to actual locale values to prevent
+        // collisions with locale-less paths like /resources/integrations,
+        // which would otherwise match with :locale="resources" and redirect
+        // to /resources/resources/integrations (a 404).
         {
-          source: "/:locale/integrations",
+          source: "/:locale(en|es|pt-BR)/integrations",
           destination: "/:locale/resources/integrations",
           permanent: true,
         },
         {
-          source: "/:locale/integrations/:path*",
+          source: "/:locale(en|es|pt-BR)/integrations/:path*",
           destination: "/:locale/resources/integrations/:path*",
           permanent: true,
         },
         // MCP servers to integrations
         {
-          source: "/:locale/mcp-servers",
+          source: "/:locale(en|es|pt-BR)/mcp-servers",
           destination: "/:locale/resources/integrations",
           permanent: true,
         },
         {
-          source: "/:locale/mcp-servers/:path*",
+          source: "/:locale(en|es|pt-BR)/mcp-servers/:path*",
           destination: "/:locale/resources/integrations/:path*",
           permanent: true,
         },


### PR DESCRIPTION
**Problem**
Links to _/resources/integrations_ (used across 12+ MDX files) incorrectly navigate to **/en/resources/resources/integrations** (a **404**) instead of the expected **/en/resources/integrations.**

**Reproduction**: Click any "MCP server catalog" link in the docs (e.g., on the [Vercel AI SDK](https://docs.arcade.dev/en/get-started/agent-frameworks/vercelai) page). The browser ends up at a 404 page with a doubled /resources/resources/ segment.

**Root Cause**
The legacy redirect rules in 
_next.config.ts_
 use an unconstrained :locale named parameter:
 ` source: "/:locale/integrations",
destination: "/:locale/resources/integrations",
`
In Next.js, :locale is a named parameter that matches any single path segment — not just actual locale values. Since Next.js redirects run before middleware, the following redirect chain occurs:

User clicks link to _/resources/integrations_ (no locale prefix)
Next.js redirect matches first: _/:locale/integrations_ captures :locale = "resources"
Redirect transforms path to _/:locale/resources/integrations_ → _/resources/resources/integrations_
Middleware detects missing locale, prepends _/en/_
Final URL: _/en/resources/resources/integrations_ → 404


**Fix**
Constrains the :locale parameter in the 4 affected redirect rules to only match actual supported locales using Next.js's regex parameter syntax:

`
// Before (matches ANY single segment)
source: "/:locale/integrations"
// After (matches only en, es, pt-BR)
source: "/:locale(en|es|pt-BR)/integrations"
This ensures the redirects only fire for paths that genuinely have a locale prefix (e.g., /en/integrations → /en/resources/integrations), and locale-less paths like /resources/integrations correctly fall through to the middleware for proper locale handling.
`


Affected Redirect Rules

- _/:locale/integrations_ → _/:locale/resources/integrations_
- _/:locale/integrations/:path_* → _/:locale/resources/integrations/:path_*
- _/:locale/mcp-servers_ → _/:locale/resources/integrations_
- _/:locale/mcp-servers/:path_* → _/:locale/resources/integrations/:path_*


**Note**
Other redirect rules in this file also use unconstrained /:locale/ patterns and could theoretically have the same class of issue if a locale-less path happens to match. The affected rules were the most impactful since /resources/integrations is widely linked across 12+ documentation pages.