### PR TITLE
Add reference to custom user verifier demo server

### DIFF
--- a/app/en/guides/user-facing-agents/secure-auth-production/page.mdx
+++ b/app/en/guides/user-facing-agents/secure-auth-production/page.mdx
@@ -47,6 +47,14 @@ When your users authorize a tool, Arcade.dev will redirect the user's browser to
 
 If you need help, join the [Implementing a custom user verifier](https://github.com/ArcadeAI/arcade-ai/discussions/486) GitHub discussion and we'll be happy to assist.
 
+<Callout type="info">
+  For a complete working example, see the [custom user verifier demo
+  server](https://github.com/ArcadeAI/custom-user-verifier). It's a minimal
+  Python Flask app you can run locally to test the verification flow, use as a
+  reference when building your own, or to provide as a sample to your coding
+  agent (e.g. Claude Code, Cursor Agent, etc).
+</Callout>
+
 import { Steps, Tabs, Callout } from "nextra/components";
 
 <Steps>

--- a/app/en/guides/user-facing-agents/secure-auth-production/page.mdx
+++ b/app/en/guides/user-facing-agents/secure-auth-production/page.mdx
@@ -52,7 +52,7 @@ If you need help, join the [Implementing a custom user verifier](https://github.
   server](https://github.com/ArcadeAI/custom-user-verifier). It's a minimal
   Python Flask app you can run locally to test the verification flow, use as a
   reference when building your own, or to provide as a sample to your coding
-  agent (e.g. Claude Code, Cursor Agent, etc).
+  agent (for example Claude Code, Cursor Agent, etc).
 
   If you're using a coding agent to help build your verifier, give it the
   [build a custom user verifier](https://github.com/ArcadeAI/arcade-dev-skills/tree/main/build-custom-user-verifier)

--- a/app/en/guides/user-facing-agents/secure-auth-production/page.mdx
+++ b/app/en/guides/user-facing-agents/secure-auth-production/page.mdx
@@ -53,6 +53,11 @@ If you need help, join the [Implementing a custom user verifier](https://github.
   Python Flask app you can run locally to test the verification flow, use as a
   reference when building your own, or to provide as a sample to your coding
   agent (e.g. Claude Code, Cursor Agent, etc).
+
+  If you're using a coding agent to help build your verifier, give it the
+  [build a custom user verifier](https://github.com/ArcadeAI/arcade-dev-skills/tree/main/build-custom-user-verifier)
+  skill — it contains the full flow, pseudocode, and common mistakes in an
+  LLM-friendly format.
 </Callout>
 
 import { Steps, Tabs, Callout } from "nextra/components";


### PR DESCRIPTION
- Add an info callout to the [Secure Auth in Production](https://docs.arcade.dev/en/guides/user-facing-agents/secure-auth-production) guide, pointing readers to the [`custom-user-verifier`](https://github.com/ArcadeAI/custom-user-verifier) demo repo as a working example.
- Link to [SKILL](https://github.com/ArcadeAI/agent-skills/blob/main/build-custom-user-verifier/SKILL.md)

### Motivation

A user [reported confusion](https://discord.com/channels/1273403187000377417/1273488498657333259/1483339772125646848) about the custom verifier flow — specifically that Arcade's redirect to their `/auth/verify` endpoint didn't include any cookies or user identity. The root cause was a misunderstanding of the verification model: Arcade only sends a `flow_id`, and the verifier is responsible for independently identifying the user from its own session.

The existing docs explain the steps correctly, but having a runnable reference implementation linked directly from the guide would help users understand the pattern faster — either by reading the code, running it locally, or handing it to a coding agent to adapt.