### PR TITLE
feat(analytics): add UTMs to docs signup links (GRO-86)

### DIFF
--- a/app/_components/analytics.tsx
+++ b/app/_components/analytics.tsx
@@ -13,17 +13,18 @@ export type LinkClickedProps = {
 };
 
 const UTM_SOURCE = "docs";
-const DEFAULT_UTM_MEDIUM = "docs-cta";
 const DEFAULT_UTM_CAMPAIGN = "docs";
 
-const buildRegisterHref = (utmMedium: string, utmCampaign: string): string => {
+const buildRegisterHref = (utmCampaign: string, utmMedium?: string): string => {
   const base = getDashboardUrl("register");
   const separator = base.includes("?") ? "&" : "?";
   const params = new URLSearchParams({
     utm_source: UTM_SOURCE,
-    utm_medium: utmMedium,
     utm_campaign: utmCampaign,
   });
+  if (utmMedium) {
+    params.set("utm_medium", utmMedium);
+  }
   return `${base}${separator}${params.toString()}`;
 };
 
@@ -32,7 +33,7 @@ export const SignupLink = ({
   children,
   className,
   utmCampaign = DEFAULT_UTM_CAMPAIGN,
-  utmMedium = DEFAULT_UTM_MEDIUM,
+  utmMedium,
 }: LinkClickedProps) => {
   const trackSignupClick = (source: string) => {
     posthog.capture("Signup clicked", {
@@ -43,7 +44,7 @@ export const SignupLink = ({
   return (
     <Link
       className={cn("text-primary", className)}
-      href={buildRegisterHref(utmMedium, utmCampaign)}
+      href={buildRegisterHref(utmCampaign, utmMedium)}
       onClick={() => trackSignupClick(linkLocation)}
     >
       {children}

--- a/app/_components/analytics.tsx
+++ b/app/_components/analytics.tsx
@@ -8,12 +8,31 @@ export type LinkClickedProps = {
   linkLocation: string;
   children?: React.ReactNode;
   className?: string;
+  utmCampaign?: string;
+  utmMedium?: string;
+};
+
+const UTM_SOURCE = "docs";
+const DEFAULT_UTM_MEDIUM = "docs-cta";
+const DEFAULT_UTM_CAMPAIGN = "docs";
+
+const buildRegisterHref = (utmMedium: string, utmCampaign: string): string => {
+  const base = getDashboardUrl("register");
+  const separator = base.includes("?") ? "&" : "?";
+  const params = new URLSearchParams({
+    utm_source: UTM_SOURCE,
+    utm_medium: utmMedium,
+    utm_campaign: utmCampaign,
+  });
+  return `${base}${separator}${params.toString()}`;
 };
 
 export const SignupLink = ({
   linkLocation,
   children,
   className,
+  utmCampaign = DEFAULT_UTM_CAMPAIGN,
+  utmMedium = DEFAULT_UTM_MEDIUM,
 }: LinkClickedProps) => {
   const trackSignupClick = (source: string) => {
     posthog.capture("Signup clicked", {
@@ -24,7 +43,7 @@ export const SignupLink = ({
   return (
     <Link
       className={cn("text-primary", className)}
-      href={getDashboardUrl("register")}
+      href={buildRegisterHref(utmMedium, utmCampaign)}
       onClick={() => trackSignupClick(linkLocation)}
     >
       {children}

--- a/app/_components/analytics.tsx
+++ b/app/_components/analytics.tsx
@@ -16,16 +16,13 @@ const UTM_SOURCE = "docs";
 const DEFAULT_UTM_CAMPAIGN = "docs";
 
 const buildRegisterHref = (utmCampaign: string, utmMedium?: string): string => {
-  const base = getDashboardUrl("register");
-  const separator = base.includes("?") ? "&" : "?";
-  const params = new URLSearchParams({
-    utm_source: UTM_SOURCE,
-    utm_campaign: utmCampaign,
-  });
+  const url = new URL(getDashboardUrl("register"));
+  url.searchParams.set("utm_source", UTM_SOURCE);
+  url.searchParams.set("utm_campaign", utmCampaign);
   if (utmMedium) {
-    params.set("utm_medium", utmMedium);
+    url.searchParams.set("utm_medium", utmMedium);
   }
-  return `${base}${separator}${params.toString()}`;
+  return url.toString();
 };
 
 export const SignupLink = ({

--- a/app/en/get-started/quickstarts/call-tool-agent/page.mdx
+++ b/app/en/get-started/quickstarts/call-tool-agent/page.mdx
@@ -20,7 +20,7 @@ Install and use the Arcade client to call Arcade Hosted Tools.
 
 <GuideOverview.Prerequisites>
 
-- An <SignupLink linkLocation="docs:call-tools-directly">Arcade account</SignupLink>
+- An <SignupLink linkLocation="docs:call-tools-directly" utmCampaign="quickstart-call-tool-agent">Arcade account</SignupLink>
 - An [Arcade API key](/get-started/setup/api-keys)
 - The [`uv` package manager](https://docs.astral.sh/uv/getting-started/installation/) if you are using Python
 - The [`bun` runtime](https://bun.com/) if you are using TypeScript

--- a/app/en/get-started/quickstarts/call-tool-agent/page.mdx
+++ b/app/en/get-started/quickstarts/call-tool-agent/page.mdx
@@ -20,7 +20,7 @@ Install and use the Arcade client to call Arcade Hosted Tools.
 
 <GuideOverview.Prerequisites>
 
-- An <SignupLink linkLocation="docs:call-tools-directly" utmCampaign="quickstart-call-tool-agent">Arcade account</SignupLink>
+- An <SignupLink linkLocation="docs:call-tools-directly" utmCampaign="docs-quickstart-call-tool-agent">Arcade account</SignupLink>
 - An [Arcade API key](/get-started/setup/api-keys)
 - The [`uv` package manager](https://docs.astral.sh/uv/getting-started/installation/) if you are using Python
 - The [`bun` runtime](https://bun.com/) if you are using TypeScript

--- a/app/en/get-started/quickstarts/call-tool-client/page.mdx
+++ b/app/en/get-started/quickstarts/call-tool-client/page.mdx
@@ -35,7 +35,7 @@ Create a coding agent using an MCP Gateway to call tools from multiple MCP serve
 
 <GuideOverview.Prerequisites>
 
-- An <SignupLink linkLocation="docs:call-tools-directly">Arcade account</SignupLink>
+- An <SignupLink linkLocation="docs:call-tools-directly" utmCampaign="quickstart-call-tool-client">Arcade account</SignupLink>
 
 </GuideOverview.Prerequisites>
 

--- a/app/en/get-started/quickstarts/call-tool-client/page.mdx
+++ b/app/en/get-started/quickstarts/call-tool-client/page.mdx
@@ -35,7 +35,7 @@ Create a coding agent using an MCP Gateway to call tools from multiple MCP serve
 
 <GuideOverview.Prerequisites>
 
-- An <SignupLink linkLocation="docs:call-tools-directly" utmCampaign="quickstart-call-tool-client">Arcade account</SignupLink>
+- An <SignupLink linkLocation="docs:call-tools-directly" utmCampaign="docs-quickstart-call-tool-client">Arcade account</SignupLink>
 
 </GuideOverview.Prerequisites>
 

--- a/app/en/get-started/quickstarts/mcp-server-quickstart/page.mdx
+++ b/app/en/get-started/quickstarts/mcp-server-quickstart/page.mdx
@@ -158,7 +158,7 @@ $env:MY_SECRET_KEY="my-secret-value"
 
 ## Connect to Arcade to unlock authorized tool calling
 
-Since the Reddit tool accesses information only available to your Reddit account, you'll need to authorize it. For this, you'll need to create an Arcade account and connect from the terminal, run:
+Since the Reddit tool accesses information only available to your Reddit account, you'll need to authorize it. For this, you'll need to create an <SignupLink linkLocation="docs:mcp-server-quickstart" utmCampaign="quickstart-mcp-server">Arcade account</SignupLink> and connect from the terminal, run:
 
 ```bash
 arcade login

--- a/app/en/get-started/quickstarts/mcp-server-quickstart/page.mdx
+++ b/app/en/get-started/quickstarts/mcp-server-quickstart/page.mdx
@@ -158,7 +158,7 @@ $env:MY_SECRET_KEY="my-secret-value"
 
 ## Connect to Arcade to unlock authorized tool calling
 
-Since the Reddit tool accesses information only available to your Reddit account, you'll need to authorize it. For this, you'll need to create an <SignupLink linkLocation="docs:mcp-server-quickstart" utmCampaign="quickstart-mcp-server">Arcade account</SignupLink> and connect from the terminal, run:
+Since the Reddit tool accesses information only available to your Reddit account, you'll need to authorize it. For this, you'll need to create an <SignupLink linkLocation="docs:mcp-server-quickstart" utmCampaign="docs-quickstart-mcp-server">Arcade account</SignupLink> and connect from the terminal, run:
 
 ```bash
 arcade login

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -160,7 +160,7 @@ export default async function RootLayout({
               }
               projectLink="https://github.com/ArcadeAI/arcade-mcp"
             >
-              <SignupLink linkLocation="docs:navbar" utmMedium="docs-navbar">
+              <SignupLink linkLocation="docs:navbar" utmMedium="navbar">
                 <NavBarButton
                   hideOnPath={[
                     "/guides/create-tools/add-tools-to-arcade-catalog",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -160,7 +160,7 @@ export default async function RootLayout({
               }
               projectLink="https://github.com/ArcadeAI/arcade-mcp"
             >
-              <SignupLink linkLocation="docs:navbar">
+              <SignupLink linkLocation="docs:navbar" utmMedium="docs-navbar">
                 <NavBarButton
                   hideOnPath={[
                     "/guides/create-tools/add-tools-to-arcade-catalog",


### PR DESCRIPTION
Linear: [GRO-86](https://linear.app/arcadedev/issue/GRO-86/add-utms-to-docs-so-we-can-track-creation-of-new-arcade-accounts)

## Summary
- `SignupLink` now appends UTMs when routing to `app.arcade.dev/register`
- All docs campaigns prefixed with `docs-` so `utm_campaign startsWith "docs"` catches everything
- Default: `utm_source=docs`, `utm_campaign=docs` (no medium)
- Navbar: adds `utm_medium=navbar`
- QuickStarts: `utm_campaign=docs-quickstart-<slug>` (call-tool-agent / call-tool-client / mcp-server)

## Test plan
- [ ] Navbar Sign Up href ends in `?utm_source=docs&utm_campaign=docs&utm_medium=navbar`
- [ ] `/en/get-started/quickstarts/call-tool-agent` SignupLink href includes `utm_campaign=docs-quickstart-call-tool-agent`
- [ ] `/en/get-started/quickstarts/call-tool-client` SignupLink href includes `utm_campaign=docs-quickstart-call-tool-client`
- [ ] `/en/get-started/quickstarts/mcp-server-quickstart` SignupLink href includes `utm_campaign=docs-quickstart-mcp-server`
- [ ] A non-QuickStart docs page SignupLink href is `?utm_source=docs&utm_campaign=docs`
- [ ] In PostHog, `utm_campaign startsWith "docs"` on `app.arcade.dev/register` pageviews returns expected traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change limited to link URL construction and a few doc pages; main risk is incorrect query param formatting or unexpected URL encoding.
> 
> **Overview**
> Docs `SignupLink` now builds the `/register` URL with **UTM query params** (`utm_source=docs`, default `utm_campaign=docs`, optional `utm_medium`) while keeping the existing PostHog click event.
> 
> Selected signup links in docs are updated to pass more specific attribution: the navbar adds `utm_medium=navbar`, and the three QuickStart guides set `utm_campaign` to `docs-quickstart-*` (plus an inline signup link in the MCP server quickstart).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b170d91eb3f18123b0d6edfe5805f0d81247b659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->