### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/app/en/resources/integrations/databases/_meta.tsx
+++ b/app/en/resources/integrations/databases/_meta.tsx
@@ -1,6 +1,26 @@
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {
+  "-- Optimized": {
+    type: "separator",
+    title: "Optimized",
+  },
+  clickhouse: {
+    title: "Clickhouse",
+    href: "/en/resources/integrations/databases/clickhouse",
+  },
+  mongodb: {
+    title: "MongoDB",
+    href: "/en/resources/integrations/databases/mongodb",
+  },
+  postgres: {
+    title: "Postgres",
+    href: "/en/resources/integrations/databases/postgres",
+  },
+  "-- Starter": {
+    type: "separator",
+    title: "Starter",
+  },
   "weaviate-api": {
     title: "Weaviate API",
     href: "/en/resources/integrations/databases/weaviate-api",

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/toolkit-docs-generator/data/toolkits/brightdata.json
+++ b/toolkit-docs-generator/data/toolkits/brightdata.json
@@ -1,7 +1,7 @@
 {
   "id": "Brightdata",
   "label": "Bright Data",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Search, Crawl and Scrape any site, at scale, without getting blocked",
   "metadata": {
     "category": "development",
@@ -18,7 +18,7 @@
     {
       "name": "ScrapeAsMarkdown",
       "qualifiedName": "Brightdata.ScrapeAsMarkdown",
-      "fullyQualifiedName": "Brightdata.ScrapeAsMarkdown@0.4.0",
+      "fullyQualifiedName": "Brightdata.ScrapeAsMarkdown@0.5.0",
       "description": "    Scrape a webpage and return content in Markdown format using Bright Data.\n\n    Examples:\n        scrape_as_markdown(\"https://example.com\") -> \"# Example Page\n\nContent...\"\n        scrape_as_markdown(\"https://news.ycombinator.com\") -> \"# Hacker News\n...\"\n    ",
       "parameters": [
         {
@@ -83,7 +83,7 @@
     {
       "name": "SearchEngine",
       "qualifiedName": "Brightdata.SearchEngine",
-      "fullyQualifiedName": "Brightdata.SearchEngine@0.4.0",
+      "fullyQualifiedName": "Brightdata.SearchEngine@0.5.0",
       "description": "    Search using Google, Bing, or Yandex with advanced parameters using Bright Data.\n\n    Examples:\n        search_engine(\"climate change\") -> \"# Search Results\n\n## Climate Change - Wikipedia\n...\"\n        search_engine(\"Python tutorials\", engine=\"bing\", num_results=5) -> \"# Bing Results\n...\"\n        search_engine(\"cats\", search_type=\"images\", country_code=\"us\") -> \"# Image Results\n...\"\n    ",
       "parameters": [
         {
@@ -281,7 +281,7 @@
     {
       "name": "WebDataFeed",
       "qualifiedName": "Brightdata.WebDataFeed",
-      "fullyQualifiedName": "Brightdata.WebDataFeed@0.4.0",
+      "fullyQualifiedName": "Brightdata.WebDataFeed@0.5.0",
       "description": "Extract structured data from various websites like LinkedIn, Amazon, Instagram, etc.\nNEVER MADE UP LINKS - IF LINKS ARE NEEDED, EXECUTE search_engine FIRST.\nSupported source types:\n- amazon_product, amazon_product_reviews\n- linkedin_person_profile, linkedin_company_profile\n- zoominfo_company_profile\n- instagram_profiles, instagram_posts, instagram_reels, instagram_comments\n- facebook_posts, facebook_marketplace_listings, facebook_company_reviews\n- x_posts\n- zillow_properties_listing\n- booking_hotel_listings\n- youtube_videos\n\nExamples:\n    web_data_feed(\"amazon_product\", \"https://amazon.com/dp/B08N5WRWNW\")\n        -> \"{\"title\": \"Product Name\", ...}\"\n    web_data_feed(\"linkedin_person_profile\", \"https://linkedin.com/in/johndoe\")\n        -> \"{\"name\": \"John Doe\", ...}\"\n    web_data_feed(\n        \"facebook_company_reviews\", \"https://facebook.com/company\", num_of_reviews=50\n    ) -> \"[{\"review\": \"...\", ...}]\"",
       "parameters": [
         {
@@ -411,6 +411,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-26T20:45:10.376Z",
+  "generatedAt": "2026-02-28T11:11:27.185Z",
   "summary": "Bright Data provides a developer toolkit for large-scale web search, crawling, and scraping, enabling reliable extraction of pages and structured data without getting blocked. It supports search queries, content-to-Markdown conversion, and configurable data feeds across many site types.\n\nDesigned for integration into data pipelines and analytics workflows with parameterized feeds and output formats.\n\n**Capabilities**\n- Scale-resistant crawling and scraping with anti-blocking behavior for sustained collection.\n- Flexible search engine queries with advanced parameters across major engines.\n- Transform pages into clean Markdown and emit structured JSON feeds for profiles, products, reviews, listings, and media.\n- Configurable extraction parameters for batching, pagination, and media handling.\n\n**Secrets**\n- API key (BRIGHTDATA_API_KEY) and zone token (BRIGHTDATA_ZONE). Example values: BRIGHTDATA_API_KEY=sk_..., BRIGHTDATA_ZONE=zone123."
 }

--- a/toolkit-docs-generator/data/toolkits/clickhouse.json
+++ b/toolkit-docs-generator/data/toolkits/clickhouse.json
@@ -1,0 +1,399 @@
+{
+  "id": "Clickhouse",
+  "label": "Clickhouse",
+  "version": "0.4.0",
+  "description": "Tools to query and explore a ClickHouse database",
+  "metadata": {
+    "category": "databases",
+    "iconUrl": "https://design-system.arcade.dev/icons/clickhouse.svg",
+    "isBYOC": false,
+    "isPro": false,
+    "type": "community",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/databases/clickhouse",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": null,
+  "tools": [
+    {
+      "name": "DiscoverDatabases",
+      "qualifiedName": "Clickhouse.DiscoverDatabases",
+      "fullyQualifiedName": "Clickhouse.DiscoverDatabases@0.4.0",
+      "description": "Discover all the databases in the ClickHouse database.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "CLICKHOUSE_DATABASE_CONNECTION_STRING"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CLICKHOUSE_DATABASE_CONNECTION_STRING",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "array",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Clickhouse.DiscoverDatabases",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DiscoverSchemas",
+      "qualifiedName": "Clickhouse.DiscoverSchemas",
+      "fullyQualifiedName": "Clickhouse.DiscoverSchemas@0.4.0",
+      "description": "Discover all the schemas in the ClickHouse database.\n\nNote: ClickHouse doesn't have schemas like PostgreSQL, so this returns a default schema name.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "CLICKHOUSE_DATABASE_CONNECTION_STRING"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CLICKHOUSE_DATABASE_CONNECTION_STRING",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "array",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Clickhouse.DiscoverSchemas",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DiscoverTables",
+      "qualifiedName": "Clickhouse.DiscoverTables",
+      "fullyQualifiedName": "Clickhouse.DiscoverTables@0.4.0",
+      "description": "Discover all the tables in the ClickHouse database when the list of tables is not known.\n\nALWAYS use this tool before any other tool that requires a table name.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "CLICKHOUSE_DATABASE_CONNECTION_STRING"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CLICKHOUSE_DATABASE_CONNECTION_STRING",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "array",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Clickhouse.DiscoverTables",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ExecuteSelectQuery",
+      "qualifiedName": "Clickhouse.ExecuteSelectQuery",
+      "fullyQualifiedName": "Clickhouse.ExecuteSelectQuery@0.4.0",
+      "description": "You have a connection to a ClickHouse database.\nExecute a SELECT query and return the results against the ClickHouse database.  No other queries (INSERT, UPDATE, DELETE, etc.) are allowed.\n\nONLY use this tool if you have already loaded the schema of the tables you need to query.  Use the <GetTableSchema> tool to load the schema if not already known.\n\nThe final query will be constructed as follows:\nSELECT {select_query_part} FROM {from_clause} JOIN {join_clause} WHERE {where_clause} HAVING {having_clause} ORDER BY {order_by_clause} LIMIT {limit} OFFSET {offset}\n\nWhen running queries, follow these rules which will help avoid errors:\n* Never \"select *\" from a table.  Always select the columns you need.\n* Always order your results by the most important columns first.  If you aren't sure, order by the primary key.\n* Always use case-insensitive queries to match strings in the query.\n* Always trim strings in the query.\n* Prefer LIKE queries over direct string matches or regex queries.\n* Only join on columns that are indexed or the primary key.  Do not join on arbitrary columns.\n* ClickHouse is case-sensitive, so be careful with table and column names.",
+      "parameters": [
+        {
+          "name": "select_clause",
+          "type": "string",
+          "required": true,
+          "description": "This is the part of the SQL query that comes after the SELECT keyword wish a comma separated list of columns you wish to return.  Do not include the SELECT keyword.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "from_clause",
+          "type": "string",
+          "required": true,
+          "description": "This is the part of the SQL query that comes after the FROM keyword.  Do not include the FROM keyword.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of rows to return.  This is the LIMIT clause of the query.  Default: 100.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "The number of rows to skip.  This is the OFFSET clause of the query.  Default: 0.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "join_clause",
+          "type": "string",
+          "required": false,
+          "description": "This is the part of the SQL query that comes after the JOIN keyword.  Do not include the JOIN keyword.  If no join is needed, leave this blank.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "where_clause",
+          "type": "string",
+          "required": false,
+          "description": "This is the part of the SQL query that comes after the WHERE keyword.  Do not include the WHERE keyword.  If no where clause is needed, leave this blank.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "having_clause",
+          "type": "string",
+          "required": false,
+          "description": "This is the part of the SQL query that comes after the HAVING keyword.  Do not include the HAVING keyword.  If no having clause is needed, leave this blank.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "group_by_clause",
+          "type": "string",
+          "required": false,
+          "description": "This is the part of the SQL query that comes after the GROUP BY keyword.  Do not include the GROUP BY keyword.  If no group by clause is needed, leave this blank.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "order_by_clause",
+          "type": "string",
+          "required": false,
+          "description": "This is the part of the SQL query that comes after the ORDER BY keyword.  Do not include the ORDER BY keyword.  If no order by clause is needed, leave this blank.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "with_clause",
+          "type": "string",
+          "required": false,
+          "description": "This is the part of the SQL query that comes after the WITH keyword when basing the query on a virtual table.  If no WITH clause is needed, leave this blank.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CLICKHOUSE_DATABASE_CONNECTION_STRING"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CLICKHOUSE_DATABASE_CONNECTION_STRING",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "array",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Clickhouse.ExecuteSelectQuery",
+        "parameters": {
+          "select_clause": {
+            "value": "users.id, users.email, orders.order_id, orders.total_amount, orders.created_at",
+            "type": "string",
+            "required": true
+          },
+          "from_clause": {
+            "value": "users",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          },
+          "join_clause": {
+            "value": "INNER JOIN orders ON users.id = orders.user_id",
+            "type": "string",
+            "required": false
+          },
+          "where_clause": {
+            "value": "lower(trim(users.email)) LIKE '%@example.com' AND orders.created_at >= '2025-01-01'",
+            "type": "string",
+            "required": false
+          },
+          "having_clause": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "group_by_clause": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "order_by_clause": {
+            "value": "users.id ASC, orders.created_at DESC",
+            "type": "string",
+            "required": false
+          },
+          "with_clause": {
+            "value": "",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetTableSchema",
+      "qualifiedName": "Clickhouse.GetTableSchema",
+      "fullyQualifiedName": "Clickhouse.GetTableSchema@0.4.0",
+      "description": "Get the schema/structure of a ClickHouse table in the ClickHouse database when the schema is not known, and the name of the table is provided.\n\nThis tool should ALWAYS be used before executing any query.  All tables in the query must be discovered first using the <DiscoverTables> tool.",
+      "parameters": [
+        {
+          "name": "schema_name",
+          "type": "string",
+          "required": true,
+          "description": "The schema to get the table schema of",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "table_name",
+          "type": "string",
+          "required": true,
+          "description": "The table to get the schema of",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CLICKHOUSE_DATABASE_CONNECTION_STRING"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CLICKHOUSE_DATABASE_CONNECTION_STRING",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "array",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Clickhouse.GetTableSchema",
+        "parameters": {
+          "schema_name": {
+            "value": "default",
+            "type": "string",
+            "required": true
+          },
+          "table_name": {
+            "value": "events",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-02-28T11:11:37.453Z",
+  "summary": "ClickHouse toolkit provides tools to explore and query a ClickHouse database, enabling safe schema discovery and read-only SELECT execution. It helps discover databases and tables, inspect table schemas, and run constrained SELECT queries that follow ClickHouse best practices.\n\n**Capabilities**\n- Discover database and table topology and surface a default schema name.\n- Retrieve precise table schemas to drive safe query construction.\n- Execute read-only SELECTs with enforced rules (explicit columns, ordering, indexed joins, case sensitivity).\n- Surface query guidance to avoid common ClickHouse pitfalls.\n\n**Secrets**\nSecret types: password, unknown. Example: CLICKHOUSE_DATABASE_CONNECTION_STRING — a connection string containing host, port, database and credentials (including password)."
+}

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-02-26T20:45:48.204Z",
+  "generatedAt": "2026-02-28T11:12:18.109Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -59,7 +59,7 @@
     {
       "id": "Brightdata",
       "label": "Bright Data",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "category": "development",
       "type": "community",
       "toolCount": 3,
@@ -73,6 +73,15 @@
       "type": "arcade_starter",
       "toolCount": 51,
       "authType": "oauth2"
+    },
+    {
+      "id": "Clickhouse",
+      "label": "Clickhouse",
+      "version": "0.4.0",
+      "category": "databases",
+      "type": "community",
+      "toolCount": 5,
+      "authType": "none"
     },
     {
       "id": "Clickup",
@@ -518,7 +527,7 @@
     {
       "id": "Linkedin",
       "label": "LinkedIn",
-      "version": "0.3.0",
+      "version": "1.1.0",
       "category": "social",
       "type": "arcade",
       "toolCount": 1,
@@ -606,6 +615,15 @@
       "authType": "oauth2"
     },
     {
+      "id": "Mongodb",
+      "label": "MongoDB",
+      "version": "0.4.0",
+      "category": "databases",
+      "type": "community",
+      "toolCount": 6,
+      "authType": "none"
+    },
+    {
       "id": "NotionToolkit",
       "label": "Notion",
       "version": "1.3.2",
@@ -649,6 +667,15 @@
       "type": "arcade_starter",
       "toolCount": 374,
       "authType": "oauth2"
+    },
+    {
+      "id": "Postgres",
+      "label": "Postgres",
+      "version": "0.6.0",
+      "category": "databases",
+      "type": "community",
+      "toolCount": 4,
+      "authType": "none"
     },
     {
       "id": "PosthogApi",
@@ -878,7 +905,7 @@
     {
       "id": "Zendesk",
       "label": "Zendesk",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "category": "customer-support",
       "type": "arcade",
       "toolCount": 6,

--- a/toolkit-docs-generator/data/toolkits/linkedin.json
+++ b/toolkit-docs-generator/data/toolkits/linkedin.json
@@ -1,7 +1,7 @@
 {
   "id": "Linkedin",
   "label": "LinkedIn",
-  "version": "0.3.0",
+  "version": "1.1.0",
   "description": "Arcade.dev LLM tools for LinkedIn",
   "metadata": {
     "category": "social",
@@ -24,7 +24,7 @@
     {
       "name": "CreateTextPost",
       "qualifiedName": "Linkedin.CreateTextPost",
-      "fullyQualifiedName": "Linkedin.CreateTextPost@0.3.0",
+      "fullyQualifiedName": "Linkedin.CreateTextPost@1.1.0",
       "description": "Share a new text post to LinkedIn.",
       "parameters": [
         {
@@ -92,6 +92,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-26T20:45:10.414Z",
+  "generatedAt": "2026-02-28T11:11:27.186Z",
   "summary": "Arcade.dev provides a toolkit for integrating with LinkedIn, enabling developers to streamline interactions with the platform's API. This toolkit allows for the creation of content directly on LinkedIn, enhancing user engagement and social sharing capabilities.\n\n**Capabilities**  \n- Seamless integration with LinkedIn's API for enhanced social interactions.  \n- Efficiently share content such as text posts to drive engagement.  \n- Simplified authentication process through OAuth2, ensuring secure access to user data.  \n\n**OAuth**  \n- Provider: LinkedIn  \n- Scopes: w_member_social  \n\n**Secrets**  \n- No secrets required for use with this toolkit."
 }

--- a/toolkit-docs-generator/data/toolkits/mongodb.json
+++ b/toolkit-docs-generator/data/toolkits/mongodb.json
@@ -1,0 +1,536 @@
+{
+  "id": "Mongodb",
+  "label": "MongoDB",
+  "version": "0.4.0",
+  "description": "Tools to query and explore a MongoDB database",
+  "metadata": {
+    "category": "databases",
+    "iconUrl": "https://design-system.arcade.dev/icons/mongodb.svg",
+    "isBYOC": false,
+    "isPro": false,
+    "type": "community",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/databases/mongodb",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": null,
+  "tools": [
+    {
+      "name": "AggregateDocuments",
+      "qualifiedName": "Mongodb.AggregateDocuments",
+      "fullyQualifiedName": "Mongodb.AggregateDocuments@0.4.0",
+      "description": "Execute a MongoDB aggregation pipeline on a collection.\n\nONLY use this tool if you have already loaded the schema of the collection you need to query.\nUse the <get_collection_schema> tool to load the schema if not already known.\n\nReturns a list of JSON strings, where each string represents a result document from the aggregation (tools cannot return complex types).\n\nAggregation pipelines allow for complex data processing including:\n* $match - filter documents\n* $group - group documents and perform calculations\n* $project - reshape documents\n* $sort - sort documents\n* $limit - limit results\n* $lookup - join with other collections\n* And many more stages",
+      "parameters": [
+        {
+          "name": "database_name",
+          "type": "string",
+          "required": true,
+          "description": "The database name to query",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "collection_name",
+          "type": "string",
+          "required": true,
+          "description": "The collection name to query",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "pipeline",
+          "type": "array",
+          "innerType": "string",
+          "required": true,
+          "description": "MongoDB aggregation pipeline as a list of JSON strings, each representing a stage. Example: ['{\"$match\": {\"status\": \"active\"}}', '{\"$group\": {\"_id\": \"$category\", \"count\": {\"$sum\": 1}}}']",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of results to return from the aggregation. Default: 1000.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "MONGODB_CONNECTION_STRING"
+      ],
+      "secretsInfo": [
+        {
+          "name": "MONGODB_CONNECTION_STRING",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "array",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Mongodb.AggregateDocuments",
+        "parameters": {
+          "database_name": {
+            "value": "sales_db",
+            "type": "string",
+            "required": true
+          },
+          "collection_name": {
+            "value": "orders",
+            "type": "string",
+            "required": true
+          },
+          "pipeline": {
+            "value": [
+              "{\"$match\": {\"status\": \"completed\", \"total\": {\"$gt\": 100}}}",
+              "{\"$group\": {\"_id\": \"$customerId\", \"ordersCount\": {\"$sum\": 1}, \"totalSpent\": {\"$sum\": \"$total\"}}}",
+              "{\"$project\": {\"customerId\": \"$_id\", \"ordersCount\": 1, \"totalSpent\": 1, \"_id\": 0}}",
+              "{\"$sort\": {\"totalSpent\": -1}}"
+            ],
+            "type": "array",
+            "required": true
+          },
+          "limit": {
+            "value": 10,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CountDocuments",
+      "qualifiedName": "Mongodb.CountDocuments",
+      "fullyQualifiedName": "Mongodb.CountDocuments@0.4.0",
+      "description": "Count documents in a MongoDB collection matching the given filter.",
+      "parameters": [
+        {
+          "name": "database_name",
+          "type": "string",
+          "required": true,
+          "description": "The database name to query",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "collection_name",
+          "type": "string",
+          "required": true,
+          "description": "The collection name to query",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "filter_dict",
+          "type": "string",
+          "required": false,
+          "description": "MongoDB filter/query as JSON string. Leave None for no filter (count all documents). Example: '{\"status\": \"active\"}'",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "MONGODB_CONNECTION_STRING"
+      ],
+      "secretsInfo": [
+        {
+          "name": "MONGODB_CONNECTION_STRING",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "integer",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Mongodb.CountDocuments",
+        "parameters": {
+          "database_name": {
+            "value": "sales_db",
+            "type": "string",
+            "required": true
+          },
+          "collection_name": {
+            "value": "customers",
+            "type": "string",
+            "required": true
+          },
+          "filter_dict": {
+            "value": "{\"status\": \"active\", \"signup_date\": {\"$gte\": \"2023-01-01\"}}",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DiscoverCollections",
+      "qualifiedName": "Mongodb.DiscoverCollections",
+      "fullyQualifiedName": "Mongodb.DiscoverCollections@0.4.0",
+      "description": "Discover all the collections in the MongoDB database when the list of collections is not known.\n\nALWAYS use this tool before any other tool that requires a collection name.",
+      "parameters": [
+        {
+          "name": "database_name",
+          "type": "string",
+          "required": true,
+          "description": "The database name to discover collections in",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "MONGODB_CONNECTION_STRING"
+      ],
+      "secretsInfo": [
+        {
+          "name": "MONGODB_CONNECTION_STRING",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "array",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Mongodb.DiscoverCollections",
+        "parameters": {
+          "database_name": {
+            "value": "inventory_db",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DiscoverDatabases",
+      "qualifiedName": "Mongodb.DiscoverDatabases",
+      "fullyQualifiedName": "Mongodb.DiscoverDatabases@0.4.0",
+      "description": "Discover all the databases in the MongoDB instance.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "MONGODB_CONNECTION_STRING"
+      ],
+      "secretsInfo": [
+        {
+          "name": "MONGODB_CONNECTION_STRING",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "array",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Mongodb.DiscoverDatabases",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "FindDocuments",
+      "qualifiedName": "Mongodb.FindDocuments",
+      "fullyQualifiedName": "Mongodb.FindDocuments@0.4.0",
+      "description": "Find documents in a MongoDB collection.\n\nONLY use this tool if you have already loaded the schema of the collection you need to query.\nUse the <get_collection_schema> tool to load the schema if not already known.\n\nReturns a list of JSON strings, where each string represents a document from the collection (tools cannot return complex types).\n\nWhen running queries, follow these rules which will help avoid errors:\n* Always specify projection to limit fields returned if you don't need all data.\n* Always sort your results by the most important fields first. If you aren't sure, sort by '_id'.\n* Use appropriate MongoDB query operators for complex filtering ($gte, $lte, $in, $regex, etc.).\n* Be mindful of case sensitivity when querying string fields.\n* Use indexes when possible (typically on _id and commonly queried fields).",
+      "parameters": [
+        {
+          "name": "database_name",
+          "type": "string",
+          "required": true,
+          "description": "The database name to query",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "collection_name",
+          "type": "string",
+          "required": true,
+          "description": "The collection name to query",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "filter_dict",
+          "type": "string",
+          "required": false,
+          "description": "MongoDB filter/query as JSON string. Leave None for no filter (find all documents). Example: '{\"status\": \"active\", \"age\": {\"$gte\": 18}}'",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "projection",
+          "type": "string",
+          "required": false,
+          "description": "Fields to include/exclude as JSON string. Use 1 to include, 0 to exclude. Example: '{\"name\": 1, \"email\": 1, \"_id\": 0}'. Leave None to include all fields.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "sort",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Sort criteria as list of JSON strings, each containing 'field' and 'direction' keys. Use 1 for ascending, -1 for descending. Example: ['{\"field\": \"name\", \"direction\": 1}', '{\"field\": \"created_at\", \"direction\": -1}']",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of documents to return. Default: 1000.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "skip",
+          "type": "integer",
+          "required": false,
+          "description": "The number of documents to skip. Default: 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "MONGODB_CONNECTION_STRING"
+      ],
+      "secretsInfo": [
+        {
+          "name": "MONGODB_CONNECTION_STRING",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "array",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Mongodb.FindDocuments",
+        "parameters": {
+          "database_name": {
+            "value": "app_db",
+            "type": "string",
+            "required": true
+          },
+          "collection_name": {
+            "value": "users",
+            "type": "string",
+            "required": true
+          },
+          "filter_dict": {
+            "value": "{\"status\": \"active\", \"age\": {\"$gte\": 18}, \"roles\": {\"$in\": [\"user\", \"admin\"]}}",
+            "type": "string",
+            "required": false
+          },
+          "projection": {
+            "value": "{\"name\": 1, \"email\": 1, \"roles\": 1, \"created_at\": 1, \"_id\": 0}",
+            "type": "string",
+            "required": false
+          },
+          "sort": {
+            "value": [
+              "{\"field\": \"created_at\", \"direction\": -1}",
+              "{\"field\": \"_id\", \"direction\": 1}"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "skip": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetCollectionSchema",
+      "qualifiedName": "Mongodb.GetCollectionSchema",
+      "fullyQualifiedName": "Mongodb.GetCollectionSchema@0.4.0",
+      "description": "Get the schema/structure of a MongoDB collection by sampling documents.\n\nSince MongoDB is schema-less, this tool samples a configurable number of documents\nto infer the schema structure and data types.\n\nThis tool should ALWAYS be used before executing any query. All collections in the query must be discovered first using the <discover_collections> tool.",
+      "parameters": [
+        {
+          "name": "database_name",
+          "type": "string",
+          "required": true,
+          "description": "The database name to get the collection schema of",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "collection_name",
+          "type": "string",
+          "required": true,
+          "description": "The collection to get the schema of",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "sample_size",
+          "type": "integer",
+          "required": false,
+          "description": "The number of documents to sample for schema discovery (default: 1000)",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "MONGODB_CONNECTION_STRING"
+      ],
+      "secretsInfo": [
+        {
+          "name": "MONGODB_CONNECTION_STRING",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Mongodb.GetCollectionSchema",
+        "parameters": {
+          "database_name": {
+            "value": "sales_db",
+            "type": "string",
+            "required": true
+          },
+          "collection_name": {
+            "value": "orders",
+            "type": "string",
+            "required": true
+          },
+          "sample_size": {
+            "value": 500,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-02-28T11:11:57.983Z",
+  "summary": "MongoDB provider: This toolkit enables discovery, schema sampling, and programmatic querying of MongoDB instances. It supports aggregation pipelines, filtered finds, and counts to extract and transform data.\n\n**Capabilities**\n\n- Discover databases and collections and infer schemas by sampling documents (required before collection queries).\n- Execute complex aggregation pipelines for joins, grouping, projection, sorting, and limits.\n- Perform targeted queries with projections, sorting, operators, and counting; results are returned as JSON strings ready for processing.\n- Emphasize using indexes and explicit projections to optimize queries and avoid errors.\n\n**Secrets**\n\n- Type: password — typically a full MongoDB connection string. Example variable: MONGODB_CONNECTION_STRING. Store securely (env or secrets manager)."
+}

--- a/toolkit-docs-generator/data/toolkits/postgres.json
+++ b/toolkit-docs-generator/data/toolkits/postgres.json
@@ -1,0 +1,371 @@
+{
+  "id": "Postgres",
+  "label": "Postgres",
+  "version": "0.6.0",
+  "description": "Tools to query and explore a postgres database",
+  "metadata": {
+    "category": "databases",
+    "iconUrl": "https://design-system.arcade.dev/icons/postgres.svg",
+    "isBYOC": false,
+    "isPro": false,
+    "type": "community",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/databases/postgres",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": null,
+  "tools": [
+    {
+      "name": "DiscoverSchemas",
+      "qualifiedName": "Postgres.DiscoverSchemas",
+      "fullyQualifiedName": "Postgres.DiscoverSchemas@0.6.0",
+      "description": "Discover all the schemas in the postgres database.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "POSTGRES_DATABASE_CONNECTION_STRING"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTGRES_DATABASE_CONNECTION_STRING",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "array",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postgres.DiscoverSchemas",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DiscoverTables",
+      "qualifiedName": "Postgres.DiscoverTables",
+      "fullyQualifiedName": "Postgres.DiscoverTables@0.6.0",
+      "description": "Discover all the tables in the postgres database when the list of tables is not known.\n\nALWAYS use this tool before any other tool that requires a table name.",
+      "parameters": [
+        {
+          "name": "schema_name",
+          "type": "string",
+          "required": false,
+          "description": "The database schema to discover tables in (default value: 'public')",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTGRES_DATABASE_CONNECTION_STRING"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTGRES_DATABASE_CONNECTION_STRING",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "array",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postgres.DiscoverTables",
+        "parameters": {
+          "schema_name": {
+            "value": "public",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ExecuteSelectQuery",
+      "qualifiedName": "Postgres.ExecuteSelectQuery",
+      "fullyQualifiedName": "Postgres.ExecuteSelectQuery@0.6.0",
+      "description": "You have a connection to a postgres database.\nExecute a SELECT query and return the results against the postgres database.  No other queries (INSERT, UPDATE, DELETE, etc.) are allowed.\n\nONLY use this tool if you have already loaded the schema of the tables you need to query.  Use the <GetTableSchema> tool to load the schema if not already known.\n\nThe final query will be constructed as follows:\nSELECT {select_query_part} FROM {from_clause} JOIN {join_clause} WHERE {where_clause} HAVING {having_clause} ORDER BY {order_by_clause} LIMIT {limit} OFFSET {offset}\n\nWhen running queries, follow these rules which will help avoid errors:\n* Never \"select *\" from a table.  Always select the columns you need.\n* Always order your results by the most important columns first.  If you aren't sure, order by the primary key.\n* Always use case-insensitive queries to match strings in the query.\n* Always trim strings in the query.\n* Prefer LIKE queries over direct string matches or regex queries.\n* Only join on columns that are indexed or the primary key.  Do not join on arbitrary columns.",
+      "parameters": [
+        {
+          "name": "select_clause",
+          "type": "string",
+          "required": true,
+          "description": "This is the part of the SQL query that comes after the SELECT keyword wish a comma separated list of columns you wish to return.  Do not include the SELECT keyword.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "from_clause",
+          "type": "string",
+          "required": true,
+          "description": "This is the part of the SQL query that comes after the FROM keyword.  Do not include the FROM keyword.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of rows to return.  This is the LIMIT clause of the query.  Default: 100.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "The number of rows to skip.  This is the OFFSET clause of the query.  Default: 0.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "join_clause",
+          "type": "string",
+          "required": false,
+          "description": "This is the part of the SQL query that comes after the JOIN keyword.  Do not include the JOIN keyword.  If no join is needed, leave this blank.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "where_clause",
+          "type": "string",
+          "required": false,
+          "description": "This is the part of the SQL query that comes after the WHERE keyword.  Do not include the WHERE keyword.  If no where clause is needed, leave this blank.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "having_clause",
+          "type": "string",
+          "required": false,
+          "description": "This is the part of the SQL query that comes after the HAVING keyword.  Do not include the HAVING keyword.  If no having clause is needed, leave this blank.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "group_by_clause",
+          "type": "string",
+          "required": false,
+          "description": "This is the part of the SQL query that comes after the GROUP BY keyword.  Do not include the GROUP BY keyword.  If no group by clause is needed, leave this blank.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "order_by_clause",
+          "type": "string",
+          "required": false,
+          "description": "This is the part of the SQL query that comes after the ORDER BY keyword.  Do not include the ORDER BY keyword.  If no order by clause is needed, leave this blank.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "with_clause",
+          "type": "string",
+          "required": false,
+          "description": "This is the part of the SQL query that comes after the WITH keyword when basing the query on a virtual table.  If no WITH clause is needed, leave this blank.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTGRES_DATABASE_CONNECTION_STRING"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTGRES_DATABASE_CONNECTION_STRING",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "array",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postgres.ExecuteSelectQuery",
+        "parameters": {
+          "select_clause": {
+            "value": "id, name, email, created_at",
+            "type": "string",
+            "required": true
+          },
+          "from_clause": {
+            "value": "public.users",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          },
+          "join_clause": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "where_clause": {
+            "value": "lower(trim(email)) LIKE '%@example.com'",
+            "type": "string",
+            "required": false
+          },
+          "having_clause": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "group_by_clause": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "order_by_clause": {
+            "value": "id ASC",
+            "type": "string",
+            "required": false
+          },
+          "with_clause": {
+            "value": "",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetTableSchema",
+      "qualifiedName": "Postgres.GetTableSchema",
+      "fullyQualifiedName": "Postgres.GetTableSchema@0.6.0",
+      "description": "Get the schema/structure of a postgres table in the postgres database when the schema is not known, and the name of the table is provided.\n\nThis tool should ALWAYS be used before executing any query.  All tables in the query must be discovered first using the <DiscoverTables> tool.",
+      "parameters": [
+        {
+          "name": "schema_name",
+          "type": "string",
+          "required": true,
+          "description": "The database schema to get the table schema of",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "table_name",
+          "type": "string",
+          "required": true,
+          "description": "The table to get the schema of",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTGRES_DATABASE_CONNECTION_STRING"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTGRES_DATABASE_CONNECTION_STRING",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "array",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postgres.GetTableSchema",
+        "parameters": {
+          "schema_name": {
+            "value": "public",
+            "type": "string",
+            "required": true
+          },
+          "table_name": {
+            "value": "customers",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-02-28T11:11:33.955Z",
+  "summary": "Arcade Postgres connects to a Postgres database and enables schema-driven exploration and safe read-only querying. It helps developers inspect schemas and table structures and execute constrained SELECT queries constructed from discovered metadata.\n\n**Capabilities**\n\n- Discover database schemas and enumerate tables to map structure; always discover tables before composing queries.\n- Load and use table schemas to drive query construction and validation so queries match actual column types and constraints.\n- Execute read-only SELECT queries only, with enforced best practices: never SELECT *, order by primary/important keys, use case-insensitive trimmed matching and LIKE, and join only on indexed/PK columns.\n- Support ordered, paginated result sets and explicit query fragment construction (select/from/join/where/having/order/limit/offset).\n\n**Secrets**\n\nThis toolkit expects connection secrets such as POSTGRES_DATABASE_CONNECTION_STRING. Secret types include password and unknown; example: a PostgreSQL connection string (postgres://user:password@host:port/dbname) stored securely."
+}

--- a/toolkit-docs-generator/data/toolkits/zendesk.json
+++ b/toolkit-docs-generator/data/toolkits/zendesk.json
@@ -1,7 +1,7 @@
 {
   "id": "Zendesk",
   "label": "Zendesk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "",
   "metadata": {
     "category": "customer-support",
@@ -25,7 +25,7 @@
     {
       "name": "AddTicketComment",
       "qualifiedName": "Zendesk.AddTicketComment",
-      "fullyQualifiedName": "Zendesk.AddTicketComment@0.5.0",
+      "fullyQualifiedName": "Zendesk.AddTicketComment@0.6.0",
       "description": "Add a comment to an existing Zendesk ticket.\n\nThe returned ticket object includes an 'html_url' field with the direct link\nto view the ticket in Zendesk.",
       "parameters": [
         {
@@ -117,7 +117,7 @@
     {
       "name": "GetTicketComments",
       "qualifiedName": "Zendesk.GetTicketComments",
-      "fullyQualifiedName": "Zendesk.GetTicketComments@0.5.0",
+      "fullyQualifiedName": "Zendesk.GetTicketComments@0.6.0",
       "description": "Get all comments for a specific Zendesk ticket, including the original description.\n\nThe first comment is always the ticket's original description/content.\nSubsequent comments show the conversation history.\n\nEach comment includes:\n- author_id: ID of the comment author\n- body: The comment text\n- created_at: Timestamp when comment was created\n- public: Whether the comment is public or internal\n- attachments: List of file attachments (if any) with file_name, content_url, size, etc.",
       "parameters": [
         {
@@ -183,7 +183,7 @@
     {
       "name": "ListTickets",
       "qualifiedName": "Zendesk.ListTickets",
-      "fullyQualifiedName": "Zendesk.ListTickets@0.5.0",
+      "fullyQualifiedName": "Zendesk.ListTickets@0.6.0",
       "description": "List tickets from your Zendesk account with offset-based pagination.\n\nBy default, returns tickets sorted by ID with newest tickets first (desc).\n\nEach ticket in the response includes an 'html_url' field with the direct link\nto view the ticket in Zendesk.\n\nPAGINATION:\n- The response includes 'next_offset' when more results are available\n- To fetch the next batch, simply pass the 'next_offset' value as the 'offset' parameter\n- If 'next_offset' is not present, you've reached the end of available results",
       "parameters": [
         {
@@ -297,7 +297,7 @@
     {
       "name": "MarkTicketSolved",
       "qualifiedName": "Zendesk.MarkTicketSolved",
-      "fullyQualifiedName": "Zendesk.MarkTicketSolved@0.5.0",
+      "fullyQualifiedName": "Zendesk.MarkTicketSolved@0.6.0",
       "description": "Mark a Zendesk ticket as solved, optionally with a final comment.\n\nThe returned ticket object includes an 'html_url' field with the direct link\nto view the ticket in Zendesk.",
       "parameters": [
         {
@@ -390,7 +390,7 @@
     {
       "name": "SearchArticles",
       "qualifiedName": "Zendesk.SearchArticles",
-      "fullyQualifiedName": "Zendesk.SearchArticles@0.5.0",
+      "fullyQualifiedName": "Zendesk.SearchArticles@0.6.0",
       "description": "Search for Help Center articles in your Zendesk knowledge base.\n\nThis tool searches specifically for published knowledge base articles that provide\nsolutions and guidance to users. At least one search parameter (query or label_names)\nmust be provided.\n\nPAGINATION:\n- The response includes 'next_offset' when more results are available\n- To fetch the next batch, simply pass the 'next_offset' value as the 'offset' parameter\n- If 'next_offset' is not present, you've reached the end of available results\n- The tool automatically handles fetching from the correct page based on your offset\n\nIMPORTANT: ALL FILTERS CAN BE COMBINED IN A SINGLE CALL\nYou can combine multiple filters (query, labels, dates) in one search request.\nDo NOT make separate tool calls - combine all relevant filters together.",
       "parameters": [
         {
@@ -596,7 +596,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Zendesk.WhoAmI",
-      "fullyQualifiedName": "Zendesk.WhoAmI@0.5.0",
+      "fullyQualifiedName": "Zendesk.WhoAmI@0.6.0",
       "description": "Get comprehensive user profile and Zendesk account information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, role, organization details, and Zendesk account context.",
       "parameters": [],
       "auth": {
@@ -648,6 +648,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-26T20:45:10.449Z",
+  "generatedAt": "2026-02-28T11:11:27.188Z",
   "summary": "Arcade's Zendesk toolkit enables seamless integration with Zendesk's customer service platform, allowing developers to interact with tickets and knowledge base articles efficiently.\n\n**Capabilities**  \n- Retrieve and manage ticket comments and statuses.  \n- List and paginate through tickets for dynamic retrieval.  \n- Search for Help Center articles using various parameters.  \n- Fetch comprehensive user profiles and account information.  \n\n**OAuth**  \n- Auth Type: OAuth2  \n- Provider: Unknown  \n- Scopes: read, tickets:write  \n\n**Secrets**  \n- Secret types: unknown, api_key  \n- Example: ZENDESK_SUBDOMAIN  "
 }


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/22519525654

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily regenerates documentation/toolkit JSON and navigation metadata; low risk beyond potential broken docs links or ordering issues in the integrations sidebar.
> 
> **Overview**
> **Adds new database integration docs entries** by introducing `Clickhouse`, `MongoDB`, and `Postgres` to the databases `_meta.tsx` navigation (grouped under a new *Optimized* separator).
> 
> **Extends the generated toolkit catalog** by adding new `clickhouse.json`, `mongodb.json`, and `postgres.json` descriptors and registering them in `toolkit-docs-generator/data/toolkits/index.json`.
> 
> **Bumps generated toolkit versions/timestamps** for `Brightdata` (`0.4.0`→`0.5.0`), `Linkedin` (`0.3.0`→`1.1.0`), and `Zendesk` (`0.5.0`→`0.6.0`), plus updates `next-env.d.ts` to import Next route types from `./.next/types/routes.d.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2740151ee95c3907533d64db375680cc8731e88e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->