### PR TITLE
Updating GH token for gen doc and update ds version actions

### DIFF
--- a/.github/workflows/generate-toolkit-docs.yml
+++ b/.github/workflows/generate-toolkit-docs.yml
@@ -81,11 +81,12 @@ jobs:
 
       - name: Create pull request
         if: steps.check-changes.outputs.has_changes == 'true'
+        id: cpr
         uses: peter-evans/create-pull-request@v7
         env:
           HUSKY: 0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DOCS_PUBLISHABLE_GH_TOKEN }}
           commit-message: "[AUTO] Adding MCP Servers docs update"
           title: "[AUTO] Adding MCP Servers docs update"
           body: |
@@ -97,3 +98,10 @@ jobs:
             - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           branch: automation/toolkit-docs-${{ github.run_id }}
           delete-branch: true
+
+      - name: Request team review
+        if: steps.check-changes.outputs.has_changes == 'true' && steps.cpr.outputs.pull-request-number != ''
+        continue-on-error: true
+        run: gh pr edit ${{ steps.cpr.outputs.pull-request-number }} --add-reviewer ArcadeAI/engineering-tools-and-dx
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_PUBLISHABLE_GH_TOKEN }}

--- a/.github/workflows/update-design-system-dependency.yml
+++ b/.github/workflows/update-design-system-dependency.yml
@@ -49,12 +49,13 @@ jobs:
 
       - name: Create pull request
         if: steps.check-changes.outputs.has_changes == 'true'
+        id: cpr
         uses: peter-evans/create-pull-request@v7
         env:
           HUSKY: 0
           SKIP_HUSKY: 1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DOCS_PUBLISHABLE_GH_TOKEN }}
           commit-message: "chore: update @arcadeai/design-system to latest"
           title: "chore: update @arcadeai/design-system to latest"
           body: |
@@ -70,3 +71,10 @@ jobs:
             pnpm-lock.yaml
           branch: automation/update-design-system-dependency
           delete-branch: true
+
+      - name: Request team review
+        if: steps.check-changes.outputs.has_changes == 'true' && steps.cpr.outputs.pull-request-number != ''
+        continue-on-error: true
+        run: gh pr edit ${{ steps.cpr.outputs.pull-request-number }} --add-reviewer ArcadeAI/engineering-tools-and-dx
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_PUBLISHABLE_GH_TOKEN }}


### PR DESCRIPTION
Fix CI checks on auto-generated PRs and add team reviewer assignment
Switch generate-toolkit-docs and update-design-system-dependency workflows from GITHUB_TOKEN to DOCS_PUBLISHABLE_GH_TOKEN when creating PRs. PRs created by GITHUB_TOKEN don't trigger further workflow events, which caused the test and validate_schemas checks to hang indefinitely as "waiting for status to be reported."

Add a best-effort Request team review step to both workflows that assigns ArcadeAI/engineering-tools-and-dx as reviewer. Uses continue-on-error: true so a permission failure never blocks PR creation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that adjust PR creation credentials and add a non-blocking reviewer assignment step; low blast radius aside from requiring the new secret to be present/permissioned.
> 
> **Overview**
> Automation workflows that open PRs now authenticate with `DOCS_PUBLISHABLE_GH_TOKEN` (instead of `GITHUB_TOKEN`) when running `peter-evans/create-pull-request`, to ensure downstream CI checks run on the generated PRs.
> 
> Both workflows also add a best-effort `gh pr edit --add-reviewer ArcadeAI/engineering-tools-and-dx` step (guarded on a created PR number and `continue-on-error`) to automatically request team review on the generated PRs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08bdf91088cd4d424ad6cc4c7d7a3caaff586f12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->