### PR TITLE
chore: update @arcadeai/design-system to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://arcade.dev/",
   "dependencies": {
-    "@arcadeai/design-system": "^3.29.2",
+    "@arcadeai/design-system": "^3.30.0",
     "@mdx-js/mdx": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
     "@next/third-parties": "16.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@arcadeai/design-system':
-        specifier: ^3.29.2
-        version: 3.29.2(@hookform/resolvers@5.2.2(react-hook-form@7.65.0(react@19.2.3)))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.548.0(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-hook-form@7.65.0(react@19.2.3))(react@19.2.3)(recharts@3.6.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1))(tailwindcss@4.1.16)
+        specifier: ^3.30.0
+        version: 3.30.0(@hookform/resolvers@5.2.2(react-hook-form@7.65.0(react@19.2.3)))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.548.0(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-hook-form@7.65.0(react@19.2.3))(react@19.2.3)(recharts@3.6.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1))(tailwindcss@4.1.16)
       '@mdx-js/mdx':
         specifier: ^3.1.1
         version: 3.1.1
@@ -214,8 +214,8 @@ packages:
       zod:
         optional: true
 
-  '@arcadeai/design-system@3.29.2':
-    resolution: {integrity: sha512-sqSQdME8KVPdO9MKQWHcN4g/2TYR44yFFoIpKPxiWXNfgOsKsskBYiWCetqaNt9kvhaQjOYwur7m7+lv9ofy1Q==}
+  '@arcadeai/design-system@3.30.0':
+    resolution: {integrity: sha512-KUoU+yed4wpNmGC481ZZZ5jJLKFDAxWyRr9JxjGj2zLE00qTIt5M0TpSUtEWYT+RjgXGSV3Ej4zOG9JqYoNJrw==}
     engines: {bun: '>=1.3.5'}
     peerDependencies:
       '@hookform/resolvers': '>=5.2.1'
@@ -4482,8 +4482,8 @@ packages:
   tabbable@6.3.0:
     resolution: {integrity: sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ==}
 
-  tailwind-merge@3.4.0:
-    resolution: {integrity: sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==}
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss-animate@1.0.7:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
@@ -4923,7 +4923,7 @@ snapshots:
     optionalDependencies:
       zod: 4.1.12
 
-  '@arcadeai/design-system@3.29.2(@hookform/resolvers@5.2.2(react-hook-form@7.65.0(react@19.2.3)))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.548.0(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-hook-form@7.65.0(react@19.2.3))(react@19.2.3)(recharts@3.6.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1))(tailwindcss@4.1.16)':
+  '@arcadeai/design-system@3.30.0(@hookform/resolvers@5.2.2(react-hook-form@7.65.0(react@19.2.3)))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.548.0(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-hook-form@7.65.0(react@19.2.3))(react@19.2.3)(recharts@3.6.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1))(tailwindcss@4.1.16)':
     dependencies:
       '@hookform/resolvers': 5.2.2(react-hook-form@7.65.0(react@19.2.3))
       class-variance-authority: 0.7.1
@@ -4938,7 +4938,7 @@ snapshots:
       react-hook-form: 7.65.0(react@19.2.3)
       react-resizable-panels: 3.0.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       recharts: 3.6.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1)
-      tailwind-merge: 3.4.0
+      tailwind-merge: 3.5.0
       tailwindcss: 4.1.16
     transitivePeerDependencies:
       - '@types/react'
@@ -10075,7 +10075,7 @@ snapshots:
 
   tabbable@6.3.0: {}
 
-  tailwind-merge@3.4.0: {}
+  tailwind-merge@3.5.0: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@4.1.16):
     dependencies:


### PR DESCRIPTION
This PR updates `@arcadeai/design-system` to the latest published version.

It runs a design-system compatibility test gate before opening this PR.
If that gate fails, the workflow stops and no PR is created.

- Trigger: `workflow_dispatch`
- Run: https://github.com/ArcadeAI/docs/actions/runs/22425478445

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only update; primary risk is minor visual/behavioral changes from the new design-system package.
> 
> **Overview**
> Updates `@arcadeai/design-system` from `^3.29.2` to `^3.30.0`.
> 
> Refreshes `pnpm-lock.yaml` for the new design-system release, including a transitive bump of `tailwind-merge` to `3.5.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6145b6ce10fef074c4f4434141813aeec02fe309. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->