### PR TITLE
update changelog

### DIFF
--- a/app/en/references/changelog/page.mdx
+++ b/app/en/references/changelog/page.mdx
@@ -9,6 +9,19 @@ import { Callout } from "nextra/components";
 
 _Here's what's new at Arcade.dev!_
 
+## 2026-03-13
+
+**Arcade MCP Servers**
+
+- `[feature - 🚀]` Add an 'include_raw_data' option to Figma_GetFileNodes for enhanced inspection of node details.
+- `[feature - 🚀]` Created a separate toolkit for Microsoft Users to enhance Outlook Mail & Calendar functionalities.
+- `[bugfix - 🐛]` Fix list item preservation in Google Docs markdown/HTML converters.
+- `[maintenance - 🔧]` Renames Outlook and SharePoint toolkits to standardized microsoft_* prefix and marks old packages as DEPRECATED.
+- `[documentation - 📝]` Update to MCP Servers documentation with generated metadata.
+- `[documentation - 📝]` Adds Attio auth provider reference page covering setup and use.
+- `[documentation - 📝]` Add tool metadata documentation to webhook payload guides and update stale repository URLs.
+
+
 ## 2026-03-06
 
 **Arcade MCP Servers**


### PR DESCRIPTION
changelog update I could not ship from the plane!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change updating a single changelog page with a new dated entry and no code or runtime behavior changes.
> 
> **Overview**
> Adds a new `2026-03-13` section to the `Changelog` page, documenting recent Arcade MCP Servers updates (Figma `include_raw_data` option, new Microsoft toolkit split, Google Docs converter fix, Microsoft toolkit rename/deprecation, and related documentation updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28ef12f1d3f54bba8dca8ce58d6544767eae1890. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->