### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/toolkit-docs-generator/data/toolkits/asana.json
+++ b/toolkit-docs-generator/data/toolkits/asana.json
@@ -1,7 +1,7 @@
 {
   "id": "Asana",
   "label": "Asana",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "Arcade tools designed for LLMs to interact with Asana",
   "metadata": {
     "category": "productivity",
@@ -24,7 +24,7 @@
     {
       "name": "AttachFileToTask",
       "qualifiedName": "Asana.AttachFileToTask",
-      "fullyQualifiedName": "Asana.AttachFileToTask@1.2.0",
+      "fullyQualifiedName": "Asana.AttachFileToTask@1.2.2",
       "description": "Attaches a file to an Asana task\n\nProvide exactly one of file_content_str, file_content_base64, or file_content_url, never more\nthan one.\n\n- Use file_content_str for text files (will be encoded using file_encoding)\n- Use file_content_base64 for binary files like images, PDFs, etc.\n- Use file_content_url if the file is hosted on an external URL",
       "parameters": [
         {
@@ -132,7 +132,7 @@
     {
       "name": "CreateTag",
       "qualifiedName": "Asana.CreateTag",
-      "fullyQualifiedName": "Asana.CreateTag@1.2.0",
+      "fullyQualifiedName": "Asana.CreateTag@1.2.2",
       "description": "Create a tag in Asana",
       "parameters": [
         {
@@ -233,7 +233,7 @@
     {
       "name": "CreateTask",
       "qualifiedName": "Asana.CreateTask",
-      "fullyQualifiedName": "Asana.CreateTask@1.2.0",
+      "fullyQualifiedName": "Asana.CreateTask@1.2.2",
       "description": "Creates a task in Asana\n\nThe task must be associated to at least one of the following: parent_task_id, project, or\nworkspace_id. If none of these are provided and the account has only one workspace, the task\nwill be associated to that workspace. If the account has multiple workspaces, an error will\nbe raised with a list of available workspaces.",
       "parameters": [
         {
@@ -385,7 +385,7 @@
     {
       "name": "GetProjectById",
       "qualifiedName": "Asana.GetProjectById",
-      "fullyQualifiedName": "Asana.GetProjectById@1.2.0",
+      "fullyQualifiedName": "Asana.GetProjectById@1.2.2",
       "description": "Get an Asana project by its ID",
       "parameters": [
         {
@@ -428,7 +428,7 @@
     {
       "name": "GetSubtasksFromATask",
       "qualifiedName": "Asana.GetSubtasksFromATask",
-      "fullyQualifiedName": "Asana.GetSubtasksFromATask@1.2.0",
+      "fullyQualifiedName": "Asana.GetSubtasksFromATask@1.2.2",
       "description": "Get the subtasks of a task",
       "parameters": [
         {
@@ -497,7 +497,7 @@
     {
       "name": "GetTagById",
       "qualifiedName": "Asana.GetTagById",
-      "fullyQualifiedName": "Asana.GetTagById@1.2.0",
+      "fullyQualifiedName": "Asana.GetTagById@1.2.2",
       "description": "Get an Asana tag by its ID",
       "parameters": [
         {
@@ -540,7 +540,7 @@
     {
       "name": "GetTaskById",
       "qualifiedName": "Asana.GetTaskById",
-      "fullyQualifiedName": "Asana.GetTaskById@1.2.0",
+      "fullyQualifiedName": "Asana.GetTaskById@1.2.2",
       "description": "Get a task by its ID",
       "parameters": [
         {
@@ -596,7 +596,7 @@
     {
       "name": "GetTasksWithoutId",
       "qualifiedName": "Asana.GetTasksWithoutId",
-      "fullyQualifiedName": "Asana.GetTasksWithoutId@1.2.0",
+      "fullyQualifiedName": "Asana.GetTasksWithoutId@1.2.2",
       "description": "Search for tasks",
       "parameters": [
         {
@@ -847,7 +847,7 @@
     {
       "name": "GetTeamById",
       "qualifiedName": "Asana.GetTeamById",
-      "fullyQualifiedName": "Asana.GetTeamById@1.2.0",
+      "fullyQualifiedName": "Asana.GetTeamById@1.2.2",
       "description": "Get an Asana team by its ID",
       "parameters": [
         {
@@ -890,7 +890,7 @@
     {
       "name": "GetUserById",
       "qualifiedName": "Asana.GetUserById",
-      "fullyQualifiedName": "Asana.GetUserById@1.2.0",
+      "fullyQualifiedName": "Asana.GetUserById@1.2.2",
       "description": "Get a user by ID",
       "parameters": [
         {
@@ -933,7 +933,7 @@
     {
       "name": "GetWorkspaceById",
       "qualifiedName": "Asana.GetWorkspaceById",
-      "fullyQualifiedName": "Asana.GetWorkspaceById@1.2.0",
+      "fullyQualifiedName": "Asana.GetWorkspaceById@1.2.2",
       "description": "Get an Asana workspace by its ID",
       "parameters": [
         {
@@ -976,7 +976,7 @@
     {
       "name": "ListProjects",
       "qualifiedName": "Asana.ListProjects",
-      "fullyQualifiedName": "Asana.ListProjects@1.2.0",
+      "fullyQualifiedName": "Asana.ListProjects@1.2.2",
       "description": "List projects in Asana",
       "parameters": [
         {
@@ -1058,7 +1058,7 @@
     {
       "name": "ListTags",
       "qualifiedName": "Asana.ListTags",
-      "fullyQualifiedName": "Asana.ListTags@1.2.0",
+      "fullyQualifiedName": "Asana.ListTags@1.2.2",
       "description": "List tags in an Asana workspace",
       "parameters": [
         {
@@ -1127,7 +1127,7 @@
     {
       "name": "ListTeams",
       "qualifiedName": "Asana.ListTeams",
-      "fullyQualifiedName": "Asana.ListTeams@1.2.0",
+      "fullyQualifiedName": "Asana.ListTeams@1.2.2",
       "description": "List teams in an Asana workspace",
       "parameters": [
         {
@@ -1196,7 +1196,7 @@
     {
       "name": "ListTeamsTheCurrentUserIsAMemberOf",
       "qualifiedName": "Asana.ListTeamsTheCurrentUserIsAMemberOf",
-      "fullyQualifiedName": "Asana.ListTeamsTheCurrentUserIsAMemberOf@1.2.0",
+      "fullyQualifiedName": "Asana.ListTeamsTheCurrentUserIsAMemberOf@1.2.2",
       "description": "List teams in Asana that the current user is a member of",
       "parameters": [
         {
@@ -1265,7 +1265,7 @@
     {
       "name": "ListUsers",
       "qualifiedName": "Asana.ListUsers",
-      "fullyQualifiedName": "Asana.ListUsers@1.2.0",
+      "fullyQualifiedName": "Asana.ListUsers@1.2.2",
       "description": "List users in Asana",
       "parameters": [
         {
@@ -1334,7 +1334,7 @@
     {
       "name": "ListWorkspaces",
       "qualifiedName": "Asana.ListWorkspaces",
-      "fullyQualifiedName": "Asana.ListWorkspaces@1.2.0",
+      "fullyQualifiedName": "Asana.ListWorkspaces@1.2.2",
       "description": "List workspaces in Asana that are visible to the authenticated user",
       "parameters": [
         {
@@ -1390,7 +1390,7 @@
     {
       "name": "MarkTaskAsCompleted",
       "qualifiedName": "Asana.MarkTaskAsCompleted",
-      "fullyQualifiedName": "Asana.MarkTaskAsCompleted@1.2.0",
+      "fullyQualifiedName": "Asana.MarkTaskAsCompleted@1.2.2",
       "description": "Mark a task in Asana as completed",
       "parameters": [
         {
@@ -1433,7 +1433,7 @@
     {
       "name": "UpdateTask",
       "qualifiedName": "Asana.UpdateTask",
-      "fullyQualifiedName": "Asana.UpdateTask@1.2.0",
+      "fullyQualifiedName": "Asana.UpdateTask@1.2.2",
       "description": "Updates a task in Asana",
       "parameters": [
         {
@@ -1562,6 +1562,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:17.634Z",
+  "generatedAt": "2026-02-26T11:25:47.037Z",
   "summary": "Arcade offers a toolkit for seamless interaction with Asana, enabling developers to automate project management tasks. The toolkit supports various functionalities tailored for managing tasks, tags, and projects efficiently.\n\n**Capabilities**\n- Create, update, and manage tasks and subtasks within Asana.\n- Attach files to tasks in various formats.\n- Retrieve detailed information about projects, teams, and users.\n- List and create tags for organized task management.\n- Mark tasks as completed to streamline workflows.\n\n**OAuth**\n- **Provider**: Asana\n- **Scopes**: default\n\n**Secrets**\n- No secret types are utilized in this toolkit."
 }

--- a/toolkit-docs-generator/data/toolkits/brightdata.json
+++ b/toolkit-docs-generator/data/toolkits/brightdata.json
@@ -1,7 +1,7 @@
 {
   "id": "Brightdata",
   "label": "Bright Data",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "Search, Crawl and Scrape any site, at scale, without getting blocked",
   "metadata": {
     "category": "development",
@@ -9,7 +9,7 @@
     "isBYOC": true,
     "isPro": false,
     "type": "community",
-    "docsLink": "https://docs.arcade.dev/en/mcp-servers/development/brightdata",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/development/brightdata",
     "isComingSoon": false,
     "isHidden": false
   },
@@ -18,7 +18,7 @@
     {
       "name": "ScrapeAsMarkdown",
       "qualifiedName": "Brightdata.ScrapeAsMarkdown",
-      "fullyQualifiedName": "Brightdata.ScrapeAsMarkdown@0.2.0",
+      "fullyQualifiedName": "Brightdata.ScrapeAsMarkdown@0.4.0",
       "description": "    Scrape a webpage and return content in Markdown format using Bright Data.\n\n    Examples:\n        scrape_as_markdown(\"https://example.com\") -> \"# Example Page\n\nContent...\"\n        scrape_as_markdown(\"https://news.ycombinator.com\") -> \"# Hacker News\n...\"\n    ",
       "parameters": [
         {
@@ -31,7 +31,10 @@
         }
       ],
       "auth": null,
-      "secrets": ["BRIGHTDATA_API_KEY", "BRIGHTDATA_ZONE"],
+      "secrets": [
+        "BRIGHTDATA_API_KEY",
+        "BRIGHTDATA_ZONE"
+      ],
       "secretsInfo": [
         {
           "name": "BRIGHTDATA_API_KEY",
@@ -39,7 +42,7 @@
         },
         {
           "name": "BRIGHTDATA_ZONE",
-          "type": "unknown"
+          "type": "token"
         }
       ],
       "output": {
@@ -51,7 +54,7 @@
         "toolName": "Brightdata.ScrapeAsMarkdown",
         "parameters": {
           "url": {
-            "value": "https://example.com",
+            "value": "https://news.ycombinator.com",
             "type": "string",
             "required": true
           }
@@ -63,7 +66,7 @@
     {
       "name": "SearchEngine",
       "qualifiedName": "Brightdata.SearchEngine",
-      "fullyQualifiedName": "Brightdata.SearchEngine@0.2.0",
+      "fullyQualifiedName": "Brightdata.SearchEngine@0.4.0",
       "description": "    Search using Google, Bing, or Yandex with advanced parameters using Bright Data.\n\n    Examples:\n        search_engine(\"climate change\") -> \"# Search Results\n\n## Climate Change - Wikipedia\n...\"\n        search_engine(\"Python tutorials\", engine=\"bing\", num_results=5) -> \"# Bing Results\n...\"\n        search_engine(\"cats\", search_type=\"images\", country_code=\"us\") -> \"# Image Results\n...\"\n    ",
       "parameters": [
         {
@@ -79,7 +82,11 @@
           "type": "string",
           "required": false,
           "description": "Search engine to use",
-          "enum": ["google", "bing", "yandex"],
+          "enum": [
+            "google",
+            "bing",
+            "yandex"
+          ],
           "inferrable": true
         },
         {
@@ -103,7 +110,12 @@
           "type": "string",
           "required": false,
           "description": "Type of search",
-          "enum": ["images", "shopping", "news", "jobs"],
+          "enum": [
+            "images",
+            "shopping",
+            "news",
+            "jobs"
+          ],
           "inferrable": true
         },
         {
@@ -155,7 +167,10 @@
         }
       ],
       "auth": null,
-      "secrets": ["BRIGHTDATA_API_KEY", "BRIGHTDATA_ZONE"],
+      "secrets": [
+        "BRIGHTDATA_API_KEY",
+        "BRIGHTDATA_ZONE"
+      ],
       "secretsInfo": [
         {
           "name": "BRIGHTDATA_API_KEY",
@@ -163,7 +178,7 @@
         },
         {
           "name": "BRIGHTDATA_ZONE",
-          "type": "unknown"
+          "type": "token"
         }
       ],
       "output": {
@@ -175,7 +190,7 @@
         "toolName": "Brightdata.SearchEngine",
         "parameters": {
           "query": {
-            "value": "climate change",
+            "value": "climate change effects",
             "type": "string",
             "required": true
           },
@@ -210,7 +225,7 @@
             "required": false
           },
           "location": {
-            "value": "California",
+            "value": "San Francisco, CA",
             "type": "string",
             "required": false
           },
@@ -232,7 +247,7 @@
     {
       "name": "WebDataFeed",
       "qualifiedName": "Brightdata.WebDataFeed",
-      "fullyQualifiedName": "Brightdata.WebDataFeed@0.2.0",
+      "fullyQualifiedName": "Brightdata.WebDataFeed@0.4.0",
       "description": "Extract structured data from various websites like LinkedIn, Amazon, Instagram, etc.\nNEVER MADE UP LINKS - IF LINKS ARE NEEDED, EXECUTE search_engine FIRST.\nSupported source types:\n- amazon_product, amazon_product_reviews\n- linkedin_person_profile, linkedin_company_profile\n- zoominfo_company_profile\n- instagram_profiles, instagram_posts, instagram_reels, instagram_comments\n- facebook_posts, facebook_marketplace_listings, facebook_company_reviews\n- x_posts\n- zillow_properties_listing\n- booking_hotel_listings\n- youtube_videos\n\nExamples:\n    web_data_feed(\"amazon_product\", \"https://amazon.com/dp/B08N5WRWNW\")\n        -> \"{\"title\": \"Product Name\", ...}\"\n    web_data_feed(\"linkedin_person_profile\", \"https://linkedin.com/in/johndoe\")\n        -> \"{\"name\": \"John Doe\", ...}\"\n    web_data_feed(\n        \"facebook_company_reviews\", \"https://facebook.com/company\", num_of_reviews=50\n    ) -> \"[{\"review\": \"...\", ...}]\"",
       "parameters": [
         {
@@ -294,7 +309,9 @@
         }
       ],
       "auth": null,
-      "secrets": ["BRIGHTDATA_API_KEY"],
+      "secrets": [
+        "BRIGHTDATA_API_KEY"
+      ],
       "secretsInfo": [
         {
           "name": "BRIGHTDATA_API_KEY",
@@ -310,22 +327,22 @@
         "toolName": "Brightdata.WebDataFeed",
         "parameters": {
           "source_type": {
-            "value": "amazon_product",
+            "value": "linkedin_person_profile",
             "type": "string",
             "required": true
           },
           "url": {
-            "value": "https://amazon.com/dp/B09G3HR42Z",
+            "value": "https://www.linkedin.com/in/{profile_id}",
             "type": "string",
             "required": true
           },
           "num_of_reviews": {
-            "value": 25,
+            "value": null,
             "type": "integer",
             "required": false
           },
           "timeout": {
-            "value": 30,
+            "value": 120,
             "type": "integer",
             "required": false
           },
@@ -340,16 +357,9 @@
       }
     }
   ],
-  "documentationChunks": [
-    {
-      "type": "section",
-      "location": "custom_section",
-      "position": "after",
-      "content": "## Secrets\n\nThis tool requires the following secrets:\n\n- `BRIGHTDATA_API_KEY`\n- `BRIGHTDATA_ZONE`\n\n### Auth\n\nThe Arcade Bright Data MCP Server uses [Bright Data](https://brightdata.com/) to access proxy networks and web scraping infrastructure.\n\n**Global Environment Variables:**\n\n- `BRIGHTDATA_API_KEY`: Your Bright Data API key. You can generate this from your [Bright Data dashboard](https://brightdata.com/cp/zones) under Account Settings → API Access.\n\n- `BRIGHTDATA_ZONE`: Your Bright Data zone name (e.g., `residential_proxy1`). This is the zone identifier you created in your Bright Data dashboard under Proxies & Scraping Infrastructure → Zones.\n\n**How to get your credentials:**\n\n1. **API Key**: Navigate to your [Bright Data Control Panel](https://brightdata.com/cp) → Settings → API Access → Generate API Token\n2. **Zone**: Go to Zones section in your dashboard, find your zone name in the format shown in the zone username: `brd-customer-{customer_id}-zone-{zone_name}`\n\nFor more details, see the [Bright Data API Documentation](https://docs.brightdata.com/api-reference).",
-      "header": "## Secrets"
-    }
-  ],
+  "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-01-26T17:26:59.556Z"
+  "generatedAt": "2026-02-26T11:26:04.539Z",
+  "summary": "Bright Data provides a developer toolkit for large-scale web search, crawling, and scraping, enabling reliable extraction of pages and structured data without getting blocked. It supports search queries, content-to-Markdown conversion, and configurable data feeds across many site types.\n\nDesigned for integration into data pipelines and analytics workflows with parameterized feeds and output formats.\n\n**Capabilities**\n- Scale-resistant crawling and scraping with anti-blocking behavior for sustained collection.\n- Flexible search engine queries with advanced parameters across major engines.\n- Transform pages into clean Markdown and emit structured JSON feeds for profiles, products, reviews, listings, and media.\n- Configurable extraction parameters for batching, pagination, and media handling.\n\n**Secrets**\n- API key (BRIGHTDATA_API_KEY) and zone token (BRIGHTDATA_ZONE). Example values: BRIGHTDATA_API_KEY=sk_..., BRIGHTDATA_ZONE=zone123."
 }

--- a/toolkit-docs-generator/data/toolkits/clickup.json
+++ b/toolkit-docs-generator/data/toolkits/clickup.json
@@ -1,7 +1,7 @@
 {
   "id": "Clickup",
   "label": "ClickUp",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "description": "Arcade.dev LLM tools for interacting with ClickUp",
   "metadata": {
     "category": "productivity",
@@ -22,7 +22,7 @@
     {
       "name": "CreateTask",
       "qualifiedName": "Clickup.CreateTask",
-      "fullyQualifiedName": "Clickup.CreateTask@1.2.1",
+      "fullyQualifiedName": "Clickup.CreateTask@1.2.3",
       "description": "Create a new task in a ClickUp list with optional planning metadata.\n\nUse this tool when you want to add a task to a specific list and optionally set\nits initial status, priority, scheduling information, and hierarchy.",
       "parameters": [
         {
@@ -172,7 +172,7 @@
     {
       "name": "CreateTaskComment",
       "qualifiedName": "Clickup.CreateTaskComment",
-      "fullyQualifiedName": "Clickup.CreateTaskComment@1.2.1",
+      "fullyQualifiedName": "Clickup.CreateTaskComment@1.2.3",
       "description": "Create a new comment on a ClickUp task with optional assignment.\n\nUse this tool to add text comments to tasks. You can optionally assign\nthe comment to a specific user for follow-up.",
       "parameters": [
         {
@@ -239,7 +239,7 @@
     {
       "name": "CreateTaskCommentReply",
       "qualifiedName": "Clickup.CreateTaskCommentReply",
-      "fullyQualifiedName": "Clickup.CreateTaskCommentReply@1.2.1",
+      "fullyQualifiedName": "Clickup.CreateTaskCommentReply@1.2.3",
       "description": "Create a new threaded reply to an existing ClickUp comment.\n\nUse this tool to add threaded replies to comments, creating conversation threads.\nYou can optionally assign the reply to a specific user for follow-up.",
       "parameters": [
         {
@@ -306,7 +306,7 @@
     {
       "name": "FuzzySearchFoldersByName",
       "qualifiedName": "Clickup.FuzzySearchFoldersByName",
-      "fullyQualifiedName": "Clickup.FuzzySearchFoldersByName@1.2.1",
+      "fullyQualifiedName": "Clickup.FuzzySearchFoldersByName@1.2.3",
       "description": "Search for folders using fuzzy matching on folder names.\n\nThis tool should ONLY be used when you cannot find the desired folder through normal context\nor direct searches. It performs fuzzy matching against folder names and returns simplified\nfolder information. Use other ClickUp tools to get full folder details or work with the folders.\n\nThis tool is also useful to avoid navigating through the ClickUp hierarchy tree\nwhen you know approximately what folder/project you're looking for\nbut don't know its exact location in the hierarchy.\n\nIn ClickUp, folders are also known as projects and serve as organizational containers for lists.\nReturns folders that match the name_to_search with match scores indicating relevance\n(1.0 = perfect match, lower scores = less relevant matches).",
       "parameters": [
         {
@@ -416,7 +416,7 @@
     {
       "name": "FuzzySearchListsByName",
       "qualifiedName": "Clickup.FuzzySearchListsByName",
-      "fullyQualifiedName": "Clickup.FuzzySearchListsByName@1.2.1",
+      "fullyQualifiedName": "Clickup.FuzzySearchListsByName@1.2.3",
       "description": "Search for lists using fuzzy matching on list names.\n\nThis tool should ONLY be used when you cannot find the desired list through normal context\nor direct searches. It performs fuzzy matching against list names and returns simplified\nlist information. Use other ClickUp tools to get full list details or work with the lists.\n\nThis tool is also useful to avoid navigating through the ClickUp hierarchy tree\nwhen you know approximately what list you're looking for\nbut don't know its exact location in the hierarchy.\n\nReturns lists that match the name_to_search with match scores indicating relevance\n(1.0 = perfect match, lower scores = less relevant matches).",
       "parameters": [
         {
@@ -542,7 +542,7 @@
     {
       "name": "FuzzySearchMembersByName",
       "qualifiedName": "Clickup.FuzzySearchMembersByName",
-      "fullyQualifiedName": "Clickup.FuzzySearchMembersByName@1.2.1",
+      "fullyQualifiedName": "Clickup.FuzzySearchMembersByName@1.2.3",
       "description": "Search for workspace members using fuzzy matching on member names.\n\nThis tool should ONLY be used when you cannot find the desired team member through\nnormal context\nIt performs fuzzy matching against member names and returns\nsimplified member information including ID, name, and email.\n\nReturns team members that match the name_to_search with match scores indicating\nrelevance (1.0 = perfect match, lower scores = less relevant matches).",
       "parameters": [
         {
@@ -622,7 +622,7 @@
     {
       "name": "FuzzySearchTasksByName",
       "qualifiedName": "Clickup.FuzzySearchTasksByName",
-      "fullyQualifiedName": "Clickup.FuzzySearchTasksByName@1.2.1",
+      "fullyQualifiedName": "Clickup.FuzzySearchTasksByName@1.2.3",
       "description": "Search for tasks using fuzzy matching on task names.\n\nThis tool should ONLY be used when you cannot find the desired task through normal context\nor direct searches. It performs fuzzy matching against task names and returns simplified\ntask information. Use the returned task IDs with get_task_by_id to retrieve full task details.\n\nThis tool is also useful to avoid navigating through the ClickUp hierarchy tree\nwhen you know approximately what task you're looking for\nbut don't know its exact location in the hierarchy.\n\nReturns the most recently updated tasks that match the name_to_search with match scores\nindicating relevance (1.0 = perfect match, lower scores = less relevant matches).",
       "parameters": [
         {
@@ -797,7 +797,7 @@
     {
       "name": "GetFoldersForSpace",
       "qualifiedName": "Clickup.GetFoldersForSpace",
-      "fullyQualifiedName": "Clickup.GetFoldersForSpace@1.2.1",
+      "fullyQualifiedName": "Clickup.GetFoldersForSpace@1.2.3",
       "description": "Retrieve folders (also called directories, project categories, or project areas) from a\nClickUp space.\n\nOnly use this tool when you already have the space ID and want to see the folders within\nthat specific space.\n\nImportant: When users mention a space(or area),\nalways use this tool to get the folders within that space.\n\nThis tool fetches folders from the specified space with support for offset-based retrieval\nand archived folder filtering. Results are sorted alphabetically by name.",
       "parameters": [
         {
@@ -890,7 +890,7 @@
     {
       "name": "GetListsForFolder",
       "qualifiedName": "Clickup.GetListsForFolder",
-      "fullyQualifiedName": "Clickup.GetListsForFolder@1.2.1",
+      "fullyQualifiedName": "Clickup.GetListsForFolder@1.2.3",
       "description": "Retrieve task lists from a ClickUp folder (when users refer to a folder as a \"directory\",\nthey mean the same thing).\n\nOnly use this tool when you already have the folder ID and want to see the lists within\nthat specific folder.\n\nImportant: When users mention a specific folder(or directory), always use this tool to get\nthe lists within that folder.\n\nThis tool fetches lists from the specified folder with support for offset-based retrieval\nand archived list filtering. Results are sorted alphabetically by name.",
       "parameters": [
         {
@@ -983,7 +983,7 @@
     {
       "name": "GetListsForSpace",
       "qualifiedName": "Clickup.GetListsForSpace",
-      "fullyQualifiedName": "Clickup.GetListsForSpace@1.2.1",
+      "fullyQualifiedName": "Clickup.GetListsForSpace@1.2.3",
       "description": "Retrieve all task lists from a ClickUp space by collecting lists from all folders within the\nspace.\n\nOnly use this tool when you have a space ID and want to see all lists across all folders\nwithin that space.\n\nThis tool provides a comprehensive view of all lists in a space with support for offset-based\nretrieval and archived list filtering. Results are sorted alphabetically by name.",
       "parameters": [
         {
@@ -1076,7 +1076,7 @@
     {
       "name": "GetMembersForWorkspace",
       "qualifiedName": "Clickup.GetMembersForWorkspace",
-      "fullyQualifiedName": "Clickup.GetMembersForWorkspace@1.2.1",
+      "fullyQualifiedName": "Clickup.GetMembersForWorkspace@1.2.3",
       "description": "Retrieve all team members from a specific ClickUp workspace.\n\nOnly use this tool when you already have the workspace ID and need to see the members\nwithin that specific workspace.\n\nThis tool fetches detailed information about all members of a ClickUp workspace,\nincluding their basic profile information and role within the workspace.\nResults are sorted and support offset-based retrieval.",
       "parameters": [
         {
@@ -1143,7 +1143,7 @@
     {
       "name": "GetSpaces",
       "qualifiedName": "Clickup.GetSpaces",
-      "fullyQualifiedName": "Clickup.GetSpaces@1.2.1",
+      "fullyQualifiedName": "Clickup.GetSpaces@1.2.3",
       "description": "Retrieve spaces from a ClickUp workspace.\n\nUse this tool when users ask for:\n- Spaces within a workspace (not folders or lists)\n- Available spaces to choose from before getting folders\n- Space discovery when you need to identify space IDs or names\n- High-level workspace organization structure\n\nNote: This is for spaces (top-level containers), not folders (which contain lists) nor lists.\nThis tool fetches spaces from the specified workspace with support for offset-based retrieval\nand archived space filtering. Results are sorted alphabetically by name.",
       "parameters": [
         {
@@ -1223,7 +1223,7 @@
     {
       "name": "GetStatusesForList",
       "qualifiedName": "Clickup.GetStatusesForList",
-      "fullyQualifiedName": "Clickup.GetStatusesForList@1.2.1",
+      "fullyQualifiedName": "Clickup.GetStatusesForList@1.2.3",
       "description": "Retrieve the possible task statuses for a specific ClickUp list.\n\nOnly use this tool when you already have the list ID and need to discover the valid\nstatuses for that specific list.\n\nUse this tool to discover valid status labels and their ordering/type for a list\nbefore creating or updating tasks, since statuses can be customized per list.",
       "parameters": [
         {
@@ -1264,7 +1264,7 @@
     {
       "name": "GetSystemGuidance",
       "qualifiedName": "Clickup.GetSystemGuidance",
-      "fullyQualifiedName": "Clickup.GetSystemGuidance@1.2.1",
+      "fullyQualifiedName": "Clickup.GetSystemGuidance@1.2.3",
       "description": "Return static guidance intended solely to help agents make informed decisions.\n\nImportant: The guidance content is for internal agent use only and should not be\ndisplayed to end users.",
       "parameters": [],
       "auth": null,
@@ -1285,7 +1285,7 @@
     {
       "name": "GetTaskById",
       "qualifiedName": "Clickup.GetTaskById",
-      "fullyQualifiedName": "Clickup.GetTaskById@1.2.1",
+      "fullyQualifiedName": "Clickup.GetTaskById@1.2.3",
       "description": "Get detailed information about a specific task by its ID. Also supports custom task IDs\nwhen workspace_id_for_custom_id is provided.\n\nUse when need more information about a task than if it id or custom id is already known.",
       "parameters": [
         {
@@ -1352,7 +1352,7 @@
     {
       "name": "GetTaskCommentReplies",
       "qualifiedName": "Clickup.GetTaskCommentReplies",
-      "fullyQualifiedName": "Clickup.GetTaskCommentReplies@1.2.1",
+      "fullyQualifiedName": "Clickup.GetTaskCommentReplies@1.2.3",
       "description": "Get threaded replies for a specific ClickUp comment with pagination support.\n\nThis tool retrieves replies to a parent comment using ClickUp's threaded\ncomment system with offset-based pagination. The parent comment itself\nis not included in the results, only the threaded replies.",
       "parameters": [
         {
@@ -1419,7 +1419,7 @@
     {
       "name": "GetTaskComments",
       "qualifiedName": "Clickup.GetTaskComments",
-      "fullyQualifiedName": "Clickup.GetTaskComments@1.2.1",
+      "fullyQualifiedName": "Clickup.GetTaskComments@1.2.3",
       "description": "Get comments for a specific ClickUp task with pagination support.\n\nThis tool retrieves comments from a task using ClickUp's specific pagination method.\nFor the first call, omit oldest_comment_id. For subsequent calls, use the\noldest_comment_id from the previous response to get the next set of comments.",
       "parameters": [
         {
@@ -1486,7 +1486,7 @@
     {
       "name": "GetTasksByAssignees",
       "qualifiedName": "Clickup.GetTasksByAssignees",
-      "fullyQualifiedName": "Clickup.GetTasksByAssignees@1.2.1",
+      "fullyQualifiedName": "Clickup.GetTasksByAssignees@1.2.3",
       "description": "Get filtered tasks assigned to specific team members with advanced filtering options.\n\nThis tool filters tasks by assignee(s) across the entire workspace.\nProvides comprehensive filtering capabilities including status and date range filtering.\n\nImportant: Use this tool when not interested in a specific task but a set of tasks from\na specific assignee\nor filtering criteria that does not include the task title(name).",
       "parameters": [
         {
@@ -1683,7 +1683,7 @@
     {
       "name": "GetTasksByScope",
       "qualifiedName": "Clickup.GetTasksByScope",
-      "fullyQualifiedName": "Clickup.GetTasksByScope@1.2.1",
+      "fullyQualifiedName": "Clickup.GetTasksByScope@1.2.3",
       "description": "Get filtered tasks from ClickUp with advanced filtering options.\n\nThis unified tool filters tasks at different organizational levels:\n\nImportant: Use this tool when not interested in a specific task but a set of tasks from a\nspecific scope\nor filtering criteria that does not include the task title(name).",
       "parameters": [
         {
@@ -1897,7 +1897,7 @@
     {
       "name": "GetWorkspaceInsights",
       "qualifiedName": "Clickup.GetWorkspaceInsights",
-      "fullyQualifiedName": "Clickup.GetWorkspaceInsights@1.2.1",
+      "fullyQualifiedName": "Clickup.GetWorkspaceInsights@1.2.3",
       "description": "Return a brief overview for a workspace using the latest updated tasks to inform the user.\n\nIncludes task summary, team insights, and container(space, folder, list) insights.",
       "parameters": [
         {
@@ -1938,7 +1938,7 @@
     {
       "name": "UpdateTask",
       "qualifiedName": "Clickup.UpdateTask",
-      "fullyQualifiedName": "Clickup.UpdateTask@1.2.1",
+      "fullyQualifiedName": "Clickup.UpdateTask@1.2.3",
       "description": "Update one or more fields of an existing ClickUp task.\n\nUse this tool to change a task's title, description, status, priority, dates,\nhierarchy (by setting a new parent), or sprint points. You can pass only the\nfields you want to modify—everything else remains unchanged.",
       "parameters": [
         {
@@ -2088,7 +2088,7 @@
     {
       "name": "UpdateTaskAssignees",
       "qualifiedName": "Clickup.UpdateTaskAssignees",
-      "fullyQualifiedName": "Clickup.UpdateTaskAssignees@1.2.1",
+      "fullyQualifiedName": "Clickup.UpdateTaskAssignees@1.2.3",
       "description": "Update task assignees by adding and/or removing specific users.\n\nUse this tool to manage task assignments by specifying which users to add or remove.\nYou can add assignees, remove assignees, or do both in a single operation.\nAt least one of the parameters (assignee_ids_to_add or assignee_ids_to_remove) must be provided.",
       "parameters": [
         {
@@ -2162,7 +2162,7 @@
     {
       "name": "UpdateTaskComment",
       "qualifiedName": "Clickup.UpdateTaskComment",
-      "fullyQualifiedName": "Clickup.UpdateTaskComment@1.2.1",
+      "fullyQualifiedName": "Clickup.UpdateTaskComment@1.2.3",
       "description": "Update an existing comment on a ClickUp task.\n\nThis tool is for updating top-level comments only, not threaded comment replies.\nUse this tool to modify comment text, change assignment, or set resolution status.\nAt least one parameter (comment_text, assignee_id, or resolution) must be provided.",
       "parameters": [
         {
@@ -2258,7 +2258,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Clickup.WhoAmI",
-      "fullyQualifiedName": "Clickup.WhoAmI@1.2.1",
+      "fullyQualifiedName": "Clickup.WhoAmI@1.2.3",
       "description": "Return current user profile and accessible workspaces (teams).\n\nThis should be the FIRST tool called when starting any ClickUp interaction.\n\nEach workspace represents\na separate team or organization with its own members, projects, and settings.",
       "parameters": [],
       "auth": {
@@ -2285,6 +2285,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:17.634Z",
+  "generatedAt": "2026-02-26T11:25:47.040Z",
   "summary": "The Arcade.dev Toolkit for ClickUp empowers developers to efficiently manage tasks, comments, and workspace structures within ClickUp through seamless API interactions. \n\n**Capabilities**\n- Create, update, and retrieve tasks and comments, enabling direct engagement with team tasks.\n- Conduct fuzzy searches for lists, folders, and members to enhance navigability.\n- Retrieve insights about workspaces and configure task statuses dynamically.\n- Manage team assignments effectively, facilitating team collaboration.\n- Execute structured queries for tasks based on specified criteria to optimize task management.\n\n**OAuth**  \n- Provider: ClickUp  \n- Note: Utilizes OAuth2 authentication for secure access.\n\n**Secrets**  \n- No secrets required for integration."
 }

--- a/toolkit-docs-generator/data/toolkits/confluence.json
+++ b/toolkit-docs-generator/data/toolkits/confluence.json
@@ -1,7 +1,7 @@
 {
   "id": "Confluence",
   "label": "Confluence",
-  "version": "2.3.0",
+  "version": "2.3.2",
   "description": "Arcade.dev LLM tools for Confluence",
   "metadata": {
     "category": "productivity",
@@ -30,7 +30,7 @@
     {
       "name": "CreatePage",
       "qualifiedName": "Confluence.CreatePage",
-      "fullyQualifiedName": "Confluence.CreatePage@2.3.0",
+      "fullyQualifiedName": "Confluence.CreatePage@2.3.2",
       "description": "Create a new page at the root of the given space.",
       "parameters": [
         {
@@ -152,7 +152,7 @@
     {
       "name": "GetAttachmentsForPage",
       "qualifiedName": "Confluence.GetAttachmentsForPage",
-      "fullyQualifiedName": "Confluence.GetAttachmentsForPage@2.3.0",
+      "fullyQualifiedName": "Confluence.GetAttachmentsForPage@2.3.2",
       "description": "Get attachments for a page by its ID or title.\n\nIf a page title is provided, then the first page with an exact matching title will be returned.",
       "parameters": [
         {
@@ -235,7 +235,7 @@
     {
       "name": "GetAvailableAtlassianClouds",
       "qualifiedName": "Confluence.GetAvailableAtlassianClouds",
-      "fullyQualifiedName": "Confluence.GetAvailableAtlassianClouds@2.3.0",
+      "fullyQualifiedName": "Confluence.GetAvailableAtlassianClouds@2.3.2",
       "description": "Get available Atlassian Clouds.",
       "parameters": [],
       "auth": {
@@ -263,7 +263,7 @@
     {
       "name": "GetPage",
       "qualifiedName": "Confluence.GetPage",
-      "fullyQualifiedName": "Confluence.GetPage@2.3.0",
+      "fullyQualifiedName": "Confluence.GetPage@2.3.2",
       "description": "Retrieve a SINGLE page's content by its ID or title.\n\nIf a title is provided, then the first page with an exact matching title will be returned.\n\nIMPORTANT: For retrieving MULTIPLE pages, use `get_pages_by_id` instead\nfor a massive performance and efficiency boost. If you call this function multiple times\ninstead of using `get_pages_by_id`, then the universe will explode.",
       "parameters": [
         {
@@ -319,7 +319,7 @@
     {
       "name": "GetPagesById",
       "qualifiedName": "Confluence.GetPagesById",
-      "fullyQualifiedName": "Confluence.GetPagesById@2.3.0",
+      "fullyQualifiedName": "Confluence.GetPagesById@2.3.2",
       "description": "Get the content of MULTIPLE pages by their ID in a single efficient request.\n\nIMPORTANT: Always use this function when you need to retrieve content from more than one page,\nrather than making multiple separate calls to get_page, because this function is significantly\nmore efficient than calling get_page multiple times.",
       "parameters": [
         {
@@ -382,7 +382,7 @@
     {
       "name": "GetSpace",
       "qualifiedName": "Confluence.GetSpace",
-      "fullyQualifiedName": "Confluence.GetSpace@2.3.0",
+      "fullyQualifiedName": "Confluence.GetSpace@2.3.2",
       "description": "Get the details of a space by its ID or key.",
       "parameters": [
         {
@@ -439,7 +439,7 @@
     {
       "name": "GetSpaceHierarchy",
       "qualifiedName": "Confluence.GetSpaceHierarchy",
-      "fullyQualifiedName": "Confluence.GetSpaceHierarchy@2.3.0",
+      "fullyQualifiedName": "Confluence.GetSpaceHierarchy@2.3.2",
       "description": "Retrieve the full hierarchical structure of a Confluence space as a tree structure\n\nOnly structural metadata is returned (not content).\nThe response is akin to the sidebar in the Confluence UI.\n\nIncludes all pages, folders, whiteboards, databases,\nsmart links, etc. organized by parent-child relationships.",
       "parameters": [
         {
@@ -497,7 +497,7 @@
     {
       "name": "ListAttachments",
       "qualifiedName": "Confluence.ListAttachments",
-      "fullyQualifiedName": "Confluence.ListAttachments@2.3.0",
+      "fullyQualifiedName": "Confluence.ListAttachments@2.3.2",
       "description": "List attachments in a workspace",
       "parameters": [
         {
@@ -585,7 +585,7 @@
     {
       "name": "ListPages",
       "qualifiedName": "Confluence.ListPages",
-      "fullyQualifiedName": "Confluence.ListPages@2.3.0",
+      "fullyQualifiedName": "Confluence.ListPages@2.3.2",
       "description": "Get the content of multiple pages by their ID",
       "parameters": [
         {
@@ -693,7 +693,7 @@
     {
       "name": "ListSpaces",
       "qualifiedName": "Confluence.ListSpaces",
-      "fullyQualifiedName": "Confluence.ListSpaces@2.3.0",
+      "fullyQualifiedName": "Confluence.ListSpaces@2.3.2",
       "description": "List all spaces sorted by name in ascending order.",
       "parameters": [
         {
@@ -763,7 +763,7 @@
     {
       "name": "RenamePage",
       "qualifiedName": "Confluence.RenamePage",
-      "fullyQualifiedName": "Confluence.RenamePage@2.3.0",
+      "fullyQualifiedName": "Confluence.RenamePage@2.3.2",
       "description": "Rename a page by changing its title.",
       "parameters": [
         {
@@ -833,7 +833,7 @@
     {
       "name": "SearchContent",
       "qualifiedName": "Confluence.SearchContent",
-      "fullyQualifiedName": "Confluence.SearchContent@2.3.0",
+      "fullyQualifiedName": "Confluence.SearchContent@2.3.2",
       "description": "Search for content in Confluence.\n\nThe search is performed across all content in the authenticated user's Confluence workspace.\nAll search terms in Confluence are case insensitive.\n\nYou can use the parameters in different ways:\n- must_contain_all: For AND logic - content must contain ALL of these\n- can_contain_any: For OR logic - content can contain ANY of these\n- Combine them: must_contain_all=['banana'] AND can_contain_any=['database', 'guide']",
       "parameters": [
         {
@@ -937,7 +937,7 @@
     {
       "name": "UpdatePageContent",
       "qualifiedName": "Confluence.UpdatePageContent",
-      "fullyQualifiedName": "Confluence.UpdatePageContent@2.3.0",
+      "fullyQualifiedName": "Confluence.UpdatePageContent@2.3.2",
       "description": "Update a page's content.",
       "parameters": [
         {
@@ -1024,7 +1024,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Confluence.WhoAmI",
-      "fullyQualifiedName": "Confluence.WhoAmI@2.3.0",
+      "fullyQualifiedName": "Confluence.WhoAmI@2.3.2",
       "description": "CALL THIS TOOL FIRST to establish user profile context.\n\nGet information about the currently logged-in user and their available Confluence clouds.",
       "parameters": [],
       "auth": {
@@ -1061,6 +1061,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:17.629Z",
+  "generatedAt": "2026-02-26T11:25:47.034Z",
   "summary": "Arcade.dev provides a comprehensive toolkit for interacting with Confluence, empowering developers to create, manage, and search content efficiently within their Confluence spaces.\n\n**Capabilities**\n- Seamlessly create, update, and rename pages.\n- Efficiently retrieve single or multiple pages and their content.\n- List and manage attachments and spaces with a hierarchical view.\n- Perform powerful search queries across all Confluence content.\n\n**OAuth**  \n- Provider: Atlassian  \n- Scopes: read:attachment:confluence, read:content-details:confluence, read:hierarchical-content:confluence, read:page:confluence, read:space:confluence, search:confluence, write:page:confluence"
 }

--- a/toolkit-docs-generator/data/toolkits/dropbox.json
+++ b/toolkit-docs-generator/data/toolkits/dropbox.json
@@ -1,7 +1,7 @@
 {
   "id": "Dropbox",
   "label": "Dropbox",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Arcade tools designed for LLMs to interact with Dropbox",
   "metadata": {
     "category": "productivity",
@@ -25,7 +25,7 @@
     {
       "name": "DownloadFile",
       "qualifiedName": "Dropbox.DownloadFile",
-      "fullyQualifiedName": "Dropbox.DownloadFile@1.1.0",
+      "fullyQualifiedName": "Dropbox.DownloadFile@1.1.2",
       "description": "Downloads the specified file.\n\nNote: either one of `file_path` or `file_id` must be provided.",
       "parameters": [
         {
@@ -81,7 +81,7 @@
     {
       "name": "ListItemsInFolder",
       "qualifiedName": "Dropbox.ListItemsInFolder",
-      "fullyQualifiedName": "Dropbox.ListItemsInFolder@1.1.0",
+      "fullyQualifiedName": "Dropbox.ListItemsInFolder@1.1.2",
       "description": "Provides a dictionary containing the list of items in the specified folder path.\n\nNote 1: when paginating, it is not necessary to provide any other argument besides the cursor.\nNote 2: when paginating, any given item (file or folder) may be returned in multiple pages.",
       "parameters": [
         {
@@ -150,7 +150,7 @@
     {
       "name": "SearchFilesAndFolders",
       "qualifiedName": "Dropbox.SearchFilesAndFolders",
-      "fullyQualifiedName": "Dropbox.SearchFilesAndFolders@1.1.0",
+      "fullyQualifiedName": "Dropbox.SearchFilesAndFolders@1.1.2",
       "description": "Returns a list of items in the specified folder path matching the search criteria.\n\nNote 1: the Dropbox API will return up to 10,000 (ten thousand) items cumulatively across\nmultiple pagination requests using the cursor token.\nNote 2: when paginating, it is not necessary to provide any other argument besides the cursor.\nNote 3: when paginating, any given item (file or folder) may be returned in multiple pages.",
       "parameters": [
         {
@@ -267,6 +267,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:17.631Z",
+  "generatedAt": "2026-02-26T11:25:47.034Z",
   "summary": "Arcade provides a toolkit for integrating with Dropbox, enabling seamless interactions with files stored in the cloud. Developers can leverage these tools for various file management capabilities.\n\n**Capabilities**\n- Download files directly from Dropbox.\n- List items in specified folders with efficient pagination.\n- Search for files and folders using customized criteria, while utilizing pagination to manage large result sets.\n\n**OAuth**\n- **Provider**: Dropbox  \n- **Scopes**: files.content.read, files.metadata.read  \n\nNo secret types are required for using this toolkit. Users simply need OAuth tokens for authentication."
 }

--- a/toolkit-docs-generator/data/toolkits/e2b.json
+++ b/toolkit-docs-generator/data/toolkits/e2b.json
@@ -1,7 +1,7 @@
 {
   "id": "E2b",
   "label": "E2B",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Arcade.dev LLM tools for running code in a sandbox using E2B",
   "metadata": {
     "category": "development",
@@ -18,7 +18,7 @@
     {
       "name": "CreateStaticMatplotlibChart",
       "qualifiedName": "E2b.CreateStaticMatplotlibChart",
-      "fullyQualifiedName": "E2b.CreateStaticMatplotlibChart@3.1.0",
+      "fullyQualifiedName": "E2b.CreateStaticMatplotlibChart@3.1.1",
       "description": "Run the provided Python code to generate a static matplotlib chart.\nThe resulting chart is returned as a base64 encoded image.",
       "parameters": [
         {
@@ -61,7 +61,7 @@
     {
       "name": "RunCode",
       "qualifiedName": "E2b.RunCode",
-      "fullyQualifiedName": "E2b.RunCode@3.1.0",
+      "fullyQualifiedName": "E2b.RunCode@3.1.1",
       "description": "Run code in a sandbox and return the output.",
       "parameters": [
         {
@@ -131,6 +131,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:17.659Z",
+  "generatedAt": "2026-02-26T11:25:47.034Z",
   "summary": "Arcade.dev provides the E2b toolkit, enabling developers to run Python code in a secure sandbox environment. This toolkit is ideal for generating visualizations and executing code snippets safely.\n\n**Capabilities**  \n- Execute Python code in a controlled environment  \n- Generate static matplotlib charts  \n- Return outputs as base64 encoded images or direct results  \n\n**OAuth**  \n- No OAuth authentication required. Use API keys for access.\n\n**Secrets**  \n- Manage API keys, such as the E2B_API_KEY, to authenticate and access the toolkit functionalities securely."
 }

--- a/toolkit-docs-generator/data/toolkits/firecrawl.json
+++ b/toolkit-docs-generator/data/toolkits/firecrawl.json
@@ -1,7 +1,7 @@
 {
   "id": "Firecrawl",
   "label": "Firecrawl",
-  "version": "3.1.0",
+  "version": "3.1.2",
   "description": "Arcade.dev LLM tools for web scraping related tasks via Firecrawl",
   "metadata": {
     "category": "development",
@@ -18,7 +18,7 @@
     {
       "name": "CancelCrawl",
       "qualifiedName": "Firecrawl.CancelCrawl",
-      "fullyQualifiedName": "Firecrawl.CancelCrawl@3.1.0",
+      "fullyQualifiedName": "Firecrawl.CancelCrawl@3.1.2",
       "description": "Cancel an asynchronous crawl job that is in progress using the Firecrawl API.",
       "parameters": [
         {
@@ -61,7 +61,7 @@
     {
       "name": "CrawlWebsite",
       "qualifiedName": "Firecrawl.CrawlWebsite",
-      "fullyQualifiedName": "Firecrawl.CrawlWebsite@3.1.0",
+      "fullyQualifiedName": "Firecrawl.CrawlWebsite@3.1.2",
       "description": "Crawl a website using Firecrawl. If the crawl is asynchronous, then returns the crawl ID.\nIf the crawl is synchronous, then returns the crawl data.",
       "parameters": [
         {
@@ -229,7 +229,7 @@
     {
       "name": "GetCrawlData",
       "qualifiedName": "Firecrawl.GetCrawlData",
-      "fullyQualifiedName": "Firecrawl.GetCrawlData@3.1.0",
+      "fullyQualifiedName": "Firecrawl.GetCrawlData@3.1.2",
       "description": "Get the data of a Firecrawl 'crawl' that is either in progress or recently completed.",
       "parameters": [
         {
@@ -272,7 +272,7 @@
     {
       "name": "GetCrawlStatus",
       "qualifiedName": "Firecrawl.GetCrawlStatus",
-      "fullyQualifiedName": "Firecrawl.GetCrawlStatus@3.1.0",
+      "fullyQualifiedName": "Firecrawl.GetCrawlStatus@3.1.2",
       "description": "Get the status of a Firecrawl 'crawl' that is either in progress or recently completed.",
       "parameters": [
         {
@@ -315,7 +315,7 @@
     {
       "name": "MapWebsite",
       "qualifiedName": "Firecrawl.MapWebsite",
-      "fullyQualifiedName": "Firecrawl.MapWebsite@3.1.0",
+      "fullyQualifiedName": "Firecrawl.MapWebsite@3.1.2",
       "description": "Map a website from a single URL to a map of the entire website.",
       "parameters": [
         {
@@ -410,7 +410,7 @@
     {
       "name": "ScrapeUrl",
       "qualifiedName": "Firecrawl.ScrapeUrl",
-      "fullyQualifiedName": "Firecrawl.ScrapeUrl@3.1.0",
+      "fullyQualifiedName": "Firecrawl.ScrapeUrl@3.1.2",
       "description": "Scrape a URL using Firecrawl and return the data in specified formats.",
       "parameters": [
         {
@@ -558,6 +558,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:17.659Z",
+  "generatedAt": "2026-02-26T11:25:47.034Z",
   "summary": "Firecrawl is an Arcade.dev toolkit designed for efficient web scraping tasks. It leverages the Firecrawl API to perform various operations, enabling developers to streamline their data extraction processes.\n\n**Capabilities**  \n- Perform asynchronous and synchronous website crawls  \n- Retrieve crawl status and data for ongoing or recent tasks  \n- Map an entire website from a single URL  \n- Scrape specific URLs and return data in various formats  \n- Cancel ongoing crawl jobs seamlessly  \n\n**OAuth**  \nNo OAuth authentication is required. An API key is utilized for accessing the Firecrawl API.  \n\n**Secrets**  \n- API Key: FIRECRAWL_API_KEY, used for authenticating requests to the Firecrawl API."
 }

--- a/toolkit-docs-generator/data/toolkits/github.json
+++ b/toolkit-docs-generator/data/toolkits/github.json
@@ -1,7 +1,7 @@
 {
   "id": "Github",
   "label": "GitHub",
-  "version": "3.1.0",
+  "version": "3.1.2",
   "description": "Arcade.dev LLM tools for Github",
   "metadata": {
     "category": "development",
@@ -22,7 +22,7 @@
     {
       "name": "AssignPullRequestUser",
       "qualifiedName": "Github.AssignPullRequestUser",
-      "fullyQualifiedName": "Github.AssignPullRequestUser@3.1.0",
+      "fullyQualifiedName": "Github.AssignPullRequestUser@3.1.2",
       "description": "Assign a user to a pull request with intelligent search and fuzzy matching.",
       "parameters": [
         {
@@ -140,7 +140,7 @@
     {
       "name": "CheckPullRequestMergeStatus",
       "qualifiedName": "Github.CheckPullRequestMergeStatus",
-      "fullyQualifiedName": "Github.CheckPullRequestMergeStatus@3.1.0",
+      "fullyQualifiedName": "Github.CheckPullRequestMergeStatus@3.1.2",
       "description": "Check if a pull request is ready to merge without attempting the merge.",
       "parameters": [
         {
@@ -227,7 +227,7 @@
     {
       "name": "CountStargazers",
       "qualifiedName": "Github.CountStargazers",
-      "fullyQualifiedName": "Github.CountStargazers@3.1.0",
+      "fullyQualifiedName": "Github.CountStargazers@3.1.2",
       "description": "Count the number of stargazers (stars) for a GitHub repository.",
       "parameters": [
         {
@@ -288,7 +288,7 @@
     {
       "name": "CreateBranch",
       "qualifiedName": "Github.CreateBranch",
-      "fullyQualifiedName": "Github.CreateBranch@3.1.0",
+      "fullyQualifiedName": "Github.CreateBranch@3.1.2",
       "description": "Create a new branch in a repository.",
       "parameters": [
         {
@@ -375,7 +375,7 @@
     {
       "name": "CreateFile",
       "qualifiedName": "Github.CreateFile",
-      "fullyQualifiedName": "Github.CreateFile@3.1.0",
+      "fullyQualifiedName": "Github.CreateFile@3.1.2",
       "description": "Create a new file or overwrite an existing file in a repository.\n\nThe explicit mode parameter reduces accidental data loss: the default CREATE mode refuses to\ntouch existing files, while OVERWRITE must be chosen intentionally.",
       "parameters": [
         {
@@ -504,7 +504,7 @@
     {
       "name": "CreateIssue",
       "qualifiedName": "Github.CreateIssue",
-      "fullyQualifiedName": "Github.CreateIssue@3.1.0",
+      "fullyQualifiedName": "Github.CreateIssue@3.1.2",
       "description": "Create an issue in a GitHub repository.\n\nOptionally add the created issue to a project by specifying add_to_project_number\nand add_to_project_scope.",
       "parameters": [
         {
@@ -682,7 +682,7 @@
     {
       "name": "CreateIssueComment",
       "qualifiedName": "Github.CreateIssueComment",
-      "fullyQualifiedName": "Github.CreateIssueComment@3.1.0",
+      "fullyQualifiedName": "Github.CreateIssueComment@3.1.2",
       "description": "Create a comment on an issue in a GitHub repository.",
       "parameters": [
         {
@@ -769,7 +769,7 @@
     {
       "name": "CreatePullRequest",
       "qualifiedName": "Github.CreatePullRequest",
-      "fullyQualifiedName": "Github.CreatePullRequest@3.1.0",
+      "fullyQualifiedName": "Github.CreatePullRequest@3.1.2",
       "description": "Create a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -954,7 +954,7 @@
     {
       "name": "CreateReplyForReviewComment",
       "qualifiedName": "Github.CreateReplyForReviewComment",
-      "fullyQualifiedName": "Github.CreateReplyForReviewComment@3.1.0",
+      "fullyQualifiedName": "Github.CreateReplyForReviewComment@3.1.2",
       "description": "Create a reply to a review comment for a pull request.\n\nOptionally resolve the conversation thread after replying by setting resolve_thread=True\nand providing the thread_id (GraphQL Node ID).",
       "parameters": [
         {
@@ -1080,7 +1080,7 @@
     {
       "name": "CreateReviewComment",
       "qualifiedName": "Github.CreateReviewComment",
-      "fullyQualifiedName": "Github.CreateReviewComment@3.1.0",
+      "fullyQualifiedName": "Github.CreateReviewComment@3.1.2",
       "description": "Create a review comment for a pull request in a GitHub repository.\n\nIMPORTANT: Line numbers must be part of the diff (changed lines only).\nGitHub's API requires line numbers that exist in the pull request diff, not just any line\nin the file. If the line wasn't changed in the PR, the comment will fail with 422 error.\n\nIf the subject_type is not 'file', then the start_line and end_line parameters are required.\nIf the subject_type is 'file', then the start_line and end_line parameters are ignored.\nIf the commit_id is not provided, the latest commit SHA from the PR will be used.\n\nTIP: Use subject_type='file' to comment on the entire file if unsure about line positions.",
       "parameters": [
         {
@@ -1264,7 +1264,7 @@
     {
       "name": "GetFileContents",
       "qualifiedName": "Github.GetFileContents",
-      "fullyQualifiedName": "Github.GetFileContents@3.1.0",
+      "fullyQualifiedName": "Github.GetFileContents@3.1.2",
       "description": "Get the contents of a file in a repository.\n\nReturns the decoded content (if text) along with metadata like SHA, size, and line count.\nFor large files, use start_line and end_line to retrieve specific line ranges.",
       "parameters": [
         {
@@ -1377,7 +1377,7 @@
     {
       "name": "GetIssue",
       "qualifiedName": "Github.GetIssue",
-      "fullyQualifiedName": "Github.GetIssue@3.1.0",
+      "fullyQualifiedName": "Github.GetIssue@3.1.2",
       "description": "Get a specific issue from a GitHub repository.",
       "parameters": [
         {
@@ -1451,7 +1451,7 @@
     {
       "name": "GetPullRequest",
       "qualifiedName": "Github.GetPullRequest",
-      "fullyQualifiedName": "Github.GetPullRequest@3.1.0",
+      "fullyQualifiedName": "Github.GetPullRequest@3.1.2",
       "description": "Get details of a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -1538,7 +1538,7 @@
     {
       "name": "GetRepository",
       "qualifiedName": "Github.GetRepository",
-      "fullyQualifiedName": "Github.GetRepository@3.1.0",
+      "fullyQualifiedName": "Github.GetRepository@3.1.2",
       "description": "Get a repository.\n\nRetrieves detailed information about a repository using the GitHub API.",
       "parameters": [
         {
@@ -1599,7 +1599,7 @@
     {
       "name": "GetReviewWorkload",
       "qualifiedName": "Github.GetReviewWorkload",
-      "fullyQualifiedName": "Github.GetReviewWorkload@3.1.0",
+      "fullyQualifiedName": "Github.GetReviewWorkload@3.1.2",
       "description": "Get pull requests awaiting review by the authenticated user.\n\nReturns PRs where user is requested as reviewer and PRs user has recently reviewed.",
       "parameters": [],
       "auth": {
@@ -1632,7 +1632,7 @@
     {
       "name": "GetUserOpenItems",
       "qualifiedName": "Github.GetUserOpenItems",
-      "fullyQualifiedName": "Github.GetUserOpenItems@3.1.0",
+      "fullyQualifiedName": "Github.GetUserOpenItems@3.1.2",
       "description": "Get user's currently open pull requests and issues across all repositories.\n\nReturns open PRs and issues authored by the authenticated user.",
       "parameters": [
         {
@@ -1680,7 +1680,7 @@
     {
       "name": "GetUserRecentActivity",
       "qualifiedName": "Github.GetUserRecentActivity",
-      "fullyQualifiedName": "Github.GetUserRecentActivity@3.1.0",
+      "fullyQualifiedName": "Github.GetUserRecentActivity@3.1.2",
       "description": "Get the authenticated user's recent pull requests, reviews, issues, and commits.\n\nReturns PRs they authored, merged PRs, PRs they reviewed, issues they opened, and commits pushed",
       "parameters": [
         {
@@ -1741,7 +1741,7 @@
     {
       "name": "ListIssues",
       "qualifiedName": "Github.ListIssues",
-      "fullyQualifiedName": "Github.ListIssues@3.1.0",
+      "fullyQualifiedName": "Github.ListIssues@3.1.2",
       "description": "List issues in a GitHub repository.",
       "parameters": [
         {
@@ -1917,7 +1917,7 @@
     {
       "name": "ListOrgRepositories",
       "qualifiedName": "Github.ListOrgRepositories",
-      "fullyQualifiedName": "Github.ListOrgRepositories@3.1.0",
+      "fullyQualifiedName": "Github.ListOrgRepositories@3.1.2",
       "description": "List repositories for the specified organization.",
       "parameters": [
         {
@@ -2045,7 +2045,7 @@
     {
       "name": "ListProjectFields",
       "qualifiedName": "Github.ListProjectFields",
-      "fullyQualifiedName": "Github.ListProjectFields@3.1.0",
+      "fullyQualifiedName": "Github.ListProjectFields@3.1.2",
       "description": "List fields for a Projects V2 project.\n\nReturns all custom fields configured for the project, including field types\nand available options for select/iteration fields.",
       "parameters": [
         {
@@ -2152,7 +2152,7 @@
     {
       "name": "ListProjectItems",
       "qualifiedName": "Github.ListProjectItems",
-      "fullyQualifiedName": "Github.ListProjectItems@3.1.0",
+      "fullyQualifiedName": "Github.ListProjectItems@3.1.2",
       "description": "List items for a Projects V2 project with optional filtering.",
       "parameters": [
         {
@@ -2354,7 +2354,7 @@
     {
       "name": "ListProjects",
       "qualifiedName": "Github.ListProjects",
-      "fullyQualifiedName": "Github.ListProjects@3.1.0",
+      "fullyQualifiedName": "Github.ListProjects@3.1.2",
       "description": "List Projects V2 across organization or user scopes.",
       "parameters": [
         {
@@ -2517,7 +2517,7 @@
     {
       "name": "ListPullRequestCommits",
       "qualifiedName": "Github.ListPullRequestCommits",
-      "fullyQualifiedName": "Github.ListPullRequestCommits@3.1.0",
+      "fullyQualifiedName": "Github.ListPullRequestCommits@3.1.2",
       "description": "List commits (from oldest to newest) on a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -2617,7 +2617,7 @@
     {
       "name": "ListPullRequests",
       "qualifiedName": "Github.ListPullRequests",
-      "fullyQualifiedName": "Github.ListPullRequests@3.1.0",
+      "fullyQualifiedName": "Github.ListPullRequests@3.1.2",
       "description": "List pull requests in a GitHub repository.\n\nBy default returns newest pull requests first (direction=DESC).",
       "parameters": [
         {
@@ -2794,7 +2794,7 @@
     {
       "name": "ListRepositoryActivities",
       "qualifiedName": "Github.ListRepositoryActivities",
-      "fullyQualifiedName": "Github.ListRepositoryActivities@3.1.0",
+      "fullyQualifiedName": "Github.ListRepositoryActivities@3.1.2",
       "description": "List repository activities.\n\nRetrieves a detailed history of changes to a repository, such as pushes, merges,\nforce pushes, and branch changes, and associates these changes with commits and users.",
       "parameters": [
         {
@@ -2975,7 +2975,7 @@
     {
       "name": "ListRepositoryCollaborators",
       "qualifiedName": "Github.ListRepositoryCollaborators",
-      "fullyQualifiedName": "Github.ListRepositoryCollaborators@3.1.0",
+      "fullyQualifiedName": "Github.ListRepositoryCollaborators@3.1.2",
       "description": "List collaborators for a repository.\n\nReturns users who have access to the repository and can be requested as reviewers\nfor pull requests. Useful for discovering who can review your PR.\n\nDetail levels:\n- basic: Only explicit collaborators (fast, minimal API calls)\n- include_org_members: Add all org members (default, moderate API calls)\n- full_profiles: Add org members + enrich with names/emails (slow, many API calls)",
       "parameters": [
         {
@@ -3128,7 +3128,7 @@
     {
       "name": "ListRepositoryLabels",
       "qualifiedName": "Github.ListRepositoryLabels",
-      "fullyQualifiedName": "Github.ListRepositoryLabels@3.1.0",
+      "fullyQualifiedName": "Github.ListRepositoryLabels@3.1.2",
       "description": "List all labels defined in a repository.",
       "parameters": [
         {
@@ -3215,7 +3215,7 @@
     {
       "name": "ListReviewCommentsInARepository",
       "qualifiedName": "Github.ListReviewCommentsInARepository",
-      "fullyQualifiedName": "Github.ListReviewCommentsInARepository@3.1.0",
+      "fullyQualifiedName": "Github.ListReviewCommentsInARepository@3.1.2",
       "description": "List review comments in a GitHub repository.",
       "parameters": [
         {
@@ -3347,7 +3347,7 @@
     {
       "name": "ListReviewCommentsOnPullRequest",
       "qualifiedName": "Github.ListReviewCommentsOnPullRequest",
-      "fullyQualifiedName": "Github.ListReviewCommentsOnPullRequest@3.1.0",
+      "fullyQualifiedName": "Github.ListReviewCommentsOnPullRequest@3.1.2",
       "description": "List review comments on a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -3505,7 +3505,7 @@
     {
       "name": "ListStargazers",
       "qualifiedName": "Github.ListStargazers",
-      "fullyQualifiedName": "Github.ListStargazers@3.1.0",
+      "fullyQualifiedName": "Github.ListStargazers@3.1.2",
       "description": "List the stargazers for a GitHub repository.\n\nReturns stargazers in chronological order (oldest first).",
       "parameters": [
         {
@@ -3592,7 +3592,7 @@
     {
       "name": "ManageLabels",
       "qualifiedName": "Github.ManageLabels",
-      "fullyQualifiedName": "Github.ManageLabels@3.1.0",
+      "fullyQualifiedName": "Github.ManageLabels@3.1.2",
       "description": "Add or remove labels from an issue or pull request.\n\nSupports fuzzy matching for typo tolerance. Both issues and pull requests\nsupport labels through the same API. You can add and remove labels in a\nsingle operation.",
       "parameters": [
         {
@@ -3730,7 +3730,7 @@
     {
       "name": "ManagePullRequestReviewers",
       "qualifiedName": "Github.ManagePullRequestReviewers",
-      "fullyQualifiedName": "Github.ManagePullRequestReviewers@3.1.0",
+      "fullyQualifiedName": "Github.ManagePullRequestReviewers@3.1.2",
       "description": "Manage reviewers for a pull request.",
       "parameters": [
         {
@@ -3870,7 +3870,7 @@
     {
       "name": "MergePullRequest",
       "qualifiedName": "Github.MergePullRequest",
-      "fullyQualifiedName": "Github.MergePullRequest@3.1.0",
+      "fullyQualifiedName": "Github.MergePullRequest@3.1.2",
       "description": "Merge a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -4013,7 +4013,7 @@
     {
       "name": "ResolveReviewThread",
       "qualifiedName": "Github.ResolveReviewThread",
-      "fullyQualifiedName": "Github.ResolveReviewThread@3.1.0",
+      "fullyQualifiedName": "Github.ResolveReviewThread@3.1.2",
       "description": "Resolve or unresolve a pull request review conversation thread.",
       "parameters": [
         {
@@ -4100,7 +4100,7 @@
     {
       "name": "SearchMyRepos",
       "qualifiedName": "Github.SearchMyRepos",
-      "fullyQualifiedName": "Github.SearchMyRepos@3.1.0",
+      "fullyQualifiedName": "Github.SearchMyRepos@3.1.2",
       "description": "Search repositories accessible to the authenticated user with fuzzy matching.",
       "parameters": [
         {
@@ -4204,7 +4204,7 @@
     {
       "name": "SearchProjectItem",
       "qualifiedName": "Github.SearchProjectItem",
-      "fullyQualifiedName": "Github.SearchProjectItem@3.1.0",
+      "fullyQualifiedName": "Github.SearchProjectItem@3.1.2",
       "description": "Search for a specific item in a Projects V2 project.",
       "parameters": [
         {
@@ -4340,7 +4340,7 @@
     {
       "name": "SetStarred",
       "qualifiedName": "Github.SetStarred",
-      "fullyQualifiedName": "Github.SetStarred@3.1.0",
+      "fullyQualifiedName": "Github.SetStarred@3.1.2",
       "description": "Star or un-star a GitHub repository.",
       "parameters": [
         {
@@ -4414,7 +4414,7 @@
     {
       "name": "SubmitPullRequestReview",
       "qualifiedName": "Github.SubmitPullRequestReview",
-      "fullyQualifiedName": "Github.SubmitPullRequestReview@3.1.0",
+      "fullyQualifiedName": "Github.SubmitPullRequestReview@3.1.2",
       "description": "Submit a review for a pull request.",
       "parameters": [
         {
@@ -4518,7 +4518,7 @@
     {
       "name": "UpdateFileLines",
       "qualifiedName": "Github.UpdateFileLines",
-      "fullyQualifiedName": "Github.UpdateFileLines@3.1.0",
+      "fullyQualifiedName": "Github.UpdateFileLines@3.1.2",
       "description": "Replace a block of lines within a file (1-indexed, inclusive). Set mode=FileUpdateMode.APPEND\nto add new content to the end of the file.",
       "parameters": [
         {
@@ -4673,7 +4673,7 @@
     {
       "name": "UpdateIssue",
       "qualifiedName": "Github.UpdateIssue",
-      "fullyQualifiedName": "Github.UpdateIssue@3.1.0",
+      "fullyQualifiedName": "Github.UpdateIssue@3.1.2",
       "description": "Update an issue in a GitHub repository.\n\nParameters that are not provided (None) will not be updated or cleared.\nUpdates apply to the issue in the repository. If the issue is in a project,\nthe project item will automatically reflect these changes.",
       "parameters": [
         {
@@ -4837,7 +4837,7 @@
     {
       "name": "UpdatePullRequest",
       "qualifiedName": "Github.UpdatePullRequest",
-      "fullyQualifiedName": "Github.UpdatePullRequest@3.1.0",
+      "fullyQualifiedName": "Github.UpdatePullRequest@3.1.2",
       "description": "Update a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -4980,7 +4980,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Github.WhoAmI",
-      "fullyQualifiedName": "Github.WhoAmI@3.1.0",
+      "fullyQualifiedName": "Github.WhoAmI@3.1.2",
       "description": "Get information about the authenticated GitHub user.\n\nReturns profile, organizations, and teams.",
       "parameters": [],
       "auth": {
@@ -5014,6 +5014,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:46.915Z",
+  "generatedAt": "2026-02-26T11:25:47.047Z",
   "summary": "Arcade.dev's GitHub toolkit exposes programmatic access to repositories, pull requests, issues, reviews, and project data. It enables automated repo/file edits, PR lifecycle handling, issue/project workflows, and user/activity discovery.\n\n**Capabilities**\n- Repository and file management: create branches and files, update file blocks, and read file contents or ranges.\n- Pull request and review workflows: create/update/merge PRs, manage reviewers, post and resolve review comments, and check merge status.\n- Issue, label, and project automation: create/update issues and comments, manage labels, and list/search Project V2 items and fields.\n- Search, auditing, and user context: list collaborators, stargazers, recent activity, and search/repos accessible to the authenticated user.\n\n**OAuth**\nProvider: GitHub\nScopes: None (no predeclared scopes; runtime consent required)\n\n**Secrets**\nGITHUB_SERVER_URL — secret type unknown; typically a GitHub Enterprise base URL (e.g., https://github.example.com). Store endpoints and tokens in a secure secrets manager."
 }

--- a/toolkit-docs-generator/data/toolkits/googlecalendar.json
+++ b/toolkit-docs-generator/data/toolkits/googlecalendar.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleCalendar",
   "label": "Google Calendar",
-  "version": "3.3.0",
+  "version": "3.3.2",
   "description": "Arcade.dev LLM tools for Google Calendar",
   "metadata": {
     "category": "productivity",
@@ -27,7 +27,7 @@
     {
       "name": "CreateEvent",
       "qualifiedName": "GoogleCalendar.CreateEvent",
-      "fullyQualifiedName": "GoogleCalendar.CreateEvent@3.3.0",
+      "fullyQualifiedName": "GoogleCalendar.CreateEvent@3.3.2",
       "description": "Create a new event/meeting/sync/meetup in the specified calendar.",
       "parameters": [
         {
@@ -201,7 +201,7 @@
     {
       "name": "DeleteEvent",
       "qualifiedName": "GoogleCalendar.DeleteEvent",
-      "fullyQualifiedName": "GoogleCalendar.DeleteEvent@3.3.0",
+      "fullyQualifiedName": "GoogleCalendar.DeleteEvent@3.3.2",
       "description": "Delete an event from Google Calendar.",
       "parameters": [
         {
@@ -274,7 +274,7 @@
     {
       "name": "FindTimeSlotsWhenEveryoneIsFree",
       "qualifiedName": "GoogleCalendar.FindTimeSlotsWhenEveryoneIsFree",
-      "fullyQualifiedName": "GoogleCalendar.FindTimeSlotsWhenEveryoneIsFree@3.3.0",
+      "fullyQualifiedName": "GoogleCalendar.FindTimeSlotsWhenEveryoneIsFree@3.3.2",
       "description": "Provides time slots when everyone is free within a given date range and time boundaries.",
       "parameters": [
         {
@@ -373,7 +373,7 @@
     {
       "name": "ListCalendars",
       "qualifiedName": "GoogleCalendar.ListCalendars",
-      "fullyQualifiedName": "GoogleCalendar.ListCalendars@3.3.0",
+      "fullyQualifiedName": "GoogleCalendar.ListCalendars@3.3.2",
       "description": "List all calendars accessible by the user.",
       "parameters": [
         {
@@ -456,7 +456,7 @@
     {
       "name": "ListEvents",
       "qualifiedName": "GoogleCalendar.ListEvents",
-      "fullyQualifiedName": "GoogleCalendar.ListEvents@3.3.0",
+      "fullyQualifiedName": "GoogleCalendar.ListEvents@3.3.2",
       "description": "List events from the specified calendar within the given datetime range.\n\nmin_end_datetime serves as the lower bound (exclusive) for an event's end time.\nmax_start_datetime serves as the upper bound (exclusive) for an event's start time.\n\nFor example:\nIf min_end_datetime is set to 2024-09-15T09:00:00 and max_start_datetime\nis set to 2024-09-16T17:00:00, the function will return events that:\n1. End after 09:00 on September 15, 2024 (exclusive)\n2. Start before 17:00 on September 16, 2024 (exclusive)\nThis means an event starting at 08:00 on September 15 and\nending at 10:00 on September 15 would be included, but an\nevent starting at 17:00 on September 16 would not be included.",
       "parameters": [
         {
@@ -539,7 +539,7 @@
     {
       "name": "UpdateEvent",
       "qualifiedName": "GoogleCalendar.UpdateEvent",
-      "fullyQualifiedName": "GoogleCalendar.UpdateEvent@3.3.0",
+      "fullyQualifiedName": "GoogleCalendar.UpdateEvent@3.3.2",
       "description": "Update an existing event in the specified calendar with the provided details.\nOnly the provided fields will be updated; others will remain unchanged.\n\n`updated_start_datetime` and `updated_end_datetime` are\nindependent and can be provided separately.",
       "parameters": [
         {
@@ -745,7 +745,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleCalendar.WhoAmI",
-      "fullyQualifiedName": "GoogleCalendar.WhoAmI@3.3.0",
+      "fullyQualifiedName": "GoogleCalendar.WhoAmI@3.3.2",
       "description": "Get comprehensive user profile and Google Calendar environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Calendar access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -776,6 +776,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:31.832Z",
+  "generatedAt": "2026-02-26T11:25:47.052Z",
   "summary": "Arcade.dev offers a toolkit for Google Calendar that streamlines event management and calendar interaction through powerful APIs. This toolkit enables developers to effectively create, update, and manage calendar events while accessing user calendars.\n\n**Capabilities:**\n- Create and delete events seamlessly.\n- Fetch user calendars and events within specified date ranges.\n- Identify time slots when all participants are available.\n- Retrieve user profile information from Google services.\n\n**OAuth:**\n- Provider: Google\n- Scopes: `https://www.googleapis.com/auth/calendar.events`, `https://www.googleapis.com/auth/calendar.readonly`, `https://www.googleapis.com/auth/userinfo.email`, `https://www.googleapis.com/auth/userinfo.profile`."
 }

--- a/toolkit-docs-generator/data/toolkits/googlecontacts.json
+++ b/toolkit-docs-generator/data/toolkits/googlecontacts.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleContacts",
   "label": "Google Contacts",
-  "version": "3.5.0",
+  "version": "3.5.2",
   "description": "Arcade.dev LLM tools for Google Contacts",
   "metadata": {
     "category": "productivity",
@@ -27,7 +27,7 @@
     {
       "name": "CreateContact",
       "qualifiedName": "GoogleContacts.CreateContact",
-      "fullyQualifiedName": "GoogleContacts.CreateContact@3.5.0",
+      "fullyQualifiedName": "GoogleContacts.CreateContact@3.5.2",
       "description": "Create a new contact record in Google Contacts.\n\nExamples:\n```\ncreate_contact(given_name=\"Alice\")\ncreate_contact(given_name=\"Alice\", family_name=\"Smith\")\ncreate_contact(given_name=\"Alice\", email=\"alice@example.com\")\ncreate_contact(given_name=\"Alice\", phone_number=\"+1234567890\")\ncreate_contact(\n    given_name=\"Alice\",\n    family_name=\"Smith\",\n    email=\"alice@example.com\",\n    phone_number=\"+1234567890\",\n)\n```",
       "parameters": [
         {
@@ -109,7 +109,7 @@
     {
       "name": "SearchContactsByEmail",
       "qualifiedName": "GoogleContacts.SearchContactsByEmail",
-      "fullyQualifiedName": "GoogleContacts.SearchContactsByEmail@3.5.0",
+      "fullyQualifiedName": "GoogleContacts.SearchContactsByEmail@3.5.2",
       "description": "Search the user's contacts in Google Contacts by email address.",
       "parameters": [
         {
@@ -165,7 +165,7 @@
     {
       "name": "SearchContactsByName",
       "qualifiedName": "GoogleContacts.SearchContactsByName",
-      "fullyQualifiedName": "GoogleContacts.SearchContactsByName@3.5.0",
+      "fullyQualifiedName": "GoogleContacts.SearchContactsByName@3.5.2",
       "description": "Search the user's contacts in Google Contacts by name.",
       "parameters": [
         {
@@ -221,7 +221,7 @@
     {
       "name": "SearchContactsByPhoneNumber",
       "qualifiedName": "GoogleContacts.SearchContactsByPhoneNumber",
-      "fullyQualifiedName": "GoogleContacts.SearchContactsByPhoneNumber@3.5.0",
+      "fullyQualifiedName": "GoogleContacts.SearchContactsByPhoneNumber@3.5.2",
       "description": "Search the user's contacts in Google Contacts by phone number.",
       "parameters": [
         {
@@ -277,7 +277,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleContacts.WhoAmI",
-      "fullyQualifiedName": "GoogleContacts.WhoAmI@3.5.0",
+      "fullyQualifiedName": "GoogleContacts.WhoAmI@3.5.2",
       "description": "Get comprehensive user profile and Google Contacts environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Contacts access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -317,6 +317,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:17.686Z",
+  "generatedAt": "2026-02-26T11:25:47.052Z",
   "summary": "Google Contacts (Arcade.dev) toolkit enables LLM-driven apps to read, create, and manage a user's Google Contacts and profile data with OAuth-backed access. It provides consolidated contact operations and user environment insights for chatbots, CRMs, and automation.\n\n**Capabilities**\n- Create and update structured contact records (names, emails, phones) and return normalized contact payloads.\n- Search and retrieve contacts by name, email, or phone with consistent result formatting and paging support.\n- Access authenticated user profile and Contacts environment metadata (permissions, profile picture, email).\n- Field validation, normalization, and merge/deduplication-ready metadata to aid downstream workflows.\n\n**OAuth**\nProvider: google\nScopes:\n- https://www.googleapis.com/auth/contacts\n- https://www.googleapis.com/auth/contacts.readonly\n- https://www.googleapis.com/auth/userinfo.email\n- https://www.googleapis.com/auth/userinfo.profile"
 }

--- a/toolkit-docs-generator/data/toolkits/googledocs.json
+++ b/toolkit-docs-generator/data/toolkits/googledocs.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleDocs",
   "label": "Google Docs",
-  "version": "5.1.0",
+  "version": "5.1.2",
   "description": "Arcade.dev LLM tools for Google Docs",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "CommentOnDocument",
       "qualifiedName": "GoogleDocs.CommentOnDocument",
-      "fullyQualifiedName": "GoogleDocs.CommentOnDocument@5.1.0",
+      "fullyQualifiedName": "GoogleDocs.CommentOnDocument@5.1.2",
       "description": "Comment on a specific document by its ID.",
       "parameters": [
         {
@@ -82,7 +82,7 @@
     {
       "name": "CreateBlankDocument",
       "qualifiedName": "GoogleDocs.CreateBlankDocument",
-      "fullyQualifiedName": "GoogleDocs.CreateBlankDocument@5.1.0",
+      "fullyQualifiedName": "GoogleDocs.CreateBlankDocument@5.1.2",
       "description": "Create a blank Google Docs document with the specified title.",
       "parameters": [
         {
@@ -125,7 +125,7 @@
     {
       "name": "CreateDocumentFromText",
       "qualifiedName": "GoogleDocs.CreateDocumentFromText",
-      "fullyQualifiedName": "GoogleDocs.CreateDocumentFromText@5.1.0",
+      "fullyQualifiedName": "GoogleDocs.CreateDocumentFromText@5.1.2",
       "description": "Create a Google Docs document with the specified title and text content.",
       "parameters": [
         {
@@ -181,7 +181,7 @@
     {
       "name": "EditDocument",
       "qualifiedName": "GoogleDocs.EditDocument",
-      "fullyQualifiedName": "GoogleDocs.EditDocument@5.1.0",
+      "fullyQualifiedName": "GoogleDocs.EditDocument@5.1.2",
       "description": "Edit a Google Docs document with the specified edit request.\n\nThis tool edits the content within the document body only. It cannot edit document metadata\nsuch as the title, permissions, sharing settings, or other document properties.\n\nThis tool does not have context about previous edits because it is stateless. If your edit\nrequest depends on knowledge about previous edits, then you should provide that context in\nthe edit requests.",
       "parameters": [
         {
@@ -269,7 +269,7 @@
     {
       "name": "GenerateGoogleFilePickerUrl",
       "qualifiedName": "GoogleDocs.GenerateGoogleFilePickerUrl",
-      "fullyQualifiedName": "GoogleDocs.GenerateGoogleFilePickerUrl@5.1.0",
+      "fullyQualifiedName": "GoogleDocs.GenerateGoogleFilePickerUrl@5.1.2",
       "description": "Generate a Google File Picker URL for user-driven file selection and authorization.\n\nThis tool generates a URL that directs the end-user to a Google File Picker interface where\nwhere they can select or upload Google Drive files. Users can grant permission to access their\nDrive files, providing a secure and authorized way to interact with their files.\n\nThis is particularly useful when prior tools (e.g., those accessing or modifying\nGoogle Docs, Google Sheets, etc.) encountered failures due to file non-existence\n(Requested entity was not found) or permission errors. Once the user completes the file\npicker flow, the prior tool can be retried.\n\nSuggest this tool to users when they are surprised or confused that the file they are\nsearching for or attempting to access cannot be found.",
       "parameters": [],
       "auth": {
@@ -295,7 +295,7 @@
     {
       "name": "GetDocumentAsDocmd",
       "qualifiedName": "GoogleDocs.GetDocumentAsDocmd",
-      "fullyQualifiedName": "GoogleDocs.GetDocumentAsDocmd@5.1.0",
+      "fullyQualifiedName": "GoogleDocs.GetDocumentAsDocmd@5.1.2",
       "description": "Get the latest version of the specified Google Docs document as DocMD.\nThe DocMD output will include tags that can be used to annotate the document with location\ninformation, the type of block, block IDs, and other metadata. If the document has tabs,\nall tabs are included in sequential order unless a specific tab_id is provided.",
       "parameters": [
         {
@@ -351,7 +351,7 @@
     {
       "name": "GetDocumentById",
       "qualifiedName": "GoogleDocs.GetDocumentById",
-      "fullyQualifiedName": "GoogleDocs.GetDocumentById@5.1.0",
+      "fullyQualifiedName": "GoogleDocs.GetDocumentById@5.1.2",
       "description": "DEPRECATED DO NOT USE THIS TOOL\nGet the latest version of the specified Google Docs document.",
       "parameters": [
         {
@@ -394,7 +394,7 @@
     {
       "name": "GetDocumentMetadata",
       "qualifiedName": "GoogleDocs.GetDocumentMetadata",
-      "fullyQualifiedName": "GoogleDocs.GetDocumentMetadata@5.1.0",
+      "fullyQualifiedName": "GoogleDocs.GetDocumentMetadata@5.1.2",
       "description": "Get metadata for a Google Docs document including hierarchical tab structure.\nReturns document title, ID, URL, total character count, and nested tab information\nwith character counts for each tab.",
       "parameters": [
         {
@@ -437,7 +437,7 @@
     {
       "name": "InsertTextAtEndOfDocument",
       "qualifiedName": "GoogleDocs.InsertTextAtEndOfDocument",
-      "fullyQualifiedName": "GoogleDocs.InsertTextAtEndOfDocument@5.1.0",
+      "fullyQualifiedName": "GoogleDocs.InsertTextAtEndOfDocument@5.1.2",
       "description": "Updates an existing Google Docs document using the batchUpdate API endpoint.",
       "parameters": [
         {
@@ -493,7 +493,7 @@
     {
       "name": "ListDocumentComments",
       "qualifiedName": "GoogleDocs.ListDocumentComments",
-      "fullyQualifiedName": "GoogleDocs.ListDocumentComments@5.1.0",
+      "fullyQualifiedName": "GoogleDocs.ListDocumentComments@5.1.2",
       "description": "List all comments on the specified Google Docs document.",
       "parameters": [
         {
@@ -549,7 +549,7 @@
     {
       "name": "SearchAndRetrieveDocuments",
       "qualifiedName": "GoogleDocs.SearchAndRetrieveDocuments",
-      "fullyQualifiedName": "GoogleDocs.SearchAndRetrieveDocuments@5.1.0",
+      "fullyQualifiedName": "GoogleDocs.SearchAndRetrieveDocuments@5.1.2",
       "description": "Searches for documents in the user's Google Drive and returns documents with their main body\ncontent and tab metadata. Excludes documents that are in the trash.\n\nReturns main body content only with metadata about tabs. Use get_document_as_docmd() to retrieve\nfull tab content for specific documents. Use search_documents() for metadata-only searches.",
       "parameters": [
         {
@@ -737,7 +737,7 @@
     {
       "name": "SearchDocuments",
       "qualifiedName": "GoogleDocs.SearchDocuments",
-      "fullyQualifiedName": "GoogleDocs.SearchDocuments@5.1.0",
+      "fullyQualifiedName": "GoogleDocs.SearchDocuments@5.1.2",
       "description": "Searches for documents in the user's Google Drive. Excludes documents in trash.\nReturns metadata only. Use get_document_metadata or get_document_as_docmd for content.",
       "parameters": [
         {
@@ -907,7 +907,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleDocs.WhoAmI",
-      "fullyQualifiedName": "GoogleDocs.WhoAmI@5.1.0",
+      "fullyQualifiedName": "GoogleDocs.WhoAmI@5.1.2",
       "description": "Get comprehensive user profile and Google Docs environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Docs access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -938,6 +938,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:17.686Z",
+  "generatedAt": "2026-02-26T11:25:47.052Z",
   "summary": "Arcade.dev Google Docs toolkit lets LLM-driven apps create, read, edit, comment on, and search Google Docs while accessing document metadata and user profile information.\n\n**Capabilities**\n- Create and populate new documents or append and edit document body content programmatically.\n- Retrieve structured document content (DocMD) and metadata including tab structure and character counts for robust context-aware workflows.\n- Search Drive for documents, list comments, and produce file-picker URLs to recover from permission or missing-file errors.\n- Access authenticated user profile and environment info to tailor behavior and permissions.\n\n**OAuth**\nProvider: google\nScopes: https://www.googleapis.com/auth/drive.file, https://www.googleapis.com/auth/userinfo.email, https://www.googleapis.com/auth/userinfo.profile\n\n**Secrets**\nType: api_key\nExample: OPENAI_API_KEY (used for LLM or external API calls; store in environment variables or a secret manager)."
 }

--- a/toolkit-docs-generator/data/toolkits/googlefinance.json
+++ b/toolkit-docs-generator/data/toolkits/googlefinance.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleFinance",
   "label": "Google Finance",
-  "version": "3.2.0",
+  "version": "3.2.2",
   "description": "Arcade.dev LLM tools for getting financial data via Google Finance",
   "metadata": {
     "category": "search",
@@ -18,7 +18,7 @@
     {
       "name": "GetStockHistoricalData",
       "qualifiedName": "GoogleFinance.GetStockHistoricalData",
-      "fullyQualifiedName": "GoogleFinance.GetStockHistoricalData@3.2.0",
+      "fullyQualifiedName": "GoogleFinance.GetStockHistoricalData@3.2.2",
       "description": "Fetch historical stock price data over a specified time window\n\nReturns a stock's price and volume data over a specified time window",
       "parameters": [
         {
@@ -96,7 +96,7 @@
     {
       "name": "GetStockSummary",
       "qualifiedName": "GoogleFinance.GetStockSummary",
-      "fullyQualifiedName": "GoogleFinance.GetStockSummary@3.2.0",
+      "fullyQualifiedName": "GoogleFinance.GetStockSummary@3.2.2",
       "description": "Retrieve the summary information for a given stock ticker using the Google Finance API.\n\nGets the stock's current price as well as price movement from the most recent trading day.",
       "parameters": [
         {
@@ -153,6 +153,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:24.335Z",
+  "generatedAt": "2026-02-26T11:25:47.052Z",
   "summary": "GoogleFinance is a toolkit provided by Arcade.dev for accessing financial data through the Google Finance API. It enables developers to retrieve and analyze comprehensive stock information efficiently.\n\n**Capabilities**  \n- Fetch historical stock price data over customizable time windows.  \n- Retrieve current stock summaries, including price and recent trading movement.  \n- Utilize API keys for secure access to financial data.\n\n**OAuth**  \n- This toolkit uses an API key (SERP_API_KEY) for authentication. No OAuth2 scopes are required.\n\n**Secrets**  \n- The toolkit requires an API key (SERP_API_KEY) for secure access to the financial data services."
 }

--- a/toolkit-docs-generator/data/toolkits/googleflights.json
+++ b/toolkit-docs-generator/data/toolkits/googleflights.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleFlights",
   "label": "Google Flights",
-  "version": "3.2.0",
+  "version": "3.2.2",
   "description": "Arcade.dev LLM tools for getting flights via Google Flights",
   "metadata": {
     "category": "search",
@@ -18,7 +18,7 @@
     {
       "name": "SearchOneWayFlights",
       "qualifiedName": "GoogleFlights.SearchOneWayFlights",
-      "fullyQualifiedName": "GoogleFlights.SearchOneWayFlights@3.2.0",
+      "fullyQualifiedName": "GoogleFlights.SearchOneWayFlights@3.2.2",
       "description": "Retrieve flight search results for a one-way flight using Google Flights",
       "parameters": [
         {
@@ -183,6 +183,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:27.068Z",
+  "generatedAt": "2026-02-26T11:25:47.054Z",
   "summary": "The Arcade toolkit for Google Flights empowers developers to seamlessly integrate flight search capabilities into their applications, allowing for efficient retrieval of flight information.  \n\n**Capabilities**  \n- Access comprehensive one-way flight search results from Google Flights.  \n- Easily integrate with existing applications for enhanced user experience.  \n- Streamlined queries for fast and relevant flight data.  \n\n**OAuth**  \n- No OAuth requirements; utilize API key for access.  \n\n**Secrets**  \n- Secret type: API key.  \n- Example: SERP_API_KEY is necessary for utilizing the flight search tool.  "
 }

--- a/toolkit-docs-generator/data/toolkits/googlehotels.json
+++ b/toolkit-docs-generator/data/toolkits/googlehotels.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleHotels",
   "label": "Google Hotels",
-  "version": "3.2.0",
+  "version": "3.2.2",
   "description": "Arcade.dev LLM tools for getting Hotel information via Google Hotels",
   "metadata": {
     "category": "search",
@@ -18,7 +18,7 @@
     {
       "name": "SearchHotels",
       "qualifiedName": "GoogleHotels.SearchHotels",
-      "fullyQualifiedName": "GoogleHotels.SearchHotels@3.2.0",
+      "fullyQualifiedName": "GoogleHotels.SearchHotels@3.2.2",
       "description": "Retrieve hotel search results using the Google Hotels API.",
       "parameters": [
         {
@@ -197,6 +197,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:27.667Z",
+  "generatedAt": "2026-02-26T11:25:47.054Z",
   "summary": "Arcade.dev provides the GoogleHotels toolkit, enabling developers to efficiently retrieve hotel information through the Google Hotels API. This toolkit facilitates hotel searches, offering a streamlined method to access comprehensive hotel data.\n\n**Capabilities:**  \n- Effortlessly search for hotels based on various parameters.  \n- Retrieve detailed hotel information including availability and pricing.  \n- Integrate smoothly with existing applications for enhanced user experience.  \n\n**OAuth:**  \n- No OAuth authentication required.\n\n**Secrets:**  \n- API Key: Use the `SERP_API_KEY` for API access and secure interactions with the Google Hotels service."
 }

--- a/toolkit-docs-generator/data/toolkits/googlejobs.json
+++ b/toolkit-docs-generator/data/toolkits/googlejobs.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleJobs",
   "label": "Google Jobs",
-  "version": "3.2.0",
+  "version": "3.2.2",
   "description": "Arcade.dev LLM tools for getting job postings via Google Jobs",
   "metadata": {
     "category": "search",
@@ -18,7 +18,7 @@
     {
       "name": "SearchJobs",
       "qualifiedName": "GoogleJobs.SearchJobs",
-      "fullyQualifiedName": "GoogleJobs.SearchJobs@3.2.0",
+      "fullyQualifiedName": "GoogleJobs.SearchJobs@3.2.2",
       "description": "Search Google Jobs using SerpAPI.",
       "parameters": [
         {
@@ -114,6 +114,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:24.680Z",
+  "generatedAt": "2026-02-26T11:25:47.056Z",
   "summary": "Arcade.dev provides the GoogleJobs toolkit, enabling developers to access job postings directly from Google Jobs through SerpAPI. This toolkit streamlines job searches, making it efficient and effective to find relevant job listings.\n\n**Capabilities**  \n- Seamless integration with Google Jobs for job postings retrieval.  \n- Comprehensive search capabilities tailored to various job criteria.  \n- Easy access to job data through a user-friendly API.\n\n**OAuth**  \n- This toolkit does not require OAuth authentication but uses an API key for access.\n\n**Secrets**  \n- Contains secrets in the form of API keys, such as the SERP_API_KEY for authenticating requests."
 }

--- a/toolkit-docs-generator/data/toolkits/googlemaps.json
+++ b/toolkit-docs-generator/data/toolkits/googlemaps.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleMaps",
   "label": "Google Maps",
-  "version": "3.2.0",
+  "version": "3.2.2",
   "description": "Arcade.dev LLM tools for getting directions via Google Maps",
   "metadata": {
     "category": "search",
@@ -18,7 +18,7 @@
     {
       "name": "GetDirectionsBetweenAddresses",
       "qualifiedName": "GoogleMaps.GetDirectionsBetweenAddresses",
-      "fullyQualifiedName": "GoogleMaps.GetDirectionsBetweenAddresses@3.2.0",
+      "fullyQualifiedName": "GoogleMaps.GetDirectionsBetweenAddresses@3.2.2",
       "description": "Get directions from Google Maps.",
       "parameters": [
         {
@@ -137,7 +137,7 @@
     {
       "name": "GetDirectionsBetweenCoordinates",
       "qualifiedName": "GoogleMaps.GetDirectionsBetweenCoordinates",
-      "fullyQualifiedName": "GoogleMaps.GetDirectionsBetweenCoordinates@3.2.0",
+      "fullyQualifiedName": "GoogleMaps.GetDirectionsBetweenCoordinates@3.2.2",
       "description": "Get directions from Google Maps.",
       "parameters": [
         {
@@ -283,6 +283,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:29.931Z",
+  "generatedAt": "2026-02-26T11:25:47.058Z",
   "summary": "Arcade.dev provides a toolkit for integrating Google Maps functionalities, enabling developers to obtain directions seamlessly. This toolkit simplifies the process of accessing vital navigation data through an easy-to-use API.\n\n**Capabilities**  \n- Retrieve directions between addresses or coordinates  \n- Access detailed route information including estimated travel time and distance  \n- Integrate with existing applications to enhance location-based services  \n\n**OAuth**  \n- This toolkit does not require OAuth authorization; however, it uses an API key for access.\n\n**Secrets**  \n- **Secret Type:** API Key  \n  **Example:** SERP_API_KEY  \n  Developers must securely store the API key to authenticate their requests."
 }

--- a/toolkit-docs-generator/data/toolkits/googlenews.json
+++ b/toolkit-docs-generator/data/toolkits/googlenews.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleNews",
   "label": "Google News",
-  "version": "3.2.0",
+  "version": "3.2.2",
   "description": "Arcade.dev LLM tools for getting new via Google News",
   "metadata": {
     "category": "search",
@@ -18,7 +18,7 @@
     {
       "name": "SearchNewsStories",
       "qualifiedName": "GoogleNews.SearchNewsStories",
-      "fullyQualifiedName": "GoogleNews.SearchNewsStories@3.2.0",
+      "fullyQualifiedName": "GoogleNews.SearchNewsStories@3.2.2",
       "description": "Search for news articles related to a given query.",
       "parameters": [
         {
@@ -101,6 +101,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:29.768Z",
+  "generatedAt": "2026-02-26T11:25:47.058Z",
   "summary": "The Arcade toolkit for GoogleNews enables developers to retrieve the latest news articles through a seamless integration with Google News. This toolkit provides efficient access to current stories based on queries, ensuring users stay informed.\n\n### Capabilities\n- Access to real-time news articles from Google News.\n- Query-based searching for specific topics or events.\n- Easy integration into applications for timely updates.\n\n### OAuth  \nNo OAuth authentication is required, but API key usage is necessary for accessing the service.\n\n### Secrets  \nDevelopers must use the following secret type for accessing the API:  \n- **API Key**: SERP_API_KEY, required for API access."
 }

--- a/toolkit-docs-generator/data/toolkits/googlesearch.json
+++ b/toolkit-docs-generator/data/toolkits/googlesearch.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleSearch",
   "label": "Google Search",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Arcade.dev LLM tools for searching via Google",
   "metadata": {
     "category": "search",
@@ -18,7 +18,7 @@
     {
       "name": "Search",
       "qualifiedName": "GoogleSearch.Search",
-      "fullyQualifiedName": "GoogleSearch.Search@3.2.0",
+      "fullyQualifiedName": "GoogleSearch.Search@3.2.1",
       "description": "Search Google using SerpAPI and return organic search results.",
       "parameters": [
         {
@@ -82,6 +82,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:27.068Z",
+  "generatedAt": "2026-02-26T11:25:47.058Z",
   "summary": "Arcade.dev provides a toolkit for integrating Google search functionalities using its GoogleSearch tool. This enables developers to seamlessly fetch and utilize organic search results in their applications.\n\n**Capabilities**\n- Perform Google searches and retrieve organic results efficiently.\n- Integrate easily with existing applications and workflows.\n- Utilize powerful search algorithms to enhance user experiences.\n\n**OAuth**\n- No OAuth required; however, an API key is needed for access.\n\n**Secrets**\n- **api_key**: Use the `SERP_API_KEY` to authenticate and authorize your search requests. Make sure to store it securely.'}"
 }

--- a/toolkit-docs-generator/data/toolkits/googleshopping.json
+++ b/toolkit-docs-generator/data/toolkits/googleshopping.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleShopping",
   "label": "Google Shopping",
-  "version": "3.2.0",
+  "version": "3.2.2",
   "description": "Arcade.dev LLM tools for shopping via Google Shopping",
   "metadata": {
     "category": "search",
@@ -18,7 +18,7 @@
     {
       "name": "SearchProducts",
       "qualifiedName": "GoogleShopping.SearchProducts",
-      "fullyQualifiedName": "GoogleShopping.SearchProducts@3.2.0",
+      "fullyQualifiedName": "GoogleShopping.SearchProducts@3.2.2",
       "description": "Search for products on Google Shopping related to a given query.",
       "parameters": [
         {
@@ -88,6 +88,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:27.072Z",
+  "generatedAt": "2026-02-26T11:25:47.058Z",
   "summary": "Arcade.dev offers a powerful toolkit for shopping via Google Shopping, enabling developers to seamlessly integrate product search functionality into their applications. This toolkit provides essential capabilities to enhance shopping experiences for users.\n\n**Capabilities**\n- Search for a variety of products on Google Shopping.\n- Seamlessly integrate product search into applications.\n- Enhance user engagement through relevant product displays.\n\n**OAuth**\n- No OAuth is required for this toolkit, but API key usage is available.\n\n**Secrets**\n- Store and manage secrets like the API key (e.g., SERP_API_KEY) securely for accessing Google Shopping services."
 }

--- a/toolkit-docs-generator/data/toolkits/googleslides.json
+++ b/toolkit-docs-generator/data/toolkits/googleslides.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleSlides",
   "label": "Google Slides",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "description": "Arcade.dev LLM tools for Google Slides",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "CommentOnPresentation",
       "qualifiedName": "GoogleSlides.CommentOnPresentation",
-      "fullyQualifiedName": "GoogleSlides.CommentOnPresentation@1.4.0",
+      "fullyQualifiedName": "GoogleSlides.CommentOnPresentation@1.4.2",
       "description": "Comment on a specific slide by its index in a Google Slides presentation.",
       "parameters": [
         {
@@ -82,7 +82,7 @@
     {
       "name": "CreatePresentation",
       "qualifiedName": "GoogleSlides.CreatePresentation",
-      "fullyQualifiedName": "GoogleSlides.CreatePresentation@1.4.0",
+      "fullyQualifiedName": "GoogleSlides.CreatePresentation@1.4.2",
       "description": "Create a new Google Slides presentation\nThe first slide will be populated with the specified title and subtitle.",
       "parameters": [
         {
@@ -138,7 +138,7 @@
     {
       "name": "CreateSlide",
       "qualifiedName": "GoogleSlides.CreateSlide",
-      "fullyQualifiedName": "GoogleSlides.CreateSlide@1.4.0",
+      "fullyQualifiedName": "GoogleSlides.CreateSlide@1.4.2",
       "description": "Create a new slide at the end of the specified presentation",
       "parameters": [
         {
@@ -207,7 +207,7 @@
     {
       "name": "GenerateGoogleFilePickerUrl",
       "qualifiedName": "GoogleSlides.GenerateGoogleFilePickerUrl",
-      "fullyQualifiedName": "GoogleSlides.GenerateGoogleFilePickerUrl@1.4.0",
+      "fullyQualifiedName": "GoogleSlides.GenerateGoogleFilePickerUrl@1.4.2",
       "description": "Generate a Google File Picker URL for user-driven file selection and authorization.\n\nThis tool generates a URL that directs the end-user to a Google File Picker interface where\nwhere they can select or upload Google Drive files. Users can grant permission to access their\nDrive files, providing a secure and authorized way to interact with their files.\n\nThis is particularly useful when prior tools (e.g., those accessing or modifying\nGoogle Docs, Google Sheets, etc.) encountered failures due to file non-existence\n(Requested entity was not found) or permission errors. Once the user completes the file\npicker flow, the prior tool can be retried.\n\nSuggest this tool to users when they are surprised or confused that the file they are\nsearching for or attempting to access cannot be found.",
       "parameters": [],
       "auth": {
@@ -233,7 +233,7 @@
     {
       "name": "GetPresentationAsMarkdown",
       "qualifiedName": "GoogleSlides.GetPresentationAsMarkdown",
-      "fullyQualifiedName": "GoogleSlides.GetPresentationAsMarkdown@1.4.0",
+      "fullyQualifiedName": "GoogleSlides.GetPresentationAsMarkdown@1.4.2",
       "description": "Get the specified Google Slides presentation and convert it to markdown.\n\nOnly retrieves the text content of the presentation and formats it as markdown.",
       "parameters": [
         {
@@ -276,7 +276,7 @@
     {
       "name": "ListPresentationComments",
       "qualifiedName": "GoogleSlides.ListPresentationComments",
-      "fullyQualifiedName": "GoogleSlides.ListPresentationComments@1.4.0",
+      "fullyQualifiedName": "GoogleSlides.ListPresentationComments@1.4.2",
       "description": "List all comments on the specified Google Slides presentation.",
       "parameters": [
         {
@@ -332,7 +332,7 @@
     {
       "name": "SearchPresentations",
       "qualifiedName": "GoogleSlides.SearchPresentations",
-      "fullyQualifiedName": "GoogleSlides.SearchPresentations@1.4.0",
+      "fullyQualifiedName": "GoogleSlides.SearchPresentations@1.4.2",
       "description": "Searches for presentations in the user's Google Drive.\nExcludes presentations that are in the trash.",
       "parameters": [
         {
@@ -503,7 +503,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleSlides.WhoAmI",
-      "fullyQualifiedName": "GoogleSlides.WhoAmI@1.4.0",
+      "fullyQualifiedName": "GoogleSlides.WhoAmI@1.4.2",
       "description": "Get comprehensive user profile and Google Slides environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Slides access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -534,6 +534,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:27.074Z",
+  "generatedAt": "2026-02-26T11:25:47.059Z",
   "summary": "Arcade.dev provides a powerful toolkit for Google Slides, enabling seamless integration and manipulation of presentations within Google Drive. This toolkit allows developers to automate various tasks related to presentation management, enhancing productivity and collaboration.\n\n**Capabilities**\n- Generate, modify, and comment on slides within presentations.\n- Create new Google Slides presentations with specified content.\n- Retrieve presentations and convert them to markdown format.\n- Search for and list presentations in the user's Google Drive.\n- Access comprehensive user profile information and permissions.\n\n**OAuth**\n- Provider: Google\n- Scopes: [https://www.googleapis.com/auth/drive.file, https://www.googleapis.com/auth/userinfo.email, https://www.googleapis.com/auth/userinfo.profile]"
 }

--- a/toolkit-docs-generator/data/toolkits/hubspot.json
+++ b/toolkit-docs-generator/data/toolkits/hubspot.json
@@ -1,7 +1,7 @@
 {
   "id": "Hubspot",
   "label": "HubSpot",
-  "version": "3.1.0",
+  "version": "3.1.2",
   "description": "Arcade tools designed for LLMs to interact with Hubspot",
   "metadata": {
     "category": "sales",
@@ -32,7 +32,7 @@
     {
       "name": "AssociateActivityToDeal",
       "qualifiedName": "Hubspot.AssociateActivityToDeal",
-      "fullyQualifiedName": "Hubspot.AssociateActivityToDeal@3.1.0",
+      "fullyQualifiedName": "Hubspot.AssociateActivityToDeal@3.1.2",
       "description": "Associate a single activity object to a deal using HubSpot standard association type.",
       "parameters": [
         {
@@ -109,7 +109,7 @@
     {
       "name": "AssociateContactToDeal",
       "qualifiedName": "Hubspot.AssociateContactToDeal",
-      "fullyQualifiedName": "Hubspot.AssociateContactToDeal@3.1.0",
+      "fullyQualifiedName": "Hubspot.AssociateContactToDeal@3.1.2",
       "description": "Associate a contact with an existing deal in HubSpot.",
       "parameters": [
         {
@@ -168,7 +168,7 @@
     {
       "name": "CreateCallActivity",
       "qualifiedName": "Hubspot.CreateCallActivity",
-      "fullyQualifiedName": "Hubspot.CreateCallActivity@3.1.0",
+      "fullyQualifiedName": "Hubspot.CreateCallActivity@3.1.2",
       "description": "Create a call engagement activity with required owner and associations.\nMust be associated with at least one of: contact, company, or deal.\nAssign to the current user if not specified otherwise.",
       "parameters": [
         {
@@ -331,7 +331,7 @@
     {
       "name": "CreateCommunicationActivity",
       "qualifiedName": "Hubspot.CreateCommunicationActivity",
-      "fullyQualifiedName": "Hubspot.CreateCommunicationActivity@3.1.0",
+      "fullyQualifiedName": "Hubspot.CreateCommunicationActivity@3.1.2",
       "description": "Create a communication activity for logging communications that are not done via\nemail, call, or meeting.\n\nThis includes SMS, WhatsApp, LinkedIn messages, physical mail, and custom channel\nconversations.\nMust be associated with at least one of: contact, company, or deal.\nThe communication will be assigned to the current user.",
       "parameters": [
         {
@@ -445,7 +445,7 @@
     {
       "name": "CreateCompany",
       "qualifiedName": "Hubspot.CreateCompany",
-      "fullyQualifiedName": "Hubspot.CreateCompany@3.1.0",
+      "fullyQualifiedName": "Hubspot.CreateCompany@3.1.2",
       "description": "Create a new company in HubSpot.\n\nBefore calling this tool, use Hubspot.GetAvailableIndustryTypes to see valid values.",
       "parameters": [
         {
@@ -579,7 +579,7 @@
     {
       "name": "CreateContact",
       "qualifiedName": "Hubspot.CreateContact",
-      "fullyQualifiedName": "Hubspot.CreateContact@3.1.0",
+      "fullyQualifiedName": "Hubspot.CreateContact@3.1.2",
       "description": "Create a contact associated with a company.",
       "parameters": [
         {
@@ -700,7 +700,7 @@
     {
       "name": "CreateDeal",
       "qualifiedName": "Hubspot.CreateDeal",
-      "fullyQualifiedName": "Hubspot.CreateDeal@3.1.0",
+      "fullyQualifiedName": "Hubspot.CreateDeal@3.1.2",
       "description": "Create a new deal in HubSpot.\n\nIf pipeline_id is not provided, the default pipeline will be used.\n\nFor custom pipelines, deal_stage must be a valid stage ID within\nthe selected pipeline. If deal_stage is not specified,\nthe first stage in the pipeline will be used automatically.\n\nIt is recommended have already pipeline data available when\nplanning to call this tool.",
       "parameters": [
         {
@@ -854,7 +854,7 @@
     {
       "name": "CreateEmailActivity",
       "qualifiedName": "Hubspot.CreateEmailActivity",
-      "fullyQualifiedName": "Hubspot.CreateEmailActivity@3.1.0",
+      "fullyQualifiedName": "Hubspot.CreateEmailActivity@3.1.2",
       "description": "Create a logged email engagement activity with essential fields including email headers.\nMust be associated with at least one of: contact, company, or deal.\nThe email will be assigned to the current user.",
       "parameters": [
         {
@@ -1122,7 +1122,7 @@
     {
       "name": "CreateMeetingActivity",
       "qualifiedName": "Hubspot.CreateMeetingActivity",
-      "fullyQualifiedName": "Hubspot.CreateMeetingActivity@3.1.0",
+      "fullyQualifiedName": "Hubspot.CreateMeetingActivity@3.1.2",
       "description": "Create a meeting with essential fields including separate date and time.\n\nThe start_date and start_time are combined to create the meeting timestamp.\nDuration can be specified in HH:MM format.\nMust be associated with at least one of: contact, company, or deal.\nThe meeting will be assigned to the current user.",
       "parameters": [
         {
@@ -1275,7 +1275,7 @@
     {
       "name": "CreateNoteActivity",
       "qualifiedName": "Hubspot.CreateNoteActivity",
-      "fullyQualifiedName": "Hubspot.CreateNoteActivity@3.1.0",
+      "fullyQualifiedName": "Hubspot.CreateNoteActivity@3.1.2",
       "description": "Create a note engagement activity with required owner and associations.\nMust be associated with at least one of: contact, company, or deal.\nAssign to the current user if not specified otherwise.",
       "parameters": [
         {
@@ -1370,7 +1370,7 @@
     {
       "name": "GetAllUsers",
       "qualifiedName": "Hubspot.GetAllUsers",
-      "fullyQualifiedName": "Hubspot.GetAllUsers@3.1.0",
+      "fullyQualifiedName": "Hubspot.GetAllUsers@3.1.2",
       "description": "Get all users/owners in the HubSpot portal.\n\nThis tool retrieves a list of all users (owners) in your HubSpot portal,\nUseful for user management and assignment operations.\n\nUse this tool when needing information about ALL users in the HubSpot portal.",
       "parameters": [],
       "auth": {
@@ -1398,7 +1398,7 @@
     {
       "name": "GetAvailableIndustryTypes",
       "qualifiedName": "Hubspot.GetAvailableIndustryTypes",
-      "fullyQualifiedName": "Hubspot.GetAvailableIndustryTypes@3.1.0",
+      "fullyQualifiedName": "Hubspot.GetAvailableIndustryTypes@3.1.2",
       "description": "Get all available industry types for HubSpot companies.\n\nReturns a sorted list of valid industry type values that can be used\nwhen creating companies.",
       "parameters": [],
       "auth": {
@@ -1425,7 +1425,7 @@
     {
       "name": "GetCallDataByKeywords",
       "qualifiedName": "Hubspot.GetCallDataByKeywords",
-      "fullyQualifiedName": "Hubspot.GetCallDataByKeywords@3.1.0",
+      "fullyQualifiedName": "Hubspot.GetCallDataByKeywords@3.1.2",
       "description": "Search for call activities with associated contacts, companies, and deals.",
       "parameters": [
         {
@@ -1522,7 +1522,7 @@
     {
       "name": "GetCommunicationDataByKeywords",
       "qualifiedName": "Hubspot.GetCommunicationDataByKeywords",
-      "fullyQualifiedName": "Hubspot.GetCommunicationDataByKeywords@3.1.0",
+      "fullyQualifiedName": "Hubspot.GetCommunicationDataByKeywords@3.1.2",
       "description": "Search for communication activities with associated contacts, companies, and deals.",
       "parameters": [
         {
@@ -1619,7 +1619,7 @@
     {
       "name": "GetCompanyDataByKeywords",
       "qualifiedName": "Hubspot.GetCompanyDataByKeywords",
-      "fullyQualifiedName": "Hubspot.GetCompanyDataByKeywords@3.1.0",
+      "fullyQualifiedName": "Hubspot.GetCompanyDataByKeywords@3.1.2",
       "description": "Retrieve company data with associated contacts, deals, calls, emails,\nmeetings, notes, and tasks.",
       "parameters": [
         {
@@ -1704,7 +1704,7 @@
     {
       "name": "GetContactDataByKeywords",
       "qualifiedName": "Hubspot.GetContactDataByKeywords",
-      "fullyQualifiedName": "Hubspot.GetContactDataByKeywords@3.1.0",
+      "fullyQualifiedName": "Hubspot.GetContactDataByKeywords@3.1.2",
       "description": "Retrieve contact data with associated companies, deals, calls, emails,\nmeetings, notes, and tasks.",
       "parameters": [
         {
@@ -1789,7 +1789,7 @@
     {
       "name": "GetDealById",
       "qualifiedName": "Hubspot.GetDealById",
-      "fullyQualifiedName": "Hubspot.GetDealById@3.1.0",
+      "fullyQualifiedName": "Hubspot.GetDealById@3.1.2",
       "description": "Retrieve a specific deal by its ID with associated contacts, companies, calls, emails,\nmeetings, notes, and tasks.",
       "parameters": [
         {
@@ -1848,7 +1848,7 @@
     {
       "name": "GetDealDataByKeywords",
       "qualifiedName": "Hubspot.GetDealDataByKeywords",
-      "fullyQualifiedName": "Hubspot.GetDealDataByKeywords@3.1.0",
+      "fullyQualifiedName": "Hubspot.GetDealDataByKeywords@3.1.2",
       "description": "Retrieve deal data with associated contacts, companies, calls, emails,\nmeetings, notes, and tasks.",
       "parameters": [
         {
@@ -1933,7 +1933,7 @@
     {
       "name": "GetDealPipelines",
       "qualifiedName": "Hubspot.GetDealPipelines",
-      "fullyQualifiedName": "Hubspot.GetDealPipelines@3.1.0",
+      "fullyQualifiedName": "Hubspot.GetDealPipelines@3.1.2",
       "description": "List HubSpot deal pipelines with their stages, optionally filtered by a search string.\n\nRecommended to be used before creating a new deal.\n\nFor example updating the stage of a deal without changing the pipeline.",
       "parameters": [
         {
@@ -1976,7 +1976,7 @@
     {
       "name": "GetDealPipelineStages",
       "qualifiedName": "Hubspot.GetDealPipelineStages",
-      "fullyQualifiedName": "Hubspot.GetDealPipelineStages@3.1.0",
+      "fullyQualifiedName": "Hubspot.GetDealPipelineStages@3.1.2",
       "description": "List stages for a specific HubSpot deal pipeline.\n\nUseful to get the stage IDs for a specific pipeline.",
       "parameters": [
         {
@@ -2019,7 +2019,7 @@
     {
       "name": "GetEmailDataByKeywords",
       "qualifiedName": "Hubspot.GetEmailDataByKeywords",
-      "fullyQualifiedName": "Hubspot.GetEmailDataByKeywords@3.1.0",
+      "fullyQualifiedName": "Hubspot.GetEmailDataByKeywords@3.1.2",
       "description": "Search for email activities with associated contacts, companies, and deals.",
       "parameters": [
         {
@@ -2116,7 +2116,7 @@
     {
       "name": "GetMeetingDataByKeywords",
       "qualifiedName": "Hubspot.GetMeetingDataByKeywords",
-      "fullyQualifiedName": "Hubspot.GetMeetingDataByKeywords@3.1.0",
+      "fullyQualifiedName": "Hubspot.GetMeetingDataByKeywords@3.1.2",
       "description": "Search for meeting activities with associated contacts, companies, and deals.",
       "parameters": [
         {
@@ -2213,7 +2213,7 @@
     {
       "name": "GetNoteDataByKeywords",
       "qualifiedName": "Hubspot.GetNoteDataByKeywords",
-      "fullyQualifiedName": "Hubspot.GetNoteDataByKeywords@3.1.0",
+      "fullyQualifiedName": "Hubspot.GetNoteDataByKeywords@3.1.2",
       "description": "Search for note activities with associated contacts, companies, and deals.",
       "parameters": [
         {
@@ -2310,7 +2310,7 @@
     {
       "name": "GetTaskDataByKeywords",
       "qualifiedName": "Hubspot.GetTaskDataByKeywords",
-      "fullyQualifiedName": "Hubspot.GetTaskDataByKeywords@3.1.0",
+      "fullyQualifiedName": "Hubspot.GetTaskDataByKeywords@3.1.2",
       "description": "Search for task activities with associated contacts, companies, and deals.",
       "parameters": [
         {
@@ -2407,7 +2407,7 @@
     {
       "name": "GetUserById",
       "qualifiedName": "Hubspot.GetUserById",
-      "fullyQualifiedName": "Hubspot.GetUserById@3.1.0",
+      "fullyQualifiedName": "Hubspot.GetUserById@3.1.2",
       "description": "Get detailed information about a specific user/owner by their ID.\n\nThis tool retrieves comprehensive information about a specific user\nin your HubSpot portal using their owner ID.",
       "parameters": [
         {
@@ -2450,7 +2450,7 @@
     {
       "name": "ListCompanies",
       "qualifiedName": "Hubspot.ListCompanies",
-      "fullyQualifiedName": "Hubspot.ListCompanies@3.1.0",
+      "fullyQualifiedName": "Hubspot.ListCompanies@3.1.2",
       "description": "List companies with associated contacts, deals, calls, emails, meetings, notes, and tasks.",
       "parameters": [
         {
@@ -2539,7 +2539,7 @@
     {
       "name": "ListContacts",
       "qualifiedName": "Hubspot.ListContacts",
-      "fullyQualifiedName": "Hubspot.ListContacts@3.1.0",
+      "fullyQualifiedName": "Hubspot.ListContacts@3.1.2",
       "description": "List contacts with associated companies, deals, calls, emails, meetings, notes, and tasks.",
       "parameters": [
         {
@@ -2654,7 +2654,7 @@
     {
       "name": "ListDeals",
       "qualifiedName": "Hubspot.ListDeals",
-      "fullyQualifiedName": "Hubspot.ListDeals@3.1.0",
+      "fullyQualifiedName": "Hubspot.ListDeals@3.1.2",
       "description": "List deals with associated contacts, companies, calls, emails, meetings, notes, and tasks.",
       "parameters": [
         {
@@ -2769,7 +2769,7 @@
     {
       "name": "ToolkitEnviromentGuidance",
       "qualifiedName": "Hubspot.ToolkitEnviromentGuidance",
-      "fullyQualifiedName": "Hubspot.ToolkitEnviromentGuidance@3.1.0",
+      "fullyQualifiedName": "Hubspot.ToolkitEnviromentGuidance@3.1.2",
       "description": "Get guidance and considerations for using the HubSpot toolkit effectively.\n\nThis tool provides important context and best practices for working with HubSpot tools.\nBased on all available HubSpot toolkit tools, some suggestions may apply to tools that are not\navailable in the current agent's configuration.",
       "parameters": [],
       "auth": null,
@@ -2790,7 +2790,7 @@
     {
       "name": "UpdateCallActivity",
       "qualifiedName": "Hubspot.UpdateCallActivity",
-      "fullyQualifiedName": "Hubspot.UpdateCallActivity@3.1.0",
+      "fullyQualifiedName": "Hubspot.UpdateCallActivity@3.1.2",
       "description": "Update a call activity directly by ID or surface matches when searching by keywords.",
       "parameters": [
         {
@@ -2954,7 +2954,7 @@
     {
       "name": "UpdateCommunicationActivity",
       "qualifiedName": "Hubspot.UpdateCommunicationActivity",
-      "fullyQualifiedName": "Hubspot.UpdateCommunicationActivity@3.1.0",
+      "fullyQualifiedName": "Hubspot.UpdateCommunicationActivity@3.1.2",
       "description": "Update a communication activity by ID or return matches for keyword searches.",
       "parameters": [
         {
@@ -3069,7 +3069,7 @@
     {
       "name": "UpdateCompany",
       "qualifiedName": "Hubspot.UpdateCompany",
-      "fullyQualifiedName": "Hubspot.UpdateCompany@3.1.0",
+      "fullyQualifiedName": "Hubspot.UpdateCompany@3.1.2",
       "description": "Update a company directly by ID or surface matches when searching by keywords.",
       "parameters": [
         {
@@ -3243,7 +3243,7 @@
     {
       "name": "UpdateContact",
       "qualifiedName": "Hubspot.UpdateContact",
-      "fullyQualifiedName": "Hubspot.UpdateContact@3.1.0",
+      "fullyQualifiedName": "Hubspot.UpdateContact@3.1.2",
       "description": "Update a contact directly by ID or list possible matches when searching by keywords.",
       "parameters": [
         {
@@ -3391,7 +3391,7 @@
     {
       "name": "UpdateDeal",
       "qualifiedName": "Hubspot.UpdateDeal",
-      "fullyQualifiedName": "Hubspot.UpdateDeal@3.1.0",
+      "fullyQualifiedName": "Hubspot.UpdateDeal@3.1.2",
       "description": "Update a deal directly by ID or surface matches when searching by keywords.",
       "parameters": [
         {
@@ -3565,7 +3565,7 @@
     {
       "name": "UpdateDealCloseDate",
       "qualifiedName": "Hubspot.UpdateDealCloseDate",
-      "fullyQualifiedName": "Hubspot.UpdateDealCloseDate@3.1.0",
+      "fullyQualifiedName": "Hubspot.UpdateDealCloseDate@3.1.2",
       "description": "Update the expected close date of an existing deal with associated contacts, companies,\ncalls, emails, meetings, notes, and tasks.",
       "parameters": [
         {
@@ -3638,7 +3638,7 @@
     {
       "name": "UpdateDealStage",
       "qualifiedName": "Hubspot.UpdateDealStage",
-      "fullyQualifiedName": "Hubspot.UpdateDealStage@3.1.0",
+      "fullyQualifiedName": "Hubspot.UpdateDealStage@3.1.2",
       "description": "Updates a deal's stage with associated contacts, companies, calls, emails,\nmeetings, notes, and tasks.\n\nSend current_pipeline_id to skip fetching the deal.\nIf pipeline changes are allowed, updates the stage and HubSpot\nmay move the deal to another pipeline.\n\nIt is recommended have already pipeline data available when\nplanning to call this tool.",
       "parameters": [
         {
@@ -3737,7 +3737,7 @@
     {
       "name": "UpdateEmailActivity",
       "qualifiedName": "Hubspot.UpdateEmailActivity",
-      "fullyQualifiedName": "Hubspot.UpdateEmailActivity@3.1.0",
+      "fullyQualifiedName": "Hubspot.UpdateEmailActivity@3.1.2",
       "description": "Update an email activity directly by ID or surface matches when searching by keywords.",
       "parameters": [
         {
@@ -3895,7 +3895,7 @@
     {
       "name": "UpdateMeetingActivity",
       "qualifiedName": "Hubspot.UpdateMeetingActivity",
-      "fullyQualifiedName": "Hubspot.UpdateMeetingActivity@3.1.0",
+      "fullyQualifiedName": "Hubspot.UpdateMeetingActivity@3.1.2",
       "description": "Update a meeting activity directly by ID or surface matches when searching by keywords.",
       "parameters": [
         {
@@ -4049,7 +4049,7 @@
     {
       "name": "UpdateNoteActivity",
       "qualifiedName": "Hubspot.UpdateNoteActivity",
-      "fullyQualifiedName": "Hubspot.UpdateNoteActivity@3.1.0",
+      "fullyQualifiedName": "Hubspot.UpdateNoteActivity@3.1.2",
       "description": "Update a note directly by ID or surface matches when searching by keywords.",
       "parameters": [
         {
@@ -4145,7 +4145,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Hubspot.WhoAmI",
-      "fullyQualifiedName": "Hubspot.WhoAmI@3.1.0",
+      "fullyQualifiedName": "Hubspot.WhoAmI@3.1.2",
       "description": "Get current user information from HubSpot.\n\nThis is typically the first tool called to understand the current user context.\n\nUse this tool when needing information about the current user basic HubSpot information.\nand the associated HubSpot portal.",
       "parameters": [],
       "auth": {
@@ -4181,6 +4181,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:27.077Z",
+  "generatedAt": "2026-02-26T11:25:47.066Z",
   "summary": "Arcade Toolkit for HubSpot enables seamless integration and interaction with HubSpot's CRM functionalities, allowing developers to leverage various activities and data management tools for enhanced customer relationship management.\n\n**Capabilities**\n- Create, update, and manage companies, contacts, and deals within HubSpot.\n- Log and associate various engagement activities such as calls, emails, meetings, and more.\n- Retrieve detailed information about users, deals, and associated data effectively.\n- Access industry types and manage user assignments efficiently.\n\n**OAuth**\n- Provider: Unknown\n- Scopes: crm.objects.companies.read, crm.objects.contacts.write, crm.objects.deals.read, oauth, sales-email-read\n\n**Secrets**\n- No existing secrets."
 }

--- a/toolkit-docs-generator/data/toolkits/imgflip.json
+++ b/toolkit-docs-generator/data/toolkits/imgflip.json
@@ -1,7 +1,7 @@
 {
   "id": "Imgflip",
   "label": "Imgflip",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Arcade tools designed for LLMs to interact with Imgflip",
   "metadata": {
     "category": "entertainment",
@@ -18,7 +18,7 @@
     {
       "name": "CreateMeme",
       "qualifiedName": "Imgflip.CreateMeme",
-      "fullyQualifiedName": "Imgflip.CreateMeme@1.1.0",
+      "fullyQualifiedName": "Imgflip.CreateMeme@1.1.2",
       "description": "Create a custom meme using an Imgflip template\n\nThis tool creates a custom meme by adding your text to an existing\nmeme template. You can specify top and bottom text, choose fonts,\nand control text sizing.",
       "parameters": [
         {
@@ -144,7 +144,7 @@
     {
       "name": "GetPopularMemes",
       "qualifiedName": "Imgflip.GetPopularMemes",
-      "fullyQualifiedName": "Imgflip.GetPopularMemes@1.1.0",
+      "fullyQualifiedName": "Imgflip.GetPopularMemes@1.1.2",
       "description": "Get popular meme templates from Imgflip\n\nThis tool retrieves a list of popular meme templates that can be used\nto create custom memes. These templates are ordered by popularity\nbased on how many times they've been captioned.",
       "parameters": [
         {
@@ -192,7 +192,7 @@
     {
       "name": "SearchMemes",
       "qualifiedName": "Imgflip.SearchMemes",
-      "fullyQualifiedName": "Imgflip.SearchMemes@1.1.0",
+      "fullyQualifiedName": "Imgflip.SearchMemes@1.1.2",
       "description": "Search for meme templates by query\n\nThis tool searches through Imgflip's database of over 1 million meme templates\nto find ones that match your search query.\n\nWhat this tool provides:\n- Search results matching your query\n- Template information including IDs, names, and URLs\n- Caption count to show popularity\n- Ready-to-use template IDs for meme creation\n\nWhen to use this tool:\n- When you're looking for specific meme types or themes\n- When you want to find memes related to particular topics\n- When you need a specific meme format that's not in popular memes\n- When you want to discover niche or specialized meme templates\n\nWhen NOT to use this tool:\n- Do NOT use this if you just want popular memes (use get_popular_memes instead)\n- Do NOT use this if you want to create a meme (use create_meme instead)",
       "parameters": [
         {
@@ -267,6 +267,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:27.080Z",
+  "generatedAt": "2026-02-26T11:25:47.062Z",
   "summary": "Arcade provides a toolkit for seamless interaction with Imgflip, empowering developers to create and manage custom memes efficiently. Users can leverage powerful tools to search, retrieve, and create memes from a vast database.\n\n**Capabilities**\n- Create personalized memes using various templates.\n- Retrieve a list of trending meme templates.\n- Search over 1 million templates based on specific queries.\n- Access detailed template information including popularity metrics.\n\n**Secrets**\n- Use IMGFLIP_USERNAME and IMGFLIP_PASSWORD for authentication needs, allowing secure access to the Imgflip platform."
 }

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-02-25T11:26:36.798Z",
+  "generatedAt": "2026-02-26T11:26:31.017Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -23,7 +23,7 @@
     {
       "id": "Asana",
       "label": "Asana",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 19,
@@ -59,7 +59,7 @@
     {
       "id": "Brightdata",
       "label": "Bright Data",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "category": "development",
       "type": "community",
       "toolCount": 3,
@@ -77,7 +77,7 @@
     {
       "id": "Clickup",
       "label": "ClickUp",
-      "version": "1.2.1",
+      "version": "1.2.3",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 24,
@@ -113,7 +113,7 @@
     {
       "id": "Confluence",
       "label": "Confluence",
-      "version": "2.3.0",
+      "version": "2.3.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 14,
@@ -185,7 +185,7 @@
     {
       "id": "Dropbox",
       "label": "Dropbox",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 3,
@@ -194,7 +194,7 @@
     {
       "id": "E2b",
       "label": "E2B",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "category": "development",
       "type": "arcade",
       "toolCount": 2,
@@ -230,7 +230,7 @@
     {
       "id": "Firecrawl",
       "label": "Firecrawl",
-      "version": "3.1.0",
+      "version": "3.1.2",
       "category": "development",
       "type": "arcade",
       "toolCount": 6,
@@ -248,7 +248,7 @@
     {
       "id": "Github",
       "label": "GitHub",
-      "version": "3.1.0",
+      "version": "3.1.2",
       "category": "development",
       "type": "arcade",
       "toolCount": 42,
@@ -284,7 +284,7 @@
     {
       "id": "GoogleCalendar",
       "label": "Google Calendar",
-      "version": "3.3.0",
+      "version": "3.3.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 7,
@@ -293,7 +293,7 @@
     {
       "id": "GoogleContacts",
       "label": "Google Contacts",
-      "version": "3.5.0",
+      "version": "3.5.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 5,
@@ -302,7 +302,7 @@
     {
       "id": "GoogleDocs",
       "label": "Google Docs",
-      "version": "5.1.0",
+      "version": "5.1.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 13,
@@ -320,7 +320,7 @@
     {
       "id": "GoogleFinance",
       "label": "Google Finance",
-      "version": "3.2.0",
+      "version": "3.2.2",
       "category": "search",
       "type": "arcade",
       "toolCount": 2,
@@ -329,7 +329,7 @@
     {
       "id": "GoogleFlights",
       "label": "Google Flights",
-      "version": "3.2.0",
+      "version": "3.2.2",
       "category": "search",
       "type": "arcade",
       "toolCount": 1,
@@ -338,7 +338,7 @@
     {
       "id": "GoogleHotels",
       "label": "Google Hotels",
-      "version": "3.2.0",
+      "version": "3.2.2",
       "category": "search",
       "type": "arcade",
       "toolCount": 1,
@@ -347,7 +347,7 @@
     {
       "id": "GoogleJobs",
       "label": "Google Jobs",
-      "version": "3.2.0",
+      "version": "3.2.2",
       "category": "search",
       "type": "arcade",
       "toolCount": 1,
@@ -356,7 +356,7 @@
     {
       "id": "GoogleMaps",
       "label": "Google Maps",
-      "version": "3.2.0",
+      "version": "3.2.2",
       "category": "search",
       "type": "arcade",
       "toolCount": 2,
@@ -365,7 +365,7 @@
     {
       "id": "GoogleNews",
       "label": "Google News",
-      "version": "3.2.0",
+      "version": "3.2.2",
       "category": "search",
       "type": "arcade",
       "toolCount": 1,
@@ -374,7 +374,7 @@
     {
       "id": "GoogleSearch",
       "label": "Google Search",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "category": "search",
       "type": "arcade",
       "toolCount": 1,
@@ -392,7 +392,7 @@
     {
       "id": "GoogleShopping",
       "label": "Google Shopping",
-      "version": "3.2.0",
+      "version": "3.2.2",
       "category": "search",
       "type": "arcade",
       "toolCount": 1,
@@ -401,7 +401,7 @@
     {
       "id": "GoogleSlides",
       "label": "Google Slides",
-      "version": "1.4.0",
+      "version": "1.4.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 8,
@@ -410,7 +410,7 @@
     {
       "id": "Hubspot",
       "label": "HubSpot",
-      "version": "3.1.0",
+      "version": "3.1.2",
       "category": "sales",
       "type": "arcade",
       "toolCount": 40,
@@ -491,7 +491,7 @@
     {
       "id": "Imgflip",
       "label": "Imgflip",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "category": "entertainment",
       "type": "arcade",
       "toolCount": 3,
@@ -509,7 +509,7 @@
     {
       "id": "Jira",
       "label": "Jira",
-      "version": "3.1.0",
+      "version": "3.1.2",
       "category": "productivity",
       "type": "auth",
       "toolCount": 43,
@@ -527,7 +527,7 @@
     {
       "id": "Linkedin",
       "label": "LinkedIn",
-      "version": "0.1.14",
+      "version": "0.3.0",
       "category": "social",
       "type": "arcade",
       "toolCount": 1,
@@ -599,7 +599,7 @@
     {
       "id": "MicrosoftTeams",
       "label": "Microsoft Teams",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "category": "social",
       "type": "arcade",
       "toolCount": 25,
@@ -626,7 +626,7 @@
     {
       "id": "NotionToolkit",
       "label": "Notion",
-      "version": "1.3.0",
+      "version": "1.3.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 8,
@@ -635,7 +635,7 @@
     {
       "id": "OutlookCalendar",
       "label": "Outlook Calendar",
-      "version": "2.3.0",
+      "version": "2.3.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 4,
@@ -644,7 +644,7 @@
     {
       "id": "OutlookMail",
       "label": "Outlook Mail",
-      "version": "2.4.0",
+      "version": "2.4.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 9,
@@ -698,7 +698,7 @@
     {
       "id": "Reddit",
       "label": "Reddit",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "category": "social",
       "type": "arcade",
       "toolCount": 11,
@@ -707,7 +707,7 @@
     {
       "id": "Salesforce",
       "label": "Salesforce",
-      "version": "2.1.0",
+      "version": "2.1.2",
       "category": "sales",
       "type": "arcade",
       "toolCount": 3,
@@ -734,7 +734,7 @@
     {
       "id": "Slack",
       "label": "Slack",
-      "version": "2.4.0",
+      "version": "2.5.1",
       "category": "social",
       "type": "arcade",
       "toolCount": 10,
@@ -752,7 +752,7 @@
     {
       "id": "Spotify",
       "label": "Spotify",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "category": "entertainment",
       "type": "arcade",
       "toolCount": 13,
@@ -770,7 +770,7 @@
     {
       "id": "Stripe",
       "label": "Stripe",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "category": "payments",
       "type": "arcade",
       "toolCount": 15,
@@ -833,7 +833,7 @@
     {
       "id": "Walmart",
       "label": "Walmart",
-      "version": "3.1.0",
+      "version": "3.1.2",
       "category": "search",
       "type": "arcade",
       "toolCount": 2,
@@ -860,7 +860,7 @@
     {
       "id": "X",
       "label": "X",
-      "version": "1.4.0",
+      "version": "1.4.2",
       "category": "social",
       "type": "arcade",
       "toolCount": 8,
@@ -878,7 +878,7 @@
     {
       "id": "Youtube",
       "label": "Youtube",
-      "version": "3.2.0",
+      "version": "3.2.2",
       "category": "search",
       "type": "arcade",
       "toolCount": 2,
@@ -887,7 +887,7 @@
     {
       "id": "Zendesk",
       "label": "Zendesk",
-      "version": "0.3.1",
+      "version": "0.5.0",
       "category": "customer-support",
       "type": "arcade",
       "toolCount": 6,
@@ -905,7 +905,7 @@
     {
       "id": "Zoom",
       "label": "Zoom",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "category": "social",
       "type": "arcade",
       "toolCount": 2,

--- a/toolkit-docs-generator/data/toolkits/jira.json
+++ b/toolkit-docs-generator/data/toolkits/jira.json
@@ -1,7 +1,7 @@
 {
   "id": "Jira",
   "label": "Jira",
-  "version": "3.1.0",
+  "version": "3.1.2",
   "description": "Arcade.dev LLM tools for interacting with Atlassian Jira",
   "metadata": {
     "category": "productivity",
@@ -35,7 +35,7 @@
     {
       "name": "AddCommentToIssue",
       "qualifiedName": "Jira.AddCommentToIssue",
-      "fullyQualifiedName": "Jira.AddCommentToIssue@3.1.0",
+      "fullyQualifiedName": "Jira.AddCommentToIssue@3.1.2",
       "description": "Add a comment to a Jira issue.",
       "parameters": [
         {
@@ -137,7 +137,7 @@
     {
       "name": "AddIssuesToSprint",
       "qualifiedName": "Jira.AddIssuesToSprint",
-      "fullyQualifiedName": "Jira.AddIssuesToSprint@3.1.0",
+      "fullyQualifiedName": "Jira.AddIssuesToSprint@3.1.2",
       "description": "Add a list of issues to a sprint.\nMaximum of 50 issues per operation.",
       "parameters": [
         {
@@ -215,7 +215,7 @@
     {
       "name": "AddLabelsToIssue",
       "qualifiedName": "Jira.AddLabelsToIssue",
-      "fullyQualifiedName": "Jira.AddLabelsToIssue@3.1.0",
+      "fullyQualifiedName": "Jira.AddLabelsToIssue@3.1.2",
       "description": "Add labels to an existing Jira issue.",
       "parameters": [
         {
@@ -305,7 +305,7 @@
     {
       "name": "AttachFileToIssue",
       "qualifiedName": "Jira.AttachFileToIssue",
-      "fullyQualifiedName": "Jira.AttachFileToIssue@3.1.0",
+      "fullyQualifiedName": "Jira.AttachFileToIssue@3.1.2",
       "description": "Add an attachment to an issue.\n\nMust provide exactly one of file_content_str or file_content_base64.",
       "parameters": [
         {
@@ -427,7 +427,7 @@
     {
       "name": "CreateIssue",
       "qualifiedName": "Jira.CreateIssue",
-      "fullyQualifiedName": "Jira.CreateIssue@3.1.0",
+      "fullyQualifiedName": "Jira.CreateIssue@3.1.2",
       "description": "Create a new Jira issue.\n\nProvide a value to one of `project` or `parent_issue` arguments. If `project` and\n`parent_issue` are not provided, the tool will select the single project available.\nIf the user has multiple, an error will be returned with the available projects to choose from.\n\nIF YOU DO NOT FOLLOW THE INSTRUCTIONS BELOW AND UNNECESSARILY CALL MULTIPLE TOOLS IN ORDER TO\nCREATE AN ISSUE, TOO MUCH CO2 WILL BE RELEASED IN THE ATMOSPHERE AND YOU WILL CAUSE THE\nDESTRUCTION OF PLANET EARTH BY CATASTROPHIC CLIMATE CHANGE.\n\nIf you have an issue type name, or a project key/name, a priority name, an assignee\nname/key/email, or a reporter name/key/email, DO NOT CALL OTHER TOOLS only to list available\nprojects, priorities, issue types, or users. Provide the name, key, or email and the tool\nwill figure out the ID, WITHOUT CAUSING CATASTROPHIC CLIMATE CHANGE.",
       "parameters": [
         {
@@ -621,7 +621,7 @@
     {
       "name": "DownloadAttachment",
       "qualifiedName": "Jira.DownloadAttachment",
-      "fullyQualifiedName": "Jira.DownloadAttachment@3.1.0",
+      "fullyQualifiedName": "Jira.DownloadAttachment@3.1.2",
       "description": "Download the contents of an attachment associated with an issue.",
       "parameters": [
         {
@@ -678,7 +678,7 @@
     {
       "name": "GetAttachmentMetadata",
       "qualifiedName": "Jira.GetAttachmentMetadata",
-      "fullyQualifiedName": "Jira.GetAttachmentMetadata@3.1.0",
+      "fullyQualifiedName": "Jira.GetAttachmentMetadata@3.1.2",
       "description": "Get the metadata of an attachment.",
       "parameters": [
         {
@@ -735,7 +735,7 @@
     {
       "name": "GetAvailableAtlassianClouds",
       "qualifiedName": "Jira.GetAvailableAtlassianClouds",
-      "fullyQualifiedName": "Jira.GetAvailableAtlassianClouds@3.1.0",
+      "fullyQualifiedName": "Jira.GetAvailableAtlassianClouds@3.1.2",
       "description": "Get available Atlassian Clouds.",
       "parameters": [],
       "auth": {
@@ -763,7 +763,7 @@
     {
       "name": "GetBoardBacklogIssues",
       "qualifiedName": "Jira.GetBoardBacklogIssues",
-      "fullyQualifiedName": "Jira.GetBoardBacklogIssues@3.1.0",
+      "fullyQualifiedName": "Jira.GetBoardBacklogIssues@3.1.2",
       "description": "Get all issues in a board's backlog with pagination support.\nReturns issues that are not currently assigned to any active sprint.\n\nThe backlog contains issues that are ready to be planned into future sprints.\nOnly boards that support backlogs (like Scrum and Kanban boards) will return results.",
       "parameters": [
         {
@@ -846,7 +846,7 @@
     {
       "name": "GetBoards",
       "qualifiedName": "Jira.GetBoards",
-      "fullyQualifiedName": "Jira.GetBoards@3.1.0",
+      "fullyQualifiedName": "Jira.GetBoards@3.1.2",
       "description": "Retrieve Jira boards either by specifying their names or IDs, or get all\navailable boards.\nAll requests support offset and limit with a maximum of 50 boards returned per call.\n\nMANDATORY ACTION: ALWAYS when you need to get multiple boards, you must\ninclude all the board identifiers in a single call rather than making\nmultiple separate tool calls, as this provides much better performance, not doing that will\nbring huge performance penalties.\n\nThe tool automatically handles mixed identifier types (names and IDs), deduplicates results, and\nfalls back from ID lookup to name lookup when needed.",
       "parameters": [
         {
@@ -937,7 +937,7 @@
     {
       "name": "GetCommentById",
       "qualifiedName": "Jira.GetCommentById",
-      "fullyQualifiedName": "Jira.GetCommentById@3.1.0",
+      "fullyQualifiedName": "Jira.GetCommentById@3.1.2",
       "description": "Get a comment by its ID.",
       "parameters": [
         {
@@ -1020,7 +1020,7 @@
     {
       "name": "GetIssueById",
       "qualifiedName": "Jira.GetIssueById",
-      "fullyQualifiedName": "Jira.GetIssueById@3.1.0",
+      "fullyQualifiedName": "Jira.GetIssueById@3.1.2",
       "description": "Get the details of a Jira issue by its ID.",
       "parameters": [
         {
@@ -1077,7 +1077,7 @@
     {
       "name": "GetIssueComments",
       "qualifiedName": "Jira.GetIssueComments",
-      "fullyQualifiedName": "Jira.GetIssueComments@3.1.0",
+      "fullyQualifiedName": "Jira.GetIssueComments@3.1.2",
       "description": "Get the comments of a Jira issue by its ID.",
       "parameters": [
         {
@@ -1189,7 +1189,7 @@
     {
       "name": "GetIssuesWithoutId",
       "qualifiedName": "Jira.GetIssuesWithoutId",
-      "fullyQualifiedName": "Jira.GetIssuesWithoutId@3.1.0",
+      "fullyQualifiedName": "Jira.GetIssuesWithoutId@3.1.2",
       "description": "Search for Jira issues when you don't have the issue ID(s).\n\nAll text-based arguments (keywords, assignee, project, labels) are case-insensitive.\n\nALWAYS PREFER THIS TOOL OVER THE `Jira.SearchIssuesWithJql` TOOL, UNLESS IT'S ABSOLUTELY\nNECESSARY TO USE A JQL QUERY TO FILTER IN A WAY THAT IS NOT SUPPORTED BY THIS TOOL.",
       "parameters": [
         {
@@ -1394,7 +1394,7 @@
     {
       "name": "GetIssueTypeById",
       "qualifiedName": "Jira.GetIssueTypeById",
-      "fullyQualifiedName": "Jira.GetIssueTypeById@3.1.0",
+      "fullyQualifiedName": "Jira.GetIssueTypeById@3.1.2",
       "description": "Get the details of a Jira issue type by its ID.",
       "parameters": [
         {
@@ -1451,7 +1451,7 @@
     {
       "name": "GetPriorityById",
       "qualifiedName": "Jira.GetPriorityById",
-      "fullyQualifiedName": "Jira.GetPriorityById@3.1.0",
+      "fullyQualifiedName": "Jira.GetPriorityById@3.1.2",
       "description": "Get the details of a priority by its ID.",
       "parameters": [
         {
@@ -1508,7 +1508,7 @@
     {
       "name": "GetProjectById",
       "qualifiedName": "Jira.GetProjectById",
-      "fullyQualifiedName": "Jira.GetProjectById@3.1.0",
+      "fullyQualifiedName": "Jira.GetProjectById@3.1.2",
       "description": "Get the details of a Jira project by its ID or key.",
       "parameters": [
         {
@@ -1565,7 +1565,7 @@
     {
       "name": "GetSprintIssues",
       "qualifiedName": "Jira.GetSprintIssues",
-      "fullyQualifiedName": "Jira.GetSprintIssues@3.1.0",
+      "fullyQualifiedName": "Jira.GetSprintIssues@3.1.2",
       "description": "Get all issues that are currently assigned to a specific sprint with pagination support.\nReturns issues that are planned for or being worked on in the sprint.",
       "parameters": [
         {
@@ -1649,7 +1649,7 @@
     {
       "name": "GetTransitionById",
       "qualifiedName": "Jira.GetTransitionById",
-      "fullyQualifiedName": "Jira.GetTransitionById@3.1.0",
+      "fullyQualifiedName": "Jira.GetTransitionById@3.1.2",
       "description": "Get a transition by its ID.",
       "parameters": [
         {
@@ -1719,7 +1719,7 @@
     {
       "name": "GetTransitionByStatusName",
       "qualifiedName": "Jira.GetTransitionByStatusName",
-      "fullyQualifiedName": "Jira.GetTransitionByStatusName@3.1.0",
+      "fullyQualifiedName": "Jira.GetTransitionByStatusName@3.1.2",
       "description": "Get a transition available for an issue by the transition name.\n\nThe response will contain screen fields available for the transition, if any.",
       "parameters": [
         {
@@ -1789,7 +1789,7 @@
     {
       "name": "GetTransitionsAvailableForIssue",
       "qualifiedName": "Jira.GetTransitionsAvailableForIssue",
-      "fullyQualifiedName": "Jira.GetTransitionsAvailableForIssue@3.1.0",
+      "fullyQualifiedName": "Jira.GetTransitionsAvailableForIssue@3.1.2",
       "description": "Get the transitions available for an existing Jira issue.",
       "parameters": [
         {
@@ -1846,7 +1846,7 @@
     {
       "name": "GetUserById",
       "qualifiedName": "Jira.GetUserById",
-      "fullyQualifiedName": "Jira.GetUserById@3.1.0",
+      "fullyQualifiedName": "Jira.GetUserById@3.1.2",
       "description": "Get user information by their ID.",
       "parameters": [
         {
@@ -1902,7 +1902,7 @@
     {
       "name": "GetUsersWithoutId",
       "qualifiedName": "Jira.GetUsersWithoutId",
-      "fullyQualifiedName": "Jira.GetUsersWithoutId@3.1.0",
+      "fullyQualifiedName": "Jira.GetUsersWithoutId@3.1.2",
       "description": "Get users without their account ID, searching by display name and email address.\n\nThe Jira user search API will return up to 1,000 (one thousand) users for any given name/email\nquery. If you need to get more users, please use the `Jira.ListAllUsers` tool.",
       "parameters": [
         {
@@ -1997,7 +1997,7 @@
     {
       "name": "ListIssueAttachmentsMetadata",
       "qualifiedName": "Jira.ListIssueAttachmentsMetadata",
-      "fullyQualifiedName": "Jira.ListIssueAttachmentsMetadata@3.1.0",
+      "fullyQualifiedName": "Jira.ListIssueAttachmentsMetadata@3.1.2",
       "description": "Get the metadata about the files attached to an issue.\n\nThis tool does NOT return the actual file contents. To get a file content,\nuse the `Jira.DownloadAttachment` tool.",
       "parameters": [
         {
@@ -2053,7 +2053,7 @@
     {
       "name": "ListIssues",
       "qualifiedName": "Jira.ListIssues",
-      "fullyQualifiedName": "Jira.ListIssues@3.1.0",
+      "fullyQualifiedName": "Jira.ListIssues@3.1.2",
       "description": "Get the issues for a given project.",
       "parameters": [
         {
@@ -2137,7 +2137,7 @@
     {
       "name": "ListIssueTypesByProject",
       "qualifiedName": "Jira.ListIssueTypesByProject",
-      "fullyQualifiedName": "Jira.ListIssueTypesByProject@3.1.0",
+      "fullyQualifiedName": "Jira.ListIssueTypesByProject@3.1.2",
       "description": "Get the list of issue types (e.g. 'Task', 'Epic', etc.) available to a given project.",
       "parameters": [
         {
@@ -2220,7 +2220,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Jira.ListLabels",
-      "fullyQualifiedName": "Jira.ListLabels@3.1.0",
+      "fullyQualifiedName": "Jira.ListLabels@3.1.2",
       "description": "Get the existing labels (tags) in the user's Jira instance.",
       "parameters": [
         {
@@ -2290,7 +2290,7 @@
     {
       "name": "ListPrioritiesAvailableToAnIssue",
       "qualifiedName": "Jira.ListPrioritiesAvailableToAnIssue",
-      "fullyQualifiedName": "Jira.ListPrioritiesAvailableToAnIssue@3.1.0",
+      "fullyQualifiedName": "Jira.ListPrioritiesAvailableToAnIssue@3.1.2",
       "description": "Browse the priorities available to be used in the specified Jira issue.",
       "parameters": [
         {
@@ -2347,7 +2347,7 @@
     {
       "name": "ListPrioritiesAvailableToAProject",
       "qualifiedName": "Jira.ListPrioritiesAvailableToAProject",
-      "fullyQualifiedName": "Jira.ListPrioritiesAvailableToAProject@3.1.0",
+      "fullyQualifiedName": "Jira.ListPrioritiesAvailableToAProject@3.1.2",
       "description": "Browse the priorities available to be used in issues in the specified Jira project.\n\nThis tool may need to loop through several API calls to get all priorities associated with\na specific project. In Jira environments with too many Projects or Priority Schemes,\nthe search may take too long, and the tool call will timeout.",
       "parameters": [
         {
@@ -2404,7 +2404,7 @@
     {
       "name": "ListPrioritiesByScheme",
       "qualifiedName": "Jira.ListPrioritiesByScheme",
-      "fullyQualifiedName": "Jira.ListPrioritiesByScheme@3.1.0",
+      "fullyQualifiedName": "Jira.ListPrioritiesByScheme@3.1.2",
       "description": "Browse the priorities associated with a priority scheme.",
       "parameters": [
         {
@@ -2487,7 +2487,7 @@
     {
       "name": "ListPrioritySchemes",
       "qualifiedName": "Jira.ListPrioritySchemes",
-      "fullyQualifiedName": "Jira.ListPrioritySchemes@3.1.0",
+      "fullyQualifiedName": "Jira.ListPrioritySchemes@3.1.2",
       "description": "Browse the priority schemes available in Jira.",
       "parameters": [
         {
@@ -2586,7 +2586,7 @@
     {
       "name": "ListProjects",
       "qualifiedName": "Jira.ListProjects",
-      "fullyQualifiedName": "Jira.ListProjects@3.1.0",
+      "fullyQualifiedName": "Jira.ListProjects@3.1.2",
       "description": "Browse projects available in Jira.",
       "parameters": [
         {
@@ -2656,7 +2656,7 @@
     {
       "name": "ListProjectsByScheme",
       "qualifiedName": "Jira.ListProjectsByScheme",
-      "fullyQualifiedName": "Jira.ListProjectsByScheme@3.1.0",
+      "fullyQualifiedName": "Jira.ListProjectsByScheme@3.1.2",
       "description": "Browse the projects associated with a priority scheme.",
       "parameters": [
         {
@@ -2752,7 +2752,7 @@
     {
       "name": "ListSprintsForBoards",
       "qualifiedName": "Jira.ListSprintsForBoards",
-      "fullyQualifiedName": "Jira.ListSprintsForBoards@3.1.0",
+      "fullyQualifiedName": "Jira.ListSprintsForBoards@3.1.2",
       "description": "Retrieve sprints from Jira boards with filtering options for planning and tracking purposes.\n\nUse this when you need to view sprints from specific boards or find sprints within specific\ndate ranges. For temporal queries like \"last month\", \"next week\", or \"this quarter\",\nprioritize date parameters over state filtering. Leave board_identifiers_list as None\nto get sprints from all available boards.\n\nDATE FILTERING PRIORITY: When users request sprints by time periods (e.g., \"last month\",\n\"next week\"), use date parameters (start_date, end_date, specific_date) rather than\nstate filtering, as temporal criteria take precedence over sprint status.\n\nReturns sprint data along with a backlog GUI URL link where you can see detailed sprint\ninformation and manage sprint items.\n\nMANDATORY ACTION: ALWAYS when you need to get sprints from multiple boards, you must\ninclude all the board identifiers in a single call rather than making\nmultiple separate tool calls, as this provides much better performance, not doing that will\nbring huge performance penalties.\n\nBOARD LIMIT: Maximum of 25 boards can be processed in a single operation. If you need to\nprocess more boards, split the request into multiple batches of 25 or fewer boards each.\n\nHandles mixed board identifiers (names and IDs) with automatic fallback and deduplication.\nAll boards are processed concurrently for optimal performance.",
       "parameters": [
         {
@@ -2905,7 +2905,7 @@
     {
       "name": "ListUsers",
       "qualifiedName": "Jira.ListUsers",
-      "fullyQualifiedName": "Jira.ListUsers@3.1.0",
+      "fullyQualifiedName": "Jira.ListUsers@3.1.2",
       "description": "Browse users in Jira.",
       "parameters": [
         {
@@ -2987,7 +2987,7 @@
     {
       "name": "MoveIssuesFromSprintToBacklog",
       "qualifiedName": "Jira.MoveIssuesFromSprintToBacklog",
-      "fullyQualifiedName": "Jira.MoveIssuesFromSprintToBacklog@3.1.0",
+      "fullyQualifiedName": "Jira.MoveIssuesFromSprintToBacklog@3.1.2",
       "description": "Move issues from active or future sprints back to the board's backlog.",
       "parameters": [
         {
@@ -3063,7 +3063,7 @@
     {
       "name": "RemoveLabelsFromIssue",
       "qualifiedName": "Jira.RemoveLabelsFromIssue",
-      "fullyQualifiedName": "Jira.RemoveLabelsFromIssue@3.1.0",
+      "fullyQualifiedName": "Jira.RemoveLabelsFromIssue@3.1.2",
       "description": "Remove labels from an existing Jira issue.",
       "parameters": [
         {
@@ -3153,7 +3153,7 @@
     {
       "name": "SearchIssuesWithJql",
       "qualifiedName": "Jira.SearchIssuesWithJql",
-      "fullyQualifiedName": "Jira.SearchIssuesWithJql@3.1.0",
+      "fullyQualifiedName": "Jira.SearchIssuesWithJql@3.1.2",
       "description": "Search for Jira issues using a JQL (Jira Query Language) query.\n\nTHIS TOOL RELEASES MORE CO2 IN THE ATMOSPHERE, WHICH CONTRIBUTES TO CLIMATE CHANGE. ALWAYS\nPREFER THE `Jira_SearchIssuesWithoutJql` TOOL OVER THIS ONE, UNLESS IT'S ABSOLUTELY\nNECESSARY TO USE A JQL QUERY TO FILTER IN A WAY THAT IS NOT SUPPORTED BY THE\n`Jira_SearchIssuesWithoutJql` TOOL OR IF THE USER PROVIDES A JQL QUERY THEMSELVES.",
       "parameters": [
         {
@@ -3236,7 +3236,7 @@
     {
       "name": "SearchIssuesWithoutJql",
       "qualifiedName": "Jira.SearchIssuesWithoutJql",
-      "fullyQualifiedName": "Jira.SearchIssuesWithoutJql@3.1.0",
+      "fullyQualifiedName": "Jira.SearchIssuesWithoutJql@3.1.2",
       "description": "Parameterized search for Jira issues (without having to provide a JQL query).\n\nTHIS TOOL RELEASES LESS CO2 THAN THE `Jira_SearchIssuesWithJql` TOOL. ALWAYS PREFER THIS ONE\nOVER USING JQL, UNLESS IT'S ABSOLUTELY NECESSARY TO USE A JQL QUERY TO FILTER IN A WAY THAT IS\nNOT SUPPORTED BY THIS TOOL OR IF THE USER PROVIDES A JQL QUERY THEMSELVES.",
       "parameters": [
         {
@@ -3441,7 +3441,7 @@
     {
       "name": "SearchProjects",
       "qualifiedName": "Jira.SearchProjects",
-      "fullyQualifiedName": "Jira.SearchProjects@3.1.0",
+      "fullyQualifiedName": "Jira.SearchProjects@3.1.2",
       "description": "Get the details of all Jira projects.",
       "parameters": [
         {
@@ -3524,7 +3524,7 @@
     {
       "name": "TransitionIssueToNewStatus",
       "qualifiedName": "Jira.TransitionIssueToNewStatus",
-      "fullyQualifiedName": "Jira.TransitionIssueToNewStatus@3.1.0",
+      "fullyQualifiedName": "Jira.TransitionIssueToNewStatus@3.1.2",
       "description": "Transition a Jira issue to a new status.",
       "parameters": [
         {
@@ -3595,7 +3595,7 @@
     {
       "name": "UpdateIssue",
       "qualifiedName": "Jira.UpdateIssue",
-      "fullyQualifiedName": "Jira.UpdateIssue@3.1.0",
+      "fullyQualifiedName": "Jira.UpdateIssue@3.1.2",
       "description": "Update an existing Jira issue.\n\nIF YOU DO NOT FOLLOW THE INSTRUCTIONS BELOW AND UNNECESSARILY CALL MULTIPLE TOOLS IN ORDER TO\nUPDATE AN ISSUE, TOO MUCH CO2 WILL BE RELEASED IN THE ATMOSPHERE AND YOU WILL CAUSE THE\nDESTRUCTION OF PLANET EARTH BY CATASTROPHIC CLIMATE CHANGE.\n\nIf you have a priority name, an assignee name/key/email, or a reporter name/key/email,\nDO NOT CALL OTHER TOOLS only to list available priorities, issue types, or users.\nProvide the name, key, or email and the tool will figure out the ID.",
       "parameters": [
         {
@@ -3802,7 +3802,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Jira.WhoAmI",
-      "fullyQualifiedName": "Jira.WhoAmI@3.1.0",
+      "fullyQualifiedName": "Jira.WhoAmI@3.1.2",
       "description": "CALL THIS TOOL FIRST to establish user profile context.\n\nGet information about the currently logged-in user and their available Jira clouds/clients.",
       "parameters": [],
       "auth": {
@@ -3831,6 +3831,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:52.888Z",
+  "generatedAt": "2026-02-26T11:25:47.073Z",
   "summary": "The Jira MCP Server provides a comprehensive set of tools for interacting with Jira, enabling users and AI applications to efficiently manage issues and projects. With this MCP Server, you can:\n\n- Create, update, and search for Jira issues using various parameters.\n- Retrieve detailed information about issues, projects, users, and issue types.\n- Manage issue labels and attachments, including adding and removing them.\n- Transition issues between different statuses and manage comments on issues.\n- Browse and list available projects, priorities, and users within Jira.\n- Browse and list information of available boards and sprints within a Jira cloud.\n\nThis MCP Server streamlines the process of issue management, making it easier to integrate Jira functionalities into applications and workflows."
 }

--- a/toolkit-docs-generator/data/toolkits/linkedin.json
+++ b/toolkit-docs-generator/data/toolkits/linkedin.json
@@ -1,7 +1,7 @@
 {
   "id": "Linkedin",
   "label": "LinkedIn",
-  "version": "0.1.14",
+  "version": "0.3.0",
   "description": "Arcade.dev LLM tools for LinkedIn",
   "metadata": {
     "category": "social",
@@ -9,20 +9,22 @@
     "isBYOC": false,
     "isPro": false,
     "type": "arcade",
-    "docsLink": "https://docs.arcade.dev/en/mcp-servers/social-communication/linkedin",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/social-communication/linkedin",
     "isComingSoon": false,
     "isHidden": false
   },
   "auth": {
     "type": "oauth2",
     "providerId": "linkedin",
-    "allScopes": ["w_member_social"]
+    "allScopes": [
+      "w_member_social"
+    ]
   },
   "tools": [
     {
       "name": "CreateTextPost",
       "qualifiedName": "Linkedin.CreateTextPost",
-      "fullyQualifiedName": "Linkedin.CreateTextPost@0.1.14",
+      "fullyQualifiedName": "Linkedin.CreateTextPost@0.3.0",
       "description": "Share a new text post to LinkedIn.",
       "parameters": [
         {
@@ -37,7 +39,9 @@
       "auth": {
         "providerId": "linkedin",
         "providerType": "oauth2",
-        "scopes": ["w_member_social"]
+        "scopes": [
+          "w_member_social"
+        ]
       },
       "secrets": [],
       "secretsInfo": [],
@@ -66,12 +70,11 @@
       "type": "markdown",
       "location": "auth",
       "position": "after",
-      "content": "The Arcade LinkedIn MCP Server uses the [LinkedIn auth provider](/references/auth-providers/linkedin) to connect to users' LinkedIn accounts.",
-      "header": "## Auth"
+      "content": "The Arcade LinkedIn MCP Server uses the [LinkedIn auth provider](/references/auth-providers/linkedin) to connect to users' LinkedIn accounts."
     }
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-01-26T17:37:12.626Z",
+  "generatedAt": "2026-02-26T11:25:47.069Z",
   "summary": "Arcade.dev provides a toolkit for integrating with LinkedIn, enabling developers to streamline interactions with the platform's API. This toolkit allows for the creation of content directly on LinkedIn, enhancing user engagement and social sharing capabilities.\n\n**Capabilities**  \n- Seamless integration with LinkedIn's API for enhanced social interactions.  \n- Efficiently share content such as text posts to drive engagement.  \n- Simplified authentication process through OAuth2, ensuring secure access to user data.  \n\n**OAuth**  \n- Provider: LinkedIn  \n- Scopes: w_member_social  \n\n**Secrets**  \n- No secrets required for use with this toolkit."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftteams.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftteams.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftTeams",
   "label": "Microsoft Teams",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "description": "Arcade.dev LLM tools for Microsoft Teams",
   "metadata": {
     "category": "social",
@@ -34,7 +34,7 @@
     {
       "name": "CreateChat",
       "qualifiedName": "MicrosoftTeams.CreateChat",
-      "fullyQualifiedName": "MicrosoftTeams.CreateChat@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.CreateChat@0.5.2",
       "description": "Creates a Microsoft Teams chat.\n\nIf the chat already exists with the specified members, the MS Graph API will return the\nexisting chat.\n\nProvide any combination of user_ids and/or user_names. When available, prefer providing\nuser_ids for optimal performance.",
       "parameters": [
         {
@@ -98,7 +98,7 @@
     {
       "name": "GetChannelMessageReplies",
       "qualifiedName": "MicrosoftTeams.GetChannelMessageReplies",
-      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessageReplies@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessageReplies@0.5.2",
       "description": "Retrieves the replies to a Microsoft Teams channel message.",
       "parameters": [
         {
@@ -168,7 +168,7 @@
     {
       "name": "GetChannelMessages",
       "qualifiedName": "MicrosoftTeams.GetChannelMessages",
-      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessages@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessages@0.5.2",
       "description": "Retrieves the messages in a Microsoft Teams channel.\n\nThe Microsoft Graph API does not support pagination for this endpoint.",
       "parameters": [
         {
@@ -251,7 +251,7 @@
     {
       "name": "GetChannelMetadata",
       "qualifiedName": "MicrosoftTeams.GetChannelMetadata",
-      "fullyQualifiedName": "MicrosoftTeams.GetChannelMetadata@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.GetChannelMetadata@0.5.2",
       "description": "Retrieves metadata about a Microsoft Teams channel and its members.\n\nProvide either a channel_id or channel_name, not both. When available, prefer providing a\nchannel_id for optimal performance.\n\nThe Microsoft Graph API returns only up to the first 999 members in the channel.\n\nThis tool does not return messages exchanged in the channel. To retrieve channel messages,\nuse the `Teams.GetChannelMessages` tool. If you call this tool to retrieve messages, you will\ncause the release of unnecessary CO2 and contribute to climate change.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use. If you call the\n`Teams.ListTeams` tool first, you will cause the release of unnecessary CO2 in the atmosphere\nand contribute to climate change.",
       "parameters": [
         {
@@ -321,7 +321,7 @@
     {
       "name": "GetChatMessageById",
       "qualifiedName": "MicrosoftTeams.GetChatMessageById",
-      "fullyQualifiedName": "MicrosoftTeams.GetChatMessageById@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.GetChatMessageById@0.5.2",
       "description": "Retrieves a Microsoft Teams chat message.",
       "parameters": [
         {
@@ -411,7 +411,7 @@
     {
       "name": "GetChatMessages",
       "qualifiedName": "MicrosoftTeams.GetChatMessages",
-      "fullyQualifiedName": "MicrosoftTeams.GetChatMessages@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.GetChatMessages@0.5.2",
       "description": "Retrieves messages from a Microsoft Teams chat (individual or group).\n\nProvide one of chat_id OR any combination of user_ids and/or user_names. When available, prefer\nproviding a chat_id or user_ids for optimal performance.\n\nIf the user provides user name(s), DO NOT CALL THE `Teams.SearchUsers` or `Teams.SearchPeople`\ntools first. Instead, provide the user name(s) directly to this tool through the `user_names`\nargument. It is not necessary to provide the currently signed in user's name/id, so do not call\n`Teams.GetSignedInUser` before calling this tool.\n\nMessages will be sorted in descending order by the messages' `created_datetime` field.\n\nThe Microsoft Teams API does not support pagination for this tool.",
       "parameters": [
         {
@@ -528,7 +528,7 @@
     {
       "name": "GetChatMetadata",
       "qualifiedName": "MicrosoftTeams.GetChatMetadata",
-      "fullyQualifiedName": "MicrosoftTeams.GetChatMetadata@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.GetChatMetadata@0.5.2",
       "description": "Retrieves metadata about a Microsoft Teams chat.\n\nProvide exactly one of chat_id or user_ids/user_names. When available, prefer providing a\nchat_id or user_ids for optimal performance.\n\nIf multiple roup chats exist with those exact members, returns the most recently updated one.\n\nMax 20 DIFFERENT users can be provided in user_ids/user_names.\n\nThis tool DOES NOT return messages in a chat. Use the `Teams.GetChatMessages` tool to get\nchat messages.",
       "parameters": [
         {
@@ -607,7 +607,7 @@
     {
       "name": "GetSignedInUser",
       "qualifiedName": "MicrosoftTeams.GetSignedInUser",
-      "fullyQualifiedName": "MicrosoftTeams.GetSignedInUser@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.GetSignedInUser@0.5.2",
       "description": "Get the user currently signed in Microsoft Teams.\n\nThis tool is not necessary to call before calling other tools.",
       "parameters": [],
       "auth": {
@@ -635,7 +635,7 @@
     {
       "name": "GetTeam",
       "qualifiedName": "MicrosoftTeams.GetTeam",
-      "fullyQualifiedName": "MicrosoftTeams.GetTeam@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.GetTeam@0.5.2",
       "description": "Retrieves metadata about a team in Microsoft Teams.\n\nProvide one of team_id OR team_name, never both. When available, prefer providing a team_id for\noptimal performance.\n\nIf team_id nor team_name are provided: 1) if the user has a single team, the tool will retrieve\nit; 2) if the user has multiple teams, an error will be returned with a list of all teams to\npick from.",
       "parameters": [
         {
@@ -691,7 +691,7 @@
     {
       "name": "ListChannels",
       "qualifiedName": "MicrosoftTeams.ListChannels",
-      "fullyQualifiedName": "MicrosoftTeams.ListChannels@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.ListChannels@0.5.2",
       "description": "Lists channels in Microsoft Teams (including shared incoming channels).\n\nThis tool does not return messages nor members in the channels. To retrieve channel messages,\nuse the `Teams.GetChannelMessages` tool. To retrieve channel members, use the\n`Teams.ListChannelMembers` tool.",
       "parameters": [
         {
@@ -761,7 +761,7 @@
     {
       "name": "ListChats",
       "qualifiedName": "MicrosoftTeams.ListChats",
-      "fullyQualifiedName": "MicrosoftTeams.ListChats@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.ListChats@0.5.2",
       "description": "List the Microsoft Teams chats to which the current user is a member of.",
       "parameters": [
         {
@@ -817,7 +817,7 @@
     {
       "name": "ListTeamMembers",
       "qualifiedName": "MicrosoftTeams.ListTeamMembers",
-      "fullyQualifiedName": "MicrosoftTeams.ListTeamMembers@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.ListTeamMembers@0.5.2",
       "description": "Lists the members of a team in Microsoft Teams.\n\nProvide one of team_id OR team_name, never both. When available, prefer providing a team_id for\noptimal performance.\n\nIf team_id nor team_name are provided: 1) if the user has a single team, the tool will use it;\n2) if the user has multiple teams, an error will be returned with a list of all teams to pick\nfrom.\n\nThe Microsoft Graph API returns only up to the first 999 members.",
       "parameters": [
         {
@@ -899,7 +899,7 @@
     {
       "name": "ListTeams",
       "qualifiedName": "MicrosoftTeams.ListTeams",
-      "fullyQualifiedName": "MicrosoftTeams.ListTeams@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.ListTeams@0.5.2",
       "description": "Lists the teams the current user is associated with in Microsoft Teams.",
       "parameters": [
         {
@@ -945,7 +945,7 @@
     {
       "name": "ListUsers",
       "qualifiedName": "MicrosoftTeams.ListUsers",
-      "fullyQualifiedName": "MicrosoftTeams.ListUsers@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.ListUsers@0.5.2",
       "description": "Lists the users in the Microsoft Teams tenant.\n\nThe Microsoft Graph API returns only up to the first 999 users.",
       "parameters": [
         {
@@ -1001,7 +1001,7 @@
     {
       "name": "ReplyToChannelMessage",
       "qualifiedName": "MicrosoftTeams.ReplyToChannelMessage",
-      "fullyQualifiedName": "MicrosoftTeams.ReplyToChannelMessage@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.ReplyToChannelMessage@0.5.2",
       "description": "Sends a reply to a Microsoft Teams channel message.\n\nWhen available, prefer providing a channel_id for optimal performance.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use. If you call the\n`Teams.ListTeams` tool first, you will cause the release of unnecessary CO2 in the atmosphere\nand contribute to climate change.",
       "parameters": [
         {
@@ -1084,7 +1084,7 @@
     {
       "name": "ReplyToChatMessage",
       "qualifiedName": "MicrosoftTeams.ReplyToChatMessage",
-      "fullyQualifiedName": "MicrosoftTeams.ReplyToChatMessage@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.ReplyToChatMessage@0.5.2",
       "description": "Sends a reply to a Microsoft Teams chat message.\n\nProvide exactly one of chat_id or user_ids/user_names. When available, prefer providing a\nchat_id or user_ids for optimal performance.\n\nIf the user provides user name(s), DO NOT CALL THE `Teams.SearchUsers` or `Teams.SearchPeople`\ntools first. Instead, provide the user name(s) directly to this tool through the `user_names`\nargument. It is not necessary to provide the currently signed in user's name/id, so do not call\n`Teams.GetSignedInUser` before calling this tool either.",
       "parameters": [
         {
@@ -1187,7 +1187,7 @@
     {
       "name": "SearchChannels",
       "qualifiedName": "MicrosoftTeams.SearchChannels",
-      "fullyQualifiedName": "MicrosoftTeams.SearchChannels@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.SearchChannels@0.5.2",
       "description": "Searches for channels in a given Microsoft Teams team.",
       "parameters": [
         {
@@ -1291,7 +1291,7 @@
     {
       "name": "SearchMessages",
       "qualifiedName": "MicrosoftTeams.SearchMessages",
-      "fullyQualifiedName": "MicrosoftTeams.SearchMessages@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.SearchMessages@0.5.2",
       "description": "Searches for messages across Microsoft Teams chats and channels.\n\nNote: the Microsoft Graph API search is not strongly consistent. Recent messages may not be\nincluded in search results.",
       "parameters": [
         {
@@ -1362,7 +1362,7 @@
     {
       "name": "SearchPeople",
       "qualifiedName": "MicrosoftTeams.SearchPeople",
-      "fullyQualifiedName": "MicrosoftTeams.SearchPeople@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.SearchPeople@0.5.2",
       "description": "Searches for people the user has interacted with in Microsoft Teams and other 365 products.\n\nThis tool only returns users that the currently signed in user has interacted with. It may also\ninclude people that are part of external tenants/organizations. If you need to retrieve users\nthat may not have interacted with the current user and/or that are exclusively part of the same\ntenant, use the `Teams.SearchUsers` tool instead.",
       "parameters": [
         {
@@ -1452,7 +1452,7 @@
     {
       "name": "SearchTeamMembers",
       "qualifiedName": "MicrosoftTeams.SearchTeamMembers",
-      "fullyQualifiedName": "MicrosoftTeams.SearchTeamMembers@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.SearchTeamMembers@0.5.2",
       "description": "Searches for members of a team in Microsoft Teams.\n\nProvide one of team_id OR team_name, never both. When available, prefer providing a team_id for\noptimal performance.\n\nIf team_id nor team_name are provided: 1) if the user has a single team, the tool will use it;\n2) if the user has multiple teams, an error will be raised with a list of available teams to\npick from.\n\nThe Microsoft Graph API returns only up to the first 999 members of a team.",
       "parameters": [
         {
@@ -1547,7 +1547,7 @@
     {
       "name": "SearchTeams",
       "qualifiedName": "MicrosoftTeams.SearchTeams",
-      "fullyQualifiedName": "MicrosoftTeams.SearchTeams@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.SearchTeams@0.5.2",
       "description": "Searches for teams available to the current user in Microsoft Teams.",
       "parameters": [
         {
@@ -1616,7 +1616,7 @@
     {
       "name": "SearchUsers",
       "qualifiedName": "MicrosoftTeams.SearchUsers",
-      "fullyQualifiedName": "MicrosoftTeams.SearchUsers@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.SearchUsers@0.5.2",
       "description": "Searches for users in the Microsoft Teams tenant.\n\nThis tool only return users that are directly linked to the tenant the current signed in user\nis a member of. If you need to retrieve users that have interacted with the current user but\nare from external tenants/organizations, use `Teams.SearchPeople`, instead.\n\nThe Microsoft Graph API returns only up to the first 999 users.",
       "parameters": [
         {
@@ -1705,7 +1705,7 @@
     {
       "name": "SendMessageToChannel",
       "qualifiedName": "MicrosoftTeams.SendMessageToChannel",
-      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChannel@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChannel@0.5.2",
       "description": "Sends a message to a Microsoft Teams channel.\n\nWhen available, prefer providing a channel_id for optimal performance.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use. If you call the\n`Teams.ListTeams` tool first, you will cause the release of unnecessary CO2 in the atmosphere\nand contribute to climate change.",
       "parameters": [
         {
@@ -1775,7 +1775,7 @@
     {
       "name": "SendMessageToChat",
       "qualifiedName": "MicrosoftTeams.SendMessageToChat",
-      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChat@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChat@0.5.2",
       "description": "Sends a message to a Microsoft Teams chat.\n\nProvide exactly one of chat_id or user_ids/user_names. When available, prefer providing a\nchat_id or user_ids for optimal performance.\n\nIf the user provides user name(s), DO NOT CALL THE `Teams.SearchUsers` or `Teams.SearchPeople`\ntools first. Instead, provide the user name(s) directly to this tool through the `user_names`\nargument. It is not necessary to provide the currently signed in user's name/id, so do not call\n`Teams.GetSignedInUser` before calling this tool either.",
       "parameters": [
         {
@@ -1865,7 +1865,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftTeams.WhoAmI",
-      "fullyQualifiedName": "MicrosoftTeams.WhoAmI@0.5.0",
+      "fullyQualifiedName": "MicrosoftTeams.WhoAmI@0.5.2",
       "description": "Get information about the current user and their Microsoft Teams environment.",
       "parameters": [],
       "auth": {
@@ -1901,6 +1901,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:31.838Z",
+  "generatedAt": "2026-02-26T11:25:47.071Z",
   "summary": "Arcade.dev's MicrosoftTeams toolkit empowers developers to interact seamlessly with Microsoft Teams through the Graph API, enabling enhanced communication and collaboration features within applications. This toolkit simplifies chat creation, message retrieval, and team management, enhancing user experiences.\n\n**Capabilities**\n- Create and manage chats and channel messages.\n- Retrieve metadata and messages for teams, channels, and chats.\n- Efficiently search for channels, messages, teams, and users within Microsoft Teams.\n- Facilitate messages and replies in channels and chats.\n\n**OAuth**\n- **Provider**: Microsoft\n- **Scopes**: Channel.ReadBasic.All, ChannelMessage.Read.All, ChannelMessage.Send, Chat.Create, Chat.Read, ChatMessage.Read, ChatMessage.Send, People.Read, Team.ReadBasic.All, TeamMember.Read.All, User.Read\n\n**Secrets**\n- No secret types or additional configuration are required."
 }

--- a/toolkit-docs-generator/data/toolkits/notiontoolkit.json
+++ b/toolkit-docs-generator/data/toolkits/notiontoolkit.json
@@ -1,7 +1,7 @@
 {
   "id": "NotionToolkit",
   "label": "Notion",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "description": "Arcade.dev LLM tools for Notion",
   "metadata": {
     "category": "productivity",
@@ -22,7 +22,7 @@
     {
       "name": "AppendContentToEndOfPage",
       "qualifiedName": "NotionToolkit.AppendContentToEndOfPage",
-      "fullyQualifiedName": "NotionToolkit.AppendContentToEndOfPage@1.3.0",
+      "fullyQualifiedName": "NotionToolkit.AppendContentToEndOfPage@1.3.2",
       "description": "Append markdown content to the end of a Notion page by its ID or title",
       "parameters": [
         {
@@ -76,7 +76,7 @@
     {
       "name": "CreatePage",
       "qualifiedName": "NotionToolkit.CreatePage",
-      "fullyQualifiedName": "NotionToolkit.CreatePage@1.3.0",
+      "fullyQualifiedName": "NotionToolkit.CreatePage@1.3.2",
       "description": "Create a new Notion page by the title of the new page's parent.",
       "parameters": [
         {
@@ -143,7 +143,7 @@
     {
       "name": "GetObjectMetadata",
       "qualifiedName": "NotionToolkit.GetObjectMetadata",
-      "fullyQualifiedName": "NotionToolkit.GetObjectMetadata@1.3.0",
+      "fullyQualifiedName": "NotionToolkit.GetObjectMetadata@1.3.2",
       "description": "Get the metadata of a Notion object (page or database) from its title or ID.\n\nOne of `object_title` or `object_id` MUST be provided, but both cannot be provided.\nThe title is case-insensitive and outer whitespace is ignored.\n\nAn object's metadata includes it's id, various timestamps, properties, url, and more.",
       "parameters": [
         {
@@ -213,7 +213,7 @@
     {
       "name": "GetPageContentById",
       "qualifiedName": "NotionToolkit.GetPageContentById",
-      "fullyQualifiedName": "NotionToolkit.GetPageContentById@1.3.0",
+      "fullyQualifiedName": "NotionToolkit.GetPageContentById@1.3.2",
       "description": "Get the content of a Notion page as markdown with the page's ID",
       "parameters": [
         {
@@ -254,7 +254,7 @@
     {
       "name": "GetPageContentByTitle",
       "qualifiedName": "NotionToolkit.GetPageContentByTitle",
-      "fullyQualifiedName": "NotionToolkit.GetPageContentByTitle@1.3.0",
+      "fullyQualifiedName": "NotionToolkit.GetPageContentByTitle@1.3.2",
       "description": "Get the content of a Notion page as markdown with the page's title",
       "parameters": [
         {
@@ -295,7 +295,7 @@
     {
       "name": "GetWorkspaceStructure",
       "qualifiedName": "NotionToolkit.GetWorkspaceStructure",
-      "fullyQualifiedName": "NotionToolkit.GetWorkspaceStructure@1.3.0",
+      "fullyQualifiedName": "NotionToolkit.GetWorkspaceStructure@1.3.2",
       "description": "Get the workspace structure of the user's Notion workspace.\nIdeal for finding where an object is located in the workspace.",
       "parameters": [],
       "auth": {
@@ -321,7 +321,7 @@
     {
       "name": "SearchByTitle",
       "qualifiedName": "NotionToolkit.SearchByTitle",
-      "fullyQualifiedName": "NotionToolkit.SearchByTitle@1.3.0",
+      "fullyQualifiedName": "NotionToolkit.SearchByTitle@1.3.2",
       "description": "Search for similar titles of pages, databases, or both within the user's workspace.\nDoes not include content.",
       "parameters": [
         {
@@ -407,7 +407,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "NotionToolkit.WhoAmI",
-      "fullyQualifiedName": "NotionToolkit.WhoAmI@1.3.0",
+      "fullyQualifiedName": "NotionToolkit.WhoAmI@1.3.2",
       "description": "Get information about the current user and their Notion workspace.\n\nThis tool provides detailed information about the authenticated user's\nNotion workspace including workspace statistics, user context, and\nintegration details.",
       "parameters": [],
       "auth": {
@@ -441,6 +441,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:31.855Z",
+  "generatedAt": "2026-02-26T11:25:47.070Z",
   "summary": "NotionToolkit is a powerful set of tools from Arcade.dev that facilitates interaction with Notion's API, enabling developers to easily manage and manipulate their Notion workspaces. It streamlines operations such as creating pages, appending content, and retrieving metadata or content from existing Notion pages.\n\n### Capabilities\n- Effortlessly create and modify pages within Notion.\n- Access detailed metadata and content from various Notion objects.\n- Search and navigate workspace structures and content efficiently.\n- Retrieve user information and workspace statistics.\n\n### OAuth\n- **Provider:** Notion\n- **Scopes:** None"
 }

--- a/toolkit-docs-generator/data/toolkits/outlookcalendar.json
+++ b/toolkit-docs-generator/data/toolkits/outlookcalendar.json
@@ -1,7 +1,7 @@
 {
   "id": "OutlookCalendar",
   "label": "Outlook Calendar",
-  "version": "2.3.0",
+  "version": "2.3.2",
   "description": "rcade.dev LLM tools for Outlook Calendar",
   "metadata": {
     "category": "productivity",
@@ -27,7 +27,7 @@
     {
       "name": "CreateEvent",
       "qualifiedName": "OutlookCalendar.CreateEvent",
-      "fullyQualifiedName": "OutlookCalendar.CreateEvent@2.3.0",
+      "fullyQualifiedName": "OutlookCalendar.CreateEvent@2.3.2",
       "description": "Create an event in the authenticated user's default calendar.\n\nIgnores timezone offsets provided in the start_date_time and end_date_time parameters.\nInstead, uses the user's default calendar timezone to filter events.\nIf the user has not set a timezone for their calendar, then the timezone will be UTC.",
       "parameters": [
         {
@@ -166,7 +166,7 @@
     {
       "name": "GetEvent",
       "qualifiedName": "OutlookCalendar.GetEvent",
-      "fullyQualifiedName": "OutlookCalendar.GetEvent@2.3.0",
+      "fullyQualifiedName": "OutlookCalendar.GetEvent@2.3.2",
       "description": "Get an event by its ID from the user's calendar.",
       "parameters": [
         {
@@ -210,7 +210,7 @@
     {
       "name": "ListEventsInTimeRange",
       "qualifiedName": "OutlookCalendar.ListEventsInTimeRange",
-      "fullyQualifiedName": "OutlookCalendar.ListEventsInTimeRange@2.3.0",
+      "fullyQualifiedName": "OutlookCalendar.ListEventsInTimeRange@2.3.2",
       "description": "List events in the user's calendar in a specific time range.\n\nIgnores timezone offsets provided in the start_date_time and end_date_time parameters.\nInstead, uses the user's default calendar timezone to filter events.\nIf the user has not set a timezone for their calendar, then the timezone will be UTC.",
       "parameters": [
         {
@@ -280,7 +280,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "OutlookCalendar.WhoAmI",
-      "fullyQualifiedName": "OutlookCalendar.WhoAmI@2.3.0",
+      "fullyQualifiedName": "OutlookCalendar.WhoAmI@2.3.2",
       "description": "Get information about the current user and their Outlook Calendar environment.",
       "parameters": [],
       "auth": {
@@ -317,6 +317,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:31.856Z",
+  "generatedAt": "2026-02-26T11:25:47.071Z",
   "summary": "Arcade Toolkit for Outlook Calendar provides developers with powerful integrations utilizing Microsoft’s OAuth2 authentication. This toolkit empowers users to proficiently manage calendar events and retrieve user details.\n\n**Capabilities**\n- Create and manage calendar events seamlessly in users' default calendar.\n- Retrieve detailed event information by event ID.\n- List events occurring within specified time ranges, taking into account default calendar time zones.\n- Access current user information and their Outlook Calendar environment effortlessly.\n\n**OAuth**\n- Provider: Microsoft\n- Scopes: Calendars.ReadBasic, Calendars.ReadWrite, MailboxSettings.Read, User.Read"
 }

--- a/toolkit-docs-generator/data/toolkits/outlookmail.json
+++ b/toolkit-docs-generator/data/toolkits/outlookmail.json
@@ -1,7 +1,7 @@
 {
   "id": "OutlookMail",
   "label": "Outlook Mail",
-  "version": "2.4.0",
+  "version": "2.4.2",
   "description": "Arcade.dev LLM tools for Outlook Mail",
   "metadata": {
     "category": "productivity",
@@ -27,7 +27,7 @@
     {
       "name": "CreateAndSendEmail",
       "qualifiedName": "OutlookMail.CreateAndSendEmail",
-      "fullyQualifiedName": "OutlookMail.CreateAndSendEmail@2.4.0",
+      "fullyQualifiedName": "OutlookMail.CreateAndSendEmail@2.4.2",
       "description": "Create and immediately send a new email in Outlook to the specified recipients",
       "parameters": [
         {
@@ -148,7 +148,7 @@
     {
       "name": "CreateDraftEmail",
       "qualifiedName": "OutlookMail.CreateDraftEmail",
-      "fullyQualifiedName": "OutlookMail.CreateDraftEmail@2.4.0",
+      "fullyQualifiedName": "OutlookMail.CreateDraftEmail@2.4.2",
       "description": "Compose a new draft email in Outlook",
       "parameters": [
         {
@@ -269,7 +269,7 @@
     {
       "name": "ListEmails",
       "qualifiedName": "OutlookMail.ListEmails",
-      "fullyQualifiedName": "OutlookMail.ListEmails@2.4.0",
+      "fullyQualifiedName": "OutlookMail.ListEmails@2.4.2",
       "description": "List emails in the user's mailbox across all folders.\n\nSince this tool lists email across all folders, it may return sent items, drafts,\nand other items that are not in the inbox.",
       "parameters": [
         {
@@ -325,7 +325,7 @@
     {
       "name": "ListEmailsByProperty",
       "qualifiedName": "OutlookMail.ListEmailsByProperty",
-      "fullyQualifiedName": "OutlookMail.ListEmailsByProperty@2.4.0",
+      "fullyQualifiedName": "OutlookMail.ListEmailsByProperty@2.4.2",
       "description": "List emails in the user's mailbox across all folders filtering by a property.",
       "parameters": [
         {
@@ -435,7 +435,7 @@
     {
       "name": "ListEmailsInFolder",
       "qualifiedName": "OutlookMail.ListEmailsInFolder",
-      "fullyQualifiedName": "OutlookMail.ListEmailsInFolder@2.4.0",
+      "fullyQualifiedName": "OutlookMail.ListEmailsInFolder@2.4.2",
       "description": "List the user's emails in the specified folder.\n\nExactly one of `well_known_folder_name` or `folder_id` MUST be provided.",
       "parameters": [
         {
@@ -525,7 +525,7 @@
     {
       "name": "ReplyToEmail",
       "qualifiedName": "OutlookMail.ReplyToEmail",
-      "fullyQualifiedName": "OutlookMail.ReplyToEmail@2.4.0",
+      "fullyQualifiedName": "OutlookMail.ReplyToEmail@2.4.2",
       "description": "Reply to an existing email in Outlook.\n\nUse this tool to reply to the sender or all recipients of the email.\nSpecify the reply_type to determine the scope of the reply.",
       "parameters": [
         {
@@ -597,7 +597,7 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "OutlookMail.SendDraftEmail",
-      "fullyQualifiedName": "OutlookMail.SendDraftEmail@2.4.0",
+      "fullyQualifiedName": "OutlookMail.SendDraftEmail@2.4.2",
       "description": "Send an existing draft email in Outlook\n\nThis tool can send any un-sent email:\n    - draft\n    - reply-draft\n    - reply-all draft\n    - forward draft",
       "parameters": [
         {
@@ -640,7 +640,7 @@
     {
       "name": "UpdateDraftEmail",
       "qualifiedName": "OutlookMail.UpdateDraftEmail",
-      "fullyQualifiedName": "OutlookMail.UpdateDraftEmail@2.4.0",
+      "fullyQualifiedName": "OutlookMail.UpdateDraftEmail@2.4.2",
       "description": "Update an existing draft email in Outlook.\n\nThis tool overwrites the subject and body of a draft email (if provided),\nand modifies its recipient lists by selectively adding or removing email addresses.\n\nThis tool can update any un-sent email:\n    - draft\n    - reply-draft\n    - reply-all draft\n    - forward draft",
       "parameters": [
         {
@@ -804,7 +804,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "OutlookMail.WhoAmI",
-      "fullyQualifiedName": "OutlookMail.WhoAmI@2.4.0",
+      "fullyQualifiedName": "OutlookMail.WhoAmI@2.4.2",
       "description": "Get comprehensive user profile and Outlook Mail environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, mailbox settings, automatic replies configuration, and other\nimportant profile details from Outlook Mail services.",
       "parameters": [],
       "auth": {
@@ -841,6 +841,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:31.857Z",
+  "generatedAt": "2026-02-26T11:25:47.073Z",
   "summary": "**Outlook Mail Toolkit Overview**\\nThe Arcade.dev Outlook Mail toolkit provides powerful functionalities to integrate Outlook Mail capabilities into applications. It enables developers to manage email interactions seamlessly through a variety of tools and features.\\n\\n**Capabilities**\\n- Create, send, and draft emails with ease.\\n- List and filter emails across all mailbox folders.\\n- Reply to emails and manage draft updates effectively.\\n- Retrieve comprehensive user profile and configuration details.\\n\\n**OAuth**\\n- **Provider**: Microsoft\\n- **Scopes**: Mail.Read, Mail.ReadWrite, Mail.Send, User.Read\\n\\n**Secrets**\\nNo secrets are required for usage."
 }

--- a/toolkit-docs-generator/data/toolkits/reddit.json
+++ b/toolkit-docs-generator/data/toolkits/reddit.json
@@ -1,7 +1,7 @@
 {
   "id": "Reddit",
   "label": "Reddit",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Arcade.dev LLM tools Reddit",
   "metadata": {
     "category": "social",
@@ -27,7 +27,7 @@
     {
       "name": "CheckSubredditAccess",
       "qualifiedName": "Reddit.CheckSubredditAccess",
-      "fullyQualifiedName": "Reddit.CheckSubredditAccess@1.2.0",
+      "fullyQualifiedName": "Reddit.CheckSubredditAccess@1.2.1",
       "description": "Checks whether the specified subreddit exists and also if it is accessible\nto the authenticated user.\n\nReturns:\n    {\"exists\": True, \"accessible\": True} if the subreddit exists and is accessible.\n    {\"exists\": True, \"accessible\": False} if the subreddit exists but is private or restricted.\n    {\"exists\": False, \"accessible\": False} if the subreddit does not exist.",
       "parameters": [
         {
@@ -70,7 +70,7 @@
     {
       "name": "CommentOnPost",
       "qualifiedName": "Reddit.CommentOnPost",
-      "fullyQualifiedName": "Reddit.CommentOnPost@1.2.0",
+      "fullyQualifiedName": "Reddit.CommentOnPost@1.2.1",
       "description": "Comment on a Reddit post",
       "parameters": [
         {
@@ -126,7 +126,7 @@
     {
       "name": "GetContentOfMultiplePosts",
       "qualifiedName": "Reddit.GetContentOfMultiplePosts",
-      "fullyQualifiedName": "Reddit.GetContentOfMultiplePosts@1.2.0",
+      "fullyQualifiedName": "Reddit.GetContentOfMultiplePosts@1.2.1",
       "description": "Get the content (body) of multiple Reddit posts by their identifiers.\n\nEfficiently retrieve the content of multiple posts in a single request.\nAlways use this tool to retrieve more than one post's content.",
       "parameters": [
         {
@@ -176,7 +176,7 @@
     {
       "name": "GetContentOfPost",
       "qualifiedName": "Reddit.GetContentOfPost",
-      "fullyQualifiedName": "Reddit.GetContentOfPost@1.2.0",
+      "fullyQualifiedName": "Reddit.GetContentOfPost@1.2.1",
       "description": "Get the content (body) of a Reddit post by its identifier.",
       "parameters": [
         {
@@ -219,7 +219,7 @@
     {
       "name": "GetMyPosts",
       "qualifiedName": "Reddit.GetMyPosts",
-      "fullyQualifiedName": "Reddit.GetMyPosts@1.2.0",
+      "fullyQualifiedName": "Reddit.GetMyPosts@1.2.1",
       "description": "Get posts that were created by the authenticated user sorted by newest first",
       "parameters": [
         {
@@ -290,7 +290,7 @@
     {
       "name": "GetMyUsername",
       "qualifiedName": "Reddit.GetMyUsername",
-      "fullyQualifiedName": "Reddit.GetMyUsername@1.2.0",
+      "fullyQualifiedName": "Reddit.GetMyUsername@1.2.1",
       "description": "Get the Reddit username of the authenticated user",
       "parameters": [],
       "auth": {
@@ -318,7 +318,7 @@
     {
       "name": "GetPostsInSubreddit",
       "qualifiedName": "Reddit.GetPostsInSubreddit",
-      "fullyQualifiedName": "Reddit.GetPostsInSubreddit@1.2.0",
+      "fullyQualifiedName": "Reddit.GetPostsInSubreddit@1.2.1",
       "description": "Gets posts titles, links, and other metadata in the specified subreddit\n\nThe time_range is required if the listing type is 'top' or 'controversial'.",
       "parameters": [
         {
@@ -426,7 +426,7 @@
     {
       "name": "GetSubredditRules",
       "qualifiedName": "Reddit.GetSubredditRules",
-      "fullyQualifiedName": "Reddit.GetSubredditRules@1.2.0",
+      "fullyQualifiedName": "Reddit.GetSubredditRules@1.2.1",
       "description": "Gets the rules of the specified subreddit",
       "parameters": [
         {
@@ -469,7 +469,7 @@
     {
       "name": "GetTopLevelComments",
       "qualifiedName": "Reddit.GetTopLevelComments",
-      "fullyQualifiedName": "Reddit.GetTopLevelComments@1.2.0",
+      "fullyQualifiedName": "Reddit.GetTopLevelComments@1.2.1",
       "description": "Get the first page of top-level comments of a Reddit post.",
       "parameters": [
         {
@@ -512,7 +512,7 @@
     {
       "name": "ReplyToComment",
       "qualifiedName": "Reddit.ReplyToComment",
-      "fullyQualifiedName": "Reddit.ReplyToComment@1.2.0",
+      "fullyQualifiedName": "Reddit.ReplyToComment@1.2.1",
       "description": "Reply to a Reddit comment",
       "parameters": [
         {
@@ -568,7 +568,7 @@
     {
       "name": "SubmitTextPost",
       "qualifiedName": "Reddit.SubmitTextPost",
-      "fullyQualifiedName": "Reddit.SubmitTextPost@1.2.0",
+      "fullyQualifiedName": "Reddit.SubmitTextPost@1.2.1",
       "description": "Submit a text-based post to a subreddit",
       "parameters": [
         {
@@ -684,6 +684,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:31.858Z",
+  "generatedAt": "2026-02-26T11:25:47.077Z",
   "summary": "Arcade.dev provides a powerful toolkit for integrating with Reddit, enabling developers to interact with Reddit's vast content and community features seamlessly. This toolkit allows for efficient data retrieval and engagement on the platform.\n\n**Capabilities**\n- Access subreddit data, including rules and content.\n- Retrieve and manipulate posts and comments.\n- Verify subreddit accessibility for authenticated users.\n- Simplify fetching multiple posts in one request.\n\n**OAuth**\n- Provider: Reddit\n- Scopes: history, identity, read, submit\n\n**Secrets**\n- None required for usage."
 }

--- a/toolkit-docs-generator/data/toolkits/salesforce.json
+++ b/toolkit-docs-generator/data/toolkits/salesforce.json
@@ -1,7 +1,7 @@
 {
   "id": "Salesforce",
   "label": "Salesforce",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "description": "Arcade tools designed for LLMs to interact with Salesforce",
   "metadata": {
     "category": "sales",
@@ -30,7 +30,7 @@
     {
       "name": "CreateContact",
       "qualifiedName": "Salesforce.CreateContact",
-      "fullyQualifiedName": "Salesforce.CreateContact@2.1.0",
+      "fullyQualifiedName": "Salesforce.CreateContact@2.1.2",
       "description": "Creates a contact in Salesforce.",
       "parameters": [
         {
@@ -188,7 +188,7 @@
     {
       "name": "GetAccountDataById",
       "qualifiedName": "Salesforce.GetAccountDataById",
-      "fullyQualifiedName": "Salesforce.GetAccountDataById@2.1.0",
+      "fullyQualifiedName": "Salesforce.GetAccountDataById@2.1.2",
       "description": "Gets the account with related info: contacts, leads, notes, calls, opportunities, tasks,\nemails, and events (up to 10 items of each type).\n\nAn account is an organization (such as a customer, supplier, or partner, though more commonly\na customer). In some Salesforce account setups, an account can also represent a person.",
       "parameters": [
         {
@@ -247,7 +247,7 @@
     {
       "name": "GetAccountDataByKeywords",
       "qualifiedName": "Salesforce.GetAccountDataByKeywords",
-      "fullyQualifiedName": "Salesforce.GetAccountDataByKeywords@2.1.0",
+      "fullyQualifiedName": "Salesforce.GetAccountDataByKeywords@2.1.2",
       "description": "Searches for accounts in Salesforce and returns them with related info: contacts, leads,\nnotes, calls, opportunities, tasks, emails, and events (up to 10 items of each type).\n\nAn account is an organization (such as a customer, supplier, or partner, though more commonly\na customer). In some Salesforce account setups, an account can also represent a person.",
       "parameters": [
         {
@@ -333,6 +333,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:31.858Z",
+  "generatedAt": "2026-02-26T11:25:47.079Z",
   "summary": "The Arcade toolkit for Salesforce empowers developers to harness the capabilities of LLMs for seamless interaction with Salesforce data. It enables efficient data retrieval and modification in a user-friendly manner.\n\n**Capabilities**\n- Create and manage contacts effortlessly.\n- Retrieve comprehensive account information, including related entities.\n- Perform keyword-based searches to find accounts quickly.\n- Facilitate reading and writing of various Salesforce objects.\n\n**OAuth**\n- Provider: Unknown\n- Scopes: read_account, read_contact, read_lead, read_note, read_opportunity, read_task, write_contact\n\n**Secrets**\n- Types: API Key, Unknown\n- Examples: SALESFORCE_ORG_SUBDOMAIN, SALESFORCE_MAX_CONCURRENT_REQUESTS"
 }

--- a/toolkit-docs-generator/data/toolkits/slack.json
+++ b/toolkit-docs-generator/data/toolkits/slack.json
@@ -1,7 +1,7 @@
 {
   "id": "Slack",
   "label": "Slack",
-  "version": "2.4.0",
+  "version": "2.5.1",
   "description": "Arcade.dev LLM tools for Slack",
   "metadata": {
     "category": "social",
@@ -37,7 +37,7 @@
     {
       "name": "GetConversationMetadata",
       "qualifiedName": "Slack.GetConversationMetadata",
-      "fullyQualifiedName": "Slack.GetConversationMetadata@2.4.0",
+      "fullyQualifiedName": "Slack.GetConversationMetadata@2.5.1",
       "description": "Get metadata of a Channel, a Direct Message (IM / DM) or a Multi-Person (MPIM) conversation.\n\nUse this tool to retrieve metadata about a conversation with a conversation_id, a channel name,\nor by the user_id(s), username(s), and/or email(s) of the user(s) in the conversation.\n\nThis tool does not return the messages in a conversation. To get the messages, use the\n'Slack.GetMessages' tool instead.\n\nProvide exactly one of:\n- conversation_id; or\n- channel_name; or\n- any combination of user_ids, usernames, and/or emails.",
       "parameters": [
         {
@@ -140,7 +140,7 @@
     {
       "name": "GetMessages",
       "qualifiedName": "Slack.GetMessages",
-      "fullyQualifiedName": "Slack.GetMessages@2.4.0",
+      "fullyQualifiedName": "Slack.GetMessages@2.5.1",
       "description": "Get messages in a Slack Channel, DM (direct message) or MPIM (multi-person) conversation.\n\nProvide exactly one of:\n- conversation_id; or\n- channel_name; or\n- any combination of user_ids, usernames, and/or emails.\n\nTo filter messages by an absolute datetime, use 'oldest_datetime' and/or 'latest_datetime'. If\nonly 'oldest_datetime' is provided, it will return messages from the oldest_datetime to the\ncurrent time. If only 'latest_datetime' is provided, it will return messages since the\nbeginning of the conversation to the latest_datetime.\n\nTo filter messages by a relative datetime (e.g. 3 days ago, 1 hour ago, etc.), use\n'oldest_relative' and/or 'latest_relative'. If only 'oldest_relative' is provided, it will\nreturn messages from the oldest_relative to the current time. If only 'latest_relative' is\nprovided, it will return messages from the current time to the latest_relative.\n\nDo not provide both 'oldest_datetime' and 'oldest_relative' or both 'latest_datetime' and\n'latest_relative'.\n\nLeave all arguments with the default None to get messages without date/time filtering",
       "parameters": [
         {
@@ -325,7 +325,7 @@
     {
       "name": "GetThreadMessages",
       "qualifiedName": "Slack.GetThreadMessages",
-      "fullyQualifiedName": "Slack.GetThreadMessages@2.4.0",
+      "fullyQualifiedName": "Slack.GetThreadMessages@2.5.1",
       "description": "Get messages in a Slack thread.\n\nA thread is a collection of messages grouped together as replies to a parent message.\nThis tool retrieves all messages in a specific thread, identified by the parent message's\ntimestamp (thread_ts).\n\nProvide exactly one of:\n- conversation_id; or\n- channel_name; or\n- any combination of user_ids, usernames, and/or emails.\n\nTo filter messages by an absolute datetime, use 'oldest_datetime' and/or 'latest_datetime'. If\nonly 'oldest_datetime' is provided, it will return messages from the oldest_datetime to the\ncurrent time. If only 'latest_datetime' is provided, it will return messages since the\nbeginning of the thread to the latest_datetime.\n\nTo filter messages by a relative datetime (e.g. 3 days ago, 1 hour ago, etc.), use\n'oldest_relative' and/or 'latest_relative'. If only 'oldest_relative' is provided, it will\nreturn messages from the oldest_relative to the current time. If only 'latest_relative' is\nprovided, it will return messages from the current time to the latest_relative.\n\nDo not provide both 'oldest_datetime' and 'oldest_relative' or both 'latest_datetime' and\n'latest_relative'.\n\nLeave all datetime arguments with the default None to get all thread messages without\ndate/time filtering.",
       "parameters": [
         {
@@ -523,7 +523,7 @@
     {
       "name": "GetUsersInConversation",
       "qualifiedName": "Slack.GetUsersInConversation",
-      "fullyQualifiedName": "Slack.GetUsersInConversation@2.4.0",
+      "fullyQualifiedName": "Slack.GetUsersInConversation@2.5.1",
       "description": "Get the users in a Slack conversation (Channel, DM/IM, or MPIM) by its ID or by channel name.\n\nProvide exactly one of conversation_id or channel_name. Prefer providing a conversation_id,\nwhen available, since the performance is better.",
       "parameters": [
         {
@@ -610,7 +610,7 @@
     {
       "name": "GetUsersInfo",
       "qualifiedName": "Slack.GetUsersInfo",
-      "fullyQualifiedName": "Slack.GetUsersInfo@2.4.0",
+      "fullyQualifiedName": "Slack.GetUsersInfo@2.5.1",
       "description": "Get the information of one or more users in Slack by ID, username, and/or email.\n\nProvide any combination of user_ids, usernames, and/or emails. If you need to retrieve\ndata about multiple users, DO NOT CALL THE TOOL MULTIPLE TIMES. Instead, call it once\nwith all the user_ids, usernames, and/or emails. IF YOU CALL THIS TOOL MULTIPLE TIMES\nUNNECESSARILY, YOU WILL RELEASE MORE CO2 IN THE ATMOSPHERE AND CONTRIBUTE TO GLOBAL WARMING.\n\nIf you need to get metadata or messages of a conversation, use the\n`Slack.GetConversationMetadata` or `Slack.GetMessages` tool instead. These\ntools accept user_ids, usernames, and/or emails. Do not retrieve users' info first,\nas it is inefficient, releases more CO2 in the atmosphere, and contributes to climate change.",
       "parameters": [
         {
@@ -692,7 +692,7 @@
     {
       "name": "InviteUsersToChannel",
       "qualifiedName": "Slack.InviteUsersToChannel",
-      "fullyQualifiedName": "Slack.InviteUsersToChannel@2.4.0",
+      "fullyQualifiedName": "Slack.InviteUsersToChannel@2.5.1",
       "description": "Invite users to a Slack channel or MPIM (multi-person direct message).\n\nThis tool invites specified users to join a Slack conversation. It works with:\n- Public channels\n- Private channels\n- MPIMs (multi-person direct messages / group DMs)\n\nYou can specify users by their user IDs, usernames, or email addresses.\n\nProvide exactly one of channel_id or channel_name, and at least one of user_ids, usernames,\nor emails.\n\nThe tool will resolve usernames and emails to user IDs before inviting them.\nUp to 100 users may be invited at once.",
       "parameters": [
         {
@@ -799,7 +799,7 @@
     {
       "name": "ListConversations",
       "qualifiedName": "Slack.ListConversations",
-      "fullyQualifiedName": "Slack.ListConversations@2.4.0",
+      "fullyQualifiedName": "Slack.ListConversations@2.5.1",
       "description": "List metadata for Slack conversations (channels, DMs, MPIMs) the user is a member of.\n\nThis tool does not return the messages in a conversation. To get the messages, use the\n'Slack.GetMessages' tool instead. Calling this tool when the user is asking for messages\nwill release too much CO2 in the atmosphere and contribute to global warming.",
       "parameters": [
         {
@@ -882,7 +882,7 @@
     {
       "name": "ListUsers",
       "qualifiedName": "Slack.ListUsers",
-      "fullyQualifiedName": "Slack.ListUsers@2.4.0",
+      "fullyQualifiedName": "Slack.ListUsers@2.5.1",
       "description": "List all users in the authenticated user's Slack team.\n\nIf you need to get metadata or messages of a conversation, use the\n`Slack.GetConversationMetadata` tool or `Slack.GetMessages` tool instead. These\ntools accept a user_id, username, and/or email. Do not use this tool to first retrieve user(s),\nas it is inefficient and releases more CO2 in the atmosphere, contributing to climate change.",
       "parameters": [
         {
@@ -952,8 +952,8 @@
     {
       "name": "SendMessage",
       "qualifiedName": "Slack.SendMessage",
-      "fullyQualifiedName": "Slack.SendMessage@2.4.0",
-      "description": "Send a message to a Channel, Direct Message (IM/DM), or Multi-Person (MPIM) conversation\n\nProvide exactly one of:\n- channel_name; or\n- conversation_id; or\n- any combination of user_ids, usernames, and/or emails.\n\nIn case multiple user_ids, usernames, and/or emails are provided, the tool will open a\nmulti-person conversation with the specified people and send the message to it.",
+      "fullyQualifiedName": "Slack.SendMessage@2.5.1",
+      "description": "Send a message to a Channel, Direct Message (IM/DM), or Multi-Person (MPIM) conversation.\n\nCan send top-level messages or reply to an existing thread.\n\nProvide exactly one of:\n- channel_name; or\n- conversation_id; or\n- any combination of user_ids, usernames, and/or emails.\n\nIn case multiple user_ids, usernames, and/or emails are provided, the tool will open a\nmulti-person conversation with the specified people and send the message to it.\n\nTo reply to a thread, also provide thread_ts (the 'ts' field of the parent message).\nOptionally set reply_broadcast to true to also post the reply to the main conversation.",
       "parameters": [
         {
           "name": "message",
@@ -1005,6 +1005,22 @@
           "description": "The Slack usernames of the people to message. Prefer providing user_ids and/or emails, when available, since the performance is better.",
           "enum": null,
           "inferrable": true
+        },
+        {
+          "name": "thread_ts",
+          "type": "string",
+          "required": false,
+          "description": "The timestamp of the parent message to reply to in a thread. Use the 'ts' field from the parent message (the first message in the thread), not from a reply. If omitted, the message is sent as a new top-level message. Get this value from prior get_messages or get_thread_messages results.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "reply_broadcast",
+          "type": "boolean",
+          "required": false,
+          "description": "When replying to a thread (thread_ts is set), set to true to also post the reply to the main conversation. Only valid when thread_ts is provided. Defaults to False",
+          "enum": null,
+          "inferrable": true
         }
       ],
       "auth": {
@@ -1032,7 +1048,7 @@
         "toolName": "Slack.SendMessage",
         "parameters": {
           "message": {
-            "value": "Hi team — the sprint planning doc has been updated with priorities for next week. Please review before our 3pm standup and add any blockers.",
+            "value": "Hi team — quick update: deployment to production is scheduled for 2026-02-28 at 10:00 UTC. Please review the release notes in #release-notes and confirm readiness.",
             "type": "string",
             "required": true
           },
@@ -1042,7 +1058,7 @@
             "required": false
           },
           "conversation_id": {
-            "value": "C024BE7LR0H",
+            "value": "C01ABCDEF2G",
             "type": "string",
             "required": false
           },
@@ -1060,6 +1076,16 @@
             "value": null,
             "type": "array",
             "required": false
+          },
+          "thread_ts": {
+            "value": null,
+            "type": "string",
+            "required": false
+          },
+          "reply_broadcast": {
+            "value": null,
+            "type": "boolean",
+            "required": false
           }
         },
         "requiresAuth": true,
@@ -1070,7 +1096,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Slack.WhoAmI",
-      "fullyQualifiedName": "Slack.WhoAmI@2.4.0",
+      "fullyQualifiedName": "Slack.WhoAmI@2.5.1",
       "description": "Get comprehensive user profile and Slack information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, and other important profile details from\nSlack services.",
       "parameters": [],
       "auth": {
@@ -1100,6 +1126,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:43.846Z",
-  "summary": "Arcade.dev's Slack toolkit enables LLMs to interact with Slack workspaces—reading and filtering messages, retrieving conversation and user metadata, and sending or managing messages and membership. It provides programmatic access to channels, DMs, threads, and user profiles for building automations, search, and integrations.\n\n**Capabilities**\n- Read and filter messages and threads with absolute or relative time windows and pagination for precise retrieval.\n- Query conversation and user metadata and resolve identifiers (IDs, usernames, emails) efficiently for context-aware actions.\n- Send messages, open group DMs, and manage membership/invitations to conversations for orchestration workflows.\n- Enumerate conversations and users for discovery, sync, and auditing tasks.\n\n**OAuth**\nProvider: slack\nScopes: channels:history, channels:read, channels:write, chat:write, groups:history, groups:read, groups:write, im:history, im:read, im:write, mpim:history, mpim:read, users:read, users:read.email"
+  "generatedAt": "2026-02-26T11:25:58.387Z",
+  "summary": "Arcade's Slack toolkit integrates with Slack via OAuth2, enabling programmatic access to conversations, users, threads, and messaging for automation and bots. It exposes tools to read conversation metadata and messages, manage threads, invite participants, and send messages.\n\n**Capabilities**\n- Retrieve and filter conversation and thread messages with absolute or relative time windows.\n- Fetch conversation metadata and resolve participant lists and user profiles at scale.\n- Send messages and threaded replies, open MPIMs, and invite users to channels.\n- List conversations and users for discovery and synchronization.\n\n**OAuth**\nProvider: slack\nScopes: channels:history, channels:read, channels:write, chat:write, groups:history, groups:read, groups:write, im:history, im:read, im:write, mpim:history, mpim:read, users:read, users:read.email"
 }

--- a/toolkit-docs-generator/data/toolkits/spotify.json
+++ b/toolkit-docs-generator/data/toolkits/spotify.json
@@ -1,7 +1,7 @@
 {
   "id": "Spotify",
   "label": "Spotify",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Arcade.dev LLM tools for Spotify",
   "metadata": {
     "category": "entertainment",
@@ -26,7 +26,7 @@
     {
       "name": "AdjustPlaybackPosition",
       "qualifiedName": "Spotify.AdjustPlaybackPosition",
-      "fullyQualifiedName": "Spotify.AdjustPlaybackPosition@1.1.0",
+      "fullyQualifiedName": "Spotify.AdjustPlaybackPosition@1.1.2",
       "description": "Adjust the playback position within the currently playing track.\n\nKnowledge of the current playback state is NOT needed to use this tool as it handles\nclamping the position to valid start/end boundaries to prevent overshooting or negative values.\n\nThis tool allows you to seek to a specific position within the currently playing track.\nYou can either provide an absolute position in milliseconds or a relative position from\nthe current playback position in milliseconds.\n\nNote:\n    Either absolute_position_ms or relative_position_ms must be provided, but not both.",
       "parameters": [
         {
@@ -83,7 +83,7 @@
     {
       "name": "GetAvailableDevices",
       "qualifiedName": "Spotify.GetAvailableDevices",
-      "fullyQualifiedName": "Spotify.GetAvailableDevices@1.1.0",
+      "fullyQualifiedName": "Spotify.GetAvailableDevices@1.1.2",
       "description": "Get the available devices",
       "parameters": [],
       "auth": {
@@ -111,7 +111,7 @@
     {
       "name": "GetCurrentlyPlaying",
       "qualifiedName": "Spotify.GetCurrentlyPlaying",
-      "fullyQualifiedName": "Spotify.GetCurrentlyPlaying@1.1.0",
+      "fullyQualifiedName": "Spotify.GetCurrentlyPlaying@1.1.2",
       "description": "Get information about the user's currently playing track",
       "parameters": [],
       "auth": {
@@ -139,7 +139,7 @@
     {
       "name": "GetPlaybackState",
       "qualifiedName": "Spotify.GetPlaybackState",
-      "fullyQualifiedName": "Spotify.GetPlaybackState@1.1.0",
+      "fullyQualifiedName": "Spotify.GetPlaybackState@1.1.2",
       "description": "Get information about the user's current playback state,\nincluding track or episode, and active device.\nThis tool does not perform any actions. Use other tools to control playback.",
       "parameters": [],
       "auth": {
@@ -167,7 +167,7 @@
     {
       "name": "GetTrackFromId",
       "qualifiedName": "Spotify.GetTrackFromId",
-      "fullyQualifiedName": "Spotify.GetTrackFromId@1.1.0",
+      "fullyQualifiedName": "Spotify.GetTrackFromId@1.1.2",
       "description": "Get information about a track",
       "parameters": [
         {
@@ -208,7 +208,7 @@
     {
       "name": "PausePlayback",
       "qualifiedName": "Spotify.PausePlayback",
-      "fullyQualifiedName": "Spotify.PausePlayback@1.1.0",
+      "fullyQualifiedName": "Spotify.PausePlayback@1.1.2",
       "description": "Pause the currently playing track, if any",
       "parameters": [],
       "auth": {
@@ -237,7 +237,7 @@
     {
       "name": "PlayArtistByName",
       "qualifiedName": "Spotify.PlayArtistByName",
-      "fullyQualifiedName": "Spotify.PlayArtistByName@1.1.0",
+      "fullyQualifiedName": "Spotify.PlayArtistByName@1.1.2",
       "description": "Plays a song by an artist and queues four more songs by the same artist",
       "parameters": [
         {
@@ -281,7 +281,7 @@
     {
       "name": "PlayTrackByName",
       "qualifiedName": "Spotify.PlayTrackByName",
-      "fullyQualifiedName": "Spotify.PlayTrackByName@1.1.0",
+      "fullyQualifiedName": "Spotify.PlayTrackByName@1.1.2",
       "description": "Plays a song by name",
       "parameters": [
         {
@@ -338,7 +338,7 @@
     {
       "name": "ResumePlayback",
       "qualifiedName": "Spotify.ResumePlayback",
-      "fullyQualifiedName": "Spotify.ResumePlayback@1.1.0",
+      "fullyQualifiedName": "Spotify.ResumePlayback@1.1.2",
       "description": "Resume the currently playing track, if any",
       "parameters": [],
       "auth": {
@@ -367,7 +367,7 @@
     {
       "name": "Search",
       "qualifiedName": "Spotify.Search",
-      "fullyQualifiedName": "Spotify.Search@1.1.0",
+      "fullyQualifiedName": "Spotify.Search@1.1.2",
       "description": "Search Spotify catalog information\n\nExplanation of the q parameter:\n    You can narrow down your search using field filters.\n    Available filters are album, artist, track, year, upc, tag:hipster, tag:new, isrc, and\n    genre. Each field filter only applies to certain result types.\n\n    The artist and year filters can be used while searching albums, artists and tracks.\n    You can filter on a single year or a range (e.g. 1955-1960).\n    The album filter can be used while searching albums and tracks.\n    The genre filter can be used while searching artists and tracks.\n    The isrc and track filters can be used while searching tracks.\n    The upc, tag:new and tag:hipster filters can only be used while searching albums.\n    The tag:new filter will return albums released in the past two weeks and tag:hipster\n    can be used to return only albums with the lowest 10% popularity.\n\n    Example: q=\"remaster track:Doxy artist:Miles Davis\"",
       "parameters": [
         {
@@ -447,7 +447,7 @@
     {
       "name": "SkipToNextTrack",
       "qualifiedName": "Spotify.SkipToNextTrack",
-      "fullyQualifiedName": "Spotify.SkipToNextTrack@1.1.0",
+      "fullyQualifiedName": "Spotify.SkipToNextTrack@1.1.2",
       "description": "Skip to the next track in the user's queue, if any",
       "parameters": [],
       "auth": {
@@ -476,7 +476,7 @@
     {
       "name": "SkipToPreviousTrack",
       "qualifiedName": "Spotify.SkipToPreviousTrack",
-      "fullyQualifiedName": "Spotify.SkipToPreviousTrack@1.1.0",
+      "fullyQualifiedName": "Spotify.SkipToPreviousTrack@1.1.2",
       "description": "Skip to the previous track in the user's queue, if any",
       "parameters": [],
       "auth": {
@@ -505,7 +505,7 @@
     {
       "name": "StartTracksPlaybackById",
       "qualifiedName": "Spotify.StartTracksPlaybackById",
-      "fullyQualifiedName": "Spotify.StartTracksPlaybackById@1.1.0",
+      "fullyQualifiedName": "Spotify.StartTracksPlaybackById@1.1.2",
       "description": "Start playback of a list of tracks (songs)",
       "parameters": [
         {
@@ -575,6 +575,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:36.166Z",
+  "generatedAt": "2026-02-26T11:25:47.079Z",
   "summary": "The Arcade toolkit for Spotify empowers developers to integrate with Spotify's music streaming services seamlessly. It enables a variety of playback functionalities and retrieval of music data.\n\n**Capabilities**\n- Control playback by adjusting position, pausing, and resuming tracks.\n- Access information on available devices and currently playing tracks.\n- Search the Spotify catalog with advanced filtering options.\n- Queue and play tracks or albums based on artist, name, or ID.\n\n**OAuth**\n- Auth is via OAuth2 with provider Spotify.\n- Required scopes include `user-modify-playback-state`, `user-read-currently-playing`, and `user-read-playback-state`."
 }

--- a/toolkit-docs-generator/data/toolkits/stripe.json
+++ b/toolkit-docs-generator/data/toolkits/stripe.json
@@ -1,7 +1,7 @@
 {
   "id": "Stripe",
   "label": "Stripe",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Arcade.dev LLM tools for Stripe",
   "metadata": {
     "category": "payments",
@@ -18,7 +18,7 @@
     {
       "name": "CreateBillingPortalSession",
       "qualifiedName": "Stripe.CreateBillingPortalSession",
-      "fullyQualifiedName": "Stripe.CreateBillingPortalSession@1.1.0",
+      "fullyQualifiedName": "Stripe.CreateBillingPortalSession@1.1.2",
       "description": "This tool will create a billing portal session.",
       "parameters": [
         {
@@ -74,7 +74,7 @@
     {
       "name": "CreateCustomer",
       "qualifiedName": "Stripe.CreateCustomer",
-      "fullyQualifiedName": "Stripe.CreateCustomer@1.1.0",
+      "fullyQualifiedName": "Stripe.CreateCustomer@1.1.2",
       "description": "This tool will create a customer in Stripe.",
       "parameters": [
         {
@@ -130,7 +130,7 @@
     {
       "name": "CreateInvoice",
       "qualifiedName": "Stripe.CreateInvoice",
-      "fullyQualifiedName": "Stripe.CreateInvoice@1.1.0",
+      "fullyQualifiedName": "Stripe.CreateInvoice@1.1.2",
       "description": "This tool will create an invoice in Stripe.",
       "parameters": [
         {
@@ -186,7 +186,7 @@
     {
       "name": "CreateInvoiceItem",
       "qualifiedName": "Stripe.CreateInvoiceItem",
-      "fullyQualifiedName": "Stripe.CreateInvoiceItem@1.1.0",
+      "fullyQualifiedName": "Stripe.CreateInvoiceItem@1.1.2",
       "description": "This tool will create an invoice item in Stripe.",
       "parameters": [
         {
@@ -255,7 +255,7 @@
     {
       "name": "CreatePaymentLink",
       "qualifiedName": "Stripe.CreatePaymentLink",
-      "fullyQualifiedName": "Stripe.CreatePaymentLink@1.1.0",
+      "fullyQualifiedName": "Stripe.CreatePaymentLink@1.1.2",
       "description": "This tool will create a payment link in Stripe.",
       "parameters": [
         {
@@ -311,7 +311,7 @@
     {
       "name": "CreatePrice",
       "qualifiedName": "Stripe.CreatePrice",
-      "fullyQualifiedName": "Stripe.CreatePrice@1.1.0",
+      "fullyQualifiedName": "Stripe.CreatePrice@1.1.2",
       "description": "This tool will create a price in Stripe. If a product has not already been",
       "parameters": [
         {
@@ -380,7 +380,7 @@
     {
       "name": "CreateProduct",
       "qualifiedName": "Stripe.CreateProduct",
-      "fullyQualifiedName": "Stripe.CreateProduct@1.1.0",
+      "fullyQualifiedName": "Stripe.CreateProduct@1.1.2",
       "description": "This tool will create a product in Stripe.",
       "parameters": [
         {
@@ -436,7 +436,7 @@
     {
       "name": "CreateRefund",
       "qualifiedName": "Stripe.CreateRefund",
-      "fullyQualifiedName": "Stripe.CreateRefund@1.1.0",
+      "fullyQualifiedName": "Stripe.CreateRefund@1.1.2",
       "description": "This tool will refund a payment intent in Stripe.",
       "parameters": [
         {
@@ -492,7 +492,7 @@
     {
       "name": "FinalizeInvoice",
       "qualifiedName": "Stripe.FinalizeInvoice",
-      "fullyQualifiedName": "Stripe.FinalizeInvoice@1.1.0",
+      "fullyQualifiedName": "Stripe.FinalizeInvoice@1.1.2",
       "description": "This tool will finalize an invoice in Stripe.",
       "parameters": [
         {
@@ -535,7 +535,7 @@
     {
       "name": "ListCustomers",
       "qualifiedName": "Stripe.ListCustomers",
-      "fullyQualifiedName": "Stripe.ListCustomers@1.1.0",
+      "fullyQualifiedName": "Stripe.ListCustomers@1.1.2",
       "description": "This tool will fetch a list of Customers from Stripe.",
       "parameters": [
         {
@@ -591,7 +591,7 @@
     {
       "name": "ListInvoices",
       "qualifiedName": "Stripe.ListInvoices",
-      "fullyQualifiedName": "Stripe.ListInvoices@1.1.0",
+      "fullyQualifiedName": "Stripe.ListInvoices@1.1.2",
       "description": "This tool will list invoices in Stripe.",
       "parameters": [
         {
@@ -647,7 +647,7 @@
     {
       "name": "ListPaymentIntents",
       "qualifiedName": "Stripe.ListPaymentIntents",
-      "fullyQualifiedName": "Stripe.ListPaymentIntents@1.1.0",
+      "fullyQualifiedName": "Stripe.ListPaymentIntents@1.1.2",
       "description": "This tool will list payment intents in Stripe.",
       "parameters": [
         {
@@ -703,7 +703,7 @@
     {
       "name": "ListPrices",
       "qualifiedName": "Stripe.ListPrices",
-      "fullyQualifiedName": "Stripe.ListPrices@1.1.0",
+      "fullyQualifiedName": "Stripe.ListPrices@1.1.2",
       "description": "This tool will fetch a list of Prices from Stripe.",
       "parameters": [
         {
@@ -759,7 +759,7 @@
     {
       "name": "ListProducts",
       "qualifiedName": "Stripe.ListProducts",
-      "fullyQualifiedName": "Stripe.ListProducts@1.1.0",
+      "fullyQualifiedName": "Stripe.ListProducts@1.1.2",
       "description": "This tool will fetch a list of Products from Stripe.",
       "parameters": [
         {
@@ -802,7 +802,7 @@
     {
       "name": "RetrieveBalance",
       "qualifiedName": "Stripe.RetrieveBalance",
-      "fullyQualifiedName": "Stripe.RetrieveBalance@1.1.0",
+      "fullyQualifiedName": "Stripe.RetrieveBalance@1.1.2",
       "description": "This tool will retrieve the balance from Stripe. It takes no input.",
       "parameters": [],
       "auth": null,
@@ -838,6 +838,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:36.194Z",
+  "generatedAt": "2026-02-26T11:25:47.080Z",
   "summary": "Arcade.dev provides a powerful toolkit for integrating with Stripe, enabling seamless management of billing, customer data, and payment processes. This toolkit simplifies common tasks, making it easier for developers to leverage Stripe's capabilities.\n\n### Capabilities\n- Create and manage customers, products, and prices.\n- Generate invoices and billing portal sessions effortlessly.\n- Retrieve and list pertinent data such as invoices and payment intents.\n- Facilitate refunds and manage financial transactions seamlessly.\n\n### Secrets\n- **API Key**: Use the `STRIPE_SECRET_KEY` for authentication when interacting with the Stripe API."
 }

--- a/toolkit-docs-generator/data/toolkits/walmart.json
+++ b/toolkit-docs-generator/data/toolkits/walmart.json
@@ -1,7 +1,7 @@
 {
   "id": "Walmart",
   "label": "Walmart",
-  "version": "3.1.0",
+  "version": "3.1.2",
   "description": "Arcade.dev LLM tools for searching for products sold by Walmart",
   "metadata": {
     "category": "search",
@@ -18,7 +18,7 @@
     {
       "name": "GetProductDetails",
       "qualifiedName": "Walmart.GetProductDetails",
-      "fullyQualifiedName": "Walmart.GetProductDetails@3.1.0",
+      "fullyQualifiedName": "Walmart.GetProductDetails@3.1.2",
       "description": "Get product details from Walmart.",
       "parameters": [
         {
@@ -61,7 +61,7 @@
     {
       "name": "SearchProducts",
       "qualifiedName": "Walmart.SearchProducts",
-      "fullyQualifiedName": "Walmart.SearchProducts@3.1.0",
+      "fullyQualifiedName": "Walmart.SearchProducts@3.1.2",
       "description": "Search Walmart products using SerpAPI.",
       "parameters": [
         {
@@ -177,6 +177,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:51.560Z",
+  "generatedAt": "2026-02-26T11:25:47.082Z",
   "summary": "Walmart's Arcade toolkit empowers developers to seamlessly integrate product search functionalities and detailed product information retrieval from Walmart. This toolkit streamlines access to Walmart's extensive product catalog, enabling enhanced user experiences and effective e-commerce solutions.\n\n**Capabilities**  \n- Retrieve comprehensive product details from Walmart's catalog  \n- Efficiently search for products with relevant filters  \n- Enhance e-commerce applications with real-time data  \n- Facilitate user-friendly product discovery  \n\n**OAuth**  \n- No OAuth required; integrates easily with an API key.  \n\n**Secrets**  \n- Requires an API key for authentication.  \n  - Example: SERP_API_KEY for product search functionality."
 }

--- a/toolkit-docs-generator/data/toolkits/x.json
+++ b/toolkit-docs-generator/data/toolkits/x.json
@@ -1,7 +1,7 @@
 {
   "id": "X",
   "label": "X",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "description": "Arcade.dev LLM tools for X (Twitter)",
   "metadata": {
     "category": "social",
@@ -26,7 +26,7 @@
     {
       "name": "DeleteTweetById",
       "qualifiedName": "X.DeleteTweetById",
-      "fullyQualifiedName": "X.DeleteTweetById@1.4.0",
+      "fullyQualifiedName": "X.DeleteTweetById@1.4.2",
       "description": "Delete a tweet on X (Twitter).",
       "parameters": [
         {
@@ -71,7 +71,7 @@
     {
       "name": "LookupSingleUserByUsername",
       "qualifiedName": "X.LookupSingleUserByUsername",
-      "fullyQualifiedName": "X.LookupSingleUserByUsername@1.4.0",
+      "fullyQualifiedName": "X.LookupSingleUserByUsername@1.4.2",
       "description": "Look up a user on X (Twitter) by their username.",
       "parameters": [
         {
@@ -115,7 +115,7 @@
     {
       "name": "LookupTweetById",
       "qualifiedName": "X.LookupTweetById",
-      "fullyQualifiedName": "X.LookupTweetById@1.4.0",
+      "fullyQualifiedName": "X.LookupTweetById@1.4.2",
       "description": "Look up a tweet on X (Twitter) by tweet ID.",
       "parameters": [
         {
@@ -159,7 +159,7 @@
     {
       "name": "PostTweet",
       "qualifiedName": "X.PostTweet",
-      "fullyQualifiedName": "X.PostTweet@1.4.0",
+      "fullyQualifiedName": "X.PostTweet@1.4.2",
       "description": "Post a tweet to X (Twitter).\n\nIMPORTANT NOTE:\nUse this tool ONLY when posting a tweet that is not a reply.\nIf you need to reply to a tweet, use the ReplyToTweet tool instead.\nIf you need to quote a tweet, you must include the quote_tweet_id parameter.",
       "parameters": [
         {
@@ -217,7 +217,7 @@
     {
       "name": "ReplyToTweet",
       "qualifiedName": "X.ReplyToTweet",
-      "fullyQualifiedName": "X.ReplyToTweet@1.4.0",
+      "fullyQualifiedName": "X.ReplyToTweet@1.4.2",
       "description": "Reply to a tweet on X (Twitter).\n\nIMPORTANT NOTE:\nUse this tool ONLY when replying to a tweet directly.\nIf you need to post a tweet that is not a reply, use the PostTweet tool instead.\nIf you need to quote a tweet on your reply, you must include the quote_tweet_id parameter.",
       "parameters": [
         {
@@ -288,7 +288,7 @@
     {
       "name": "SearchRecentTweetsByKeywords",
       "qualifiedName": "X.SearchRecentTweetsByKeywords",
-      "fullyQualifiedName": "X.SearchRecentTweetsByKeywords@1.4.0",
+      "fullyQualifiedName": "X.SearchRecentTweetsByKeywords@1.4.2",
       "description": "Search for recent tweets (last 7 days) on X (Twitter) by required keywords and phrases.\nIncludes replies and reposts.\nOne of the following input parameters MUST be provided: keywords, phrases",
       "parameters": [
         {
@@ -380,7 +380,7 @@
     {
       "name": "SearchRecentTweetsByUsername",
       "qualifiedName": "X.SearchRecentTweetsByUsername",
-      "fullyQualifiedName": "X.SearchRecentTweetsByUsername@1.4.0",
+      "fullyQualifiedName": "X.SearchRecentTweetsByUsername@1.4.2",
       "description": "Search for recent tweets (last 7 days) on X (Twitter) by username.\nIncludes replies and reposts.",
       "parameters": [
         {
@@ -450,7 +450,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "X.WhoAmI",
-      "fullyQualifiedName": "X.WhoAmI@1.4.0",
+      "fullyQualifiedName": "X.WhoAmI@1.4.2",
       "description": "Get information about the authenticated X (Twitter) user.\n\nReturns the current user's profile including their username, name, description,\nfollower counts, and other account information.",
       "parameters": [],
       "auth": {
@@ -480,6 +480,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:51.561Z",
+  "generatedAt": "2026-02-26T11:25:47.082Z",
   "summary": "X provider toolkit enables programmatic access to X (Twitter) for reading and managing tweets and user profiles, optimized for LLM-driven flows. It supports posting, replying, deleting, searching recent tweets, and retrieving the authenticated account.\n\n**Capabilities**\n- Query and filter recent tweets and user timelines with keyword and username search.\n- Compose and manage tweet lifecycle: create non-reply posts, reply/quote responsibly, and delete owned tweets.\n- Access authenticated identity and act on behalf of the user within granted scopes.\n- Enforce action constraints and parameter validation (e.g., use Post for non-replies, Reply for replies, include quote_tweet_id when quoting).\n\n**OAuth**\nProvider: x\nScopes: tweet.read, tweet.write, users.read"
 }

--- a/toolkit-docs-generator/data/toolkits/youtube.json
+++ b/toolkit-docs-generator/data/toolkits/youtube.json
@@ -1,7 +1,7 @@
 {
   "id": "Youtube",
   "label": "Youtube",
-  "version": "3.2.0",
+  "version": "3.2.2",
   "description": "Arcade.dev LLM tools for searching for YouTube videos&#34;",
   "metadata": {
     "category": "search",
@@ -18,7 +18,7 @@
     {
       "name": "GetYoutubeVideoDetails",
       "qualifiedName": "Youtube.GetYoutubeVideoDetails",
-      "fullyQualifiedName": "Youtube.GetYoutubeVideoDetails@3.2.0",
+      "fullyQualifiedName": "Youtube.GetYoutubeVideoDetails@3.2.2",
       "description": "Get details about a YouTube video.",
       "parameters": [
         {
@@ -87,7 +87,7 @@
     {
       "name": "SearchForVideos",
       "qualifiedName": "Youtube.SearchForVideos",
-      "fullyQualifiedName": "Youtube.SearchForVideos@3.2.0",
+      "fullyQualifiedName": "Youtube.SearchForVideos@3.2.2",
       "description": "Search for YouTube videos related to the query.",
       "parameters": [
         {
@@ -170,6 +170,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:52.891Z",
+  "generatedAt": "2026-02-26T11:25:47.084Z",
   "summary": "Arcade.dev provides a toolkit for interacting with YouTube, enabling developers to search for videos and retrieve video details seamlessly. This toolkit simplifies tasks related to enhancing applications with YouTube content.\n\n**Capabilities**  \n- Search for videos based on specific queries  \n- Retrieve detailed information about YouTube videos  \n- Supports integration of YouTube functionalities into applications  \n- Allows quick access to video data for enhanced user experiences  \n\n**OAuth**  \n- No OAuth authentication required. \n\n**Secrets**  \n- API Key: Use the `SERP_API_KEY` to authenticate API requests for video data."
 }

--- a/toolkit-docs-generator/data/toolkits/zendesk.json
+++ b/toolkit-docs-generator/data/toolkits/zendesk.json
@@ -1,7 +1,7 @@
 {
   "id": "Zendesk",
   "label": "Zendesk",
-  "version": "0.3.1",
+  "version": "0.5.0",
   "description": "",
   "metadata": {
     "category": "customer-support",
@@ -9,20 +9,23 @@
     "isBYOC": false,
     "isPro": false,
     "type": "arcade",
-    "docsLink": "https://docs.arcade.dev/en/mcp-servers/customer-support/zendesk",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/customer-support/zendesk",
     "isComingSoon": false,
     "isHidden": false
   },
   "auth": {
     "type": "oauth2",
     "providerId": "zendesk",
-    "allScopes": ["read", "tickets:write"]
+    "allScopes": [
+      "read",
+      "tickets:write"
+    ]
   },
   "tools": [
     {
       "name": "AddTicketComment",
       "qualifiedName": "Zendesk.AddTicketComment",
-      "fullyQualifiedName": "Zendesk.AddTicketComment@0.3.1",
+      "fullyQualifiedName": "Zendesk.AddTicketComment@0.5.0",
       "description": "Add a comment to an existing Zendesk ticket.\n\nThe returned ticket object includes an 'html_url' field with the direct link\nto view the ticket in Zendesk.",
       "parameters": [
         {
@@ -53,9 +56,13 @@
       "auth": {
         "providerId": "zendesk",
         "providerType": "oauth2",
-        "scopes": ["tickets:write"]
+        "scopes": [
+          "tickets:write"
+        ]
       },
-      "secrets": ["ZENDESK_SUBDOMAIN"],
+      "secrets": [
+        "ZENDESK_SUBDOMAIN"
+      ],
       "secretsInfo": [
         {
           "name": "ZENDESK_SUBDOMAIN",
@@ -93,7 +100,7 @@
     {
       "name": "GetTicketComments",
       "qualifiedName": "Zendesk.GetTicketComments",
-      "fullyQualifiedName": "Zendesk.GetTicketComments@0.3.1",
+      "fullyQualifiedName": "Zendesk.GetTicketComments@0.5.0",
       "description": "Get all comments for a specific Zendesk ticket, including the original description.\n\nThe first comment is always the ticket's original description/content.\nSubsequent comments show the conversation history.\n\nEach comment includes:\n- author_id: ID of the comment author\n- body: The comment text\n- created_at: Timestamp when comment was created\n- public: Whether the comment is public or internal\n- attachments: List of file attachments (if any) with file_name, content_url, size, etc.",
       "parameters": [
         {
@@ -108,9 +115,13 @@
       "auth": {
         "providerId": "zendesk",
         "providerType": "oauth2",
-        "scopes": ["read"]
+        "scopes": [
+          "read"
+        ]
       },
-      "secrets": ["ZENDESK_SUBDOMAIN"],
+      "secrets": [
+        "ZENDESK_SUBDOMAIN"
+      ],
       "secretsInfo": [
         {
           "name": "ZENDESK_SUBDOMAIN",
@@ -138,7 +149,7 @@
     {
       "name": "ListTickets",
       "qualifiedName": "Zendesk.ListTickets",
-      "fullyQualifiedName": "Zendesk.ListTickets@0.3.1",
+      "fullyQualifiedName": "Zendesk.ListTickets@0.5.0",
       "description": "List tickets from your Zendesk account with offset-based pagination.\n\nBy default, returns tickets sorted by ID with newest tickets first (desc).\n\nEach ticket in the response includes an 'html_url' field with the direct link\nto view the ticket in Zendesk.\n\nPAGINATION:\n- The response includes 'next_offset' when more results are available\n- To fetch the next batch, simply pass the 'next_offset' value as the 'offset' parameter\n- If 'next_offset' is not present, you've reached the end of available results",
       "parameters": [
         {
@@ -146,7 +157,13 @@
           "type": "string",
           "required": false,
           "description": "The status of tickets to filter by. Defaults to 'open'",
-          "enum": ["new", "open", "pending", "solved", "closed"],
+          "enum": [
+            "new",
+            "open",
+            "pending",
+            "solved",
+            "closed"
+          ],
           "inferrable": true
         },
         {
@@ -170,16 +187,23 @@
           "type": "string",
           "required": false,
           "description": "Sort order for tickets by ID. 'asc' returns oldest first, 'desc' returns newest first. Defaults to 'desc'",
-          "enum": ["asc", "desc"],
+          "enum": [
+            "asc",
+            "desc"
+          ],
           "inferrable": true
         }
       ],
       "auth": {
         "providerId": "zendesk",
         "providerType": "oauth2",
-        "scopes": ["read"]
+        "scopes": [
+          "read"
+        ]
       },
-      "secrets": ["ZENDESK_SUBDOMAIN"],
+      "secrets": [
+        "ZENDESK_SUBDOMAIN"
+      ],
       "secretsInfo": [
         {
           "name": "ZENDESK_SUBDOMAIN",
@@ -222,7 +246,7 @@
     {
       "name": "MarkTicketSolved",
       "qualifiedName": "Zendesk.MarkTicketSolved",
-      "fullyQualifiedName": "Zendesk.MarkTicketSolved@0.3.1",
+      "fullyQualifiedName": "Zendesk.MarkTicketSolved@0.5.0",
       "description": "Mark a Zendesk ticket as solved, optionally with a final comment.\n\nThe returned ticket object includes an 'html_url' field with the direct link\nto view the ticket in Zendesk.",
       "parameters": [
         {
@@ -253,9 +277,13 @@
       "auth": {
         "providerId": "zendesk",
         "providerType": "oauth2",
-        "scopes": ["tickets:write"]
+        "scopes": [
+          "tickets:write"
+        ]
       },
-      "secrets": ["ZENDESK_SUBDOMAIN"],
+      "secrets": [
+        "ZENDESK_SUBDOMAIN"
+      ],
       "secretsInfo": [
         {
           "name": "ZENDESK_SUBDOMAIN",
@@ -293,7 +321,7 @@
     {
       "name": "SearchArticles",
       "qualifiedName": "Zendesk.SearchArticles",
-      "fullyQualifiedName": "Zendesk.SearchArticles@0.3.1",
+      "fullyQualifiedName": "Zendesk.SearchArticles@0.5.0",
       "description": "Search for Help Center articles in your Zendesk knowledge base.\n\nThis tool searches specifically for published knowledge base articles that provide\nsolutions and guidance to users. At least one search parameter (query or label_names)\nmust be provided.\n\nPAGINATION:\n- The response includes 'next_offset' when more results are available\n- To fetch the next batch, simply pass the 'next_offset' value as the 'offset' parameter\n- If 'next_offset' is not present, you've reached the end of available results\n- The tool automatically handles fetching from the correct page based on your offset\n\nIMPORTANT: ALL FILTERS CAN BE COMBINED IN A SINGLE CALL\nYou can combine multiple filters (query, labels, dates) in one search request.\nDo NOT make separate tool calls - combine all relevant filters together.",
       "parameters": [
         {
@@ -342,7 +370,10 @@
           "type": "string",
           "required": false,
           "description": "Field to sort articles by. Defaults to relevance according to the search query",
-          "enum": ["created_at", "relevance"],
+          "enum": [
+            "created_at",
+            "relevance"
+          ],
           "inferrable": true
         },
         {
@@ -350,7 +381,10 @@
           "type": "string",
           "required": false,
           "description": "Sort order direction. Defaults to descending",
-          "enum": ["asc", "desc"],
+          "enum": [
+            "asc",
+            "desc"
+          ],
           "inferrable": true
         },
         {
@@ -389,9 +423,13 @@
       "auth": {
         "providerId": "zendesk",
         "providerType": "oauth2",
-        "scopes": ["read"]
+        "scopes": [
+          "read"
+        ]
       },
-      "secrets": ["ZENDESK_SUBDOMAIN"],
+      "secrets": [
+        "ZENDESK_SUBDOMAIN"
+      ],
       "secretsInfo": [
         {
           "name": "ZENDESK_SUBDOMAIN",
@@ -412,7 +450,10 @@
             "required": false
           },
           "label_names": {
-            "value": ["setup", "account"],
+            "value": [
+              "setup",
+              "account"
+            ],
             "type": "array",
             "required": false
           },
@@ -469,15 +510,19 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Zendesk.WhoAmI",
-      "fullyQualifiedName": "Zendesk.WhoAmI@0.3.1",
+      "fullyQualifiedName": "Zendesk.WhoAmI@0.5.0",
       "description": "Get comprehensive user profile and Zendesk account information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, role, organization details, and Zendesk account context.",
       "parameters": [],
       "auth": {
         "providerId": "zendesk",
         "providerType": "oauth2",
-        "scopes": ["read"]
+        "scopes": [
+          "read"
+        ]
       },
-      "secrets": ["ZENDESK_SUBDOMAIN"],
+      "secrets": [
+        "ZENDESK_SUBDOMAIN"
+      ],
       "secretsInfo": [
         {
           "name": "ZENDESK_SUBDOMAIN",
@@ -500,6 +545,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-01-26T17:47:02.796Z",
+  "generatedAt": "2026-02-26T11:25:47.084Z",
   "summary": "Arcade's Zendesk toolkit enables seamless integration with Zendesk's customer service platform, allowing developers to interact with tickets and knowledge base articles efficiently.\n\n**Capabilities**  \n- Retrieve and manage ticket comments and statuses.  \n- List and paginate through tickets for dynamic retrieval.  \n- Search for Help Center articles using various parameters.  \n- Fetch comprehensive user profiles and account information.  \n\n**OAuth**  \n- Auth Type: OAuth2  \n- Provider: Unknown  \n- Scopes: read, tickets:write  \n\n**Secrets**  \n- Secret types: unknown, api_key  \n- Example: ZENDESK_SUBDOMAIN  "
 }

--- a/toolkit-docs-generator/data/toolkits/zoom.json
+++ b/toolkit-docs-generator/data/toolkits/zoom.json
@@ -1,7 +1,7 @@
 {
   "id": "Zoom",
   "label": "Zoom",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Arcade.dev LLM tools for Zoom",
   "metadata": {
     "category": "social",
@@ -25,7 +25,7 @@
     {
       "name": "GetMeetingInvitation",
       "qualifiedName": "Zoom.GetMeetingInvitation",
-      "fullyQualifiedName": "Zoom.GetMeetingInvitation@1.1.0",
+      "fullyQualifiedName": "Zoom.GetMeetingInvitation@1.1.2",
       "description": "Retrieve the invitation note for a specific Zoom meeting.",
       "parameters": [
         {
@@ -68,7 +68,7 @@
     {
       "name": "ListUpcomingMeetings",
       "qualifiedName": "Zoom.ListUpcomingMeetings",
-      "fullyQualifiedName": "Zoom.ListUpcomingMeetings@1.1.0",
+      "fullyQualifiedName": "Zoom.ListUpcomingMeetings@1.1.2",
       "description": "List a Zoom user's upcoming meetings within the next 24 hours.",
       "parameters": [
         {
@@ -112,6 +112,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-25T11:25:56.497Z",
+  "generatedAt": "2026-02-26T11:25:47.085Z",
   "summary": "Arcade.dev provides a toolkit for integrating with Zoom, enabling developers to leverage its functionalities in applications seamlessly. This toolkit allows for efficient access to Zoom meetings and invitations.\n\n**Capabilities**\n- Retrieve detailed information about specific Zoom meetings.\n- List upcoming meetings for a user within the next 24 hours.\n- Simplify access and interaction with Zoom's meeting management features.\n\n**OAuth**\n- Provider: Zoom  \n- Scopes: meeting:read:invitation, meeting:read:list_upcoming_meetings  \n\n**Secrets**\n- No secret types required for this toolkit."
 }


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/22439846276

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Automated updates to generated toolkit JSON docs (version bumps, timestamps, and minor metadata/secret typing changes) with no code-path logic changes; low risk aside from potential doc/metadata regressions.
> 
> **Overview**
> Updates the generated toolkit docs JSON for multiple MCP servers by bumping toolkit/tool `fullyQualifiedName` versions and refreshing `generatedAt` timestamps.
> 
> Notable metadata tweaks include Bright Data’s `docsLink` path update, adding a generated `summary` while removing its prior custom `documentationChunks`, and correcting `BRIGHTDATA_ZONE` secret type to `token` plus updating examples/sample parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73fb1d0150661e305129defaabd34947e6137998. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->