### PR TITLE
Better documentation for MCP-aligned tool metadata

### DIFF
--- a/app/_components/glossary-term.tsx
+++ b/app/_components/glossary-term.tsx
@@ -13,7 +13,7 @@ const MAX_DEFINITION_LENGTH = 200;
 type GlossaryTermProps = {
   term: string;
   definition: string;
-  link: string;
+  link?: string;
   children?: React.ReactNode;
 };
 
@@ -60,13 +60,15 @@ export function GlossaryTerm({
           <p className="text-gray-600 text-xs leading-relaxed dark:text-gray-400">
             {truncatedDef}
           </p>
-          <Link
-            className="inline-block text-blue-600 text-xs hover:underline dark:text-blue-400"
-            href={link}
-            onClick={() => setOpen(false)}
-          >
-            View in glossary →
-          </Link>
+          {link && (
+            <Link
+              className="inline-block text-blue-600 text-xs hover:underline dark:text-blue-400"
+              href={link}
+              onClick={() => setOpen(false)}
+            >
+              View in glossary →
+            </Link>
+          )}
         </div>
       </PopoverContent>
     </Popover>

--- a/app/_components/toolkit-docs/components/tool-metadata-section.tsx
+++ b/app/_components/toolkit-docs/components/tool-metadata-section.tsx
@@ -2,6 +2,7 @@
 
 import { Badge } from "@arcadeai/design-system";
 import { Check, ChevronDown, Lightbulb, Minus, X } from "lucide-react";
+import { GlossaryTerm } from "../../glossary-term";
 import {
   TOOL_METADATA_FALLBACK_STYLE,
   TOOL_METADATA_OPERATION_STYLES,
@@ -19,10 +20,29 @@ const BEHAVIOR_LABELS: Record<BehaviorFlagKey, string> = {
 };
 
 const BEHAVIOR_DESCRIPTIONS: Record<BehaviorFlagKey, string> = {
-  readOnly: "Does not modify remote state.",
-  destructive: "May delete or overwrite remote data.",
-  idempotent: "Safe to retry without extra side effects.",
-  openWorld: "Can call out to external systems.",
+  readOnly: "Reads data without modifying any state in the target system.",
+  destructive: "May permanently delete or overwrite data in the target system.",
+  idempotent:
+    "Repeated calls with the same inputs produce no additional effect.",
+  openWorld: "Communicates with external APIs, databases, or other services.",
+};
+
+const BEHAVIOR_GLOSSARY: Record<BehaviorFlagKey, { definition: string }> = {
+  readOnly: {
+    definition: "If true, the tool does not modify its environment.",
+  },
+  destructive: {
+    definition:
+      "If true, the tool may perform destructive updates to its environment. If false, the tool performs only additive updates.",
+  },
+  idempotent: {
+    definition:
+      "If true, calling the tool repeatedly with the same arguments will have no additional effect on its environment.",
+  },
+  openWorld: {
+    definition:
+      "If true, this tool may interact with an open world of external entities. If false, the tool's domain of interaction is closed.",
+  },
 };
 
 export type BehaviorRow = {
@@ -194,7 +214,10 @@ export function ToolMetadataSection({
                 >
                   <div className="flex items-center justify-between gap-2">
                     <span className="font-medium text-foreground text-xs">
-                      {row.label}
+                      <GlossaryTerm
+                        definition={BEHAVIOR_GLOSSARY[row.key].definition}
+                        term={row.label}
+                      />
                     </span>
                     <div className="flex shrink-0">
                       <BooleanBadge value={row.value} />

--- a/app/en/guides/create-tools/tool-basics/add-tool-metadata/page.mdx
+++ b/app/en/guides/create-tools/tool-basics/add-tool-metadata/page.mdx
@@ -170,21 +170,12 @@ For tools with no external service and no resource effects, `operations` can be 
 
 These four booleans are projected directly to MCP tool annotations. Always specify all four for production metadata.
 
-**`read_only`** -- Does this tool only observe, with zero side effects?
-
-Set `True` when the tool never mutates any state in the target system. If there's any doubt, set it to `False`.
-
-**`destructive`** -- Can this tool cause irreversible data loss?
-
-Set `True` when the tool can delete or permanently destroy data. Be conservative -- when in doubt, mark it `True`. Even soft-deletes that auto-purge should be `destructive=True`. The exception: archive operations that are fully reversible should use `Operation.UPDATE` with `destructive=False`.
-
-**`idempotent`** -- If you call this tool twice with the same input, does the second call change anything?
-
-Set `True` when repeated calls with identical input produce no additional effect. A practical test: would an accidental retry cause a problem? If no, it's idempotent. If it would create a duplicate, it's not.
-
-**`open_world`** -- Does this tool talk to anything outside the process?
-
-Set `True` for any tool that calls an external API, queries a database, or accesses a file system. Set `False` only for pure computation with no network, disk, or OS calls.
+| Flag | Default | Description |
+| --- | --- | --- |
+| `read_only` | `False` | If true, the tool does not modify its environment. |
+| `destructive` | `True` | If true, the tool may perform destructive updates to its environment. If false, the tool performs only additive updates. Only meaningful when `read_only=False`. |
+| `idempotent` | `False` | If true, calling the tool repeatedly with the same arguments will have no additional effect on its environment. Only meaningful when `read_only=False`. |
+| `open_world` | `True` | If true, this tool may interact with an open world of external entities. If false, the tool's domain of interaction is closed. For example, the world of a web search tool is open, whereas that of a memory tool is not. |
 
 ### Flag-to-annotation mapping
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation/UI-only changes; primary risk is minor UI regression around the new optional `GlossaryTerm` link and tooltip rendering.
> 
> **Overview**
> Improves MCP-aligned tool metadata docs and presentation by replacing the long-form flag explanations with a concise table including defaults and tighter definitions.
> 
> In the toolkit docs UI, behavior flag labels now render as `GlossaryTerm` tooltips with canonical definitions, and the short descriptions were rewritten for clarity; `GlossaryTerm` was updated to make `link` optional and only show the “View in glossary” link when provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d27f206d9d8a731ba1ac24faebb3a799f4627ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->