### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-17T11:27:15.976Z",
+  "generatedAt": "2026-04-18T18:47:30.637Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -509,7 +509,7 @@
     {
       "id": "Linear",
       "label": "Linear",
-      "version": "3.3.2",
+      "version": "3.3.3",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 39,

--- a/toolkit-docs-generator/data/toolkits/linear.json
+++ b/toolkit-docs-generator/data/toolkits/linear.json
@@ -1,7 +1,7 @@
 {
   "id": "Linear",
   "label": "Linear",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Arcade tools designed for LLMs to interact with Linear",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "AddComment",
       "qualifiedName": "Linear.AddComment",
-      "fullyQualifiedName": "Linear.AddComment@3.3.2",
+      "fullyQualifiedName": "Linear.AddComment@3.3.3",
       "description": "Add a comment to an issue.",
       "parameters": [
         {
@@ -99,7 +99,7 @@
     {
       "name": "AddProjectComment",
       "qualifiedName": "Linear.AddProjectComment",
-      "fullyQualifiedName": "Linear.AddProjectComment@3.3.2",
+      "fullyQualifiedName": "Linear.AddProjectComment@3.3.3",
       "description": "Add a comment to a project's document content.\n\nIMPORTANT: Due to Linear API limitations, comments created via the API will NOT\nappear visually anchored inline in the document (no yellow highlight on text).\nThe comment will be stored and can be retrieved via list_project_comments, but\nit will appear in the comments panel rather than inline in the document.\n\nFor true inline comments that are visually anchored to text, users should create\nthem directly in the Linear UI by selecting text and adding a comment.\n\nThe quoted_text parameter stores metadata about what text the comment references,\nwhich is useful for context even though the comment won't be visually anchored.",
       "parameters": [
         {
@@ -198,7 +198,7 @@
     {
       "name": "AddProjectToInitiative",
       "qualifiedName": "Linear.AddProjectToInitiative",
-      "fullyQualifiedName": "Linear.AddProjectToInitiative@3.3.2",
+      "fullyQualifiedName": "Linear.AddProjectToInitiative@3.3.3",
       "description": "Link a project to an initiative.\n\nBoth initiative and project can be specified by ID or name.\nIf a name is provided, fuzzy matching is used to resolve it.",
       "parameters": [
         {
@@ -284,7 +284,7 @@
     {
       "name": "ArchiveInitiative",
       "qualifiedName": "Linear.ArchiveInitiative",
-      "fullyQualifiedName": "Linear.ArchiveInitiative@3.3.2",
+      "fullyQualifiedName": "Linear.ArchiveInitiative@3.3.3",
       "description": "Archive an initiative.\n\nArchived initiatives are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -357,7 +357,7 @@
     {
       "name": "ArchiveIssue",
       "qualifiedName": "Linear.ArchiveIssue",
-      "fullyQualifiedName": "Linear.ArchiveIssue@3.3.2",
+      "fullyQualifiedName": "Linear.ArchiveIssue@3.3.3",
       "description": "Archive an issue.\n\nArchived issues are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -417,7 +417,7 @@
     {
       "name": "ArchiveProject",
       "qualifiedName": "Linear.ArchiveProject",
-      "fullyQualifiedName": "Linear.ArchiveProject@3.3.2",
+      "fullyQualifiedName": "Linear.ArchiveProject@3.3.3",
       "description": "Archive a project.\n\nArchived projects are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -490,7 +490,7 @@
     {
       "name": "CreateInitiative",
       "qualifiedName": "Linear.CreateInitiative",
-      "fullyQualifiedName": "Linear.CreateInitiative@3.3.2",
+      "fullyQualifiedName": "Linear.CreateInitiative@3.3.3",
       "description": "Create a new Linear initiative.\n\nInitiatives are high-level strategic goals that group related projects.",
       "parameters": [
         {
@@ -596,7 +596,7 @@
     {
       "name": "CreateIssue",
       "qualifiedName": "Linear.CreateIssue",
-      "fullyQualifiedName": "Linear.CreateIssue@3.3.2",
+      "fullyQualifiedName": "Linear.CreateIssue@3.3.3",
       "description": "Create a new Linear issue with validation.\n\nWhen assignee is None or '@me', the issue is assigned to the authenticated user.\nAll entity references (team, assignee, labels, state, project, cycle, parent)\nare validated before creation. If an entity is not found, suggestions are\nreturned to help correct the input.",
       "parameters": [
         {
@@ -762,7 +762,7 @@
     {
       "name": "CreateIssueRelation",
       "qualifiedName": "Linear.CreateIssueRelation",
-      "fullyQualifiedName": "Linear.CreateIssueRelation@3.3.2",
+      "fullyQualifiedName": "Linear.CreateIssueRelation@3.3.3",
       "description": "Create a relation between two issues.\n\nRelation types define the relationship from the source issue's perspective:\n- blocks: Source issue blocks the related issue\n- blockedBy: Source issue is blocked by the related issue\n- duplicate: Source issue is a duplicate of the related issue\n- related: Issues are related (bidirectional)",
       "parameters": [
         {
@@ -853,7 +853,7 @@
     {
       "name": "CreateProject",
       "qualifiedName": "Linear.CreateProject",
-      "fullyQualifiedName": "Linear.CreateProject@3.3.2",
+      "fullyQualifiedName": "Linear.CreateProject@3.3.3",
       "description": "Create a new Linear project.\n\nTeam is validated before creation. If team is not found, suggestions are\nreturned to help correct the input. Lead is validated if provided.",
       "parameters": [
         {
@@ -1024,7 +1024,7 @@
     {
       "name": "CreateProjectUpdate",
       "qualifiedName": "Linear.CreateProjectUpdate",
-      "fullyQualifiedName": "Linear.CreateProjectUpdate@3.3.2",
+      "fullyQualifiedName": "Linear.CreateProjectUpdate@3.3.3",
       "description": "Create a project status update.\n\nProject updates are posts that communicate progress, blockers, or status\nchanges to stakeholders. They appear in the project's Updates tab and\ncan include a health status indicator.",
       "parameters": [
         {
@@ -1114,7 +1114,7 @@
     {
       "name": "GetCycle",
       "qualifiedName": "Linear.GetCycle",
-      "fullyQualifiedName": "Linear.GetCycle@3.3.2",
+      "fullyQualifiedName": "Linear.GetCycle@3.3.3",
       "description": "Get detailed information about a specific Linear cycle.",
       "parameters": [
         {
@@ -1174,7 +1174,7 @@
     {
       "name": "GetInitiative",
       "qualifiedName": "Linear.GetInitiative",
-      "fullyQualifiedName": "Linear.GetInitiative@3.3.2",
+      "fullyQualifiedName": "Linear.GetInitiative@3.3.3",
       "description": "Get detailed information about a specific Linear initiative.\n\nSupports lookup by ID or name (with fuzzy matching for name).",
       "parameters": [
         {
@@ -1276,7 +1276,7 @@
     {
       "name": "GetInitiativeDescription",
       "qualifiedName": "Linear.GetInitiativeDescription",
-      "fullyQualifiedName": "Linear.GetInitiativeDescription@3.3.2",
+      "fullyQualifiedName": "Linear.GetInitiativeDescription@3.3.3",
       "description": "Get an initiative's full description with pagination support.\n\nUse this tool when you need the complete description of an initiative that\nwas truncated in the get_initiative response. Supports chunked reading for\nvery large descriptions.",
       "parameters": [
         {
@@ -1362,7 +1362,7 @@
     {
       "name": "GetIssue",
       "qualifiedName": "Linear.GetIssue",
-      "fullyQualifiedName": "Linear.GetIssue@3.3.2",
+      "fullyQualifiedName": "Linear.GetIssue@3.3.3",
       "description": "Get detailed information about a specific Linear issue.\n\nAccepts either the issue UUID or the human-readable identifier (like TOO-123).",
       "parameters": [
         {
@@ -1474,7 +1474,7 @@
     {
       "name": "GetNotifications",
       "qualifiedName": "Linear.GetNotifications",
-      "fullyQualifiedName": "Linear.GetNotifications@3.3.2",
+      "fullyQualifiedName": "Linear.GetNotifications@3.3.3",
       "description": "Get the authenticated user's notifications.\n\nReturns notifications including issue mentions, comments, assignments,\nand state changes.",
       "parameters": [
         {
@@ -1560,7 +1560,7 @@
     {
       "name": "GetProject",
       "qualifiedName": "Linear.GetProject",
-      "fullyQualifiedName": "Linear.GetProject@3.3.2",
+      "fullyQualifiedName": "Linear.GetProject@3.3.3",
       "description": "Get detailed information about a specific Linear project.\n\nSupports lookup by ID, slug_id, or name (with fuzzy matching for name).",
       "parameters": [
         {
@@ -1676,7 +1676,7 @@
     {
       "name": "GetProjectDescription",
       "qualifiedName": "Linear.GetProjectDescription",
-      "fullyQualifiedName": "Linear.GetProjectDescription@3.3.2",
+      "fullyQualifiedName": "Linear.GetProjectDescription@3.3.3",
       "description": "Get a project's full description with pagination support.\n\nUse this tool when you need the complete description of a project that\nwas truncated in the get_project response. Supports chunked reading for\nvery large descriptions.",
       "parameters": [
         {
@@ -1762,7 +1762,7 @@
     {
       "name": "GetRecentActivity",
       "qualifiedName": "Linear.GetRecentActivity",
-      "fullyQualifiedName": "Linear.GetRecentActivity@3.3.2",
+      "fullyQualifiedName": "Linear.GetRecentActivity@3.3.3",
       "description": "Get the authenticated user's recent issue activity.\n\nReturns issues the user has recently created or been assigned to\nwithin the specified time period.",
       "parameters": [
         {
@@ -1835,7 +1835,7 @@
     {
       "name": "GetTeam",
       "qualifiedName": "Linear.GetTeam",
-      "fullyQualifiedName": "Linear.GetTeam@3.3.2",
+      "fullyQualifiedName": "Linear.GetTeam@3.3.3",
       "description": "Get detailed information about a specific Linear team.\n\nSupports lookup by ID, key (like TOO, ENG), or name (with fuzzy matching).",
       "parameters": [
         {
@@ -1925,7 +1925,7 @@
     {
       "name": "LinkGithubToIssue",
       "qualifiedName": "Linear.LinkGithubToIssue",
-      "fullyQualifiedName": "Linear.LinkGithubToIssue@3.3.2",
+      "fullyQualifiedName": "Linear.LinkGithubToIssue@3.3.3",
       "description": "Link a GitHub PR, commit, or issue to a Linear issue.\n\nAutomatically detects the artifact type from the URL and generates\nan appropriate title if not provided.",
       "parameters": [
         {
@@ -2011,7 +2011,7 @@
     {
       "name": "ListComments",
       "qualifiedName": "Linear.ListComments",
-      "fullyQualifiedName": "Linear.ListComments@3.3.2",
+      "fullyQualifiedName": "Linear.ListComments@3.3.3",
       "description": "List comments on an issue.\n\nReturns comments with user info, timestamps, and reply threading info.",
       "parameters": [
         {
@@ -2097,7 +2097,7 @@
     {
       "name": "ListCycles",
       "qualifiedName": "Linear.ListCycles",
-      "fullyQualifiedName": "Linear.ListCycles@3.3.2",
+      "fullyQualifiedName": "Linear.ListCycles@3.3.3",
       "description": "List Linear cycles, optionally filtered by team and status.\n\nCycles are time-boxed iterations (like sprints) for organizing work.",
       "parameters": [
         {
@@ -2209,7 +2209,7 @@
     {
       "name": "ListInitiatives",
       "qualifiedName": "Linear.ListInitiatives",
-      "fullyQualifiedName": "Linear.ListInitiatives@3.3.2",
+      "fullyQualifiedName": "Linear.ListInitiatives@3.3.3",
       "description": "List Linear initiatives, optionally filtered by keywords and other criteria.\n\nReturns all initiatives when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2315,7 +2315,7 @@
     {
       "name": "ListIssues",
       "qualifiedName": "Linear.ListIssues",
-      "fullyQualifiedName": "Linear.ListIssues@3.3.2",
+      "fullyQualifiedName": "Linear.ListIssues@3.3.3",
       "description": "List Linear issues, optionally filtered by keywords and other criteria.\n\nReturns all issues when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2498,7 +2498,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Linear.ListLabels",
-      "fullyQualifiedName": "Linear.ListLabels@3.3.2",
+      "fullyQualifiedName": "Linear.ListLabels@3.3.3",
       "description": "List available issue labels in the workspace.\n\nReturns labels that can be applied to issues. Use label IDs or names\nwhen creating or updating issues.",
       "parameters": [
         {
@@ -2558,7 +2558,7 @@
     {
       "name": "ListProjectComments",
       "qualifiedName": "Linear.ListProjectComments",
-      "fullyQualifiedName": "Linear.ListProjectComments@3.3.2",
+      "fullyQualifiedName": "Linear.ListProjectComments@3.3.3",
       "description": "List comments on a project's document content.\n\nReturns comments with user info, timestamps, quoted text for inline comments,\nand reply threading info. Replies are nested under their parent comments.\n\nUse comment_filter to control which comments are returned:\n- only_quoted (default): Only comments attached to a quote in the text\n- only_unquoted: Only comments not attached to a particular quote\n- all: All comments regardless of being attached to a quote or not",
       "parameters": [
         {
@@ -2687,7 +2687,7 @@
     {
       "name": "ListProjects",
       "qualifiedName": "Linear.ListProjects",
-      "fullyQualifiedName": "Linear.ListProjects@3.3.2",
+      "fullyQualifiedName": "Linear.ListProjects@3.3.3",
       "description": "List Linear projects, optionally filtered by keywords and other criteria.\n\nReturns all projects when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2812,7 +2812,7 @@
     {
       "name": "ListTeams",
       "qualifiedName": "Linear.ListTeams",
-      "fullyQualifiedName": "Linear.ListTeams@3.3.2",
+      "fullyQualifiedName": "Linear.ListTeams@3.3.3",
       "description": "List Linear teams, optionally filtered by keywords and other criteria.\n\nReturns all teams when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2924,7 +2924,7 @@
     {
       "name": "ListWorkflowStates",
       "qualifiedName": "Linear.ListWorkflowStates",
-      "fullyQualifiedName": "Linear.ListWorkflowStates@3.3.2",
+      "fullyQualifiedName": "Linear.ListWorkflowStates@3.3.3",
       "description": "List available workflow states in the workspace.\n\nReturns workflow states that can be used for issue transitions.\nStates are team-specific and have different types.",
       "parameters": [
         {
@@ -3017,7 +3017,7 @@
     {
       "name": "ManageIssueSubscription",
       "qualifiedName": "Linear.ManageIssueSubscription",
-      "fullyQualifiedName": "Linear.ManageIssueSubscription@3.3.2",
+      "fullyQualifiedName": "Linear.ManageIssueSubscription@3.3.3",
       "description": "Subscribe to or unsubscribe from an issue's notifications.",
       "parameters": [
         {
@@ -3090,7 +3090,7 @@
     {
       "name": "ReplyToComment",
       "qualifiedName": "Linear.ReplyToComment",
-      "fullyQualifiedName": "Linear.ReplyToComment@3.3.2",
+      "fullyQualifiedName": "Linear.ReplyToComment@3.3.3",
       "description": "Reply to an existing comment on an issue.\n\nCreates a threaded reply to the specified parent comment.",
       "parameters": [
         {
@@ -3176,7 +3176,7 @@
     {
       "name": "ReplyToProjectComment",
       "qualifiedName": "Linear.ReplyToProjectComment",
-      "fullyQualifiedName": "Linear.ReplyToProjectComment@3.3.2",
+      "fullyQualifiedName": "Linear.ReplyToProjectComment@3.3.3",
       "description": "Reply to an existing comment on a project document.\n\nCreates a threaded reply to the specified parent comment.",
       "parameters": [
         {
@@ -3275,7 +3275,7 @@
     {
       "name": "TransitionIssueState",
       "qualifiedName": "Linear.TransitionIssueState",
-      "fullyQualifiedName": "Linear.TransitionIssueState@3.3.2",
+      "fullyQualifiedName": "Linear.TransitionIssueState@3.3.3",
       "description": "Transition a Linear issue to a new workflow state.\n\nThe target state is validated against the team's available states.",
       "parameters": [
         {
@@ -3361,7 +3361,7 @@
     {
       "name": "UpdateComment",
       "qualifiedName": "Linear.UpdateComment",
-      "fullyQualifiedName": "Linear.UpdateComment@3.3.2",
+      "fullyQualifiedName": "Linear.UpdateComment@3.3.3",
       "description": "Update an existing comment.",
       "parameters": [
         {
@@ -3434,7 +3434,7 @@
     {
       "name": "UpdateInitiative",
       "qualifiedName": "Linear.UpdateInitiative",
-      "fullyQualifiedName": "Linear.UpdateInitiative@3.3.2",
+      "fullyQualifiedName": "Linear.UpdateInitiative@3.3.3",
       "description": "Update a Linear initiative with partial updates.\n\nOnly fields that are explicitly provided will be updated.",
       "parameters": [
         {
@@ -3553,7 +3553,7 @@
     {
       "name": "UpdateIssue",
       "qualifiedName": "Linear.UpdateIssue",
-      "fullyQualifiedName": "Linear.UpdateIssue@3.3.2",
+      "fullyQualifiedName": "Linear.UpdateIssue@3.3.3",
       "description": "Update a Linear issue with partial updates.\n\nOnly fields that are explicitly provided will be updated. All entity\nreferences are validated before update.",
       "parameters": [
         {
@@ -3584,7 +3584,7 @@
           "name": "assignee",
           "type": "string",
           "required": false,
-          "description": "New assignee name or email. Use '@me' for current user. Must be a team member. Only updated if provided.",
+          "description": "New assignee name or email. Use '@me' for current user. Use one of the following strings to clear assignee: '', 'none', 'null', or 'unassigned'. Only updated if provided.",
           "enum": null,
           "inferrable": true
         },
@@ -3808,7 +3808,7 @@
     {
       "name": "UpdateProject",
       "qualifiedName": "Linear.UpdateProject",
-      "fullyQualifiedName": "Linear.UpdateProject@3.3.2",
+      "fullyQualifiedName": "Linear.UpdateProject@3.3.3",
       "description": "Update a Linear project with partial updates.\n\nOnly fields that are explicitly provided will be updated. All entity\nreferences are validated before update.\n\nIMPORTANT: Updating the 'content' field will break any existing inline\ncomment anchoring. The comments will still exist and be retrievable via\nlist_project_comments, but they will no longer appear visually anchored\nto text in the Linear UI. The 'description' field can be safely updated\nwithout affecting inline comments.",
       "parameters": [
         {
@@ -4012,7 +4012,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Linear.WhoAmI",
-      "fullyQualifiedName": "Linear.WhoAmI@3.3.2",
+      "fullyQualifiedName": "Linear.WhoAmI@3.3.3",
       "description": "Get the authenticated user's profile and team memberships.\n\nReturns the current user's information including their name, email,\norganization, and the teams they belong to.",
       "parameters": [],
       "auth": {
@@ -4066,5 +4066,5 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-04-10T11:26:08.882Z"
+  "generatedAt": "2026-04-18T18:47:30.292Z"
 }


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: workflow_dispatch
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/24611369706

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Auto-generated docs metadata update; changes are confined to JSON docs/registry and should not affect runtime behavior.
> 
> **Overview**
> **Auto-generated toolkit docs refresh.** Updates `toolkit-docs-generator/data/toolkits/index.json` and `linear.json` generation timestamps and bumps the Linear toolkit version to `3.3.3` (including all `fullyQualifiedName` version suffixes).
> 
> Also updates the `Linear.UpdateIssue` `assignee` parameter description to document supported values for clearing an assignee.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c303702896849413e61a314bb0f142acbe70b41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->