### PR TITLE
chore: update @arcadeai/design-system to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "lint": "pnpm exec ultracite check",
     "format": "pnpm exec ultracite fix",
     "prepare": "husky install",
-
     "translate": "pnpm dlx tsx scripts/i18n-sync/index.ts && pnpm format",
     "llmstxt": "pnpm dlx tsx scripts/generate-llmstxt.ts",
     "test": "vitest --run",
@@ -40,7 +39,7 @@
   },
   "homepage": "https://arcade.dev/",
   "dependencies": {
-    "@arcadeai/design-system": "^3.33.1",
+    "@arcadeai/design-system": "^3.33.2",
     "@mdx-js/mdx": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
     "@next/third-parties": "16.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@arcadeai/design-system':
-        specifier: ^3.33.1
-        version: 3.33.1(@hookform/resolvers@5.2.2(react-hook-form@7.65.0(react@19.2.3)))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.548.0(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-hook-form@7.65.0(react@19.2.3))(react@19.2.3)(recharts@3.6.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1))(tailwindcss@4.1.16)
+        specifier: ^3.33.2
+        version: 3.33.2(@hookform/resolvers@5.2.2(react-hook-form@7.65.0(react@19.2.3)))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.548.0(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-hook-form@7.65.0(react@19.2.3))(react@19.2.3)(recharts@3.6.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1))(tailwindcss@4.1.16)
       '@mdx-js/mdx':
         specifier: ^3.1.1
         version: 3.1.1
@@ -267,8 +267,8 @@ packages:
       zod:
         optional: true
 
-  '@arcadeai/design-system@3.33.1':
-    resolution: {integrity: sha512-Sg4CnRxksmwTTvjouMtzD9Id/AoTKVpIU+cDXQar4vS7BcBzlgW8bFsDV9e/87QfBaJ9a3cP4FlYwReRICckKA==}
+  '@arcadeai/design-system@3.33.2':
+    resolution: {integrity: sha512-kIll+bDNUsrxR0ap/BY1CRrYR9KDfuRvlf84zkJETofVmmaHsT7iB8ZeNU4OPLqEG22T6wXGlGSCtnRfDd3p6w==}
     engines: {bun: '>=1.3.5'}
     peerDependencies:
       '@hookform/resolvers': '>=5.2.1'
@@ -5185,7 +5185,7 @@ snapshots:
     optionalDependencies:
       zod: 4.1.12
 
-  '@arcadeai/design-system@3.33.1(@hookform/resolvers@5.2.2(react-hook-form@7.65.0(react@19.2.3)))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.548.0(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-hook-form@7.65.0(react@19.2.3))(react@19.2.3)(recharts@3.6.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1))(tailwindcss@4.1.16)':
+  '@arcadeai/design-system@3.33.2(@hookform/resolvers@5.2.2(react-hook-form@7.65.0(react@19.2.3)))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.548.0(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-hook-form@7.65.0(react@19.2.3))(react@19.2.3)(recharts@3.6.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1))(tailwindcss@4.1.16)':
     dependencies:
       '@hookform/resolvers': 5.2.2(react-hook-form@7.65.0(react@19.2.3))
       '@streamdown/code': 1.0.3(react@19.2.3)


### PR DESCRIPTION
This PR updates `@arcadeai/design-system` to the latest published version.

It runs a design-system compatibility test gate before opening this PR.
If that gate fails, the workflow stops and no PR is created.

- Trigger: `workflow_dispatch`
- Run: https://github.com/ArcadeAI/docs/actions/runs/22963274370

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump limited to a patch-level update of the shared design system; main risk is minor UI/behavior changes introduced by the new package version.
> 
> **Overview**
> Updates the `@arcadeai/design-system` dependency from `3.33.1` to `3.33.2` and refreshes `pnpm-lock.yaml` to match the new resolved version/integrity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e19f55d081652d022169eded77739ed1f912247. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->