### PR TITLE
fix(toolkit-docs-generator): preserve previous summary when LLM unavailable or fails

### DIFF
--- a/toolkit-docs-generator/src/merger/data-merger.ts
+++ b/toolkit-docs-generator/src/merger/data-merger.ts
@@ -963,6 +963,10 @@ export class DataMerger {
     }
 
     if (!this.toolkitSummaryGenerator) {
+      // Preserve previous summary when no LLM generator is available
+      if (previousToolkit?.summary) {
+        result.toolkit.summary = previousToolkit.summary;
+      }
       return;
     }
 
@@ -980,6 +984,10 @@ export class DataMerger {
       result.warnings.push(
         `Summary generation failed for ${result.toolkit.id}: ${message}`
       );
+      // Preserve previous summary when LLM generation fails
+      if (previousToolkit?.summary) {
+        result.toolkit.summary = previousToolkit.summary;
+      }
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #926 by preserving the previous toolkit summary in two critical fallback paths where it was being silently dropped.

## Problem

The `DataMerger.maybeGenerateSummary` method in `toolkit-docs-generator/src/merger/data-merger.ts` was silently wiping the `summary` field in two scenarios:

1. **No LLM generator available**: When `toolkitSummaryGenerator` is undefined (e.g., `--skip-summary` flag or missing LLM environment variables) and the toolkit signature has changed, the function would return without preserving the previous summary.

2. **LLM call fails**: When the generator throws an exception (rate limit, transient API error, invalid JSON response), the catch block would log a warning but leave `result.toolkit.summary` undefined.

This caused hand-refined summaries to disappear from toolkit pages after automated docs updates, affecting toolkits like `github`, `jira`, `googledocs`, `linear`, `salesforce`, and `daytona`.

## Solution

The fix carries `previousToolkit?.summary` forward in both fallback paths:

1. After the "no generator" check (line 965-968), if a previous summary exists, it's now preserved
2. In the catch block after LLM generation fails (line 978-983), if a previous summary exists, it's now preserved

This ensures that a slightly stale summary is always better than losing hand-refined content entirely.

## Changes

- Modified `maybeGenerateSummary` method in `toolkit-docs-generator/src/merger/data-merger.ts`:
  - Added fallback to preserve `previousToolkit.summary` when no LLM generator is available
  - Added fallback to preserve `previousToolkit.summary` when LLM generation throws an error
  - Added inline comments explaining the preservation logic

## Testing

All 527 existing tests pass, including:
- `data-merger.test.ts` (56 tests) - verifies summary generation and reuse behavior
- All other toolkit-docs-generator tests
- Integration tests for the full docs generation pipeline

## Impact

This fix prevents future regressions where toolkit summaries are silently dropped during automated updates. Toolkits that lost their summaries will need to be restored in follow-up PRs (separate from this bugfix).

## Related

- Issue #926 - Root cause analysis and impact assessment
- Commits f6e474d7, 77b2697e - Manual restoration of lost summaries for 11 affected toolkits
- Commit 417a51fd - Earlier fix attempt that was dropped during merge (this PR restores and extends that fix)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://arcade-ai.slack.com/archives/D097C9M4UR3/p1776477398108289?thread_ts=1776477398.108289&cid=D097C9M4UR3)

<div><a href="https://cursor.com/agents/bc-daf28027-2d0e-556a-a95b-157332e8ab06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-daf28027-2d0e-556a-a95b-157332e8ab06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

