### PR TITLE
[TEST — DO NOT MERGE] Demo for #932 secret-coherence pipeline

### DIFF
--- a/toolkit-docs-generator/data/toolkits/github.json
+++ b/toolkit-docs-generator/data/toolkits/github.json
@@ -85,12 +85,17 @@
         "scopes": []
       },
       "secrets": [
-        "GITHUB_SERVER_URL"
+        "GITHUB_SERVER_URL",
+        "GITHUB_CLASSIC_PERSONAL_ACCESS_TOKEN"
       ],
       "secretsInfo": [
         {
           "name": "GITHUB_SERVER_URL",
           "type": "unknown"
+        },
+        {
+          "name": "GITHUB_CLASSIC_PERSONAL_ACCESS_TOKEN",
+          "type": "token"
         }
       ],
       "output": {


### PR DESCRIPTION
## ⚠️ Testing-only PR — do not merge

Base branch is [#932](https://github.com/ArcadeAI/docs/pull/932), not `main`. Close this PR after testing; the phantom secret must not land on main.

## What changed compared to the first test run

The first trigger on this branch ([#936](https://github.com/ArcadeAI/docs/pull/936)) produced no cleanup because `--skip-unchanged` short-circuits before `enforceSecretCoherence` runs when the Engine API's summary endpoint reports no version change for `github`. The phantom secret diff was never evaluated.

#932 now has a `workflow_dispatch.inputs.providers` input that bypasses `--skip-unchanged` and `--all` for manual runs. This branch is rebased on that change.

## How to run it (updated)

1. Confirm `ANTHROPIC_API_KEY` is set as a repo secret. Without it the scanner runs but the LLM edit is skipped.
2. Go to **Actions → Generate toolkit docs → Run workflow**.
3. Pick branch `test/secret-coherence-demo`.
4. In the `providers` input, enter: `Github`.
5. Click **Run workflow**.

The run now uses `--providers Github` without `--skip-unchanged`, so the generator processes `Github` end-to-end — the scanner diffs the committed JSON (with the phantom) against fresh Engine API data (without it), identifies `GITHUB_CLASSIC_PERSONAL_ACCESS_TOKEN` as removed, scans chunks, and (if the Anthropic key is present) drives Sonnet 4.6 to minimally edit the stale references out.

## What you should see in the AUTO PR

In the resulting `[AUTO]` PR's diff on `toolkit-docs-generator/data/toolkits/github.json`:

- ✓ Phantom secret removed from `Github.AssignPullRequestUser` `.secrets` / `.secretsInfo` (that happens automatically because Engine API doesn't return it).
- ✓ The `custom_section` chunk (the Secrets Setup section) drops the row / note lines that reference `GITHUB_CLASSIC_PERSONAL_ACCESS_TOKEN`, leaving the `GITHUB_SERVER_URL` row intact.
- ✓ Unrelated chunks (Enterprise Support callout, App Permissions Summary, Configuration & Setup) stay byte-identical — confirms the edit is minimal.
- ✓ The run log should include a warning like `Stale secret reference in toolkit_chunk #N: GITHUB_CLASSIC_PERSONAL_ACCESS_TOKEN`.

## When done

Close this PR without merging. Delete the branch.

Refs #932