### PR TITLE
chore: update @arcadeai/design-system to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://arcade.dev/",
   "dependencies": {
-    "@arcadeai/design-system": "3.38.0",
+    "@arcadeai/design-system": "3.38.1",
     "@mdx-js/mdx": "3.1.1",
     "@mdx-js/react": "3.1.1",
     "@next/third-parties": "16.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@arcadeai/design-system':
-        specifier: 3.38.0
-        version: 3.38.0(@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.73.1(react@19.2.5))(react@19.2.5)(recharts@3.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1))(tailwindcss@4.2.4)
+        specifier: 3.38.1
+        version: 3.38.1(@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.73.1(react@19.2.5))(react@19.2.5)(recharts@3.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1))(tailwindcss@4.2.4)
       '@mdx-js/mdx':
         specifier: 3.1.1
         version: 3.1.1
@@ -267,8 +267,8 @@ packages:
       zod:
         optional: true
 
-  '@arcadeai/design-system@3.38.0':
-    resolution: {integrity: sha512-dWTT3Oe2tth6goqOc2bdYi8KwGAUnhPwC4D2VkTBwV50H3QIuEzUIB8y+6ur/54iqS9/oQUkst6iwMjR/qzTSg==}
+  '@arcadeai/design-system@3.38.1':
+    resolution: {integrity: sha512-1AJtRVGLJi8xVFu7chCaBepSvrjQlzpSxR07fv+LGik29wgcZeVmgFhCo0P1o/smq8Rv6yCnHUZrC+juUcOHnA==}
     engines: {bun: '>=1.3.5'}
     peerDependencies:
       '@hookform/resolvers': '>=5.2.1'
@@ -5168,7 +5168,7 @@ snapshots:
     optionalDependencies:
       zod: 4.3.6
 
-  '@arcadeai/design-system@3.38.0(@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.73.1(react@19.2.5))(react@19.2.5)(recharts@3.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1))(tailwindcss@4.2.4)':
+  '@arcadeai/design-system@3.38.1(@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.73.1(react@19.2.5))(react@19.2.5)(recharts@3.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1))(tailwindcss@4.2.4)':
     dependencies:
       '@hookform/resolvers': 5.2.2(react-hook-form@7.73.1(react@19.2.5))
       '@streamdown/code': 1.1.0(react@19.2.5)


### PR DESCRIPTION
This PR updates `@arcadeai/design-system` to the latest published version.

It runs a design-system compatibility test gate before opening this PR.
If that gate fails, the workflow stops and no PR is created.

- Trigger: `workflow_dispatch`
- Run: https://github.com/ArcadeAI/docs/actions/runs/25000252621

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency patch update limited to the design system version bump and lockfile changes; any risk is confined to potential UI/style regressions from the upstream package.
> 
> **Overview**
> Updates the docs site to use `@arcadeai/design-system@3.38.1` (from `3.38.0`) and refreshes `pnpm-lock.yaml` to match the new resolved package/integrity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc3dc9363cc27339d84dec32a7110e341a7c8958. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->