### PR TITLE
Add note about HubSpot legacy app requirement

### DIFF
--- a/app/en/references/auth-providers/hubspot/page.mdx
+++ b/app/en/references/auth-providers/hubspot/page.mdx
@@ -45,6 +45,12 @@ Before showing how to configure your Hubspot app credentials, let's go through t
 
 Hubspot has two types of apps: Public and Private. You will need to create a Public one.
 
+<Callout type="warning">
+  HubSpot is migrating to a new app platform (version 2025.2). We are aware of
+  this change and will update these instructions accordingly. For now, use a
+  **Legacy → Public** app, which continues to work for OAuth-based integrations.
+</Callout>
+
 Follow [Hubspot's tutorial](https://developers.hubspot.com/docs/guides/apps/public-apps/overview) to create your Public App. You will need a [developer account](https://app.hubspot.com/signup-hubspot/developers) to do this.
 
 When creating your app, use the following settings:


### PR DESCRIPTION
## Summary
- HubSpot is migrating to a new app platform (2025.2), which is causing confusion for users seeing "No legacy apps available"
- Adds a warning callout clarifying that Legacy → Public apps still work for OAuth-based integrations
- Full doc updates for the new CLI-based flow are pending

## Test plan
- [ ] Visit `/en/references/auth-providers/hubspot` and confirm the warning callout appears under "Create a Hubspot App"