### PR TITLE
docs: add copy-paste ACR + Claude setup guide

### DIFF
--- a/ACR_CLAUDE_SETUP.md
+++ b/ACR_CLAUDE_SETUP.md
@@ -1,0 +1,114 @@
+# Setup ACR + Claude Code (copy/paste guide)
+
+Run this from your repository root.
+
+```bash
+set -euo pipefail
+
+# 1) Install Claude Code CLI (recommended)
+curl -fsSL https://claude.ai/install.sh | bash
+
+# Ensure claude is on PATH in this shell
+export PATH="$HOME/.local/bin:$PATH"
+
+# 2) Install ACR
+if ! command -v go >/dev/null 2>&1; then
+  echo "Go is required. Install Go 1.25+ first, then rerun."
+  exit 1
+fi
+
+go install github.com/richhaase/agentic-code-reviewer/cmd/acr@latest
+
+# Ensure acr is on PATH in this shell
+export PATH="$(go env GOPATH)/bin:$PATH"
+
+# 3) Create project-local Claude command + skill
+mkdir -p .claude/commands .claude/skills/acr-help
+
+cat > .claude/commands/acr-run.md <<'MD'
+---
+description: Run ACR locally with Claude reviewers
+argument-hint: "[extra-acr-args]"
+disable-model-invocation: true
+---
+
+Run Agentic Code Reviewer in this repository with Claude for review and summarization.
+
+```bash
+acr --reviewer-agent claude --summarizer-agent claude --local --verbose $ARGUMENTS
+```
+
+After it completes:
+1. Group findings by severity.
+2. Start with security, data loss, and crash risks.
+3. Include file paths and concrete fixes.
+MD
+
+cat > .claude/skills/acr-help/SKILL.md <<'MD'
+---
+name: acr-help
+description: Explain and run ACR with Claude in this repo.
+disable-model-invocation: true
+argument-hint: "[extra-acr-args]"
+allowed-tools: Bash(acr *) Bash(git status) Read Grep Glob
+---
+
+Use this skill when the user wants to run ACR and interpret results.
+
+## Quick run
+
+```bash
+acr --reviewer-agent claude --summarizer-agent claude --local --verbose $ARGUMENTS
+```
+
+## How to use output
+
+1. Fix high-severity findings first.
+2. For each finding, provide:
+   - Risk
+   - File and line
+   - Suggested patch
+3. If no findings, report: "LGTM locally."
+
+## Useful variants
+
+```bash
+# More coverage, avoid rate limits
+acr -r 8 -c 3 --reviewer-agent claude --summarizer-agent claude --local
+
+# Compare against develop
+acr -b develop --reviewer-agent claude --summarizer-agent claude --local
+
+# Review PR (requires gh auth)
+acr --pr 123 --reviewer-agent claude --summarizer-agent claude
+```
+MD
+
+echo "Setup complete."
+echo "Open Claude in this repo and use:"
+echo "  /acr-run"
+echo "  /acr-help"
+```
+
+## Authenticate once
+
+```bash
+claude
+```
+
+Follow the login flow.
+
+Optional (only for PR posting from ACR):
+
+```bash
+gh auth login
+```
+
+## Daily usage in Claude
+
+- Run local review:
+  - `/acr-run`
+- Run with custom flags:
+  - `/acr-run -r 8 -c 3 -b develop`
+- Show instructions:
+  - `/acr-help`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `ACR_CLAUDE_SETUP.md` at repo root
- include one copy/paste bash setup script for Claude Code + ACR install
- include steps to create project-local Claude command (`/acr-run`) and skill (`/acr-help`)
- include one-time authentication and daily usage examples

## Notes
- This is a user-requested convenience guide designed for easy copy/paste setup.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3aa1ac92-d3f8-40a6-acd4-37c0bc3d8770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3aa1ac92-d3f8-40a6-acd4-37c0bc3d8770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

