### PR TITLE
[TOO-423]  Adding callout to Sllack docks

### DIFF
--- a/toolkit-docs-generator/data/toolkits/slack.json
+++ b/toolkit-docs-generator/data/toolkits/slack.json
@@ -1293,7 +1293,14 @@
       }
     }
   ],
-  "documentationChunks": [],
+  "documentationChunks": [
+    {
+      "type": "markdown",
+      "location": "header",
+      "position": "after",
+      "content": "<Callout type=\"info\" title=\"Channel creation not supported\">\nManaging channels in Slack requires the `channels:manage` scope, which is only available with bot tokens. Arcade uses user tokens (the type of token Arcade supports), so creating new channels is not possible with this toolkit. You can invite users to an existing channel, but channel creation is not supported.\n</Callout>"
+    }
+  ],
   "customImports": [],
   "subPages": [],
   "generatedAt": "2026-02-26T20:45:10.433Z",

--- a/toolkit-docs-generator/tests/scenarios/removed-toolkit-cleanup.test.ts
+++ b/toolkit-docs-generator/tests/scenarios/removed-toolkit-cleanup.test.ts
@@ -120,8 +120,7 @@ describe("Scenario: Removed toolkit files are deleted after change detection", (
 
     expect(result.deleted).toEqual(["oldkit.json"]);
     const remaining = await readdir(dir);
-    expect(remaining).not.toContain("oldkit.json");
-    expect(remaining).toContain("github.json");
+    expect(remaining.sort()).toEqual(["github.json", "index.json"].sort());
   });
 
   it("deletes all JSON files for multiple toolkits removed from the API", async () => {
@@ -152,9 +151,7 @@ describe("Scenario: Removed toolkit files are deleted after change detection", (
       ["complextools.json", "deepwiki.json"].sort()
     );
     const remaining = await readdir(dir);
-    expect(remaining).toContain("github.json");
-    expect(remaining).not.toContain("deepwiki.json");
-    expect(remaining).not.toContain("complextools.json");
+    expect(remaining.sort()).toEqual(["github.json", "index.json"].sort());
   });
 
   it("never deletes unchanged or modified toolkits — only removed ones", async () => {
@@ -192,9 +189,9 @@ describe("Scenario: Removed toolkit files are deleted after change detection", (
 
     expect(result.deleted).toEqual(["gonekit.json"]);
     const remaining = await readdir(dir);
-    expect(remaining).toContain("github.json");
-    expect(remaining).toContain("slack.json");
-    expect(remaining).not.toContain("gonekit.json");
+    expect(remaining.sort()).toEqual(
+      ["github.json", "slack.json", "index.json"].sort()
+    );
   });
 
   it("rebuilds index.json that no longer lists the removed toolkit", async () => {
@@ -249,8 +246,9 @@ describe("Scenario: Removed toolkit files are deleted after change detection", (
 
     expect(result.deleted).toHaveLength(0);
     const remaining = await readdir(dir);
-    expect(remaining).toContain("github.json");
-    expect(remaining).toContain("slack.json");
+    expect(remaining.sort()).toEqual(
+      ["github.json", "slack.json", "index.json"].sort()
+    );
   });
 
   it("handles mixed-case toolkit IDs: diff returns CamelCase, file on disk is lowercase", async () => {
@@ -280,8 +278,7 @@ describe("Scenario: Removed toolkit files are deleted after change detection", (
 
     expect(result.deleted).toEqual(["googlecalendar.json"]);
     const remaining = await readdir(dir);
-    expect(remaining).not.toContain("googlecalendar.json");
-    expect(remaining).toContain("slack.json");
+    expect(remaining.sort()).toEqual(["slack.json", "index.json"].sort());
   });
 
   it("treats a zero-tools API response as removed and deletes the stale file", async () => {
@@ -312,8 +309,7 @@ describe("Scenario: Removed toolkit files are deleted after change detection", (
 
     expect(result.deleted).toEqual(["brokenkit.json"]);
     const remaining = await readdir(dir);
-    expect(remaining).not.toContain("brokenkit.json");
-    expect(remaining).toContain("github.json");
+    expect(remaining.sort()).toEqual(["github.json", "index.json"].sort());
   });
 
   it("merging removed IDs with pre-existing exclusions deletes each file exactly once", async () => {
@@ -345,5 +341,7 @@ describe("Scenario: Removed toolkit files are deleted after change detection", (
 
     expect(result.deleted).toEqual(["oldkit.json"]);
     expect(result.warnings).toHaveLength(0);
+    const remaining = await readdir(dir);
+    expect(remaining.sort()).toEqual(["github.json", "index.json"].sort());
   });
 });


### PR DESCRIPTION
Closes TOO-423

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change plus test expectation updates; no runtime logic changes beyond asserting `index.json` presence during cleanup scenarios.
> 
> **Overview**
> Adds a **Slack docs header callout** explaining that channel creation is not supported because it requires the `channels:manage` scope (bot tokens), while Arcade uses user tokens.
> 
> Updates the removed-toolkit cleanup scenario tests to assert the *exact* remaining output files, including `index.json`, after excluded/removed toolkit JSON files are deleted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9325428ea186d7de9fb3d201867035f2d8124e86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->