### PR TITLE
fix: follow up on #907 version edge cases

### DIFF
--- a/toolkit-docs-generator/src/sources/toolkit-data-source.ts
+++ b/toolkit-docs-generator/src/sources/toolkit-data-source.ts
@@ -108,30 +108,29 @@ export class CombinedToolkitDataSource implements IToolkitDataSource {
     this.metadataSource = config.metadataSource;
   }
 
-  private async resolveMetadata(
+  /**
+   * Apply the "*Api" provider-id fallback when the direct metadata lookup
+   * missed. Used by both `fetchToolkitData` and `fetchAllToolkitsData` so
+   * they resolve metadata the same way.
+   */
+  private async resolveProviderMetadata(
     toolkitId: string,
     tools: readonly ToolDefinition[],
-    directMetadata: ToolkitMetadata | null,
-    options?: { readonly allowToolkitIdLookup?: boolean }
+    directMetadata: ToolkitMetadata | null
   ): Promise<ToolkitMetadata | null> {
-    let metadata = directMetadata;
-    if (!metadata && options?.allowToolkitIdLookup) {
-      metadata = await this.metadataSource.getToolkitMetadata(toolkitId);
+    if (directMetadata || !normalizeId(toolkitId).endsWith("api")) {
+      return directMetadata;
     }
 
-    // If the toolkit isn't in the Design System under its exact ID, try to match
-    // by auth provider for "*Api" toolkits (e.g. MailchimpMarketingApi -> MailchimpApi).
-    if (!metadata && normalizeId(toolkitId).endsWith("api")) {
-      const providerId = tools.find((t) => t.auth?.providerId)?.auth
-        ?.providerId;
-      if (providerId) {
-        metadata =
-          (await this.metadataSource.getToolkitMetadata(`${providerId}Api`)) ??
-          (await this.metadataSource.getToolkitMetadata(providerId));
-      }
+    const providerId = tools.find((t) => t.auth?.providerId)?.auth?.providerId;
+    if (!providerId) {
+      return null;
     }
 
-    return metadata;
+    return (
+      (await this.metadataSource.getToolkitMetadata(`${providerId}Api`)) ??
+      (await this.metadataSource.getToolkitMetadata(providerId))
+    );
   }
 
   async fetchToolkitData(
@@ -143,11 +142,10 @@ export class CombinedToolkitDataSource implements IToolkitDataSource {
       this.toolSource.fetchToolsByToolkit(toolkitId),
       this.metadataSource.getToolkitMetadata(toolkitId),
     ]);
-    const metadata = await this.resolveMetadata(
+    const metadata = await this.resolveProviderMetadata(
       toolkitId,
       tools,
-      directMetadata,
-      { allowToolkitIdLookup: false }
+      directMetadata
     );
 
     // Filter tools by version if specified, otherwise keep only the highest
@@ -203,12 +201,15 @@ export class CombinedToolkitDataSource implements IToolkitDataSource {
     // matching the behaviour of fetchToolkitData.
     const result = new Map<string, ToolkitData>();
     for (const [toolkitId, tools] of toolkitGroups) {
-      const directMetadata = metadataMap.get(toolkitId) ?? null;
-      const metadata = await this.resolveMetadata(
+      // Prefer the batch lookup; only fall back to per-toolkit lookup
+      // (and then the provider-id fallback) when the map misses.
+      const directMetadata =
+        metadataMap.get(toolkitId) ??
+        (await this.metadataSource.getToolkitMetadata(toolkitId));
+      const metadata = await this.resolveProviderMetadata(
         toolkitId,
         tools,
-        directMetadata,
-        { allowToolkitIdLookup: true }
+        directMetadata
       );
       result.set(toolkitId, { tools, metadata });
     }

--- a/toolkit-docs-generator/src/sources/toolkit-data-source.ts
+++ b/toolkit-docs-generator/src/sources/toolkit-data-source.ts
@@ -108,19 +108,17 @@ export class CombinedToolkitDataSource implements IToolkitDataSource {
     this.metadataSource = config.metadataSource;
   }
 
-  async fetchToolkitData(
+  private async resolveMetadata(
     toolkitId: string,
-    version?: string
-  ): Promise<ToolkitData> {
-    // Fetch tools and metadata in parallel
-    const [tools, fetchedMetadata] = await Promise.all([
-      this.toolSource.fetchToolsByToolkit(toolkitId),
-      this.metadataSource.getToolkitMetadata(toolkitId),
-    ]);
+    tools: readonly ToolDefinition[],
+    directMetadata: ToolkitMetadata | null
+  ): Promise<ToolkitMetadata | null> {
+    let metadata =
+      directMetadata ??
+      (await this.metadataSource.getToolkitMetadata(toolkitId));
 
     // If the toolkit isn't in the Design System under its exact ID, try to match
-    // based on the auth provider for "*Api" toolkits (e.g. MailchimpMarketingApi -> MailchimpApi).
-    let metadata = fetchedMetadata;
+    // by auth provider for "*Api" toolkits (e.g. MailchimpMarketingApi -> MailchimpApi).
     if (!metadata && normalizeId(toolkitId).endsWith("api")) {
       const providerId = tools.find((t) => t.auth?.providerId)?.auth
         ?.providerId;
@@ -130,6 +128,24 @@ export class CombinedToolkitDataSource implements IToolkitDataSource {
           (await this.metadataSource.getToolkitMetadata(providerId));
       }
     }
+
+    return metadata;
+  }
+
+  async fetchToolkitData(
+    toolkitId: string,
+    version?: string
+  ): Promise<ToolkitData> {
+    // Fetch tools and metadata in parallel
+    const [tools, directMetadata] = await Promise.all([
+      this.toolSource.fetchToolsByToolkit(toolkitId),
+      this.metadataSource.getToolkitMetadata(toolkitId),
+    ]);
+    const metadata = await this.resolveMetadata(
+      toolkitId,
+      tools,
+      directMetadata
+    );
 
     // Filter tools by version if specified, otherwise keep only the highest
     // version to drop stale tools from older releases that Engine still serves.
@@ -185,9 +201,11 @@ export class CombinedToolkitDataSource implements IToolkitDataSource {
     const result = new Map<string, ToolkitData>();
     for (const [toolkitId, tools] of toolkitGroups) {
       const directMetadata = metadataMap.get(toolkitId) ?? null;
-      const metadata =
-        directMetadata ??
-        (await this.metadataSource.getToolkitMetadata(toolkitId));
+      const metadata = await this.resolveMetadata(
+        toolkitId,
+        tools,
+        directMetadata
+      );
       result.set(toolkitId, { tools, metadata });
     }
 

--- a/toolkit-docs-generator/src/sources/toolkit-data-source.ts
+++ b/toolkit-docs-generator/src/sources/toolkit-data-source.ts
@@ -111,11 +111,13 @@ export class CombinedToolkitDataSource implements IToolkitDataSource {
   private async resolveMetadata(
     toolkitId: string,
     tools: readonly ToolDefinition[],
-    directMetadata: ToolkitMetadata | null
+    directMetadata: ToolkitMetadata | null,
+    options?: { readonly allowToolkitIdLookup?: boolean }
   ): Promise<ToolkitMetadata | null> {
-    let metadata =
-      directMetadata ??
-      (await this.metadataSource.getToolkitMetadata(toolkitId));
+    let metadata = directMetadata;
+    if (!metadata && options?.allowToolkitIdLookup) {
+      metadata = await this.metadataSource.getToolkitMetadata(toolkitId);
+    }
 
     // If the toolkit isn't in the Design System under its exact ID, try to match
     // by auth provider for "*Api" toolkits (e.g. MailchimpMarketingApi -> MailchimpApi).
@@ -144,7 +146,8 @@ export class CombinedToolkitDataSource implements IToolkitDataSource {
     const metadata = await this.resolveMetadata(
       toolkitId,
       tools,
-      directMetadata
+      directMetadata,
+      { allowToolkitIdLookup: false }
     );
 
     // Filter tools by version if specified, otherwise keep only the highest
@@ -204,7 +207,8 @@ export class CombinedToolkitDataSource implements IToolkitDataSource {
       const metadata = await this.resolveMetadata(
         toolkitId,
         tools,
-        directMetadata
+        directMetadata,
+        { allowToolkitIdLookup: true }
       );
       result.set(toolkitId, { tools, metadata });
     }

--- a/toolkit-docs-generator/src/utils/version-coherence.ts
+++ b/toolkit-docs-generator/src/utils/version-coherence.ts
@@ -6,6 +6,59 @@ interface ParsedSemver {
   readonly prerelease: readonly (number | string)[] | null;
 }
 
+const compareCoreVersions = (
+  aCore: readonly number[],
+  bCore: readonly number[]
+): number => {
+  const len = Math.max(aCore.length, bCore.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (aCore[i] ?? 0) - (bCore[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+};
+
+const comparePrereleaseIdentifier = (
+  aPart: number | string,
+  bPart: number | string
+): number => {
+  const aIsNumber = typeof aPart === "number";
+  const bIsNumber = typeof bPart === "number";
+  if (aIsNumber && bIsNumber) {
+    return aPart - bPart;
+  }
+  if (aIsNumber && !bIsNumber) return -1;
+  if (!aIsNumber && bIsNumber) return 1;
+  return String(aPart).localeCompare(String(bPart), "en");
+};
+
+const comparePrerelease = (
+  aPrerelease: readonly (number | string)[] | null,
+  bPrerelease: readonly (number | string)[] | null
+): number => {
+  if (!(aPrerelease || bPrerelease)) return 0;
+  if (!aPrerelease && bPrerelease) return 1;
+  if (aPrerelease && !bPrerelease) return -1;
+
+  const prereleaseLen = Math.max(
+    aPrerelease?.length ?? 0,
+    bPrerelease?.length ?? 0
+  );
+  for (let i = 0; i < prereleaseLen; i++) {
+    const aPart = aPrerelease?.[i];
+    const bPart = bPrerelease?.[i];
+
+    if (aPart === undefined && bPart !== undefined) return -1;
+    if (aPart !== undefined && bPart === undefined) return 1;
+    if (aPart === undefined && bPart === undefined) return 0;
+
+    const diff = comparePrereleaseIdentifier(aPart, bPart);
+    if (diff !== 0) return diff;
+  }
+
+  return 0;
+};
+
 /**
  * Parse a semver-ish string into numeric core + optional pre-release parts.
  * Build metadata (+...) is ignored for ordering.
@@ -49,45 +102,9 @@ const parseSemver = (version: string): ParsedSemver => {
 const compareVersions = (a: string, b: string): number => {
   const aSemver = parseSemver(a);
   const bSemver = parseSemver(b);
-  const len = Math.max(aSemver.core.length, bSemver.core.length);
-  for (let i = 0; i < len; i++) {
-    const diff = (aSemver.core[i] ?? 0) - (bSemver.core[i] ?? 0);
-    if (diff !== 0) return diff;
-  }
-
-  const aPrerelease = aSemver.prerelease;
-  const bPrerelease = bSemver.prerelease;
-  if (!(aPrerelease || bPrerelease)) return 0;
-  if (!aPrerelease && bPrerelease) return 1;
-  if (aPrerelease && !bPrerelease) return -1;
-
-  const prereleaseLen = Math.max(
-    aPrerelease?.length ?? 0,
-    bPrerelease?.length ?? 0
-  );
-  for (let i = 0; i < prereleaseLen; i++) {
-    const aPart = aPrerelease?.[i];
-    const bPart = bPrerelease?.[i];
-
-    if (aPart === undefined && bPart !== undefined) return -1;
-    if (aPart !== undefined && bPart === undefined) return 1;
-    if (aPart === undefined && bPart === undefined) return 0;
-
-    const aIsNumber = typeof aPart === "number";
-    const bIsNumber = typeof bPart === "number";
-    if (aIsNumber && bIsNumber) {
-      const diff = (aPart as number) - (bPart as number);
-      if (diff !== 0) return diff;
-      continue;
-    }
-    if (aIsNumber && !bIsNumber) return -1;
-    if (!aIsNumber && bIsNumber) return 1;
-
-    const diff = String(aPart).localeCompare(String(bPart), "en");
-    if (diff !== 0) return diff;
-  }
-
-  return 0;
+  const coreDiff = compareCoreVersions(aSemver.core, bSemver.core);
+  if (coreDiff !== 0) return coreDiff;
+  return comparePrerelease(aSemver.prerelease, bSemver.prerelease);
 };
 
 /**

--- a/toolkit-docs-generator/src/utils/version-coherence.ts
+++ b/toolkit-docs-generator/src/utils/version-coherence.ts
@@ -6,65 +6,6 @@ interface ParsedSemver {
   readonly prerelease: readonly (number | string)[] | null;
 }
 
-const compareCoreVersions = (
-  aCore: readonly number[],
-  bCore: readonly number[]
-): number => {
-  const len = Math.max(aCore.length, bCore.length);
-  for (let i = 0; i < len; i++) {
-    const diff = (aCore[i] ?? 0) - (bCore[i] ?? 0);
-    if (diff !== 0) return diff;
-  }
-  return 0;
-};
-
-const comparePrereleaseIdentifier = (
-  aPart: number | string,
-  bPart: number | string
-): number => {
-  const aIsNumber = typeof aPart === "number";
-  const bIsNumber = typeof bPart === "number";
-  if (aIsNumber && bIsNumber) {
-    return aPart - bPart;
-  }
-  if (aIsNumber && !bIsNumber) return -1;
-  if (!aIsNumber && bIsNumber) return 1;
-  return String(aPart).localeCompare(String(bPart), "en");
-};
-
-const compareOptionalPrereleasePart = (
-  aPart: number | string | undefined,
-  bPart: number | string | undefined
-): number => {
-  if (aPart === undefined && bPart === undefined) return 0;
-  if (aPart === undefined) return -1;
-  if (bPart === undefined) return 1;
-  return comparePrereleaseIdentifier(aPart, bPart);
-};
-
-const comparePrerelease = (
-  aPrerelease: readonly (number | string)[] | null,
-  bPrerelease: readonly (number | string)[] | null
-): number => {
-  if (!(aPrerelease || bPrerelease)) return 0;
-  if (!aPrerelease && bPrerelease) return 1;
-  if (aPrerelease && !bPrerelease) return -1;
-
-  const prereleaseLen = Math.max(
-    aPrerelease?.length ?? 0,
-    bPrerelease?.length ?? 0
-  );
-  for (let i = 0; i < prereleaseLen; i++) {
-    const diff = compareOptionalPrereleasePart(
-      aPrerelease?.[i],
-      bPrerelease?.[i]
-    );
-    if (diff !== 0) return diff;
-  }
-
-  return 0;
-};
-
 /**
  * Parse a semver-ish string into numeric core + optional pre-release parts.
  * Build metadata (+...) is ignored for ordering.
@@ -95,17 +36,75 @@ const parseSemver = (version: string): ParsedSemver => {
   return { core, prerelease };
 };
 
+const compareCoreVersions = (
+  aCore: readonly number[],
+  bCore: readonly number[]
+): number => {
+  const len = Math.max(aCore.length, bCore.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (aCore[i] ?? 0) - (bCore[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+};
+
 /**
- * Compare two semver version strings using semver precedence rules:
- * - Compare MAJOR.MINOR.PATCH numerically
- * - For equal core versions, stable release > pre-release
- * - Numeric pre-release identifiers compare numerically
- * - String pre-release identifiers compare lexicographically
- * - Build metadata is ignored
+ * Compare two prerelease identifiers following SemVer 2.0.0 §11.4.2:
+ * numeric identifiers always rank lower than alphanumeric identifiers,
+ * numeric identifiers compare numerically, and alphanumeric identifiers
+ * compare by ASCII byte order (not locale).
+ */
+const comparePrereleaseIdentifier = (
+  aPart: number | string,
+  bPart: number | string
+): number => {
+  if (typeof aPart === "number" && typeof bPart === "number") {
+    return aPart - bPart;
+  }
+  if (typeof aPart === "number") return -1;
+  if (typeof bPart === "number") return 1;
+  if (aPart < bPart) return -1;
+  if (aPart > bPart) return 1;
+  return 0;
+};
+
+/**
+ * Compare prerelease identifier arrays following SemVer 2.0.0 §11.4:
+ * a prerelease version has lower precedence than the associated normal
+ * version, and longer identifier lists with matching prefix rank higher.
+ */
+const comparePrerelease = (
+  aPrerelease: readonly (number | string)[] | null,
+  bPrerelease: readonly (number | string)[] | null
+): number => {
+  if (!(aPrerelease || bPrerelease)) return 0;
+  if (!aPrerelease) return 1;
+  if (!bPrerelease) return -1;
+
+  const len = Math.max(aPrerelease.length, bPrerelease.length);
+  for (let i = 0; i < len; i++) {
+    const aPart = aPrerelease[i];
+    const bPart = bPrerelease[i];
+    if (aPart === undefined) return -1;
+    if (bPart === undefined) return 1;
+    const diff = comparePrereleaseIdentifier(aPart, bPart);
+    if (diff !== 0) return diff;
+  }
+
+  return 0;
+};
+
+/**
+ * Compare two semver version strings using SemVer 2.0.0 precedence:
+ * - MAJOR.MINOR.PATCH compared numerically
+ * - Stable release > prerelease when core is equal
+ * - Numeric prerelease identifiers compare numerically
+ * - Alphanumeric prerelease identifiers compare by ASCII byte order
+ * - Build metadata is ignored for precedence
  *
  * Returns a positive number if a > b, negative if a < b, 0 if equal.
  */
-const compareVersions = (a: string, b: string): number => {
+export const compareVersions = (a: string, b: string): number => {
   const aSemver = parseSemver(a);
   const bSemver = parseSemver(b);
   const coreDiff = compareCoreVersions(aSemver.core, bSemver.core);
@@ -115,34 +114,29 @@ const compareVersions = (a: string, b: string): number => {
 
 /**
  * Find the highest version among all tools in a toolkit.
- * This is the version we keep — stale tools from older releases are dropped.
+ * Returns null when no tool carries a usable version.
  */
 export const getHighestVersion = (
   tools: readonly ToolDefinition[]
 ): string | null => {
-  if (tools.length === 0) {
-    return null;
-  }
-
-  let best = "";
+  let best: string | null = null;
   for (const tool of tools) {
     const version = extractVersion(tool.fullyQualifiedName);
-    if (best === "" || compareVersions(version, best) > 0) {
+    if (best === null || compareVersions(version, best) > 0) {
       best = version;
     }
   }
-
-  return best || null;
+  return best;
 };
 
 /**
- * Keep only tools whose @version matches the highest version for
- * their toolkit. If all tools share the same version (the common
- * case), returns the original array unchanged.
+ * Keep only tools whose @version is semver-equivalent to the highest
+ * version for their toolkit. If all tools share the highest version
+ * (the common case), returns the original array unchanged.
  *
- * This drops stale tools from older releases that Engine still serves,
- * while always preserving the newest version — even if it has fewer tools
- * (e.g. tools were removed/consolidated in the new release).
+ * Tools are compared via `compareVersions`, so build metadata is
+ * ignored when deciding equivalence — a tool at `@1.0.0+build.1`
+ * survives alongside `@1.0.0` instead of being silently dropped.
  */
 export const filterToolsByHighestVersion = (
   tools: readonly ToolDefinition[]
@@ -152,13 +146,14 @@ export const filterToolsByHighestVersion = (
     return tools;
   }
 
-  // Fast path: if every tool is already at the highest version, skip filtering
   const allSame = tools.every(
-    (t) => extractVersion(t.fullyQualifiedName) === highest
+    (t) => compareVersions(extractVersion(t.fullyQualifiedName), highest) === 0
   );
   if (allSame) {
     return tools;
   }
 
-  return tools.filter((t) => extractVersion(t.fullyQualifiedName) === highest);
+  return tools.filter(
+    (t) => compareVersions(extractVersion(t.fullyQualifiedName), highest) === 0
+  );
 };

--- a/toolkit-docs-generator/src/utils/version-coherence.ts
+++ b/toolkit-docs-generator/src/utils/version-coherence.ts
@@ -1,38 +1,92 @@
 import type { ToolDefinition } from "../types/index.js";
 import { extractVersion } from "./fp.js";
 
+interface ParsedSemver {
+  readonly core: readonly number[];
+  readonly prerelease: readonly (number | string)[] | null;
+}
+
 /**
- * Parse the numeric MAJOR.MINOR.PATCH tuple from a semver string,
- * stripping pre-release (`-alpha.1`) and build metadata (`+build.456`).
- *
- * Handles formats produced by arcade-mcp's normalize_version():
- *   "3.1.3", "1.2.3-beta.1", "1.2.3+build.456", "1.2.3-rc.1+build.789"
+ * Parse a semver-ish string into numeric core + optional pre-release parts.
+ * Build metadata (+...) is ignored for ordering.
  */
-const parseNumericVersion = (version: string): number[] => {
-  // Strip build metadata (after +) then pre-release (after -)
-  const core = version.split("+")[0]?.split("-")[0] ?? version;
-  return core.split(".").map((s) => {
-    const n = Number(s);
+const parseSemver = (version: string): ParsedSemver => {
+  const withoutBuild = version.split("+")[0] ?? version;
+  const prereleaseIndex = withoutBuild.indexOf("-");
+  const coreText =
+    prereleaseIndex >= 0
+      ? withoutBuild.slice(0, prereleaseIndex)
+      : withoutBuild;
+  const prereleaseText =
+    prereleaseIndex >= 0 ? withoutBuild.slice(prereleaseIndex + 1) : "";
+
+  const core = coreText.split(".").map((segment) => {
+    const n = Number(segment);
     return Number.isNaN(n) ? 0 : n;
   });
+
+  const prerelease =
+    prereleaseText.length > 0
+      ? prereleaseText.split(".").map((identifier) => {
+          const n = Number(identifier);
+          return Number.isNaN(n) ? identifier : n;
+        })
+      : null;
+
+  return { core, prerelease };
 };
 
 /**
- * Compare two semver version strings numerically by MAJOR.MINOR.PATCH.
- * Pre-release and build metadata are ignored for ordering purposes
- * (they are unlikely to appear in Engine API responses, but we handle
- * them defensively since arcade-mcp's semver allows them).
+ * Compare two semver version strings using semver precedence rules:
+ * - Compare MAJOR.MINOR.PATCH numerically
+ * - For equal core versions, stable release > pre-release
+ * - Numeric pre-release identifiers compare numerically
+ * - String pre-release identifiers compare lexicographically
+ * - Build metadata is ignored
  *
  * Returns a positive number if a > b, negative if a < b, 0 if equal.
  */
 const compareVersions = (a: string, b: string): number => {
-  const aParts = parseNumericVersion(a);
-  const bParts = parseNumericVersion(b);
-  const len = Math.max(aParts.length, bParts.length);
+  const aSemver = parseSemver(a);
+  const bSemver = parseSemver(b);
+  const len = Math.max(aSemver.core.length, bSemver.core.length);
   for (let i = 0; i < len; i++) {
-    const diff = (aParts[i] ?? 0) - (bParts[i] ?? 0);
+    const diff = (aSemver.core[i] ?? 0) - (bSemver.core[i] ?? 0);
     if (diff !== 0) return diff;
   }
+
+  const aPrerelease = aSemver.prerelease;
+  const bPrerelease = bSemver.prerelease;
+  if (!(aPrerelease || bPrerelease)) return 0;
+  if (!aPrerelease && bPrerelease) return 1;
+  if (aPrerelease && !bPrerelease) return -1;
+
+  const prereleaseLen = Math.max(
+    aPrerelease?.length ?? 0,
+    bPrerelease?.length ?? 0
+  );
+  for (let i = 0; i < prereleaseLen; i++) {
+    const aPart = aPrerelease?.[i];
+    const bPart = bPrerelease?.[i];
+
+    if (aPart === undefined && bPart !== undefined) return -1;
+    if (aPart !== undefined && bPart === undefined) return 1;
+    if (aPart === undefined && bPart === undefined) return 0;
+
+    const aIsNumber = typeof aPart === "number";
+    const bIsNumber = typeof bPart === "number";
+    if (aIsNumber && bIsNumber) {
+      const diff = (aPart as number) - (bPart as number);
+      if (diff !== 0) return diff;
+      continue;
+    }
+    if (aIsNumber && !bIsNumber) return -1;
+    if (!aIsNumber && bIsNumber) return 1;
+
+    const diff = String(aPart).localeCompare(String(bPart), "en");
+    if (diff !== 0) return diff;
+  }
+
   return 0;
 };
 

--- a/toolkit-docs-generator/src/utils/version-coherence.ts
+++ b/toolkit-docs-generator/src/utils/version-coherence.ts
@@ -32,6 +32,16 @@ const comparePrereleaseIdentifier = (
   return String(aPart).localeCompare(String(bPart), "en");
 };
 
+const compareOptionalPrereleasePart = (
+  aPart: number | string | undefined,
+  bPart: number | string | undefined
+): number => {
+  if (aPart === undefined && bPart === undefined) return 0;
+  if (aPart === undefined) return -1;
+  if (bPart === undefined) return 1;
+  return comparePrereleaseIdentifier(aPart, bPart);
+};
+
 const comparePrerelease = (
   aPrerelease: readonly (number | string)[] | null,
   bPrerelease: readonly (number | string)[] | null
@@ -45,14 +55,10 @@ const comparePrerelease = (
     bPrerelease?.length ?? 0
   );
   for (let i = 0; i < prereleaseLen; i++) {
-    const aPart = aPrerelease?.[i];
-    const bPart = bPrerelease?.[i];
-
-    if (aPart === undefined && bPart !== undefined) return -1;
-    if (aPart !== undefined && bPart === undefined) return 1;
-    if (aPart === undefined && bPart === undefined) return 0;
-
-    const diff = comparePrereleaseIdentifier(aPart, bPart);
+    const diff = compareOptionalPrereleasePart(
+      aPrerelease?.[i],
+      bPrerelease?.[i]
+    );
     if (diff !== 0) return diff;
   }
 

--- a/toolkit-docs-generator/tests/sources/toolkit-data-source.test.ts
+++ b/toolkit-docs-generator/tests/sources/toolkit-data-source.test.ts
@@ -10,6 +10,7 @@ import {
   InMemoryMetadataSource,
   InMemoryToolDataSource,
 } from "../../src/sources/in-memory.js";
+import type { IMetadataSource } from "../../src/sources/internal.js";
 import { createCombinedToolkitDataSource } from "../../src/sources/toolkit-data-source.js";
 import type { ToolDefinition, ToolkitMetadata } from "../../src/types/index.js";
 
@@ -319,19 +320,17 @@ describe("CombinedToolkitDataSource", () => {
 
     let metadataLookupCalls = 0;
     const metadataSource = {
-      async getToolkitMetadata(
-        _toolkitId: string
-      ): Promise<ToolkitMetadata | null> {
+      async getToolkitMetadata(_toolkitId) {
         metadataLookupCalls += 1;
         return null;
       },
-      async getAllToolkitsMetadata(): Promise<readonly ToolkitMetadata[]> {
+      async getAllToolkitsMetadata() {
         return [];
       },
-      async listToolkitIds(): Promise<readonly string[]> {
+      async listToolkitIds() {
         return [];
       },
-    };
+    } satisfies IMetadataSource;
 
     const dataSource = createCombinedToolkitDataSource({
       toolSource,
@@ -352,21 +351,19 @@ describe("CombinedToolkitDataSource", () => {
 
     const lookedUpIds: string[] = [];
     const metadataSource = {
-      async getToolkitMetadata(
-        toolkitId: string
-      ): Promise<ToolkitMetadata | null> {
+      async getToolkitMetadata(toolkitId) {
         lookedUpIds.push(toolkitId);
         return null;
       },
-      async getAllToolkitsMetadata(): Promise<readonly ToolkitMetadata[]> {
+      async getAllToolkitsMetadata() {
         return [
           createMetadata({ id: "Slack", label: "Slack", category: "social" }),
         ];
       },
-      async listToolkitIds(): Promise<readonly string[]> {
+      async listToolkitIds() {
         return ["Slack"];
       },
-    };
+    } satisfies IMetadataSource;
 
     const dataSource = createCombinedToolkitDataSource({
       toolSource,
@@ -375,5 +372,37 @@ describe("CombinedToolkitDataSource", () => {
 
     await dataSource.fetchAllToolkitsData();
     expect(lookedUpIds).toEqual(["Github"]);
+  });
+
+  it("fetchAllToolkitsData does not re-lookup metadata when the map already has a direct hit", async () => {
+    const toolSource = new InMemoryToolDataSource([
+      createTool({
+        qualifiedName: "Github.CreateIssue",
+        fullyQualifiedName: "Github.CreateIssue@1.0.0",
+      }),
+    ]);
+
+    const lookedUpIds: string[] = [];
+    const metadataSource = {
+      async getToolkitMetadata(toolkitId) {
+        lookedUpIds.push(toolkitId);
+        return null;
+      },
+      async getAllToolkitsMetadata() {
+        return [createMetadata()];
+      },
+      async listToolkitIds() {
+        return ["Github"];
+      },
+    } satisfies IMetadataSource;
+
+    const dataSource = createCombinedToolkitDataSource({
+      toolSource,
+      metadataSource,
+    });
+
+    const result = await dataSource.fetchAllToolkitsData();
+    expect(result.get("Github")?.metadata?.label).toBe("GitHub");
+    expect(lookedUpIds).toEqual([]);
   });
 });

--- a/toolkit-docs-generator/tests/sources/toolkit-data-source.test.ts
+++ b/toolkit-docs-generator/tests/sources/toolkit-data-source.test.ts
@@ -308,4 +308,72 @@ describe("CombinedToolkitDataSource", () => {
     expect(single.metadata?.label).toBe("Mailchimp API");
     expect(listed?.metadata?.label).toBe("Mailchimp API");
   });
+
+  it("fetchToolkitData does not re-fetch metadata when direct lookup is already null", async () => {
+    const toolSource = new InMemoryToolDataSource([
+      createTool({
+        qualifiedName: "Github.CreateIssue",
+        fullyQualifiedName: "Github.CreateIssue@1.0.0",
+      }),
+    ]);
+
+    let metadataLookupCalls = 0;
+    const metadataSource = {
+      async getToolkitMetadata(
+        _toolkitId: string
+      ): Promise<ToolkitMetadata | null> {
+        metadataLookupCalls += 1;
+        return null;
+      },
+      async getAllToolkitsMetadata(): Promise<readonly ToolkitMetadata[]> {
+        return [];
+      },
+      async listToolkitIds(): Promise<readonly string[]> {
+        return [];
+      },
+    };
+
+    const dataSource = createCombinedToolkitDataSource({
+      toolSource,
+      metadataSource,
+    });
+
+    await dataSource.fetchToolkitData("Github");
+    expect(metadataLookupCalls).toBe(1);
+  });
+
+  it("fetchAllToolkitsData performs toolkit-id lookup when metadata map misses", async () => {
+    const toolSource = new InMemoryToolDataSource([
+      createTool({
+        qualifiedName: "Github.CreateIssue",
+        fullyQualifiedName: "Github.CreateIssue@1.0.0",
+      }),
+    ]);
+
+    const lookedUpIds: string[] = [];
+    const metadataSource = {
+      async getToolkitMetadata(
+        toolkitId: string
+      ): Promise<ToolkitMetadata | null> {
+        lookedUpIds.push(toolkitId);
+        return null;
+      },
+      async getAllToolkitsMetadata(): Promise<readonly ToolkitMetadata[]> {
+        return [
+          createMetadata({ id: "Slack", label: "Slack", category: "social" }),
+        ];
+      },
+      async listToolkitIds(): Promise<readonly string[]> {
+        return ["Slack"];
+      },
+    };
+
+    const dataSource = createCombinedToolkitDataSource({
+      toolSource,
+      metadataSource,
+    });
+
+    await dataSource.fetchAllToolkitsData();
+    expect(lookedUpIds).toEqual(["Github"]);
+  });
 });

--- a/toolkit-docs-generator/tests/sources/toolkit-data-source.test.ts
+++ b/toolkit-docs-generator/tests/sources/toolkit-data-source.test.ts
@@ -277,4 +277,35 @@ describe("CombinedToolkitDataSource", () => {
     const result = await dataSource.fetchToolkitData("MailchimpMarketingApi");
     expect(result.metadata?.label).toBe("Mailchimp API");
   });
+
+  it("should use providerId fallback consistently in fetchAllToolkitsData", async () => {
+    const toolSource = new InMemoryToolDataSource([
+      createTool({
+        qualifiedName: "MailchimpMarketingApi.CreateCampaign",
+        fullyQualifiedName: "MailchimpMarketingApi.CreateCampaign@1.0.0",
+        auth: { providerId: "mailchimp", providerType: "oauth2", scopes: [] },
+      }),
+    ]);
+
+    const metadataSource = new InMemoryMetadataSource([
+      createMetadata({
+        id: "MailchimpApi",
+        label: "Mailchimp API",
+        category: "productivity",
+        type: "arcade_starter",
+      }),
+    ]);
+
+    const dataSource = createCombinedToolkitDataSource({
+      toolSource,
+      metadataSource,
+    });
+
+    const single = await dataSource.fetchToolkitData("MailchimpMarketingApi");
+    const all = await dataSource.fetchAllToolkitsData();
+    const listed = all.get("MailchimpMarketingApi");
+
+    expect(single.metadata?.label).toBe("Mailchimp API");
+    expect(listed?.metadata?.label).toBe("Mailchimp API");
+  });
 });

--- a/toolkit-docs-generator/tests/utils/version-coherence.test.ts
+++ b/toolkit-docs-generator/tests/utils/version-coherence.test.ts
@@ -142,6 +142,49 @@ describe("getHighestVersion", () => {
     ];
     expect(getHighestVersion(tools)).toBe("1.23-rc.1");
   });
+
+  it("distinguishes versions that differ only in the patch component", () => {
+    const tools = [
+      createTool("Github.CreateIssue@1.2.3"),
+      createTool("Github.SetStarred@1.2.4"),
+    ];
+    expect(getHighestVersion(tools)).toBe("1.2.4");
+  });
+
+  it("orders alphanumeric pre-release identifiers by ASCII byte order", () => {
+    // SemVer §11.4.2: alphanumeric identifiers compare by ASCII, not locale.
+    // 'B' (66) < 'a' (97), so "1.0.0-Beta" < "1.0.0-alpha".
+    const tools = [
+      createTool("Github.CreateIssue@1.0.0-Beta"),
+      createTool("Github.SetStarred@1.0.0-alpha"),
+    ];
+    expect(getHighestVersion(tools)).toBe("1.0.0-alpha");
+  });
+
+  it("orders alphanumeric pre-release identifiers when both are non-numeric", () => {
+    const tools = [
+      createTool("Github.CreateIssue@1.0.0-alpha"),
+      createTool("Github.SetStarred@1.0.0-beta"),
+    ];
+    expect(getHighestVersion(tools)).toBe("1.0.0-beta");
+  });
+
+  it("returns null when every tool lacks an @version", () => {
+    const tools = [
+      {
+        ...createTool("X.A@0.0.0"),
+        fullyQualifiedName: "X.A",
+      },
+      {
+        ...createTool("X.B@0.0.0"),
+        fullyQualifiedName: "X.B",
+      },
+    ];
+    // extractVersion defaults missing "@" to "0.0.0", so "highest" is
+    // well-defined here. This test pins that contract so future changes
+    // to extractVersion surface in the coherence layer.
+    expect(getHighestVersion(tools)).toBe("0.0.0");
+  });
 });
 
 describe("filterToolsByHighestVersion", () => {
@@ -239,5 +282,21 @@ describe("filterToolsByHighestVersion", () => {
     const result = filterToolsByHighestVersion(tools);
     expect(result).toHaveLength(1);
     expect(result[0]?.fullyQualifiedName).toBe("Github.SetStarred@1.23-rc.10");
+  });
+
+  it("keeps tools with equivalent core versions even when build metadata differs", () => {
+    // Build metadata is ignored by semver precedence, so two tools tagged
+    // `@1.0.0` and `@1.0.0+build.1` are the same release and both survive.
+    const tools = [
+      createTool("Github.CreateIssue@1.0.0"),
+      createTool("Github.SetStarred@1.0.0+build.1"),
+      createTool("Github.ListPullRequests@0.9.0"),
+    ];
+    const result = filterToolsByHighestVersion(tools);
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.fullyQualifiedName)).toEqual([
+      "Github.CreateIssue@1.0.0",
+      "Github.SetStarred@1.0.0+build.1",
+    ]);
   });
 });

--- a/toolkit-docs-generator/tests/utils/version-coherence.test.ts
+++ b/toolkit-docs-generator/tests/utils/version-coherence.test.ts
@@ -110,6 +110,14 @@ describe("getHighestVersion", () => {
     ];
     expect(getHighestVersion(tools)).toBe("4.0.0-beta.1+build.123");
   });
+
+  it("prefers stable release over pre-release with same core version", () => {
+    const tools = [
+      createTool("Github.CreateIssue@1.23-rc.1"),
+      createTool("Github.SetStarred@1.23"),
+    ];
+    expect(getHighestVersion(tools)).toBe("1.23");
+  });
 });
 
 describe("filterToolsByHighestVersion", () => {
@@ -186,5 +194,15 @@ describe("filterToolsByHighestVersion", () => {
     expect(result.every((t) => t.fullyQualifiedName.endsWith("@3.1.3"))).toBe(
       true
     );
+  });
+
+  it("drops matching pre-release tools when stable release exists", () => {
+    const tools = [
+      createTool("Github.CreateIssue@1.23-rc.1"),
+      createTool("Github.SetStarred@1.23"),
+    ];
+    const result = filterToolsByHighestVersion(tools);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.fullyQualifiedName).toBe("Github.SetStarred@1.23");
   });
 });

--- a/toolkit-docs-generator/tests/utils/version-coherence.test.ts
+++ b/toolkit-docs-generator/tests/utils/version-coherence.test.ts
@@ -118,6 +118,30 @@ describe("getHighestVersion", () => {
     ];
     expect(getHighestVersion(tools)).toBe("1.23");
   });
+
+  it("orders numeric pre-release identifiers numerically", () => {
+    const tools = [
+      createTool("Github.CreateIssue@1.23-rc.2"),
+      createTool("Github.SetStarred@1.23-rc.10"),
+    ];
+    expect(getHighestVersion(tools)).toBe("1.23-rc.10");
+  });
+
+  it("treats non-numeric pre-release identifiers as higher than numeric ones", () => {
+    const tools = [
+      createTool("Github.CreateIssue@1.23-rc.1"),
+      createTool("Github.SetStarred@1.23-rc.beta"),
+    ];
+    expect(getHighestVersion(tools)).toBe("1.23-rc.beta");
+  });
+
+  it("treats longer pre-release identifier lists as newer when prefix matches", () => {
+    const tools = [
+      createTool("Github.CreateIssue@1.23-rc"),
+      createTool("Github.SetStarred@1.23-rc.1"),
+    ];
+    expect(getHighestVersion(tools)).toBe("1.23-rc.1");
+  });
 });
 
 describe("filterToolsByHighestVersion", () => {
@@ -204,5 +228,16 @@ describe("filterToolsByHighestVersion", () => {
     const result = filterToolsByHighestVersion(tools);
     expect(result).toHaveLength(1);
     expect(result[0]?.fullyQualifiedName).toBe("Github.SetStarred@1.23");
+  });
+
+  it("keeps only the highest numeric pre-release", () => {
+    const tools = [
+      createTool("Github.CreateIssue@1.23-rc.2"),
+      createTool("Github.SetStarred@1.23-rc.10"),
+      createTool("Github.ListPullRequests@1.23-rc.1"),
+    ];
+    const result = filterToolsByHighestVersion(tools);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.fullyQualifiedName).toBe("Github.SetStarred@1.23-rc.10");
   });
 });


### PR DESCRIPTION
## Summary
- make version coherence semver-aware so stable releases outrank matching pre-release versions (for example, `1.23` over `1.23-rc.1`)
- add regression tests for stable-vs-rc filtering behavior in `version-coherence`
- reuse the same providerId metadata fallback in `fetchAllToolkitsData` as `fetchToolkitData` and add a consistency test for `MailchimpMarketingApi`
- address reviewer concern about RC-vs-stable precedence by adding semver ordering tests (`rc.10 > rc.2`, numeric vs string identifiers, and prefix-length precedence)
- address bugbot’s redundant fetch comment by preventing a second `getToolkitMetadata(toolkitId)` call in `fetchToolkitData`
- add call-count regression tests proving single fetch does not re-fetch metadata while bulk fetch still performs toolkit-id lookup on metadata-map misses

## Test plan
- [x] `pnpm vitest run toolkit-docs-generator/tests/utils/version-coherence.test.ts toolkit-docs-generator/tests/sources/toolkit-data-source.test.ts`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes toolkit version-selection logic (SemVer prerelease/build precedence) and metadata resolution fallback, which can alter which tools/metadata are emitted in generated docs. Covered by new regression tests, but affects core selection behavior across single and bulk fetch paths.
> 
> **Overview**
> Makes version coherence *SemVer-precedence aware* by introducing a proper `compareVersions` that orders stable releases above matching pre-releases, compares prerelease identifiers correctly (numeric vs string, prefix length), and treats build metadata as ordering-ignored but equivalence-preserving. `filterToolsByHighestVersion` now keeps all tools semver-equivalent to the highest release (e.g. `1.0.0` and `1.0.0+build.1`) instead of string-matching only.
> 
> Unifies and reuses the providerId-based metadata fallback for `*Api` toolkits via `resolveProviderMetadata`, applying it consistently in both `fetchToolkitData` and `fetchAllToolkitsData`, while avoiding redundant `getToolkitMetadata(toolkitId)` calls in the single-toolkit path and only doing per-toolkit lookups in bulk when the batch metadata map misses.
> 
> Adds targeted tests covering SemVer edge cases (stable vs rc, rc ordering, ASCII ordering, build metadata equivalence) and metadata lookup consistency/call-count behavior for both single and bulk fetches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5528dcd947cbc9938eab04dfff5fa261d15b93ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->