### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/app/en/resources/integrations/development/_meta.tsx
+++ b/app/en/resources/integrations/development/_meta.tsx
@@ -65,6 +65,10 @@ const meta: MetaRecord = {
     title: "Vercel API",
     href: "/en/resources/integrations/development/vercel-api",
   },
+  "zoho-creator-api": {
+    title: "Zoho Creator API",
+    href: "/en/resources/integrations/development/zoho-creator-api",
+  },
 };
 
 export default meta;

--- a/toolkit-docs-generator/data/toolkits/gmail.json
+++ b/toolkit-docs-generator/data/toolkits/gmail.json
@@ -1,7 +1,7 @@
 {
   "id": "Gmail",
   "label": "Gmail",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Arcade.dev LLM tools for Gmail",
   "metadata": {
     "category": "productivity",
@@ -30,7 +30,7 @@
     {
       "name": "ChangeEmailLabels",
       "qualifiedName": "Gmail.ChangeEmailLabels",
-      "fullyQualifiedName": "Gmail.ChangeEmailLabels@4.2.0",
+      "fullyQualifiedName": "Gmail.ChangeEmailLabels@4.2.1",
       "description": "Add and remove labels from an email using the Gmail API.",
       "parameters": [
         {
@@ -124,7 +124,7 @@
     {
       "name": "CreateLabel",
       "qualifiedName": "Gmail.CreateLabel",
-      "fullyQualifiedName": "Gmail.CreateLabel@4.2.0",
+      "fullyQualifiedName": "Gmail.CreateLabel@4.2.1",
       "description": "Create a new label in the user's mailbox.",
       "parameters": [
         {
@@ -184,7 +184,7 @@
     {
       "name": "DeleteDraftEmail",
       "qualifiedName": "Gmail.DeleteDraftEmail",
-      "fullyQualifiedName": "Gmail.DeleteDraftEmail@4.2.0",
+      "fullyQualifiedName": "Gmail.DeleteDraftEmail@4.2.1",
       "description": "Delete a draft email using the Gmail API.",
       "parameters": [
         {
@@ -244,7 +244,7 @@
     {
       "name": "GetThread",
       "qualifiedName": "Gmail.GetThread",
-      "fullyQualifiedName": "Gmail.GetThread@4.2.0",
+      "fullyQualifiedName": "Gmail.GetThread@4.2.1",
       "description": "Get the specified thread by ID.",
       "parameters": [
         {
@@ -304,7 +304,7 @@
     {
       "name": "ListDraftEmails",
       "qualifiedName": "Gmail.ListDraftEmails",
-      "fullyQualifiedName": "Gmail.ListDraftEmails@4.2.0",
+      "fullyQualifiedName": "Gmail.ListDraftEmails@4.2.1",
       "description": "Lists draft emails in the user's draft mailbox using the Gmail API.",
       "parameters": [
         {
@@ -364,7 +364,7 @@
     {
       "name": "ListEmails",
       "qualifiedName": "Gmail.ListEmails",
-      "fullyQualifiedName": "Gmail.ListEmails@4.2.0",
+      "fullyQualifiedName": "Gmail.ListEmails@4.2.1",
       "description": "Read emails from a Gmail account and extract plain text content.",
       "parameters": [
         {
@@ -424,7 +424,7 @@
     {
       "name": "ListEmailsByHeader",
       "qualifiedName": "Gmail.ListEmailsByHeader",
-      "fullyQualifiedName": "Gmail.ListEmailsByHeader@4.2.0",
+      "fullyQualifiedName": "Gmail.ListEmailsByHeader@4.2.1",
       "description": "Search for emails by header using the Gmail API.",
       "parameters": [
         {
@@ -570,7 +570,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Gmail.ListLabels",
-      "fullyQualifiedName": "Gmail.ListLabels@4.2.0",
+      "fullyQualifiedName": "Gmail.ListLabels@4.2.1",
       "description": "List all the labels in the user's mailbox.",
       "parameters": [],
       "auth": {
@@ -615,7 +615,7 @@
     {
       "name": "ListThreads",
       "qualifiedName": "Gmail.ListThreads",
-      "fullyQualifiedName": "Gmail.ListThreads@4.2.0",
+      "fullyQualifiedName": "Gmail.ListThreads@4.2.1",
       "description": "List threads in the user's mailbox.",
       "parameters": [
         {
@@ -701,7 +701,7 @@
     {
       "name": "ReplyToEmail",
       "qualifiedName": "Gmail.ReplyToEmail",
-      "fullyQualifiedName": "Gmail.ReplyToEmail@4.2.0",
+      "fullyQualifiedName": "Gmail.ReplyToEmail@4.2.1",
       "description": "Send a reply to an email message.",
       "parameters": [
         {
@@ -823,7 +823,7 @@
     {
       "name": "SearchThreads",
       "qualifiedName": "Gmail.SearchThreads",
-      "fullyQualifiedName": "Gmail.SearchThreads@4.2.0",
+      "fullyQualifiedName": "Gmail.SearchThreads@4.2.1",
       "description": "Search for threads in the user's mailbox",
       "parameters": [
         {
@@ -999,7 +999,7 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "Gmail.SendDraftEmail",
-      "fullyQualifiedName": "Gmail.SendDraftEmail@4.2.0",
+      "fullyQualifiedName": "Gmail.SendDraftEmail@4.2.1",
       "description": "Send a draft email using the Gmail API.",
       "parameters": [
         {
@@ -1059,7 +1059,7 @@
     {
       "name": "SendEmail",
       "qualifiedName": "Gmail.SendEmail",
-      "fullyQualifiedName": "Gmail.SendEmail@4.2.0",
+      "fullyQualifiedName": "Gmail.SendEmail@4.2.1",
       "description": "Send an email using the Gmail API.",
       "parameters": [
         {
@@ -1194,7 +1194,7 @@
     {
       "name": "TrashEmail",
       "qualifiedName": "Gmail.TrashEmail",
-      "fullyQualifiedName": "Gmail.TrashEmail@4.2.0",
+      "fullyQualifiedName": "Gmail.TrashEmail@4.2.1",
       "description": "Move an email to the trash folder using the Gmail API.",
       "parameters": [
         {
@@ -1254,7 +1254,7 @@
     {
       "name": "UpdateDraftEmail",
       "qualifiedName": "Gmail.UpdateDraftEmail",
-      "fullyQualifiedName": "Gmail.UpdateDraftEmail@4.2.0",
+      "fullyQualifiedName": "Gmail.UpdateDraftEmail@4.2.1",
       "description": "Update an existing email draft using the Gmail API.",
       "parameters": [
         {
@@ -1386,7 +1386,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Gmail.WhoAmI",
-      "fullyQualifiedName": "Gmail.WhoAmI@4.2.0",
+      "fullyQualifiedName": "Gmail.WhoAmI@4.2.1",
       "description": "Get comprehensive user profile and Gmail account information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Gmail account statistics, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1433,7 +1433,7 @@
     {
       "name": "WriteDraftEmail",
       "qualifiedName": "Gmail.WriteDraftEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftEmail@4.2.0",
+      "fullyQualifiedName": "Gmail.WriteDraftEmail@4.2.1",
       "description": "Compose a new email draft using the Gmail API.",
       "parameters": [
         {
@@ -1567,7 +1567,7 @@
     {
       "name": "WriteDraftReplyEmail",
       "qualifiedName": "Gmail.WriteDraftReplyEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@4.2.0",
+      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@4.2.1",
       "description": "Compose a draft reply to an email message.",
       "parameters": [
         {
@@ -1699,6 +1699,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-02-26T20:45:10.394Z",
+  "generatedAt": "2026-04-16T11:32:31.013Z",
   "summary": "Arcade.dev's Gmail toolkit enables seamless integration with the Gmail API, allowing developers to manage emails and labels effectively within their applications.\n\n**Capabilities**\n- Manage email threads and labels.\n- Compose, send, and manage drafts.\n- Retrieve detailed user profile information.\n- Support for email searching and filtering.\n- Efficiently handle email status changes such as trashing.\n\n**OAuth**\n- **Provider**: Google\n- **Scopes**: Access to read, compose, modify, and send Gmail emails, alongside user profile information.\n\n**Secrets**\n- No secret types required for toolkit operation."
 }

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-10T11:26:09.339Z",
+  "generatedAt": "2026-04-16T11:32:31.519Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -257,7 +257,7 @@
     {
       "id": "Gmail",
       "label": "Gmail",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 18,
@@ -882,6 +882,15 @@
       "category": "payments",
       "type": "arcade_starter",
       "toolCount": 511,
+      "authType": "oauth2"
+    },
+    {
+      "id": "ZohoCreatorApi",
+      "label": "Zoho Creator API",
+      "version": "0.2.0",
+      "category": "development",
+      "type": "arcade_starter",
+      "toolCount": 19,
       "authType": "oauth2"
     },
     {

--- a/toolkit-docs-generator/data/toolkits/zohocreatorapi.json
+++ b/toolkit-docs-generator/data/toolkits/zohocreatorapi.json
@@ -1,0 +1,1150 @@
+{
+  "id": "ZohoCreatorApi",
+  "label": "Zoho Creator API",
+  "version": "0.2.0",
+  "description": "Tools that enable LLMs to interact directly with the Zoho Creator API.",
+  "metadata": {
+    "category": "development",
+    "iconUrl": "https://design-system.arcade.dev/icons/zoho-creator.svg",
+    "isBYOC": false,
+    "isPro": false,
+    "type": "arcade_starter",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/development/zoho-creator-api",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": {
+    "type": "oauth2",
+    "providerId": "zoho",
+    "allScopes": [
+      "ZohoCreator.bulk.CREATE",
+      "ZohoCreator.bulk.READ",
+      "ZohoCreator.dashboard.READ",
+      "ZohoCreator.form.CREATE",
+      "ZohoCreator.meta.application.READ",
+      "ZohoCreator.meta.form.READ",
+      "ZohoCreator.report.DELETE",
+      "ZohoCreator.report.READ",
+      "ZohoCreator.report.UPDATE"
+    ]
+  },
+  "tools": [
+    {
+      "name": "AddRecordsToZohoForm",
+      "qualifiedName": "ZohoCreatorApi.AddRecordsToZohoForm",
+      "fullyQualifiedName": "ZohoCreatorApi.AddRecordsToZohoForm@0.2.0",
+      "description": "Add multiple records to a Zoho Creator form efficiently.\n\n    Use this tool to add up to 200 records at once to a specified form within your Zoho Creator application. Each JSON object in the input represents a record to be added, subject to validation. Suitable for situations needing bulk data import or batch entry creation.\n\n    Note: Understanding the request schema is necessary to properly create\n    the stringified JSON input object for execution.\n\nThis operation also requires path, query parameters.\n\n    Modes:\n    - GET_REQUEST_SCHEMA: Returns the schema. Only call if you don't\n      already have it. Do NOT call repeatedly if you already received\n      the schema.\n    - EXECUTE: Performs the operation with the provided request body\n      JSON.\n      Note: You must also provide the required path, query parameters when executing.\n\n    If you need the schema, call with mode='get_request_schema' ONCE, then execute.\n    ",
+      "parameters": [
+        {
+          "name": "mode",
+          "type": "string",
+          "required": true,
+          "description": "Operation mode: 'get_request_schema' returns the OpenAPI spec for the request body, 'execute' performs the actual operation",
+          "enum": [
+            "get_request_schema",
+            "execute"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "form_private_link",
+          "type": "string",
+          "required": false,
+          "description": "The unique identifier for accessing a specific form in Zoho Creator securely. Required for access control.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "zoho_account_owner_name",
+          "type": "string",
+          "required": false,
+          "description": "The account owner's name associated with the Zoho Creator application. This is needed to authenticate and route the records correctly.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "application_link_name",
+          "type": "string",
+          "required": false,
+          "description": "The unique identifier for the Zoho application where the form resides. Required to locate the specific application.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "zoho_form_link_name",
+          "type": "string",
+          "required": false,
+          "description": "The unique link name of the form in Zoho Creator where records will be added.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "request_body",
+          "type": "string",
+          "required": false,
+          "description": "Stringified JSON representing the request body. Required when mode is 'execute', ignored when mode is 'get_request_schema'",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": []
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "CreateBulkReadJob",
+      "qualifiedName": "ZohoCreatorApi.CreateBulkReadJob",
+      "fullyQualifiedName": "ZohoCreatorApi.CreateBulkReadJob@0.2.0",
+      "description": "Initiate a bulk read job to export records.\n\n    Use this tool to create a bulk read job in Zoho, which allows you to export records from a specified report. This is useful for managing large datasets efficiently.\n\n    Note: Understanding the request schema is necessary to properly create\n    the stringified JSON input object for execution.\n\nThis operation also requires path parameters.\n\n    Modes:\n    - GET_REQUEST_SCHEMA: Returns the schema. Only call if you don't\n      already have it. Do NOT call repeatedly if you already received\n      the schema.\n    - EXECUTE: Performs the operation with the provided request body\n      JSON.\n      Note: You must also provide the required path parameters when executing.\n\n    If you need the schema, call with mode='get_request_schema' ONCE, then execute.\n    ",
+      "parameters": [
+        {
+          "name": "mode",
+          "type": "string",
+          "required": true,
+          "description": "Operation mode: 'get_request_schema' returns the OpenAPI spec for the request body, 'execute' performs the actual operation",
+          "enum": [
+            "get_request_schema",
+            "execute"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "account_owner_name",
+          "type": "string",
+          "required": false,
+          "description": "The name of the account owner in Zoho for whom the bulk read job is being created. This should match the official account details.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "application_link_name",
+          "type": "string",
+          "required": false,
+          "description": "The name of the application within Zoho to export records from.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "report_reference_name",
+          "type": "string",
+          "required": false,
+          "description": "Specifies the unique link or name of the report from which records will be exported in Zoho.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "request_body",
+          "type": "string",
+          "required": false,
+          "description": "Stringified JSON representing the request body. Required when mode is 'execute', ignored when mode is 'get_request_schema'",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": [
+          "ZohoCreator.bulk.CREATE"
+        ]
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "DeleteReportRecords",
+      "qualifiedName": "ZohoCreatorApi.DeleteReportRecords",
+      "fullyQualifiedName": "ZohoCreatorApi.DeleteReportRecords@0.2.0",
+      "description": "Delete records from a specified Zoho Creator report.\n\n    Use this tool to delete up to 200 records from a specified report in your Zoho Creator application. This action will adhere to any custom validations configured for the target form.\n\n    Note: Understanding the request schema is necessary to properly create\n    the stringified JSON input object for execution.\n\nThis operation also requires path, query parameters.\n\n    Modes:\n    - GET_REQUEST_SCHEMA: Returns the schema. Only call if you don't\n      already have it. Do NOT call repeatedly if you already received\n      the schema.\n    - EXECUTE: Performs the operation with the provided request body\n      JSON.\n      Note: You must also provide the required path, query parameters when executing.\n\n    If you need the schema, call with mode='get_request_schema' ONCE, then execute.\n    ",
+      "parameters": [
+        {
+          "name": "mode",
+          "type": "string",
+          "required": true,
+          "description": "Operation mode: 'get_request_schema' returns the OpenAPI spec for the request body, 'execute' performs the actual operation",
+          "enum": [
+            "get_request_schema",
+            "execute"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "account_owner_name",
+          "type": "string",
+          "required": false,
+          "description": "The name of the Zoho account owner. It identifies whose account the deletion should occur under.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "application_link_name",
+          "type": "string",
+          "required": false,
+          "description": "The unique identifier for the application within Zoho Creator.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "report_identifier",
+          "type": "string",
+          "required": false,
+          "description": "The name of the report from which records should be deleted. Must match the link name configured in Zoho Creator.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "process_records_up_to_limit",
+          "type": "boolean",
+          "required": false,
+          "description": "Boolean to enable processing records up to the 200-record limit per request.  Only used when mode is 'execute'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "request_body",
+          "type": "string",
+          "required": false,
+          "description": "Stringified JSON representing the request body. Required when mode is 'execute', ignored when mode is 'get_request_schema'",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": [
+          "ZohoCreator.report.DELETE"
+        ]
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "DeleteZohoRecord",
+      "qualifiedName": "ZohoCreatorApi.DeleteZohoRecord",
+      "fullyQualifiedName": "ZohoCreatorApi.DeleteZohoRecord@0.2.0",
+      "description": "Delete a specific record in Zoho Creator by ID.\n\n    This tool deletes a specific record in Zoho Creator using its ID. It is used when a user wants to remove a record that appears in a report. The deletion follows custom validations set for the form.\n\n    Note: Understanding the request schema is necessary to properly create\n    the stringified JSON input object for execution.\n\nThis operation also requires path parameters.\n\n    Modes:\n    - GET_REQUEST_SCHEMA: Returns the schema. Only call if you don't\n      already have it. Do NOT call repeatedly if you already received\n      the schema.\n    - EXECUTE: Performs the operation with the provided request body\n      JSON.\n      Note: You must also provide the required path parameters when executing.\n\n    If you need the schema, call with mode='get_request_schema' ONCE, then execute.\n    ",
+      "parameters": [
+        {
+          "name": "mode",
+          "type": "string",
+          "required": true,
+          "description": "Operation mode: 'get_request_schema' returns the OpenAPI spec for the request body, 'execute' performs the actual operation",
+          "enum": [
+            "get_request_schema",
+            "execute"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "zoho_account_owner_name",
+          "type": "string",
+          "required": false,
+          "description": "The account owner's name in Zoho. Required to specify which user's account to access.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "application_link_name",
+          "type": "string",
+          "required": false,
+          "description": "The unique identifier for the Zoho Creator application. Provide this to specify which application contains the record to delete.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "report_link_name",
+          "type": "string",
+          "required": false,
+          "description": "The unique name of the report in Zoho where the record is listed. This identifies which report contains the record to be deleted.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "record_id",
+          "type": "string",
+          "required": false,
+          "description": "The unique ID of the record to be deleted from Zoho Creator. This must match the ID displayed in the relevant Zoho report.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "request_body",
+          "type": "string",
+          "required": false,
+          "description": "Stringified JSON representing the request body. Required when mode is 'execute', ignored when mode is 'get_request_schema'",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": [
+          "ZohoCreator.report.DELETE"
+        ]
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "FetchRecordDetail",
+      "qualifiedName": "ZohoCreatorApi.FetchRecordDetail",
+      "fullyQualifiedName": "ZohoCreatorApi.FetchRecordDetail@0.2.0",
+      "description": "Fetches detailed view data of a record by ID.\n\nUse this tool to fetch detailed information of a specific record identified by its ID in a Zoho app. It does not include related data blocks.",
+      "parameters": [
+        {
+          "name": "application_private_link",
+          "type": "string",
+          "required": true,
+          "description": "The private link identifier of the Zoho application, necessary for accessing the specific record's detail view.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "account_owner_name",
+          "type": "string",
+          "required": true,
+          "description": "The name of the account owner in Zoho. This specifies the owner of the account to which the app belongs.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "application_link_name",
+          "type": "string",
+          "required": true,
+          "description": "The unique identifier or slug for the specific Zoho app to query. This determines which app's data is accessed.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "report_link_name",
+          "type": "string",
+          "required": true,
+          "description": "The link name of the report from which to fetch the record detail. It identifies the specific report in the Zoho app.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "record_id",
+          "type": "string",
+          "required": true,
+          "description": "The unique identifier of the record to fetch detailed information for. It should be a string corresponding to the record's ID in the Zoho app.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": []
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "FetchWorkspaceAppMeta",
+      "qualifiedName": "ZohoCreatorApi.FetchWorkspaceAppMeta",
+      "fullyQualifiedName": "ZohoCreatorApi.FetchWorkspaceAppMeta@0.2.0",
+      "description": "Fetch meta information of applications in a workspace.\n\nUse this tool to retrieve the meta information for applications hosted in a specific workspace you have access to. Useful for gaining insights into application details.",
+      "parameters": [
+        {
+          "name": "workspace_account_owner_name",
+          "type": "string",
+          "required": true,
+          "description": "The name of the account owner for the workspace you want to fetch application meta information from.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": [
+          "ZohoCreator.dashboard.READ"
+        ]
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "FetchZohoAppSections",
+      "qualifiedName": "ZohoCreatorApi.FetchZohoAppSections",
+      "fullyQualifiedName": "ZohoCreatorApi.FetchZohoAppSections@0.2.0",
+      "description": "Fetch details of sections and components in Zoho Creator apps.\n\nUse this tool to retrieve information about the sections, forms, reports, and pages of a Zoho Creator application's web form factor.",
+      "parameters": [
+        {
+          "name": "zoho_account_owner_name",
+          "type": "string",
+          "required": true,
+          "description": "The account owner's username in Zoho. Required to fetch data for the specified application.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "zoho_application_link_name",
+          "type": "string",
+          "required": true,
+          "description": "The unique link name of the Zoho Creator application whose sections and components you want to fetch.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": [
+          "ZohoCreator.meta.application.READ"
+        ]
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "FetchZohoCreatorPagesMeta",
+      "qualifiedName": "ZohoCreatorApi.FetchZohoCreatorPagesMeta",
+      "fullyQualifiedName": "ZohoCreatorApi.FetchZohoCreatorPagesMeta@0.2.0",
+      "description": "Fetches meta information of pages in a Zoho Creator app.\n\nThis tool retrieves the meta information of all the pages present in a specified Zoho Creator application. Use it to gather detailed metadata about the app's pages, which can aid in app management and analysis.",
+      "parameters": [
+        {
+          "name": "account_owner_name",
+          "type": "string",
+          "required": true,
+          "description": "The name of the account owner in Zoho. This identifies the owner of the application for which the page metadata is fetched.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "zoho_app_link_name",
+          "type": "string",
+          "required": true,
+          "description": "The unique identifier for the Zoho Creator application to fetch page metadata.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": [
+          "ZohoCreator.meta.application.READ"
+        ]
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "FetchZohoFormFieldsMetadata",
+      "qualifiedName": "ZohoCreatorApi.FetchZohoFormFieldsMetadata",
+      "fullyQualifiedName": "ZohoCreatorApi.FetchZohoFormFieldsMetadata@0.2.0",
+      "description": "Fetches metadata of fields in a Zoho Creator form.\n\nUse this tool to obtain meta information about all the fields within a specified form in a Zoho Creator application. It should be called when you need to understand the structure or details of the form fields such as field types, names, etc.",
+      "parameters": [
+        {
+          "name": "account_owner_name",
+          "type": "string",
+          "required": true,
+          "description": "The Zoho account owner's username. Required to identify the specific account that owns the application.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "application_link_name",
+          "type": "string",
+          "required": true,
+          "description": "The unique link name of the Zoho Creator application. It identifies which application's form metadata to fetch.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "form_identifier",
+          "type": "string",
+          "required": true,
+          "description": "The unique identifier or link name of the Zoho Creator form to fetch metadata for.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": [
+          "ZohoCreator.meta.form.READ"
+        ]
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "FetchZohoFormMetaInformation",
+      "qualifiedName": "ZohoCreatorApi.FetchZohoFormMetaInformation",
+      "fullyQualifiedName": "ZohoCreatorApi.FetchZohoFormMetaInformation@0.2.0",
+      "description": "Fetch meta information of Zoho Creator app forms.\n\nThis tool retrieves the meta information of all forms in a specified Zoho Creator application. Use it to obtain details about the forms within the application.",
+      "parameters": [
+        {
+          "name": "zoho_account_owner_name",
+          "type": "string",
+          "required": true,
+          "description": "The name of the account owner for the Zoho Creator application. Required for authentication and identifying the account context.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "zoho_app_link_name",
+          "type": "string",
+          "required": true,
+          "description": "The unique link name of the Zoho Creator application. This identifies the app whose form meta information is to be fetched.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": [
+          "ZohoCreator.meta.application.READ"
+        ]
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "FetchZohoRecordDetail",
+      "qualifiedName": "ZohoCreatorApi.FetchZohoRecordDetail",
+      "fullyQualifiedName": "ZohoCreatorApi.FetchZohoRecordDetail@0.2.0",
+      "description": "Fetches detailed view data of a Zoho record by ID.\n\nUse this tool to fetch the detailed information of a specific record in Zoho, identified by its record ID. This tool does not retrieve related records, only the detailed view of the specific identified record.",
+      "parameters": [
+        {
+          "name": "account_owner_name",
+          "type": "string",
+          "required": true,
+          "description": "The name of the account owner in Zoho to fetch the record for. This identifies the specific account under which the record exists.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "application_identifier",
+          "type": "string",
+          "required": true,
+          "description": "The name of the application in Zoho used to uniquely identify which app's record details are to be fetched.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "report_link_name",
+          "type": "string",
+          "required": true,
+          "description": "The specific name of the report in Zoho from which the data will be fetched.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "record_id",
+          "type": "string",
+          "required": true,
+          "description": "The unique ID of the Zoho record to fetch its detailed information.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": [
+          "ZohoCreator.report.READ"
+        ]
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "FetchZohoRecords",
+      "qualifiedName": "ZohoCreatorApi.FetchZohoRecords",
+      "fullyQualifiedName": "ZohoCreatorApi.FetchZohoRecords@0.2.0",
+      "description": "Fetch records from a Zoho Creator report.\n\nUse this tool to retrieve up to 200 records from the quick view fields of a specified Zoho Creator report.",
+      "parameters": [
+        {
+          "name": "account_owner_identifier",
+          "type": "string",
+          "required": true,
+          "description": "The unique identifier for the Zoho account owner. Required to fetch the report data.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "application_link_name",
+          "type": "string",
+          "required": true,
+          "description": "The unique identifier for the Zoho Creator application. It specifies which app's report to fetch.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "report_link_name",
+          "type": "string",
+          "required": true,
+          "description": "The unique link name of the Zoho Creator report to fetch records from.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "start_record_index",
+          "type": "integer",
+          "required": false,
+          "description": "The starting index of records to retrieve from the report. Must be an integer.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "record_limit",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of records to retrieve, up to 200.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "filter_criteria",
+          "type": "string",
+          "required": false,
+          "description": "Specify conditions to filter records. Use Zoho Creator query format for filtering.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": [
+          "ZohoCreator.report.READ"
+        ]
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "FetchZohoReportRecords",
+      "qualifiedName": "ZohoCreatorApi.FetchZohoReportRecords",
+      "fullyQualifiedName": "ZohoCreatorApi.FetchZohoReportRecords@0.2.0",
+      "description": "Fetch records displayed by a Zoho Creator report.\n\nUse this tool to retrieve up to 200 records from a Zoho Creator report. It accesses the data in the fields shown in the report's quick view.",
+      "parameters": [
+        {
+          "name": "zoho_private_link",
+          "type": "string",
+          "required": true,
+          "description": "The private link URL or identifier for accessing a specific Zoho Creator report.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "account_owner_name",
+          "type": "string",
+          "required": true,
+          "description": "The username of the Zoho account owner. Required to identify the correct account for fetching report records.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "zoho_application_link_name",
+          "type": "string",
+          "required": true,
+          "description": "The unique link name of the Zoho Creator application from which to fetch report records.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "report_link_name",
+          "type": "string",
+          "required": true,
+          "description": "The unique link name of the Zoho report to fetch records from. It's required to specify which report to access.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "record_fetch_start_index",
+          "type": "integer",
+          "required": false,
+          "description": "Specify the starting index for records to be fetched. Use an integer value.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "record_limit",
+          "type": "integer",
+          "required": false,
+          "description": "Specify the maximum number of records to fetch, up to 200.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "filter_criteria",
+          "type": "string",
+          "required": false,
+          "description": "A string to filter records based on specific conditions, formatted as 'Field_Name Operator Value'.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": []
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "FetchZohoReportsMeta",
+      "qualifiedName": "ZohoCreatorApi.FetchZohoReportsMeta",
+      "fullyQualifiedName": "ZohoCreatorApi.FetchZohoReportsMeta@0.2.0",
+      "description": "Fetches meta information of reports in Zoho Creator.\n\nThis tool retrieves the meta information for all reports within a specified Zoho Creator application. Use it to gain insights into the report configurations and structures available in a particular app.",
+      "parameters": [
+        {
+          "name": "zoho_account_owner_name",
+          "type": "string",
+          "required": true,
+          "description": "The name of the account owner in Zoho. Used to identify which account's report metadata to fetch.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "zoho_app_link_name",
+          "type": "string",
+          "required": true,
+          "description": "The unique link name of the Zoho Creator application to fetch report metadata from. This identifies the specific app within your Zoho account.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": [
+          "ZohoCreator.meta.application.READ"
+        ]
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "GetApplicationMetaInfo",
+      "qualifiedName": "ZohoCreatorApi.GetApplicationMetaInfo",
+      "fullyQualifiedName": "ZohoCreatorApi.GetApplicationMetaInfo@0.2.0",
+      "description": "Fetches meta information of accessible applications.\n\nUse this tool to retrieve the meta information of all applications you have access to in Zoho.",
+      "parameters": [],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": [
+          "ZohoCreator.dashboard.READ"
+        ]
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "GetBulkReadJobDetails",
+      "qualifiedName": "ZohoCreatorApi.GetBulkReadJobDetails",
+      "fullyQualifiedName": "ZohoCreatorApi.GetBulkReadJobDetails@0.2.0",
+      "description": "Retrieve details of a completed bulk read job in Zoho Creator.\n\nThis tool retrieves information about a bulk read job that was executed previously in Zoho Creator. It is useful when you need to check the status or outcome of a specific bulk read job.",
+      "parameters": [
+        {
+          "name": "account_owner_name",
+          "type": "string",
+          "required": true,
+          "description": "The name of the account owner in Zoho. Required for identifying the correct account.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "application_link_name",
+          "type": "string",
+          "required": true,
+          "description": "The name of the Zoho Creator application. Used to identify which application's bulk read job details are being retrieved.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "report_link_name",
+          "type": "string",
+          "required": true,
+          "description": "The link name of the report for which the bulk read job details are requested. This is required to specify the report in Zoho Creator.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "job_id",
+          "type": "string",
+          "required": true,
+          "description": "The unique identifier for the bulk read job to retrieve details for. This should be a string value.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": [
+          "ZohoCreator.bulk.READ"
+        ]
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "InsertRecordsInZohoForm",
+      "qualifiedName": "ZohoCreatorApi.InsertRecordsInZohoForm",
+      "fullyQualifiedName": "ZohoCreatorApi.InsertRecordsInZohoForm@0.2.0",
+      "description": "Add records to a form in Zoho Creator.\n\n    Use this tool to add one or more records to a specified form in your Zoho Creator application. It allows up to 200 records per request, subject to validation.\n\n    Note: Understanding the request schema is necessary to properly create\n    the stringified JSON input object for execution.\n\nThis operation also requires path parameters.\n\n    Modes:\n    - GET_REQUEST_SCHEMA: Returns the schema. Only call if you don't\n      already have it. Do NOT call repeatedly if you already received\n      the schema.\n    - EXECUTE: Performs the operation with the provided request body\n      JSON.\n      Note: You must also provide the required path parameters when executing.\n\n    If you need the schema, call with mode='get_request_schema' ONCE, then execute.\n    ",
+      "parameters": [
+        {
+          "name": "mode",
+          "type": "string",
+          "required": true,
+          "description": "Operation mode: 'get_request_schema' returns the OpenAPI spec for the request body, 'execute' performs the actual operation",
+          "enum": [
+            "get_request_schema",
+            "execute"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "zoho_account_owner_name",
+          "type": "string",
+          "required": false,
+          "description": "The name of the account owner in Zoho. This is required to identify which account the records should be added to.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "application_link_name",
+          "type": "string",
+          "required": false,
+          "description": "The unique identifier of the application in which the form is located. This is necessary to specify the target Zoho Creator application.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "form_link_name",
+          "type": "string",
+          "required": false,
+          "description": "The unique link name of the form in Zoho Creator where records will be added.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "request_body",
+          "type": "string",
+          "required": false,
+          "description": "Stringified JSON representing the request body. Required when mode is 'execute', ignored when mode is 'get_request_schema'",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": [
+          "ZohoCreator.form.CREATE"
+        ]
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "UpdateZohoCreatorReportRecords",
+      "qualifiedName": "ZohoCreatorApi.UpdateZohoCreatorReportRecords",
+      "fullyQualifiedName": "ZohoCreatorApi.UpdateZohoCreatorReportRecords@0.2.0",
+      "description": "Update records in a Zoho Creator report.\n\n    Use this tool to update up to 200 records in a specific report of a Zoho Creator application, ensuring compliance with data validation.\n\n    Note: Understanding the request schema is necessary to properly create\n    the stringified JSON input object for execution.\n\nThis operation also requires path, query parameters.\n\n    Modes:\n    - GET_REQUEST_SCHEMA: Returns the schema. Only call if you don't\n      already have it. Do NOT call repeatedly if you already received\n      the schema.\n    - EXECUTE: Performs the operation with the provided request body\n      JSON.\n      Note: You must also provide the required path, query parameters when executing.\n\n    If you need the schema, call with mode='get_request_schema' ONCE, then execute.\n    ",
+      "parameters": [
+        {
+          "name": "mode",
+          "type": "string",
+          "required": true,
+          "description": "Operation mode: 'get_request_schema' returns the OpenAPI spec for the request body, 'execute' performs the actual operation",
+          "enum": [
+            "get_request_schema",
+            "execute"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "account_owner_name",
+          "type": "string",
+          "required": false,
+          "description": "The username of the owner of the Zoho account associated with the application. Required for determining access and permissions.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "application_link_name",
+          "type": "string",
+          "required": false,
+          "description": "The unique identifier (link name) of the Zoho Creator application. Required to specify the target app for updating records.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "report_link_name",
+          "type": "string",
+          "required": false,
+          "description": "The name or identifier of the report in Zoho Creator whose records you want to update.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "process_until_limit_enabled",
+          "type": "boolean",
+          "required": false,
+          "description": "Set to true to process records until reaching a limit of 200.  Only used when mode is 'execute'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "request_body",
+          "type": "string",
+          "required": false,
+          "description": "Stringified JSON representing the request body. Required when mode is 'execute', ignored when mode is 'get_request_schema'",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": [
+          "ZohoCreator.report.UPDATE"
+        ]
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    },
+    {
+      "name": "UpdateZohoRecord",
+      "qualifiedName": "ZohoCreatorApi.UpdateZohoRecord",
+      "fullyQualifiedName": "ZohoCreatorApi.UpdateZohoRecord@0.2.0",
+      "description": "Update a specific record in Zoho Creator by ID.\n\n    Use this tool to update a specific record within a Zoho Creator application. This tool is useful when modifications are needed on existing entries identified by their record ID, and respects the data validations configured for the form.\n\n    Note: Understanding the request schema is necessary to properly create\n    the stringified JSON input object for execution.\n\nThis operation also requires path parameters.\n\n    Modes:\n    - GET_REQUEST_SCHEMA: Returns the schema. Only call if you don't\n      already have it. Do NOT call repeatedly if you already received\n      the schema.\n    - EXECUTE: Performs the operation with the provided request body\n      JSON.\n      Note: You must also provide the required path parameters when executing.\n\n    If you need the schema, call with mode='get_request_schema' ONCE, then execute.\n    ",
+      "parameters": [
+        {
+          "name": "mode",
+          "type": "string",
+          "required": true,
+          "description": "Operation mode: 'get_request_schema' returns the OpenAPI spec for the request body, 'execute' performs the actual operation",
+          "enum": [
+            "get_request_schema",
+            "execute"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "zoho_account_owner_name",
+          "type": "string",
+          "required": false,
+          "description": "The account owner's name in Zoho. Used to identify the correct Zoho Creator account for the update operation.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "application_link_name",
+          "type": "string",
+          "required": false,
+          "description": "The unique name of the Zoho Creator application where the record resides.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "report_link_name",
+          "type": "string",
+          "required": false,
+          "description": "The string identifier of the report in Zoho Creator where the record is located.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "record_id",
+          "type": "string",
+          "required": false,
+          "description": "The unique identifier for the record to be updated in Zoho Creator. This ID specifies which record in the report will be modified.  Required when mode is 'execute', ignored when mode is 'get_request_schema'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "request_body",
+          "type": "string",
+          "required": false,
+          "description": "Stringified JSON representing the request body. Required when mode is 'execute', ignored when mode is 'get_request_schema'",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "zoho",
+        "providerType": "oauth2",
+        "scopes": [
+          "ZohoCreator.report.UPDATE"
+        ]
+      },
+      "secrets": [
+        "ZOHO_SERVER_URL"
+      ],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Response from the API endpoint ''."
+      },
+      "documentationChunks": [],
+      "metadata": null
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-04-16T11:32:31.216Z"
+}


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/24507713605

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc/metadata-only updates (generated JSON and nav link changes) with no production runtime logic changes; main risk is broken links or incorrect toolkit metadata.
> 
> **Overview**
> Adds the generated `ZohoCreatorApi` toolkit definition (OAuth scopes + 19 tools) and registers it in the toolkits index and the development integrations nav (`zoho-creator-api`).
> 
> Bumps the generated Gmail toolkit docs from `4.2.0` to `4.2.1` (updating `fullyQualifiedName`s) and refreshes `generatedAt` timestamps in `gmail.json` and `index.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a87cbd7653ce81f572aaf14a5d9c50a8d558dbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->