### PR TITLE
Fixing LLMTXT gen after removing local md gen

### DIFF
--- a/toolkit-docs-generator/data/toolkits/brightdata.json
+++ b/toolkit-docs-generator/data/toolkits/brightdata.json
@@ -411,6 +411,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-28T11:11:27.185Z",
+  "generatedAt": "2026-03-01T11:12:08.063Z",
   "summary": "Bright Data provides a developer toolkit for large-scale web search, crawling, and scraping, enabling reliable extraction of pages and structured data without getting blocked. It supports search queries, content-to-Markdown conversion, and configurable data feeds across many site types.\n\nDesigned for integration into data pipelines and analytics workflows with parameterized feeds and output formats.\n\n**Capabilities**\n- Scale-resistant crawling and scraping with anti-blocking behavior for sustained collection.\n- Flexible search engine queries with advanced parameters across major engines.\n- Transform pages into clean Markdown and emit structured JSON feeds for profiles, products, reviews, listings, and media.\n- Configurable extraction parameters for batching, pagination, and media handling.\n\n**Secrets**\n- API key (BRIGHTDATA_API_KEY) and zone token (BRIGHTDATA_ZONE). Example values: BRIGHTDATA_API_KEY=sk_..., BRIGHTDATA_ZONE=zone123."
 }

--- a/toolkit-docs-generator/data/toolkits/clickhouse.json
+++ b/toolkit-docs-generator/data/toolkits/clickhouse.json
@@ -114,7 +114,7 @@
       "secretsInfo": [
         {
           "name": "CLICKHOUSE_DATABASE_CONNECTION_STRING",
-          "type": "unknown"
+          "type": "password"
         }
       ],
       "output": {
@@ -250,17 +250,17 @@
         "toolName": "Clickhouse.ExecuteSelectQuery",
         "parameters": {
           "select_clause": {
-            "value": "users.id, users.email, orders.order_id, orders.total_amount, orders.created_at",
+            "value": "e.event_id, e.user_id, lower(trim(e.event_type)) AS event_type, e.event_time, lower(trim(u.country)) AS country",
             "type": "string",
             "required": true
           },
           "from_clause": {
-            "value": "users",
+            "value": "analytics.events AS e",
             "type": "string",
             "required": true
           },
           "limit": {
-            "value": 50,
+            "value": 100,
             "type": "integer",
             "required": false
           },
@@ -270,12 +270,12 @@
             "required": false
           },
           "join_clause": {
-            "value": "INNER JOIN orders ON users.id = orders.user_id",
+            "value": "analytics.users AS u ON e.user_id = u.id",
             "type": "string",
             "required": false
           },
           "where_clause": {
-            "value": "lower(trim(users.email)) LIKE '%@example.com' AND orders.created_at >= '2025-01-01'",
+            "value": "lower(trim(e.event_type)) LIKE 'purchase%' AND lower(trim(u.country)) = 'us' AND e.event_time >= toDateTime('2026-01-01 00:00:00')",
             "type": "string",
             "required": false
           },
@@ -290,7 +290,7 @@
             "required": false
           },
           "order_by_clause": {
-            "value": "users.id ASC, orders.created_at DESC",
+            "value": "e.event_time DESC, e.event_id ASC",
             "type": "string",
             "required": false
           },
@@ -361,12 +361,12 @@
         "toolName": "Clickhouse.GetTableSchema",
         "parameters": {
           "schema_name": {
-            "value": "default",
+            "value": "analytics",
             "type": "string",
             "required": true
           },
           "table_name": {
-            "value": "events",
+            "value": "user_events",
             "type": "string",
             "required": true
           }
@@ -394,6 +394,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-28T11:11:37.453Z",
-  "summary": "ClickHouse toolkit provides tools to explore and query a ClickHouse database, enabling safe schema discovery and read-only SELECT execution. It helps discover databases and tables, inspect table schemas, and run constrained SELECT queries that follow ClickHouse best practices.\n\n**Capabilities**\n- Discover database and table topology and surface a default schema name.\n- Retrieve precise table schemas to drive safe query construction.\n- Execute read-only SELECTs with enforced rules (explicit columns, ordering, indexed joins, case sensitivity).\n- Surface query guidance to avoid common ClickHouse pitfalls.\n\n**Secrets**\nSecret types: password, unknown. Example: CLICKHOUSE_DATABASE_CONNECTION_STRING — a connection string containing host, port, database and credentials (including password)."
+  "generatedAt": "2026-03-01T11:12:22.108Z",
+  "summary": "Arcade ClickHouse toolkit provides programmatic access to ClickHouse databases, enabling discovery, schema inspection, and safe read-only querying. It helps explore databases and tables, load table schemas, and execute SELECT queries while enforcing rules that reduce errors and preserve performance.\n\n**Capabilities**\n- Discover databases and tables and load table schemas to support safe query construction.\n- Execute read-only, parameterized SELECT queries with guidance on joins, ordering, and string handling.\n- Enforce best practices (no SELECT *, careful case-sensitive identifiers, indexed joins, explicit column selection) to minimize errors and improve performance.\n\n**Secrets**\n- Accepts connection secrets (password, unknown) via CLICKHOUSE_DATABASE_CONNECTION_STRING — typically a DSN containing host, port, database, user, and password."
 }

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-02-28T11:12:18.109Z",
+  "generatedAt": "2026-03-01T11:12:36.819Z",
   "version": "1.0.0",
   "toolkits": [
     {

--- a/toolkit-docs-generator/data/toolkits/linkedin.json
+++ b/toolkit-docs-generator/data/toolkits/linkedin.json
@@ -92,6 +92,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-28T11:11:27.186Z",
+  "generatedAt": "2026-03-01T11:12:08.065Z",
   "summary": "Arcade.dev provides a toolkit for integrating with LinkedIn, enabling developers to streamline interactions with the platform's API. This toolkit allows for the creation of content directly on LinkedIn, enhancing user engagement and social sharing capabilities.\n\n**Capabilities**  \n- Seamless integration with LinkedIn's API for enhanced social interactions.  \n- Efficiently share content such as text posts to drive engagement.  \n- Simplified authentication process through OAuth2, ensuring secure access to user data.  \n\n**OAuth**  \n- Provider: LinkedIn  \n- Scopes: w_member_social  \n\n**Secrets**  \n- No secrets required for use with this toolkit."
 }

--- a/toolkit-docs-generator/data/toolkits/mongodb.json
+++ b/toolkit-docs-generator/data/toolkits/mongodb.json
@@ -74,7 +74,7 @@
         "toolName": "Mongodb.AggregateDocuments",
         "parameters": {
           "database_name": {
-            "value": "sales_db",
+            "value": "shopDB",
             "type": "string",
             "required": true
           },
@@ -85,10 +85,11 @@
           },
           "pipeline": {
             "value": [
-              "{\"$match\": {\"status\": \"completed\", \"total\": {\"$gt\": 100}}}",
-              "{\"$group\": {\"_id\": \"$customerId\", \"ordersCount\": {\"$sum\": 1}, \"totalSpent\": {\"$sum\": \"$total\"}}}",
-              "{\"$project\": {\"customerId\": \"$_id\", \"ordersCount\": 1, \"totalSpent\": 1, \"_id\": 0}}",
-              "{\"$sort\": {\"totalSpent\": -1}}"
+              "{\"$match\": {\"status\": \"completed\"}}",
+              "{\"$unwind\": \"$items\"}",
+              "{\"$group\": {\"_id\": \"$items.productId\", \"totalQuantity\": {\"$sum\": \"$items.quantity\"}, \"totalSales\": {\"$sum\": {\"$multiply\": [\"$items.quantity\", \"$items.price\"]}}, \"productName\": {\"$first\": \"$items.name\"}}}",
+              "{\"$project\": {\"_id\": 0, \"productId\": \"$_id\", \"productName\": 1, \"totalQuantity\": 1, \"totalSales\": 1}}",
+              "{\"$sort\": {\"totalSales\": -1}}"
             ],
             "type": "array",
             "required": true
@@ -168,17 +169,17 @@
         "toolName": "Mongodb.CountDocuments",
         "parameters": {
           "database_name": {
-            "value": "sales_db",
+            "value": "app_db",
             "type": "string",
             "required": true
           },
           "collection_name": {
-            "value": "customers",
+            "value": "users",
             "type": "string",
             "required": true
           },
           "filter_dict": {
-            "value": "{\"status\": \"active\", \"signup_date\": {\"$gte\": \"2023-01-01\"}}",
+            "value": "{\"status\": \"active\"}",
             "type": "string",
             "required": false
           }
@@ -236,7 +237,7 @@
         "toolName": "Mongodb.DiscoverCollections",
         "parameters": {
           "database_name": {
-            "value": "inventory_db",
+            "value": "example_database",
             "type": "string",
             "required": true
           }
@@ -386,29 +387,29 @@
         "toolName": "Mongodb.FindDocuments",
         "parameters": {
           "database_name": {
-            "value": "app_db",
+            "value": "ecommerce",
             "type": "string",
             "required": true
           },
           "collection_name": {
-            "value": "users",
+            "value": "orders",
             "type": "string",
             "required": true
           },
           "filter_dict": {
-            "value": "{\"status\": \"active\", \"age\": {\"$gte\": 18}, \"roles\": {\"$in\": [\"user\", \"admin\"]}}",
+            "value": "{\"status\": \"shipped\", \"total\": {\"$gte\": 100}}",
             "type": "string",
             "required": false
           },
           "projection": {
-            "value": "{\"name\": 1, \"email\": 1, \"roles\": 1, \"created_at\": 1, \"_id\": 0}",
+            "value": "{\"order_id\": 1, \"customer_id\": 1, \"total\": 1, \"status\": 1, \"created_at\": 1, \"_id\": 0}",
             "type": "string",
             "required": false
           },
           "sort": {
             "value": [
               "{\"field\": \"created_at\", \"direction\": -1}",
-              "{\"field\": \"_id\", \"direction\": 1}"
+              "{\"field\": \"total\", \"direction\": -1}"
             ],
             "type": "array",
             "required": false
@@ -531,6 +532,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-28T11:11:57.983Z",
-  "summary": "MongoDB provider: This toolkit enables discovery, schema sampling, and programmatic querying of MongoDB instances. It supports aggregation pipelines, filtered finds, and counts to extract and transform data.\n\n**Capabilities**\n\n- Discover databases and collections and infer schemas by sampling documents (required before collection queries).\n- Execute complex aggregation pipelines for joins, grouping, projection, sorting, and limits.\n- Perform targeted queries with projections, sorting, operators, and counting; results are returned as JSON strings ready for processing.\n- Emphasize using indexes and explicit projections to optimize queries and avoid errors.\n\n**Secrets**\n\n- Type: password — typically a full MongoDB connection string. Example variable: MONGODB_CONNECTION_STRING. Store securely (env or secrets manager)."
+  "generatedAt": "2026-03-01T11:12:23.245Z",
+  "summary": "Arcade's MongoDB toolkit provides tools to query and explore MongoDB instances. It enables schema sampling, collection discovery, filtered reads, counts, and aggregation pipelines for data exploration and analytics.\n\n**Capabilities**\n- Discover databases/collections and sample documents to infer schema structure before querying.\n- Perform efficient reads with projection, sorting and complex filtering to limit payloads and improve performance.\n- Execute aggregation pipelines for transformations, joins, grouping and analytics workflows.\n- Follow operational best practices: always discover collections first, fetch collection schema before queries, use indexes and limit returned fields.\n\n**Secrets**\n- password: MONGODB_CONNECTION_STRING — a connection string/credentials (e.g., mongodb+srv://user:password@cluster.example.com/db). Store securely and supply at runtime."
 }

--- a/toolkit-docs-generator/data/toolkits/postgres.json
+++ b/toolkit-docs-generator/data/toolkits/postgres.json
@@ -80,7 +80,7 @@
       "secretsInfo": [
         {
           "name": "POSTGRES_DATABASE_CONNECTION_STRING",
-          "type": "unknown"
+          "type": "password"
         }
       ],
       "output": {
@@ -222,7 +222,7 @@
         "toolName": "Postgres.ExecuteSelectQuery",
         "parameters": {
           "select_clause": {
-            "value": "id, name, email, created_at",
+            "value": "users.id, users.name, users.email",
             "type": "string",
             "required": true
           },
@@ -247,7 +247,7 @@
             "required": false
           },
           "where_clause": {
-            "value": "lower(trim(email)) LIKE '%@example.com'",
+            "value": "LOWER(TRIM(users.email)) LIKE '%@example.com' AND users.active = true",
             "type": "string",
             "required": false
           },
@@ -262,7 +262,7 @@
             "required": false
           },
           "order_by_clause": {
-            "value": "id ASC",
+            "value": "users.id DESC",
             "type": "string",
             "required": false
           },
@@ -338,7 +338,7 @@
             "required": true
           },
           "table_name": {
-            "value": "customers",
+            "value": "users",
             "type": "string",
             "required": true
           }
@@ -366,6 +366,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-28T11:11:33.955Z",
-  "summary": "Arcade Postgres connects to a Postgres database and enables schema-driven exploration and safe read-only querying. It helps developers inspect schemas and table structures and execute constrained SELECT queries constructed from discovered metadata.\n\n**Capabilities**\n\n- Discover database schemas and enumerate tables to map structure; always discover tables before composing queries.\n- Load and use table schemas to drive query construction and validation so queries match actual column types and constraints.\n- Execute read-only SELECT queries only, with enforced best practices: never SELECT *, order by primary/important keys, use case-insensitive trimmed matching and LIKE, and join only on indexed/PK columns.\n- Support ordered, paginated result sets and explicit query fragment construction (select/from/join/where/having/order/limit/offset).\n\n**Secrets**\n\nThis toolkit expects connection secrets such as POSTGRES_DATABASE_CONNECTION_STRING. Secret types include password and unknown; example: a PostgreSQL connection string (postgres://user:password@host:port/dbname) stored securely."
+  "generatedAt": "2026-03-01T11:12:15.524Z",
+  "summary": "Postgres provider enables read-only exploration and querying of a PostgreSQL database within the Arcade toolkit. It provides schema discovery, table inspection, and constrained SELECT execution to build reliable, safe queries.\n\n**Capabilities**\n- Discover database schemas and table structures to drive query composition rather than guessing table/column names.\n- Execute read-only SELECT queries with enforced construction rules (explicit columns, ORDER BY, LIMIT/OFFSET, JOIN/HAVING/WHERE clauses).\n- Require discovery of tables and schemas before executing queries to prevent errors and ensure correct joins.\n- Enforce safe query conventions: no SELECT *, case-insensitive and trimmed string matching, prefer LIKE, join only on indexed or primary-key columns.\n\n**Secrets**\n- Secret type: password. Example secret: POSTGRES_DATABASE_CONNECTION_STRING (e.g. postgres://user:password@host:5432/dbname) used to authenticate and connect; store and handle securely."
 }

--- a/toolkit-docs-generator/data/toolkits/zendesk.json
+++ b/toolkit-docs-generator/data/toolkits/zendesk.json
@@ -648,6 +648,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-28T11:11:27.188Z",
+  "generatedAt": "2026-03-01T11:12:08.066Z",
   "summary": "Arcade's Zendesk toolkit enables seamless integration with Zendesk's customer service platform, allowing developers to interact with tickets and knowledge base articles efficiently.\n\n**Capabilities**  \n- Retrieve and manage ticket comments and statuses.  \n- List and paginate through tickets for dynamic retrieval.  \n- Search for Help Center articles using various parameters.  \n- Fetch comprehensive user profiles and account information.  \n\n**OAuth**  \n- Auth Type: OAuth2  \n- Provider: Unknown  \n- Scopes: read, tickets:write  \n\n**Secrets**  \n- Secret types: unknown, api_key  \n- Example: ZENDESK_SUBDOMAIN  "
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to generated toolkit documentation JSON (timestamps, summaries, secret typing, and sample queries), with no runtime code or behavior changes.
> 
> **Overview**
> Regenerates several `toolkit-docs-generator/data/toolkits/*.json` artifacts, updating `generatedAt` timestamps and rewriting toolkit `summary` text for ClickHouse, MongoDB, and Postgres.
> 
> Tightens secret metadata by marking ClickHouse/Postgres connection strings as `password` (instead of `unknown`) and updates embedded `codeExample` snippets for ClickHouse, MongoDB, and Postgres queries/parameters. Also bumps the global toolkits `index.json` `generatedAt` timestamp.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d12db225f017650b0dac31d098ebc60111d2f745. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->