### PR TITLE
Fix Python setup link on Google ADK overview page

### DIFF
--- a/app/en/get-started/agent-frameworks/google-adk/overview/page.mdx
+++ b/app/en/get-started/agent-frameworks/google-adk/overview/page.mdx
@@ -11,7 +11,7 @@ description: "Integrate Arcade tools with Google ADK agents"
 
 Choose your language to set up Arcade with Google ADK:
 
-- **[Python setup](/get-started/agent-frameworks/google-adk/setup-python)** - Build an agent with Arcade tools using the `google-adk-arcade` package
+- **[Python setup](/en/get-started/agent-frameworks/google-adk/setup-python)** - Build an agent with Arcade tools using the `google-adk-arcade` package
 - **[TypeScript setup](/get-started/agent-frameworks/google-adk/setup-typescript)** - Build an agent with Arcade tools using `@arcadeai/arcadejs`
 
 ## What you can build


### PR DESCRIPTION
## Summary
- Fixes the "Python setup" link on the Google ADK overview page to include the `/en/` locale prefix
- The link was resolving to `https://docs.arcade.dev/get-started/agent-frameworks/google-adk/setup-python` instead of `https://docs.arcade.dev/en/get-started/agent-frameworks/google-adk/setup-python`

## Test plan
- [ ] Click "Python setup" link on https://docs.arcade.dev/en/get-started/agent-frameworks/google-adk/overview and confirm it navigates to `.../en/get-started/agent-frameworks/google-adk/setup-python`

🤖 Generated with [Claude Code](https://claude.com/claude-code)