### PR TITLE
Fix tool feedback survey

### DIFF
--- a/app/_components/tool-feedback-survey.tsx
+++ b/app/_components/tool-feedback-survey.tsx
@@ -11,15 +11,21 @@ export const ToolFeedbackSurvey = () => {
   const [completed, setCompleted] = useState(false);
 
   useEffect(() => {
-    const unsubscribe = posthog.onFeatureFlags(() => {
+    let mounted = true;
+    posthog.onFeatureFlags(() => {
       posthog.getSurveys((surveys) => {
+        if (!mounted) {
+          return;
+        }
         const survey = surveys.find((s) => s.id === SURVEY_ID);
         if (survey) {
           setSurveyData(survey);
         }
       }, true);
     });
-    return unsubscribe;
+    return () => {
+      mounted = false;
+    };
   }, []);
 
   const handleSurveyComplete = () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small lifecycle change in a client component to avoid updating React state after unmount; only affects when the PostHog survey data is set.
> 
> **Overview**
> Fixes `ToolFeedbackSurvey`’s PostHog initialization to avoid relying on an `unsubscribe` return value and to prevent `setSurveyData` from running after the component unmounts.
> 
> The effect now tracks a local `mounted` flag and only updates state while mounted, cleaning up by flipping the flag on unmount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6756e6bc26592f593cdda34cb23ac7bff29e0ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->