### PR TITLE
update changelog

### DIFF
--- a/app/en/references/changelog/page.mdx
+++ b/app/en/references/changelog/page.mdx
@@ -11,11 +11,6 @@ _Here's what's new at Arcade.dev!_
 
 ## 2026-03-06
 
-**Frameworks**
-
-- `[feature - 🚀]` Switches search functionality from Pagefind to Algolia with a new custom search component.
-- `[documentation - 📝]` Added documentation for audit logs, including REST endpoints and pagination.
-
 **Arcade MCP Servers**
 
 - `[bugfix - 🐛]` Fix MCP server header deletion not persisting.
@@ -30,15 +25,16 @@ _Here's what's new at Arcade.dev!_
 
 **Platform and Engine**
 
-- `[bugfix - 🐛]` Fixes GitHub API client URL construction to prevent URL doubling and 404 errors.
 - `[feature - 🚀]` Allow users to select multiple filters at once in the audit logs API.
 - `[feature - 🚀]` Enhanced audit log rendering on small screens for improved responsiveness.
 
 **Misc**
 
+- `[feature - 🚀]` Switches docs search functionality from Pagefind to Algolia with a new custom search component.
 - `[documentation - 📝]` Added instructions for using the Claude code MCP client.
 - `[documentation - 📝]` Reorganizes the security documentation into more logical locations.
 - `[documentation - 📝]` Clarify OAuth-based integrations requiring HubSpot legacy app.
+- `[documentation - 📝]` Added documentation for audit logs, including REST endpoints and pagination.
 
 ## 2026-02-27
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a changelog page; no runtime code paths are affected.
> 
> **Overview**
> Adds a new `2026-03-06` entry to the docs changelog, covering recent MCP server bugfixes/docs updates, a CLI template-generation improvement, audit log filtering/UI enhancements, and misc documentation notes (including the switch from Pagefind to Algolia search).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 544ad6cecb6472abc56bceddb9ba27d3f7283eff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->