### PR TITLE
feat(toolkit-docs-generator): latest-version coherence filter

### DIFF
--- a/toolkit-docs-generator/src/diff/toolkit-diff.ts
+++ b/toolkit-docs-generator/src/diff/toolkit-diff.ts
@@ -7,7 +7,6 @@
 
 import {
   buildComparableToolSignature,
-  extractVersion,
   stableStringify,
 } from "../merger/data-merger.js";
 import type {
@@ -16,6 +15,7 @@ import type {
   ToolDefinition,
   ToolkitMetadata,
 } from "../types/index.js";
+import { extractVersion } from "../utils/index.js";
 
 // ============================================================================
 // Types

--- a/toolkit-docs-generator/src/merger/data-merger.ts
+++ b/toolkit-docs-generator/src/merger/data-merger.ts
@@ -341,10 +341,6 @@ export const getProviderId = (
   return toolWithAuth?.auth?.providerId ?? null;
 };
 
-// Re-export extractVersion so existing consumers (e.g. toolkit-diff.ts)
-// that import it from this module continue to work.
-export { extractVersion } from "../utils/fp.js";
-
 /**
  * Create default metadata for toolkits not found in Design System
  */

--- a/toolkit-docs-generator/src/merger/data-merger.ts
+++ b/toolkit-docs-generator/src/merger/data-merger.ts
@@ -23,6 +23,7 @@ import type {
   ToolkitMetadata,
 } from "../types/index.js";
 import { mapWithConcurrency } from "../utils/concurrency.js";
+import { extractVersion } from "../utils/fp.js";
 import {
   detectMetadataChanges,
   formatFreshnessWarnings,
@@ -340,13 +341,10 @@ export const getProviderId = (
   return toolWithAuth?.auth?.providerId ?? null;
 };
 
-/**
- * Extract version from fully qualified name
- */
-export const extractVersion = (fullyQualifiedName: string): string => {
-  const parts = fullyQualifiedName.split("@");
-  return parts[1] ?? "0.0.0";
-};
+// Re-export extractVersion so existing consumers (e.g. toolkit-diff.ts)
+// that import it from this module continue to work.
+export { extractVersion } from "../utils/fp.js";
+
 /**
  * Create default metadata for toolkits not found in Design System
  */

--- a/toolkit-docs-generator/src/sources/toolkit-data-source.ts
+++ b/toolkit-docs-generator/src/sources/toolkit-data-source.ts
@@ -9,7 +9,7 @@
 import { join } from "path";
 import type { ToolDefinition, ToolkitMetadata } from "../types/index.js";
 import { normalizeId } from "../utils/fp.js";
-import { filterToolsByMajorityVersion } from "../utils/version-coherence.js";
+import { filterToolsByHighestVersion } from "../utils/version-coherence.js";
 import {
   type ArcadeApiSourceConfig,
   createArcadeApiSource,
@@ -131,14 +131,14 @@ export class CombinedToolkitDataSource implements IToolkitDataSource {
       }
     }
 
-    // Filter tools by version if specified, otherwise apply majority-version
-    // coherence to drop stale tools from older releases that Engine still serves.
+    // Filter tools by version if specified, otherwise keep only the highest
+    // version to drop stale tools from older releases that Engine still serves.
     const filteredTools = version
       ? tools.filter((tool) => {
           const toolVersion = tool.fullyQualifiedName.split("@")[1];
           return toolVersion === version;
         })
-      : filterToolsByMajorityVersion(tools);
+      : filterToolsByHighestVersion(tools);
 
     return {
       tools: filteredTools,
@@ -169,10 +169,10 @@ export class CombinedToolkitDataSource implements IToolkitDataSource {
       metadataMap.set(metadata.id, metadata);
     }
 
-    // Filter each toolkit to its majority version to drop stale
+    // Filter each toolkit to its highest version to drop stale
     // tools from older releases that Engine still serves.
     for (const [toolkitId, tools] of toolkitGroups) {
-      const filtered = filterToolsByMajorityVersion(tools);
+      const filtered = filterToolsByHighestVersion(tools);
       if (filtered !== tools) {
         toolkitGroups.set(toolkitId, filtered as ToolDefinition[]);
       }

--- a/toolkit-docs-generator/src/sources/toolkit-data-source.ts
+++ b/toolkit-docs-generator/src/sources/toolkit-data-source.ts
@@ -174,7 +174,7 @@ export class CombinedToolkitDataSource implements IToolkitDataSource {
     for (const [toolkitId, tools] of toolkitGroups) {
       const filtered = filterToolsByMajorityVersion(tools);
       if (filtered !== tools) {
-        toolkitGroups.set(toolkitId, [...filtered]);
+        toolkitGroups.set(toolkitId, filtered as ToolDefinition[]);
       }
     }
 

--- a/toolkit-docs-generator/src/sources/toolkit-data-source.ts
+++ b/toolkit-docs-generator/src/sources/toolkit-data-source.ts
@@ -9,6 +9,7 @@
 import { join } from "path";
 import type { ToolDefinition, ToolkitMetadata } from "../types/index.js";
 import { normalizeId } from "../utils/fp.js";
+import { filterToolsByMajorityVersion } from "../utils/version-coherence.js";
 import {
   type ArcadeApiSourceConfig,
   createArcadeApiSource,
@@ -130,13 +131,14 @@ export class CombinedToolkitDataSource implements IToolkitDataSource {
       }
     }
 
-    // Filter tools by version if specified
+    // Filter tools by version if specified, otherwise apply majority-version
+    // coherence to drop stale tools from older releases that Engine still serves.
     const filteredTools = version
       ? tools.filter((tool) => {
           const toolVersion = tool.fullyQualifiedName.split("@")[1];
           return toolVersion === version;
         })
-      : tools;
+      : filterToolsByMajorityVersion(tools);
 
     return {
       tools: filteredTools,
@@ -165,6 +167,15 @@ export class CombinedToolkitDataSource implements IToolkitDataSource {
     const metadataMap = new Map<string, ToolkitMetadata>();
     for (const metadata of allMetadata) {
       metadataMap.set(metadata.id, metadata);
+    }
+
+    // Filter each toolkit to its majority version to drop stale
+    // tools from older releases that Engine still serves.
+    for (const [toolkitId, tools] of toolkitGroups) {
+      const filtered = filterToolsByMajorityVersion(tools);
+      if (filtered !== tools) {
+        toolkitGroups.set(toolkitId, [...filtered]);
+      }
     }
 
     // Combine into ToolkitData map.

--- a/toolkit-docs-generator/src/utils/fp.ts
+++ b/toolkit-docs-generator/src/utils/fp.ts
@@ -160,6 +160,15 @@ export const deepMerge = <T extends object>(
 };
 
 /**
+ * Extract version from a fully qualified tool name.
+ * "Github.CreateIssue@3.1.3" → "3.1.3"
+ */
+export const extractVersion = (fullyQualifiedName: string): string => {
+  const parts = fullyQualifiedName.split("@");
+  return parts[1] ?? "0.0.0";
+};
+
+/**
  * Normalize a string for comparison (lowercase, remove hyphens/underscores)
  */
 export const normalizeId = (id: string): string =>

--- a/toolkit-docs-generator/src/utils/index.ts
+++ b/toolkit-docs-generator/src/utils/index.ts
@@ -10,3 +10,7 @@ export { readIgnoreList } from "./ignore-list.js";
 export * from "./logger.js";
 export * from "./progress.js";
 export * from "./retry.js";
+export {
+  filterToolsByMajorityVersion,
+  getMajorityVersion,
+} from "./version-coherence.js";

--- a/toolkit-docs-generator/src/utils/index.ts
+++ b/toolkit-docs-generator/src/utils/index.ts
@@ -11,6 +11,6 @@ export * from "./logger.js";
 export * from "./progress.js";
 export * from "./retry.js";
 export {
-  filterToolsByMajorityVersion,
-  getMajorityVersion,
+  filterToolsByHighestVersion,
+  getHighestVersion,
 } from "./version-coherence.js";

--- a/toolkit-docs-generator/src/utils/version-coherence.ts
+++ b/toolkit-docs-generator/src/utils/version-coherence.ts
@@ -1,17 +1,24 @@
 import type { ToolDefinition } from "../types/index.js";
+import { extractVersion } from "./fp.js";
 
 /**
- * Extract version from a fully qualified tool name.
- * "Github.CreateIssue@3.1.3" → "3.1.3"
+ * Compare two semver-like version strings numerically.
+ * Returns a positive number if a > b, negative if a < b, 0 if equal.
  */
-const extractVersion = (fullyQualifiedName: string): string => {
-  const parts = fullyQualifiedName.split("@");
-  return parts[1] ?? "0.0.0";
+const compareVersions = (a: string, b: string): number => {
+  const aParts = a.split(".").map(Number);
+  const bParts = b.split(".").map(Number);
+  const len = Math.max(aParts.length, bParts.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (aParts[i] ?? 0) - (bParts[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
 };
 
 /**
  * Compute the version shared by the most tools in a toolkit.
- * Ties are broken by lexicographic comparison (highest version wins).
+ * Ties are broken by numeric semver comparison (highest version wins).
  */
 export const getMajorityVersion = (
   tools: readonly ToolDefinition[]
@@ -29,7 +36,10 @@ export const getMajorityVersion = (
   let bestVersion = "";
   let bestCount = 0;
   for (const [version, count] of counts) {
-    if (count > bestCount || (count === bestCount && version > bestVersion)) {
+    if (
+      count > bestCount ||
+      (count === bestCount && compareVersions(version, bestVersion) > 0)
+    ) {
       bestVersion = version;
       bestCount = count;
     }

--- a/toolkit-docs-generator/src/utils/version-coherence.ts
+++ b/toolkit-docs-generator/src/utils/version-coherence.ts
@@ -2,12 +2,32 @@ import type { ToolDefinition } from "../types/index.js";
 import { extractVersion } from "./fp.js";
 
 /**
- * Compare two semver-like version strings numerically.
+ * Parse the numeric MAJOR.MINOR.PATCH tuple from a semver string,
+ * stripping pre-release (`-alpha.1`) and build metadata (`+build.456`).
+ *
+ * Handles formats produced by arcade-mcp's normalize_version():
+ *   "3.1.3", "1.2.3-beta.1", "1.2.3+build.456", "1.2.3-rc.1+build.789"
+ */
+const parseNumericVersion = (version: string): number[] => {
+  // Strip build metadata (after +) then pre-release (after -)
+  const core = version.split("+")[0]?.split("-")[0] ?? version;
+  return core.split(".").map((s) => {
+    const n = Number(s);
+    return Number.isNaN(n) ? 0 : n;
+  });
+};
+
+/**
+ * Compare two semver version strings numerically by MAJOR.MINOR.PATCH.
+ * Pre-release and build metadata are ignored for ordering purposes
+ * (they are unlikely to appear in Engine API responses, but we handle
+ * them defensively since arcade-mcp's semver allows them).
+ *
  * Returns a positive number if a > b, negative if a < b, 0 if equal.
  */
 const compareVersions = (a: string, b: string): number => {
-  const aParts = a.split(".").map(Number);
-  const bParts = b.split(".").map(Number);
+  const aParts = parseNumericVersion(a);
+  const bParts = parseNumericVersion(b);
   const len = Math.max(aParts.length, bParts.length);
   for (let i = 0; i < len; i++) {
     const diff = (aParts[i] ?? 0) - (bParts[i] ?? 0);

--- a/toolkit-docs-generator/src/utils/version-coherence.ts
+++ b/toolkit-docs-generator/src/utils/version-coherence.ts
@@ -37,59 +37,51 @@ const compareVersions = (a: string, b: string): number => {
 };
 
 /**
- * Compute the version shared by the most tools in a toolkit.
- * Ties are broken by numeric semver comparison (highest version wins).
+ * Find the highest version among all tools in a toolkit.
+ * This is the version we keep — stale tools from older releases are dropped.
  */
-export const getMajorityVersion = (
+export const getHighestVersion = (
   tools: readonly ToolDefinition[]
 ): string | null => {
   if (tools.length === 0) {
     return null;
   }
 
-  const counts = new Map<string, number>();
+  let best = "";
   for (const tool of tools) {
     const version = extractVersion(tool.fullyQualifiedName);
-    counts.set(version, (counts.get(version) ?? 0) + 1);
-  }
-
-  let bestVersion = "";
-  let bestCount = 0;
-  for (const [version, count] of counts) {
-    if (
-      count > bestCount ||
-      (count === bestCount && compareVersions(version, bestVersion) > 0)
-    ) {
-      bestVersion = version;
-      bestCount = count;
+    if (best === "" || compareVersions(version, best) > 0) {
+      best = version;
     }
   }
 
-  return bestVersion || null;
+  return best || null;
 };
 
 /**
- * Keep only tools whose @version matches the majority version for
- * their toolkit.  If all tools share the same version (the common
+ * Keep only tools whose @version matches the highest version for
+ * their toolkit. If all tools share the same version (the common
  * case), returns the original array unchanged.
+ *
+ * This drops stale tools from older releases that Engine still serves,
+ * while always preserving the newest version — even if it has fewer tools
+ * (e.g. tools were removed/consolidated in the new release).
  */
-export const filterToolsByMajorityVersion = (
+export const filterToolsByHighestVersion = (
   tools: readonly ToolDefinition[]
 ): readonly ToolDefinition[] => {
-  const majorityVersion = getMajorityVersion(tools);
-  if (majorityVersion === null) {
+  const highest = getHighestVersion(tools);
+  if (highest === null) {
     return tools;
   }
 
-  // Fast path: if every tool is already at the majority version, skip filtering
+  // Fast path: if every tool is already at the highest version, skip filtering
   const allSame = tools.every(
-    (t) => extractVersion(t.fullyQualifiedName) === majorityVersion
+    (t) => extractVersion(t.fullyQualifiedName) === highest
   );
   if (allSame) {
     return tools;
   }
 
-  return tools.filter(
-    (t) => extractVersion(t.fullyQualifiedName) === majorityVersion
-  );
+  return tools.filter((t) => extractVersion(t.fullyQualifiedName) === highest);
 };

--- a/toolkit-docs-generator/src/utils/version-coherence.ts
+++ b/toolkit-docs-generator/src/utils/version-coherence.ts
@@ -1,0 +1,65 @@
+import type { ToolDefinition } from "../types/index.js";
+
+/**
+ * Extract version from a fully qualified tool name.
+ * "Github.CreateIssue@3.1.3" → "3.1.3"
+ */
+const extractVersion = (fullyQualifiedName: string): string => {
+  const parts = fullyQualifiedName.split("@");
+  return parts[1] ?? "0.0.0";
+};
+
+/**
+ * Compute the version shared by the most tools in a toolkit.
+ * Ties are broken by lexicographic comparison (highest version wins).
+ */
+export const getMajorityVersion = (
+  tools: readonly ToolDefinition[]
+): string | null => {
+  if (tools.length === 0) {
+    return null;
+  }
+
+  const counts = new Map<string, number>();
+  for (const tool of tools) {
+    const version = extractVersion(tool.fullyQualifiedName);
+    counts.set(version, (counts.get(version) ?? 0) + 1);
+  }
+
+  let bestVersion = "";
+  let bestCount = 0;
+  for (const [version, count] of counts) {
+    if (count > bestCount || (count === bestCount && version > bestVersion)) {
+      bestVersion = version;
+      bestCount = count;
+    }
+  }
+
+  return bestVersion || null;
+};
+
+/**
+ * Keep only tools whose @version matches the majority version for
+ * their toolkit.  If all tools share the same version (the common
+ * case), returns the original array unchanged.
+ */
+export const filterToolsByMajorityVersion = (
+  tools: readonly ToolDefinition[]
+): readonly ToolDefinition[] => {
+  const majorityVersion = getMajorityVersion(tools);
+  if (majorityVersion === null) {
+    return tools;
+  }
+
+  // Fast path: if every tool is already at the majority version, skip filtering
+  const allSame = tools.every(
+    (t) => extractVersion(t.fullyQualifiedName) === majorityVersion
+  );
+  if (allSame) {
+    return tools;
+  }
+
+  return tools.filter(
+    (t) => extractVersion(t.fullyQualifiedName) === majorityVersion
+  );
+};

--- a/toolkit-docs-generator/tests/merger/data-merger.test.ts
+++ b/toolkit-docs-generator/tests/merger/data-merger.test.ts
@@ -9,7 +9,6 @@ import {
   computeAllScopes,
   DataMerger,
   determineAuthType,
-  extractVersion,
   getProviderId,
   groupToolsByToolkit,
   mergeToolkit,
@@ -32,6 +31,7 @@ import type {
   ToolDefinition,
   ToolkitMetadata,
 } from "../../src/types/index.js";
+import { extractVersion } from "../../src/utils/index.js";
 
 // ============================================================================
 // Test Fixtures - Realistic data matching production schema

--- a/toolkit-docs-generator/tests/scenarios/stale-version-tools.test.ts
+++ b/toolkit-docs-generator/tests/scenarios/stale-version-tools.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Scenario Test: Stale version tools are filtered out
+ *
+ * Verifies that when the Engine API returns tools at mixed versions for the
+ * same toolkit, the majority-version coherence filter drops stale tools before
+ * they reach the diff or merger.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  detectChanges,
+  getChangedToolkitIds,
+  hasChanges,
+} from "../../src/diff/index.js";
+import {
+  InMemoryMetadataSource,
+  InMemoryToolDataSource,
+} from "../../src/sources/in-memory.js";
+import { createCombinedToolkitDataSource } from "../../src/sources/toolkit-data-source.js";
+import type { MergedToolkit, ToolDefinition } from "../../src/types/index.js";
+
+const createTool = (
+  overrides: Partial<ToolDefinition> = {}
+): ToolDefinition => ({
+  name: "TestTool",
+  qualifiedName: "Github.TestTool",
+  fullyQualifiedName: "Github.TestTool@3.1.3",
+  description: "A test tool",
+  parameters: [],
+  auth: null,
+  secrets: [],
+  output: null,
+  ...overrides,
+});
+
+const createMergedToolkit = (
+  id: string,
+  version: string,
+  toolNames: string[]
+): MergedToolkit => ({
+  id,
+  label: id,
+  version,
+  description: "A toolkit",
+  metadata: {
+    category: "development",
+    iconUrl: "https://example.com/icon.svg",
+    isBYOC: false,
+    isPro: false,
+    type: "arcade",
+    docsLink: "https://docs.example.com",
+    isComingSoon: false,
+    isHidden: false,
+  },
+  auth: null,
+  tools: toolNames.map((name) => ({
+    name,
+    qualifiedName: `${id}.${name}`,
+    fullyQualifiedName: `${id}.${name}@${version}`,
+    description: "A test tool",
+    parameters: [],
+    auth: null,
+    secrets: [],
+    secretsInfo: [],
+    output: null,
+    documentationChunks: [],
+  })),
+  documentationChunks: [],
+  customImports: [],
+  subPages: [],
+  generatedAt: new Date().toISOString(),
+});
+
+describe("Scenario: Stale version tools filtered by majority-version coherence", () => {
+  it("fetchAllToolkitsData drops stale tools at non-majority versions", async () => {
+    // Simulate Engine API returning mixed-version Github tools
+    const toolSource = new InMemoryToolDataSource([
+      createTool({
+        name: "CreateIssue",
+        qualifiedName: "Github.CreateIssue",
+        fullyQualifiedName: "Github.CreateIssue@3.1.3",
+      }),
+      createTool({
+        name: "ListPullRequests",
+        qualifiedName: "Github.ListPullRequests",
+        fullyQualifiedName: "Github.ListPullRequests@3.1.3",
+      }),
+      createTool({
+        name: "SetStarred",
+        qualifiedName: "Github.SetStarred",
+        fullyQualifiedName: "Github.SetStarred@3.1.3",
+      }),
+      // Stale tools from older version
+      createTool({
+        name: "GetNotificationSummary",
+        qualifiedName: "Github.GetNotificationSummary",
+        fullyQualifiedName: "Github.GetNotificationSummary@2.0.1",
+      }),
+      createTool({
+        name: "ListNotifications",
+        qualifiedName: "Github.ListNotifications",
+        fullyQualifiedName: "Github.ListNotifications@2.0.1",
+      }),
+    ]);
+    const metadataSource = new InMemoryMetadataSource([]);
+    const dataSource = createCombinedToolkitDataSource({
+      toolSource,
+      metadataSource,
+    });
+
+    const result = await dataSource.fetchAllToolkitsData();
+    const github = result.get("Github");
+
+    expect(github).toBeDefined();
+    expect(github?.tools).toHaveLength(3);
+    expect(
+      github?.tools.every((t) => t.fullyQualifiedName.endsWith("@3.1.3"))
+    ).toBe(true);
+  });
+
+  it("diff correctly reflects removal when previous output had stale tools", async () => {
+    // After filtering, the data source returns only @3.1.3 tools
+    const filteredTools = new Map([
+      [
+        "Github",
+        [
+          createTool({
+            name: "CreateIssue",
+            qualifiedName: "Github.CreateIssue",
+            fullyQualifiedName: "Github.CreateIssue@3.1.3",
+          }),
+          createTool({
+            name: "ListPullRequests",
+            qualifiedName: "Github.ListPullRequests",
+            fullyQualifiedName: "Github.ListPullRequests@3.1.3",
+          }),
+          createTool({
+            name: "SetStarred",
+            qualifiedName: "Github.SetStarred",
+            fullyQualifiedName: "Github.SetStarred@3.1.3",
+          }),
+        ],
+      ],
+    ]);
+
+    // Previous output (before the filter existed) had stale tools
+    const previousToolkits = new Map([
+      [
+        "Github",
+        createMergedToolkit("Github", "3.1.3", [
+          "CreateIssue",
+          "ListPullRequests",
+          "SetStarred",
+          "GetNotificationSummary",
+          "ListNotifications",
+        ]),
+      ],
+    ]);
+
+    const result = detectChanges(filteredTools, previousToolkits);
+
+    // The diff should detect the change (stale tools removed)
+    expect(hasChanges(result)).toBe(true);
+    const changedIds = getChangedToolkitIds(result);
+    expect(changedIds).toContain("Github");
+    expect(result.summary.modifiedToolkits).toBe(1);
+  });
+
+  it("diff sees no changes when previous output already had clean data", async () => {
+    // After filtering, data source returns only @3.1.3 tools
+    const filteredTools = new Map([
+      [
+        "Github",
+        [
+          createTool({
+            name: "CreateIssue",
+            qualifiedName: "Github.CreateIssue",
+            fullyQualifiedName: "Github.CreateIssue@3.1.3",
+          }),
+          createTool({
+            name: "ListPullRequests",
+            qualifiedName: "Github.ListPullRequests",
+            fullyQualifiedName: "Github.ListPullRequests@3.1.3",
+          }),
+        ],
+      ],
+    ]);
+
+    // Previous output already had only the majority-version tools
+    const previousToolkits = new Map([
+      [
+        "Github",
+        createMergedToolkit("Github", "3.1.3", [
+          "CreateIssue",
+          "ListPullRequests",
+        ]),
+      ],
+    ]);
+
+    const result = detectChanges(filteredTools, previousToolkits);
+
+    expect(hasChanges(result)).toBe(false);
+    expect(getChangedToolkitIds(result)).toHaveLength(0);
+  });
+});

--- a/toolkit-docs-generator/tests/scenarios/stale-version-tools.test.ts
+++ b/toolkit-docs-generator/tests/scenarios/stale-version-tools.test.ts
@@ -2,7 +2,7 @@
  * Scenario Test: Stale version tools are filtered out
  *
  * Verifies that when the Engine API returns tools at mixed versions for the
- * same toolkit, the majority-version coherence filter drops stale tools before
+ * same toolkit, the highest-version coherence filter drops stale tools before
  * they reach the diff or merger.
  */
 import { describe, expect, it } from "vitest";
@@ -71,8 +71,8 @@ const createMergedToolkit = (
   generatedAt: new Date().toISOString(),
 });
 
-describe("Scenario: Stale version tools filtered by majority-version coherence", () => {
-  it("fetchAllToolkitsData drops stale tools at non-majority versions", async () => {
+describe("Scenario: Stale version tools filtered by highest-version coherence", () => {
+  it("fetchAllToolkitsData drops stale tools at older versions", async () => {
     // Simulate Engine API returning mixed-version Github tools
     const toolSource = new InMemoryToolDataSource([
       createTool({
@@ -186,7 +186,7 @@ describe("Scenario: Stale version tools filtered by majority-version coherence",
       ],
     ]);
 
-    // Previous output already had only the majority-version tools
+    // Previous output already had only the highest-version tools
     const previousToolkits = new Map([
       [
         "Github",

--- a/toolkit-docs-generator/tests/sources/toolkit-data-source.test.ts
+++ b/toolkit-docs-generator/tests/sources/toolkit-data-source.test.ts
@@ -160,7 +160,7 @@ describe("CombinedToolkitDataSource", () => {
     expect(weaviate?.metadata?.label).toBe("Weaviate API");
   });
 
-  it("should filter out stale tools at non-majority versions in fetchAllToolkitsData", async () => {
+  it("should filter out stale tools at older versions in fetchAllToolkitsData", async () => {
     const toolSource = new InMemoryToolDataSource([
       createTool({
         name: "CreateIssue",
@@ -193,7 +193,7 @@ describe("CombinedToolkitDataSource", () => {
     ).toBe(true);
   });
 
-  it("should apply majority-version filter in fetchToolkitData when no version specified", async () => {
+  it("should apply highest-version filter in fetchToolkitData when no version specified", async () => {
     const toolSource = new InMemoryToolDataSource([
       createTool({
         name: "CreateIssue",
@@ -244,7 +244,7 @@ describe("CombinedToolkitDataSource", () => {
       metadataSource,
     });
 
-    // Explicit version bypasses majority filter
+    // Explicit version bypasses highest-version filter
     const result = await dataSource.fetchToolkitData("Github", "2.0.1");
 
     expect(result.tools).toHaveLength(1);

--- a/toolkit-docs-generator/tests/sources/toolkit-data-source.test.ts
+++ b/toolkit-docs-generator/tests/sources/toolkit-data-source.test.ts
@@ -160,6 +160,97 @@ describe("CombinedToolkitDataSource", () => {
     expect(weaviate?.metadata?.label).toBe("Weaviate API");
   });
 
+  it("should filter out stale tools at non-majority versions in fetchAllToolkitsData", async () => {
+    const toolSource = new InMemoryToolDataSource([
+      createTool({
+        name: "CreateIssue",
+        qualifiedName: "Github.CreateIssue",
+        fullyQualifiedName: "Github.CreateIssue@3.1.3",
+      }),
+      createTool({
+        name: "ListPullRequests",
+        qualifiedName: "Github.ListPullRequests",
+        fullyQualifiedName: "Github.ListPullRequests@3.1.3",
+      }),
+      createTool({
+        name: "GetNotificationSummary",
+        qualifiedName: "Github.GetNotificationSummary",
+        fullyQualifiedName: "Github.GetNotificationSummary@2.0.1",
+      }),
+    ]);
+    const metadataSource = new InMemoryMetadataSource([createMetadata()]);
+    const dataSource = createCombinedToolkitDataSource({
+      toolSource,
+      metadataSource,
+    });
+
+    const result = await dataSource.fetchAllToolkitsData();
+    const github = result.get("Github");
+
+    expect(github?.tools).toHaveLength(2);
+    expect(
+      github?.tools.every((t) => t.fullyQualifiedName.endsWith("@3.1.3"))
+    ).toBe(true);
+  });
+
+  it("should apply majority-version filter in fetchToolkitData when no version specified", async () => {
+    const toolSource = new InMemoryToolDataSource([
+      createTool({
+        name: "CreateIssue",
+        qualifiedName: "Github.CreateIssue",
+        fullyQualifiedName: "Github.CreateIssue@3.1.3",
+      }),
+      createTool({
+        name: "ListPullRequests",
+        qualifiedName: "Github.ListPullRequests",
+        fullyQualifiedName: "Github.ListPullRequests@3.1.3",
+      }),
+      createTool({
+        name: "GetNotificationSummary",
+        qualifiedName: "Github.GetNotificationSummary",
+        fullyQualifiedName: "Github.GetNotificationSummary@2.0.1",
+      }),
+    ]);
+    const metadataSource = new InMemoryMetadataSource([createMetadata()]);
+    const dataSource = createCombinedToolkitDataSource({
+      toolSource,
+      metadataSource,
+    });
+
+    const result = await dataSource.fetchToolkitData("Github");
+
+    expect(result.tools).toHaveLength(2);
+    expect(
+      result.tools.every((t) => t.fullyQualifiedName.endsWith("@3.1.3"))
+    ).toBe(true);
+  });
+
+  it("should still allow explicit version filter in fetchToolkitData", async () => {
+    const toolSource = new InMemoryToolDataSource([
+      createTool({
+        name: "CreateIssue",
+        qualifiedName: "Github.CreateIssue",
+        fullyQualifiedName: "Github.CreateIssue@3.1.3",
+      }),
+      createTool({
+        name: "GetNotificationSummary",
+        qualifiedName: "Github.GetNotificationSummary",
+        fullyQualifiedName: "Github.GetNotificationSummary@2.0.1",
+      }),
+    ]);
+    const metadataSource = new InMemoryMetadataSource([createMetadata()]);
+    const dataSource = createCombinedToolkitDataSource({
+      toolSource,
+      metadataSource,
+    });
+
+    // Explicit version bypasses majority filter
+    const result = await dataSource.fetchToolkitData("Github", "2.0.1");
+
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0]?.fullyQualifiedName).toContain("@2.0.1");
+  });
+
   it("should fall back to providerId metadata for *Api toolkits", async () => {
     const toolSource = new InMemoryToolDataSource([
       createTool({

--- a/toolkit-docs-generator/tests/utils/version-coherence.test.ts
+++ b/toolkit-docs-generator/tests/utils/version-coherence.test.ts
@@ -55,7 +55,7 @@ describe("getMajorityVersion", () => {
     expect(getMajorityVersion(tools)).toBe("1.0.0");
   });
 
-  it("breaks ties by picking the lexicographically higher version", () => {
+  it("breaks ties by picking the numerically higher version", () => {
     const tools = [
       createTool("Github.CreateIssue@1.0.0"),
       createTool("Github.ListPullRequests@1.0.0"),
@@ -63,6 +63,16 @@ describe("getMajorityVersion", () => {
       createTool("Github.GetStar@2.0.0"),
     ];
     expect(getMajorityVersion(tools)).toBe("2.0.0");
+  });
+
+  it("handles multi-digit version components correctly in tie-break", () => {
+    const tools = [
+      createTool("Github.CreateIssue@9.0.0"),
+      createTool("Github.ListPullRequests@9.0.0"),
+      createTool("Github.SetStarred@10.0.0"),
+      createTool("Github.GetStar@10.0.0"),
+    ];
+    expect(getMajorityVersion(tools)).toBe("10.0.0");
   });
 });
 
@@ -109,7 +119,7 @@ describe("filterToolsByMajorityVersion", () => {
     expect(result).toHaveLength(1);
   });
 
-  it("breaks ties by keeping tools at the higher version", () => {
+  it("breaks ties by keeping tools at the numerically higher version", () => {
     const tools = [
       createTool("Github.CreateIssue@1.0.0"),
       createTool("Github.ListPullRequests@1.0.0"),

--- a/toolkit-docs-generator/tests/utils/version-coherence.test.ts
+++ b/toolkit-docs-generator/tests/utils/version-coherence.test.ts
@@ -1,11 +1,11 @@
 /**
- * Tests for majority-version coherence filter
+ * Tests for highest-version coherence filter
  */
 import { describe, expect, it } from "vitest";
 import type { ToolDefinition } from "../../src/types/index.js";
 import {
-  filterToolsByMajorityVersion,
-  getMajorityVersion,
+  filterToolsByHighestVersion,
+  getHighestVersion,
 } from "../../src/utils/version-coherence.js";
 
 const createTool = (
@@ -23,9 +23,9 @@ const createTool = (
   ...overrides,
 });
 
-describe("getMajorityVersion", () => {
+describe("getHighestVersion", () => {
   it("returns null for empty array", () => {
-    expect(getMajorityVersion([])).toBeNull();
+    expect(getHighestVersion([])).toBeNull();
   });
 
   it("returns the version when all tools share the same version", () => {
@@ -34,10 +34,10 @@ describe("getMajorityVersion", () => {
       createTool("Github.ListPullRequests@3.1.3"),
       createTool("Github.SetStarred@3.1.3"),
     ];
-    expect(getMajorityVersion(tools)).toBe("3.1.3");
+    expect(getHighestVersion(tools)).toBe("3.1.3");
   });
 
-  it("returns the majority version when mixed", () => {
+  it("returns the highest version when mixed", () => {
     const tools = [
       createTool("Github.CreateIssue@3.1.3"),
       createTool("Github.ListPullRequests@3.1.3"),
@@ -47,78 +47,84 @@ describe("getMajorityVersion", () => {
       createTool("Github.GetNotificationSummary@2.0.1"),
       createTool("Github.ListNotifications@2.0.1"),
     ];
-    expect(getMajorityVersion(tools)).toBe("3.1.3");
+    expect(getHighestVersion(tools)).toBe("3.1.3");
   });
 
   it("returns the version for a single tool", () => {
     const tools = [createTool("Github.CreateIssue@1.0.0")];
-    expect(getMajorityVersion(tools)).toBe("1.0.0");
+    expect(getHighestVersion(tools)).toBe("1.0.0");
   });
 
-  it("breaks ties by picking the numerically higher version", () => {
+  it("picks the numerically higher version regardless of tool count", () => {
     const tools = [
       createTool("Github.CreateIssue@1.0.0"),
       createTool("Github.ListPullRequests@1.0.0"),
       createTool("Github.SetStarred@2.0.0"),
-      createTool("Github.GetStar@2.0.0"),
     ];
-    expect(getMajorityVersion(tools)).toBe("2.0.0");
+    expect(getHighestVersion(tools)).toBe("2.0.0");
   });
 
-  it("handles multi-digit version components correctly in tie-break", () => {
+  it("picks newer version even when it has fewer tools", () => {
+    // New release @4.0.0 consolidated tools — only 2 remain.
+    // Old stale tools @3.1.3 still outnumber it. Highest version wins.
+    const tools = [
+      createTool("Github.CreateIssue@3.1.3"),
+      createTool("Github.ListPullRequests@3.1.3"),
+      createTool("Github.SetStarred@3.1.3"),
+      createTool("Github.GetStar@3.1.3"),
+      createTool("Github.ListStars@3.1.3"),
+      createTool("Github.Search@4.0.0"),
+      createTool("Github.Advanced@4.0.0"),
+    ];
+    expect(getHighestVersion(tools)).toBe("4.0.0");
+  });
+
+  it("handles multi-digit version components correctly", () => {
     const tools = [
       createTool("Github.CreateIssue@9.0.0"),
-      createTool("Github.ListPullRequests@9.0.0"),
       createTool("Github.SetStarred@10.0.0"),
-      createTool("Github.GetStar@10.0.0"),
     ];
-    expect(getMajorityVersion(tools)).toBe("10.0.0");
+    expect(getHighestVersion(tools)).toBe("10.0.0");
   });
 
-  it("handles pre-release versions in tie-break comparison", () => {
+  it("handles pre-release versions", () => {
     const tools = [
       createTool("Github.CreateIssue@1.0.0-alpha.1"),
-      createTool("Github.ListPullRequests@1.0.0-alpha.1"),
       createTool("Github.SetStarred@2.0.0-beta.1"),
-      createTool("Github.GetStar@2.0.0-beta.1"),
     ];
-    expect(getMajorityVersion(tools)).toBe("2.0.0-beta.1");
+    expect(getHighestVersion(tools)).toBe("2.0.0-beta.1");
   });
 
-  it("handles build metadata versions in tie-break comparison", () => {
+  it("handles build metadata versions", () => {
     const tools = [
       createTool("Github.CreateIssue@1.0.0+build.456"),
-      createTool("Github.ListPullRequests@1.0.0+build.456"),
       createTool("Github.SetStarred@3.0.0+build.789"),
-      createTool("Github.GetStar@3.0.0+build.789"),
     ];
-    expect(getMajorityVersion(tools)).toBe("3.0.0+build.789");
+    expect(getHighestVersion(tools)).toBe("3.0.0+build.789");
   });
 
   it("handles pre-release + build metadata combined", () => {
     const tools = [
       createTool("Github.CreateIssue@1.2.3-rc.1+build.789"),
-      createTool("Github.ListPullRequests@1.2.3-rc.1+build.789"),
       createTool("Github.SetStarred@4.0.0-beta.1+build.123"),
-      createTool("Github.GetStar@4.0.0-beta.1+build.123"),
     ];
-    expect(getMajorityVersion(tools)).toBe("4.0.0-beta.1+build.123");
+    expect(getHighestVersion(tools)).toBe("4.0.0-beta.1+build.123");
   });
 });
 
-describe("filterToolsByMajorityVersion", () => {
+describe("filterToolsByHighestVersion", () => {
   it("returns the same array reference when all tools share the same version", () => {
     const tools = [
       createTool("Github.CreateIssue@3.1.3"),
       createTool("Github.ListPullRequests@3.1.3"),
       createTool("Github.SetStarred@3.1.3"),
     ];
-    const result = filterToolsByMajorityVersion(tools);
+    const result = filterToolsByHighestVersion(tools);
     expect(result).toBe(tools); // same reference
     expect(result).toHaveLength(3);
   });
 
-  it("filters out minority-version tools", () => {
+  it("filters out older-version tools", () => {
     const tools = [
       createTool("Github.CreateIssue@3.1.3"),
       createTool("Github.ListPullRequests@3.1.3"),
@@ -128,39 +134,42 @@ describe("filterToolsByMajorityVersion", () => {
       createTool("Github.GetNotificationSummary@2.0.1"),
       createTool("Github.ListNotifications@2.0.1"),
     ];
-    const result = filterToolsByMajorityVersion(tools);
+    const result = filterToolsByHighestVersion(tools);
     expect(result).toHaveLength(5);
     expect(result.every((t) => t.fullyQualifiedName.endsWith("@3.1.3"))).toBe(
       true
     );
   });
 
+  it("keeps newer version even when it has fewer tools", () => {
+    const tools = [
+      createTool("Github.CreateIssue@3.1.3"),
+      createTool("Github.ListPullRequests@3.1.3"),
+      createTool("Github.SetStarred@3.1.3"),
+      createTool("Github.GetStar@3.1.3"),
+      createTool("Github.ListStars@3.1.3"),
+      createTool("Github.Search@4.0.0"),
+      createTool("Github.Advanced@4.0.0"),
+    ];
+    const result = filterToolsByHighestVersion(tools);
+    expect(result).toHaveLength(2);
+    expect(result.every((t) => t.fullyQualifiedName.endsWith("@4.0.0"))).toBe(
+      true
+    );
+  });
+
   it("returns the original array for empty input", () => {
     const tools: ToolDefinition[] = [];
-    const result = filterToolsByMajorityVersion(tools);
+    const result = filterToolsByHighestVersion(tools);
     expect(result).toBe(tools);
     expect(result).toHaveLength(0);
   });
 
   it("returns a single tool unchanged", () => {
     const tools = [createTool("Github.CreateIssue@1.0.0")];
-    const result = filterToolsByMajorityVersion(tools);
+    const result = filterToolsByHighestVersion(tools);
     expect(result).toBe(tools);
     expect(result).toHaveLength(1);
-  });
-
-  it("breaks ties by keeping tools at the numerically higher version", () => {
-    const tools = [
-      createTool("Github.CreateIssue@1.0.0"),
-      createTool("Github.ListPullRequests@1.0.0"),
-      createTool("Github.SetStarred@2.0.0"),
-      createTool("Github.GetStar@2.0.0"),
-    ];
-    const result = filterToolsByMajorityVersion(tools);
-    expect(result).toHaveLength(2);
-    expect(result.every((t) => t.fullyQualifiedName.endsWith("@2.0.0"))).toBe(
-      true
-    );
   });
 
   it("handles tools with no @ version gracefully", () => {
@@ -172,7 +181,7 @@ describe("filterToolsByMajorityVersion", () => {
         fullyQualifiedName: "Github.Broken",
       },
     ];
-    const result = filterToolsByMajorityVersion(tools);
+    const result = filterToolsByHighestVersion(tools);
     expect(result).toHaveLength(2);
     expect(result.every((t) => t.fullyQualifiedName.endsWith("@3.1.3"))).toBe(
       true

--- a/toolkit-docs-generator/tests/utils/version-coherence.test.ts
+++ b/toolkit-docs-generator/tests/utils/version-coherence.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for majority-version coherence filter
+ */
+import { describe, expect, it } from "vitest";
+import type { ToolDefinition } from "../../src/types/index.js";
+import {
+  filterToolsByMajorityVersion,
+  getMajorityVersion,
+} from "../../src/utils/version-coherence.js";
+
+const createTool = (
+  fullyQualifiedName: string,
+  overrides: Partial<ToolDefinition> = {}
+): ToolDefinition => ({
+  name: fullyQualifiedName.split("@")[0]?.split(".")[1] ?? "Tool",
+  qualifiedName: fullyQualifiedName.split("@")[0] ?? "",
+  fullyQualifiedName,
+  description: "A test tool",
+  parameters: [],
+  auth: null,
+  secrets: [],
+  output: null,
+  ...overrides,
+});
+
+describe("getMajorityVersion", () => {
+  it("returns null for empty array", () => {
+    expect(getMajorityVersion([])).toBeNull();
+  });
+
+  it("returns the version when all tools share the same version", () => {
+    const tools = [
+      createTool("Github.CreateIssue@3.1.3"),
+      createTool("Github.ListPullRequests@3.1.3"),
+      createTool("Github.SetStarred@3.1.3"),
+    ];
+    expect(getMajorityVersion(tools)).toBe("3.1.3");
+  });
+
+  it("returns the majority version when mixed", () => {
+    const tools = [
+      createTool("Github.CreateIssue@3.1.3"),
+      createTool("Github.ListPullRequests@3.1.3"),
+      createTool("Github.SetStarred@3.1.3"),
+      createTool("Github.GetStar@3.1.3"),
+      createTool("Github.ListStars@3.1.3"),
+      createTool("Github.GetNotificationSummary@2.0.1"),
+      createTool("Github.ListNotifications@2.0.1"),
+    ];
+    expect(getMajorityVersion(tools)).toBe("3.1.3");
+  });
+
+  it("returns the version for a single tool", () => {
+    const tools = [createTool("Github.CreateIssue@1.0.0")];
+    expect(getMajorityVersion(tools)).toBe("1.0.0");
+  });
+
+  it("breaks ties by picking the lexicographically higher version", () => {
+    const tools = [
+      createTool("Github.CreateIssue@1.0.0"),
+      createTool("Github.ListPullRequests@1.0.0"),
+      createTool("Github.SetStarred@2.0.0"),
+      createTool("Github.GetStar@2.0.0"),
+    ];
+    expect(getMajorityVersion(tools)).toBe("2.0.0");
+  });
+});
+
+describe("filterToolsByMajorityVersion", () => {
+  it("returns the same array reference when all tools share the same version", () => {
+    const tools = [
+      createTool("Github.CreateIssue@3.1.3"),
+      createTool("Github.ListPullRequests@3.1.3"),
+      createTool("Github.SetStarred@3.1.3"),
+    ];
+    const result = filterToolsByMajorityVersion(tools);
+    expect(result).toBe(tools); // same reference
+    expect(result).toHaveLength(3);
+  });
+
+  it("filters out minority-version tools", () => {
+    const tools = [
+      createTool("Github.CreateIssue@3.1.3"),
+      createTool("Github.ListPullRequests@3.1.3"),
+      createTool("Github.SetStarred@3.1.3"),
+      createTool("Github.GetStar@3.1.3"),
+      createTool("Github.ListStars@3.1.3"),
+      createTool("Github.GetNotificationSummary@2.0.1"),
+      createTool("Github.ListNotifications@2.0.1"),
+    ];
+    const result = filterToolsByMajorityVersion(tools);
+    expect(result).toHaveLength(5);
+    expect(result.every((t) => t.fullyQualifiedName.endsWith("@3.1.3"))).toBe(
+      true
+    );
+  });
+
+  it("returns the original array for empty input", () => {
+    const tools: ToolDefinition[] = [];
+    const result = filterToolsByMajorityVersion(tools);
+    expect(result).toBe(tools);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns a single tool unchanged", () => {
+    const tools = [createTool("Github.CreateIssue@1.0.0")];
+    const result = filterToolsByMajorityVersion(tools);
+    expect(result).toBe(tools);
+    expect(result).toHaveLength(1);
+  });
+
+  it("breaks ties by keeping tools at the higher version", () => {
+    const tools = [
+      createTool("Github.CreateIssue@1.0.0"),
+      createTool("Github.ListPullRequests@1.0.0"),
+      createTool("Github.SetStarred@2.0.0"),
+      createTool("Github.GetStar@2.0.0"),
+    ];
+    const result = filterToolsByMajorityVersion(tools);
+    expect(result).toHaveLength(2);
+    expect(result.every((t) => t.fullyQualifiedName.endsWith("@2.0.0"))).toBe(
+      true
+    );
+  });
+
+  it("handles tools with no @ version gracefully", () => {
+    const tools = [
+      createTool("Github.CreateIssue@3.1.3"),
+      createTool("Github.ListPullRequests@3.1.3"),
+      {
+        ...createTool("Github.Broken@0.0.0"),
+        fullyQualifiedName: "Github.Broken",
+      },
+    ];
+    const result = filterToolsByMajorityVersion(tools);
+    expect(result).toHaveLength(2);
+    expect(result.every((t) => t.fullyQualifiedName.endsWith("@3.1.3"))).toBe(
+      true
+    );
+  });
+});

--- a/toolkit-docs-generator/tests/utils/version-coherence.test.ts
+++ b/toolkit-docs-generator/tests/utils/version-coherence.test.ts
@@ -74,6 +74,36 @@ describe("getMajorityVersion", () => {
     ];
     expect(getMajorityVersion(tools)).toBe("10.0.0");
   });
+
+  it("handles pre-release versions in tie-break comparison", () => {
+    const tools = [
+      createTool("Github.CreateIssue@1.0.0-alpha.1"),
+      createTool("Github.ListPullRequests@1.0.0-alpha.1"),
+      createTool("Github.SetStarred@2.0.0-beta.1"),
+      createTool("Github.GetStar@2.0.0-beta.1"),
+    ];
+    expect(getMajorityVersion(tools)).toBe("2.0.0-beta.1");
+  });
+
+  it("handles build metadata versions in tie-break comparison", () => {
+    const tools = [
+      createTool("Github.CreateIssue@1.0.0+build.456"),
+      createTool("Github.ListPullRequests@1.0.0+build.456"),
+      createTool("Github.SetStarred@3.0.0+build.789"),
+      createTool("Github.GetStar@3.0.0+build.789"),
+    ];
+    expect(getMajorityVersion(tools)).toBe("3.0.0+build.789");
+  });
+
+  it("handles pre-release + build metadata combined", () => {
+    const tools = [
+      createTool("Github.CreateIssue@1.2.3-rc.1+build.789"),
+      createTool("Github.ListPullRequests@1.2.3-rc.1+build.789"),
+      createTool("Github.SetStarred@4.0.0-beta.1+build.123"),
+      createTool("Github.GetStar@4.0.0-beta.1+build.123"),
+    ];
+    expect(getMajorityVersion(tools)).toBe("4.0.0-beta.1+build.123");
+  });
 });
 
 describe("filterToolsByMajorityVersion", () => {


### PR DESCRIPTION
## Summary

- Adds `filterToolsByMajorityVersion()` utility that computes the version shared by the most tools in a toolkit and drops tools at other versions
- Applied in both `fetchAllToolkitsData()` and `fetchToolkitData()` (when no explicit version is passed) in `CombinedToolkitDataSource`
- Fixes stale tools from older toolkit releases (e.g. Github notification tools at `@2.0.1` alongside 35+ tools at `@3.1.3`) surviving through the docs pipeline indefinitely

## Problem

The Engine `/v1/tool_metadata` endpoint returns tools at mixed versions for the same toolkit. The docs generator trusts this as-is, grouping tools by toolkit ID with no version filtering. The `--skip-unchanged` flow compounds this — it correctly sees no change run after run (because the API keeps returning the same stale tools), preserving old output indefinitely.

## Solution

After grouping tools by toolkit ID, compute the majority version (the version shared by the most tools), then keep only tools at that version. This drops stale tools before they reach the diff or merger. Explicit version parameters bypass the filter.

## Test plan

- [x] Unit tests for `getMajorityVersion` and `filterToolsByMajorityVersion` (11 tests)
- [x] Integration tests for `CombinedToolkitDataSource` version filtering (3 new tests)
- [x] Scenario test: mixed-version tools → filter → clean diff (3 tests)
- [x] Full test suite passes (499 tests, 0 type errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tools are included in generated docs/diffs by automatically dropping older-version tools when Engine returns mixed versions, which can cause large output churn if current data has inconsistencies.
> 
> **Overview**
> Adds a highest-version coherence filter so each toolkit keeps only tools at the numerically highest `@version` when no explicit version is requested, dropping stale tools from older releases in both `fetchToolkitData()` and `fetchAllToolkitsData()`.
> 
> Introduces `utils/version-coherence.ts` (plus exports) and moves `extractVersion` into `utils/fp.ts` while re-exporting it from `data-merger.ts` for compatibility. Updates the merger to **preserve a previous toolkit summary** when the tool signature changes but summary generation is disabled (no LLM), and adds unit/scenario tests covering mixed-version filtering and diff/summary behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 417a51fd98dfba74227b471639b2f5e76a54b215. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->