### PR TITLE
docs: document NetworkTransportError and updated HTTP adapter routing

### DIFF
--- a/app/_components/error-hierarchy.tsx
+++ b/app/_components/error-hierarchy.tsx
@@ -19,6 +19,7 @@ ToolkitError                                  # (Abstract base class)
             ├── RetryableToolError            # Tool can be retried with extra context
             ├── ContextRequiredToolError      # Additional context needed before retry
             ├── FatalToolError                # Unhandled bugs in the tool implementation
+            ├── NetworkTransportError         # No HTTP response received (timeout, DNS, TLS, etc.)
             └── UpstreamError                 # HTTP/API errors from external services
                 └── UpstreamRateLimitError    # Rate limiting errors from service
 `}</code>

--- a/app/en/guides/create-tools/error-handling/useful-tool-errors/page.mdx
+++ b/app/en/guides/create-tools/error-handling/useful-tool-errors/page.mdx
@@ -40,6 +40,12 @@ def fetch_data(
     return response.json()
 ```
 
+The HTTP error adapter routes exceptions from `httpx` and `requests` based on whether a complete response was received:
+
+- **Real HTTP responses** (4xx/5xx) → `UpstreamError` (with `status_code`). 429 becomes `UpstreamRateLimitError`.
+- **No response received** (connect/read timeouts, DNS failures, connection errors, TLS handshake failures, decoding errors, redirect-loop exhaustion) → `NetworkTransportError` with `status_code=None`. Classified by `ErrorKind` as `NETWORK_TRANSPORT_RUNTIME_TIMEOUT`, `NETWORK_TRANSPORT_RUNTIME_UNREACHABLE`, or `NETWORK_TRANSPORT_RUNTIME_UNMAPPED`.
+- **Client construction bugs** (`InvalidURL`, `UnsupportedProtocol`, `MissingSchema`, `InvalidSchema`, `InvalidHeader`, `InvalidProxyURL`, `URLRequired`, `SSLError`) → `FatalToolError`. These indicate a tool-authoring mistake or local TLS configuration issue and are not retryable.
+
 ### Explicit error adapters
 
 For tools using specific SDKs, you can specify error adapters explicitly:

--- a/app/en/guides/create-tools/error-handling/useful-tool-errors/page.mdx
+++ b/app/en/guides/create-tools/error-handling/useful-tool-errors/page.mdx
@@ -40,11 +40,11 @@ def fetch_data(
     return response.json()
 ```
 
-The HTTP error adapter routes exceptions from `httpx` and `requests` based on whether a complete response was received:
+The HTTP error adapter routes exceptions from `httpx` and `requests` based on whether the client received a complete response:
 
 - **Real HTTP responses** (4xx/5xx) → `UpstreamError` (with `status_code`). 429 becomes `UpstreamRateLimitError`.
 - **No response received** (connect/read timeouts, DNS failures, connection errors, TLS handshake failures, decoding errors, redirect-loop exhaustion) → `NetworkTransportError` with `status_code=None`. Classified by `ErrorKind` as `NETWORK_TRANSPORT_RUNTIME_TIMEOUT`, `NETWORK_TRANSPORT_RUNTIME_UNREACHABLE`, or `NETWORK_TRANSPORT_RUNTIME_UNMAPPED`.
-- **Client construction bugs** (`InvalidURL`, `UnsupportedProtocol`, `MissingSchema`, `InvalidSchema`, `InvalidHeader`, `InvalidProxyURL`, `URLRequired`, `SSLError`) → `FatalToolError`. These indicate a tool-authoring mistake or local TLS configuration issue and are not retryable.
+- **Client construction bugs** (`InvalidURL`, `UnsupportedProtocol`, `MissingSchema`, `InvalidSchema`, `InvalidHeader`, `InvalidProxyURL`, `URLRequired`, `SSLError`) → `FatalToolError`. These are not retryable and typically indicate a tool-authoring mistake (hardcoded invalid URL, schema, or header) or a local TLS configuration issue. If your tool accepts caller-provided URLs or headers and passes them directly to the HTTP client without validation, invalid caller input is also routed here—validate caller-supplied values before use.
 
 ### Explicit error adapters
 

--- a/app/en/guides/create-tools/error-handling/useful-tool-errors/page.mdx
+++ b/app/en/guides/create-tools/error-handling/useful-tool-errors/page.mdx
@@ -44,7 +44,7 @@ The HTTP error adapter routes exceptions from `httpx` and `requests` based on wh
 
 - **Real HTTP responses** (4xx/5xx) → `UpstreamError` (with `status_code`). 429 becomes `UpstreamRateLimitError`.
 - **No response received** (connect/read timeouts, DNS failures, connection errors, TLS handshake failures, decoding errors, redirect-loop exhaustion) → `NetworkTransportError` with `status_code=None`. Classified by `ErrorKind` as `NETWORK_TRANSPORT_RUNTIME_TIMEOUT`, `NETWORK_TRANSPORT_RUNTIME_UNREACHABLE`, or `NETWORK_TRANSPORT_RUNTIME_UNMAPPED`.
-- **Client construction bugs** (`InvalidURL`, `UnsupportedProtocol`, `MissingSchema`, `InvalidSchema`, `InvalidHeader`, `InvalidProxyURL`, `URLRequired`, `SSLError`) → `FatalToolError`. These are not retryable and typically indicate a tool-authoring mistake (hardcoded invalid URL, schema, or header) or a local TLS configuration issue. If your tool accepts caller-provided URLs or headers and passes them directly to the HTTP client without validation, invalid caller input is also routed here—validate caller-supplied values before use.
+- **Client construction bugs** (`InvalidURL`, `UnsupportedProtocol`, `MissingSchema`, `InvalidSchema`, `InvalidHeader`, `InvalidProxyURL`, `URLRequired`, `SSLError`) → `FatalToolError`. These are not retryable and typically indicate a tool-authoring mistake (hardcoded invalid URL, schema, or header) or a local TLS configuration issue. If your tool accepts caller-provided URLs or headers and passes them directly to the HTTP client without validation, invalid caller input is also routed here. Validate caller-supplied values before use.
 
 ### Explicit error adapters
 

--- a/app/en/guides/tool-calling/error-handling/page.mdx
+++ b/app/en/guides/tool-calling/error-handling/page.mdx
@@ -60,6 +60,11 @@ def handle_tool_error(error: OutputError) -> None:
     elif error_kind.startswith("UPSTREAM_"):
         # The tool encountered an error from an upstream service
         print(error.message)
+    elif error_kind.startswith("NETWORK_TRANSPORT_"):
+        # The HTTP request never received a complete response (timeout, DNS
+        # failure, TLS handshake, etc.). These are typically transient and
+        # safe to retry.
+        print(error.message)
 
 
 client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
@@ -123,6 +128,11 @@ function handleToolError(error) {
     console.log(`Wait for ${secondsToWait} seconds before retrying the tool call`);
   } else if (errorKind.startsWith("UPSTREAM_")) {
     // The tool encountered an error from an upstream service
+    console.log(error.message);
+  } else if (errorKind.startsWith("NETWORK_TRANSPORT_")) {
+    // The HTTP request never received a complete response (timeout, DNS
+    // failure, TLS handshake, etc.). These are typically transient and
+    // safe to retry.
     console.log(error.message);
   }
 }
@@ -202,6 +212,11 @@ import org.slf4j.LoggerFactory;
     logger.error("Wait for {} before retrying the tool call", timeToWait);
   } else if (errorKind.asString().startsWith("UPSTREAM_")) {
     // The tool encountered an error from an upstream service
+    logger.error(error.message());
+  } else if (errorKind.asString().startsWith("NETWORK_TRANSPORT_")) {
+    // The HTTP request never received a complete response (timeout, DNS
+    // failure, TLS handshake, etc.). These are typically transient and
+    // safe to retry.
     logger.error(error.message());
   }
 }

--- a/app/en/references/mcp/python/errors/page.mdx
+++ b/app/en/references/mcp/python/errors/page.mdx
@@ -147,11 +147,11 @@ Rate limit error from an upstream service.
 
 ### `NetworkTransportError`
 
-Error raised when an HTTP request never received a complete response (e.g. connect/read timeouts, DNS failures, TLS handshake errors, decoding errors, redirect-loop exhaustion). Sibling of `UpstreamError` under `ToolExecutionError`. Unlike `UpstreamError`, `status_code` is always `None` because no response was received. Classified by `ErrorKind` into one of:
+Error raised when an HTTP request never received a complete response (for example, connect/read timeouts, DNS failures, TLS handshake errors, decoding errors, redirect-loop exhaustion). Sibling of `UpstreamError` under `ToolExecutionError`. Unlike `UpstreamError`, `status_code` is always `None` because the client received no response. Classified by `ErrorKind` into one of:
 
-- `NETWORK_TRANSPORT_RUNTIME_TIMEOUT` — pool, connect, or read timeouts
-- `NETWORK_TRANSPORT_RUNTIME_UNREACHABLE` — DNS, connection, TLS handshake, or remote-protocol failures
-- `NETWORK_TRANSPORT_RUNTIME_UNMAPPED` — decode errors, redirect exhaustion, and other transport-level fallbacks
+- `NETWORK_TRANSPORT_RUNTIME_TIMEOUT`—pool, connect, or read timeouts
+- `NETWORK_TRANSPORT_RUNTIME_UNREACHABLE`—DNS, connection, TLS handshake, or remote-protocol failures
+- `NETWORK_TRANSPORT_RUNTIME_UNMAPPED`—decode errors, redirect exhaustion, and other transport-level fallbacks
 
 ### `ContextRequiredToolError`
 

--- a/app/en/references/mcp/python/errors/page.mdx
+++ b/app/en/references/mcp/python/errors/page.mdx
@@ -145,6 +145,14 @@ Error from an upstream service the tool depends on.
 
 Rate limit error from an upstream service.
 
+### `NetworkTransportError`
+
+Error raised when an HTTP request never received a complete response (e.g. connect/read timeouts, DNS failures, TLS handshake errors, decoding errors, redirect-loop exhaustion). Sibling of `UpstreamError` under `ToolExecutionError`. Unlike `UpstreamError`, `status_code` is always `None` because no response was received. Classified by `ErrorKind` into one of:
+
+- `NETWORK_TRANSPORT_RUNTIME_TIMEOUT` — pool, connect, or read timeouts
+- `NETWORK_TRANSPORT_RUNTIME_UNREACHABLE` — DNS, connection, TLS handshake, or remote-protocol failures
+- `NETWORK_TRANSPORT_RUNTIME_UNMAPPED` — decode errors, redirect exhaustion, and other transport-level fallbacks
+
 ### `ContextRequiredToolError`
 
 Error raised when a tool requires a context that was not provided.


### PR DESCRIPTION
## Summary

Documents the new `NetworkTransportError` class and updated HTTP adapter routing landing in:
- [arcade-mcp#823](https://github.com/ArcadeAI/arcade-mcp/pull/823) — class + ErrorKind additions
- [arcade-mcp#820](https://github.com/ArcadeAI/arcade-mcp/pull/820) — HTTP adapter routing that uses the class
- [monorepo#911](https://github.com/ArcadeAI/monorepo/pull/911) — engine ErrorKind constants + Datadog dashboards

### What's new

- `NetworkTransportError` — sibling of `UpstreamError` under `ToolExecutionError`, for failures where no complete HTTP response was received (timeouts, connection errors, decoding, redirect exhaustion). Has `status_code=None`.
- Three new `ErrorKind` values: `NETWORK_TRANSPORT_RUNTIME_TIMEOUT`, `_UNREACHABLE`, `_UNMAPPED`.
- HTTP adapter now routes client-construction bugs (`InvalidURL`, `UnsupportedProtocol`, `MissingSchema`, `SSLError`, etc.) to `FatalToolError` instead of `UpstreamError`.

### Files changed

| File | Change |
|---|---|
| `app/_components/error-hierarchy.tsx` | Add `NetworkTransportError` row to the ASCII hierarchy diagram |
| `app/en/references/mcp/python/errors/page.mdx` | Add `NetworkTransportError` entry and list the 3 new `ErrorKind` values |
| `app/en/guides/create-tools/error-handling/useful-tool-errors/page.mdx` | Routing summary: `UpstreamError` vs `NetworkTransportError` vs `FatalToolError` for HTTP adapter |
| `app/en/guides/tool-calling/error-handling/page.mdx` | Extend Python/JS/Java client examples with a `NETWORK_TRANSPORT_` branch |

## Test plan

- [ ] Visual review of the hierarchy diagram on both guide pages
- [ ] Confirm code examples still render correctly
- [ ] Verify the 3 new `ErrorKind` values are correctly linked
- [ ] Cross-check with the linked arcade-mcp PRs for naming consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk doc-only changes updating error taxonomy and example branches; main risk is minor confusion if naming drifts from released client/server versions.
> 
> **Overview**
> Documents the new `NetworkTransportError` as a sibling to `UpstreamError` for HTTP failures where *no response is received*, including its `status_code=None` behavior and the new `ErrorKind` classifications.
> 
> Updates the error-hierarchy diagram and the HTTP adapter routing guidance to distinguish **real HTTP responses** (`UpstreamError`/`UpstreamRateLimitError`) vs **transport failures** (`NetworkTransportError`) vs **client construction bugs** (`FatalToolError`), and extends Python/JS/Java client error-handling examples with a `NETWORK_TRANSPORT_` branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6e861447439cd12ce36a1cd218a1fcd636b0827. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->