### PR TITLE
Add loading and success states to copy page button

### DIFF
--- a/app/_components/copy-page-override.tsx
+++ b/app/_components/copy-page-override.tsx
@@ -56,7 +56,7 @@ function getCopyButton(): HTMLButtonElement | null {
 export function CopyPageOverride() {
   const pathname = usePathname();
   const isFetchingRef = useRef(false);
-  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const setButtonState = useCallback(
     (button: HTMLButtonElement, text: string) => {


### PR DESCRIPTION
## Summary

Currently, there is no visual feedback indicating that the button starter or has finished fetching the markdown and copying it. This PR adds the visual feedback.

- Show loading state ("Copying…" with spinner) while fetching markdown
- Show success state ("Copied" with green checkmark) on successful copy
- Show error state ("Failed to copy" with red X) if fetch fails
- Both button and dropdown paths now provide consistent visual feedback
