### PR TITLE
Update search UI for DocSearch content indexing

### DIFF
--- a/app/_components/algolia-search.tsx
+++ b/app/_components/algolia-search.tsx
@@ -78,9 +78,8 @@ function Breadcrumb({ hit }: { hit: DocSearchRecord }) {
     hit.hierarchy.lvl5,
   ].filter(Boolean) as string[];
 
-  // For content-type hits, show full breadcrumb. For heading hits, show parent levels only.
-  const breadcrumbLevels =
-    hit.type === "content" ? levels : levels.slice(0, -1);
+  // Exclude the deepest level — it's already shown as the hit title
+  const breadcrumbLevels = levels.slice(0, -1);
 
   if (breadcrumbLevels.length === 0) {
     return null;


### PR DESCRIPTION
## Summary
- Updates the Algolia search component to consume the richer record format produced by `helpers.docsearch()` crawler config
- Displays heading hierarchy breadcrumbs (e.g., "Getting Started › Auth › OAuth 2.0") above each result
- Shows content snippet highlights for body-text matches using `<Snippet>`
- Adds `<Configure>` widget for snippet length, deduplication, and hit count
- Converts full Algolia URLs to relative paths with anchor hash for proper navigation
- Backward compatible with the existing flat record format (title/description)

## Requires
Algolia Crawler action update to use `helpers.docsearch()` with `content` selectors (configured separately in the Algolia dashboard).

## Test plan
- [ ] Run crawler with new docsearch action to populate the `_docsearch` index
- [ ] Set `NEXT_PUBLIC_ALGOLIA_INDEX_NAME` to the new docsearch index locally
- [ ] Verify search results show heading breadcrumbs and content snippets
- [ ] Verify clicking a content result navigates to the correct page section (anchor)
- [ ] Verify search still works if pointed at the old index (legacy fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Algolia hits are interpreted and linked (DocSearch hierarchy/content records and URL rewriting), which could affect result rendering and navigation if index data differs from expectations.
> 
> **Overview**
> Updates the Algolia search modal to consume DocSearch-style records (`hierarchy`, `type`, `content`) while keeping a fallback for legacy `title`/`description` hits.
> 
> Search results now show heading *breadcrumbs*, choose the displayed title based on the closest matching hierarchy level, and render body-text matches using `Snippet` for `content` hits. The search query is configured via `Configure` (snippet length/ellipsis, `distinct`, and `hitsPerPage`), and hit links are normalized from full URLs to safe same-site relative paths (including hash anchors).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6624f004a2e291e4cf1e3020dfd06f37f2e7033c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->