### PR TITLE
fix(sitemap): include generated toolkit pages

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,12 +1,26 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { MetadataRoute } from "next";
+import { listToolkitRoutes } from "./_lib/toolkit-static-params";
 
 const SITE_URL = process.env.SITE_URL ?? "https://docs.arcade.dev";
 const NORMALIZED_SITE_URL = SITE_URL.replace(/\/+$/, "");
 const APP_DIR = path.join(process.cwd(), "app");
+const TOOLKIT_DATA_DIR = path.join(
+  process.cwd(),
+  "toolkit-docs-generator",
+  "data",
+  "toolkits"
+);
 const SKIP_DIRS = new Set(["_meta", "_api", "_redirects", "api"]);
 const INDEX_SUFFIX_REGEX = /\/index$/;
+// Toolkit pages live at /en/resources/integrations/{category}/{toolkitId}.
+// `others` is not a real on-disk category — it's a catch-all bucket used by
+// listToolkitRoutes for uncategorized toolkits, and it redirects to the
+// integrations index via next.config.ts — so we never emit those URLs.
+const TOOLKIT_URL_LOCALE = "en";
+const TOOLKIT_URL_PREFIX = "/resources/integrations";
+const EXCLUDED_TOOLKIT_CATEGORIES = new Set(["others"]);
 let cachedRoutes: Promise<MetadataRoute.Sitemap> | null = null;
 
 async function collectRoutes(dir: string): Promise<MetadataRoute.Sitemap> {
@@ -43,11 +57,90 @@ async function collectRoutes(dir: string): Promise<MetadataRoute.Sitemap> {
   return entries;
 }
 
+const TOOLKIT_ID_NORMALIZER = /[^a-z0-9]+/g;
+const normalizeToolkitKey = (value: string) =>
+  value.toLowerCase().replace(TOOLKIT_ID_NORMALIZER, "");
+
+// listToolkitRoutes returns URL slugs (e.g. "google-calendar"), but the data
+// files on disk are keyed by the raw toolkit id (e.g. "GoogleCalendar"). Build
+// a lookup from normalized key → filename once per sitemap build so we can
+// attach accurate lastmod timestamps without a quadratic readdir scan.
+async function loadToolkitDataIndex(): Promise<Map<string, string>> {
+  const index = new Map<string, string>();
+  try {
+    const entries = await fs.readdir(TOOLKIT_DATA_DIR);
+    for (const entry of entries) {
+      if (!entry.endsWith(".json") || entry === "index.json") {
+        continue;
+      }
+      const stem = entry.slice(0, -".json".length);
+      index.set(normalizeToolkitKey(stem), entry);
+    }
+  } catch {
+    // Empty index is fine — we fall back to the current build time.
+  }
+  return index;
+}
+
+async function collectToolkitRoutes(): Promise<MetadataRoute.Sitemap> {
+  let routes: Awaited<ReturnType<typeof listToolkitRoutes>>;
+  try {
+    routes = await listToolkitRoutes();
+  } catch {
+    // If the toolkit data dir is unavailable (e.g. in a minimal test env),
+    // fall back gracefully rather than breaking the whole sitemap build.
+    return [];
+  }
+
+  const dataIndex = await loadToolkitDataIndex();
+  const now = new Date();
+  const entries: MetadataRoute.Sitemap = [];
+  const seen = new Set<string>();
+
+  for (const route of routes) {
+    if (EXCLUDED_TOOLKIT_CATEGORIES.has(route.category)) {
+      continue;
+    }
+
+    const url = `${NORMALIZED_SITE_URL}/${TOOLKIT_URL_LOCALE}${TOOLKIT_URL_PREFIX}/${route.category}/${route.toolkitId}`;
+    if (seen.has(url)) {
+      continue;
+    }
+    seen.add(url);
+
+    const dataFile = dataIndex.get(normalizeToolkitKey(route.toolkitId));
+    let lastModified: Date = now;
+    if (dataFile) {
+      try {
+        const stats = await fs.stat(path.join(TOOLKIT_DATA_DIR, dataFile));
+        lastModified = stats.mtime;
+      } catch {
+        // Keep `now` as the fallback lastmod.
+      }
+    }
+    entries.push({ url, lastModified });
+  }
+
+  return entries;
+}
+
 export default function sitemap(): Promise<MetadataRoute.Sitemap> {
   if (!cachedRoutes) {
-    cachedRoutes = collectRoutes(APP_DIR).then((routes) => {
-      routes.sort((a, b) => a.url.localeCompare(b.url));
-      return routes;
+    cachedRoutes = Promise.all([
+      collectRoutes(APP_DIR),
+      collectToolkitRoutes(),
+    ]).then(([mdxRoutes, toolkitRoutes]) => {
+      const seen = new Set<string>();
+      const combined: MetadataRoute.Sitemap = [];
+      for (const entry of [...mdxRoutes, ...toolkitRoutes]) {
+        if (seen.has(entry.url)) {
+          continue;
+        }
+        seen.add(entry.url);
+        combined.push(entry);
+      }
+      combined.sort((a, b) => a.url.localeCompare(b.url));
+      return combined;
     });
   }
 

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -19,8 +19,21 @@ test("sitemap lists expected URLs", async () => {
       true
     );
 
-    // Known page should be present
+    // Known static page should be present
     expect(urls).toContain("https://example.test/en/references/changelog");
+
+    // Generated toolkit pages should be present. These are backed by the
+    // dynamic [toolkitId] routes that the old filesystem walk skipped.
+    expect(urls).toContain(
+      "https://example.test/en/resources/integrations/development/firecrawl"
+    );
+    const toolkitUrls = urls.filter((url) =>
+      url.includes("/en/resources/integrations/")
+    );
+    expect(toolkitUrls.length).toBeGreaterThan(10);
+
+    // Dynamic-segment placeholders must never leak into sitemap URLs.
+    expect(urls.every((url) => !url.includes("["))).toBe(true);
 
     // No duplicates
     const duplicates = urls.filter(


### PR DESCRIPTION
## Summary

Toolkit pages live at `/en/resources/integrations/{category}/{toolkitId}` and are statically generated at build time on Vercel via `generateStaticParams` + `dynamicParams = false`. However, the sitemap walk in `app/sitemap.ts` hard-skips any directory whose name contains `[`, which excludes all ten `[toolkitId]` dynamic-route folders. As a result, the 99 toolkit URLs never made it into `sitemap.xml` — so Algolia DocSearch (which uses the sitemap to discover URLs) never crawled them, and none of the toolkit content appeared in docs search even though the HTML was live.

This PR fixes that.

## What changed

- `app/sitemap.ts`
  - Keeps the existing MDX filesystem walk (still skipping `[toolkitId]` dirs, because a dynamic segment is not a single URL).
  - After the walk, appends one sitemap entry per toolkit by calling the existing `listToolkitRoutes()` helper.
  - Attaches accurate `lastModified` from each toolkit's underlying `toolkit-docs-generator/data/toolkits/{id}.json` file, using a normalized-key lookup because URL slugs (e.g. `google-calendar`) differ from data-file stems (e.g. `GoogleCalendar`).
  - Excludes the `others` category — it has no on-disk route and is redirected to `/resources/integrations` via `next.config.ts`.
  - De-duplicates by URL across both sources before sorting.
- `tests/sitemap.test.ts`
  - Asserts a known toolkit URL (`/en/resources/integrations/development/firecrawl`) is present.
  - Asserts we now have >10 integration URLs.
  - Asserts no `[` placeholder leaks into any sitemap URL.
  - Keeps the existing no-duplicates and known-static-page checks.

## Verification

Before (live `https://docs.arcade.dev/sitemap.xml`): **132 URLs**, 0 toolkit URLs.

After (generated locally with this branch):

```
Total sitemap entries: 231
Toolkit URLs: 99
By category:
  customer-support: 9, databases: 5, development: 15, entertainment: 2,
  payments: 3, productivity: 36, sales: 11, search: 11, social: 7
Any [toolkitId] leak? false
```

### Checks run locally

- `pnpm test` — 47 test files, **512/512 passing** (includes 3 assertions in `tests/sitemap.test.ts`).
- `pnpm lint` — clean. One pre-existing, unrelated Biome complexity warning in `toolkit-docs-generator/src/cli/exclusion-cleanup.ts` (not touched here).
- `pnpm exec tsc --noEmit` — clean.

## Follow-up after deploy

Once this merges and deploys, the Algolia DocSearch crawler will pick up the new URLs on its next scheduled run. Triggering a manual reindex from the Algolia crawler dashboard will backfill toolkit content into the search index faster.

## Test plan

- [ ] CI green (tests, lint, type-check, redirect checks, Vale).
- [ ] After deploy, confirm `https://docs.arcade.dev/sitemap.xml` contains `/en/resources/integrations/development/firecrawl` and other toolkit URLs.
- [ ] After crawler reindex, confirm docs search returns toolkit results (e.g. search "firecrawl", "intercom", "google calendar").

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds additional sitemap entries and supporting file-stat lookups with defensive fallbacks; main risk is incorrect/duplicate sitemap URLs or timestamps rather than runtime app behavior.
> 
> **Overview**
> Sitemap generation now **includes statically-generated toolkit integration pages** under `/en/resources/integrations/{category}/{toolkitId}` by appending routes from `listToolkitRoutes()` to the existing filesystem-based MDX crawl.
> 
> Toolkit URLs are **de-duplicated and sorted** alongside MDX routes, the `others` category is excluded, and each toolkit entry attempts to use the corresponding `toolkit-docs-generator/data/toolkits/*.json` mtime for `lastModified` (with graceful fallbacks when data isn’t available).
> 
> Tests are updated to assert a known toolkit URL is present, ensure a minimum count of integration URLs, and verify no dynamic-segment placeholders (`[ ... ]`) appear in sitemap output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a7c281af6ca533e1e9c7df0ccb2b3a562a320c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->