### PR TITLE
docs: tighten Pro Tools and BYOC glossary copy

### DIFF
--- a/app/en/resources/glossary/page.mdx
+++ b/app/en/resources/glossary/page.mdx
@@ -172,17 +172,25 @@ A 'tool execution' is a single call to a tool to interact with a remote system o
 
 _Learn more about [tool executions](/guides/tool-calling)._
 
-### Standard and Pro Tool executions
+### Standard and Pro Tool Executions
 
-Arcade tools are divided into 2 categories: Standard and Pro. While all tools have some cost for Arcade to run, Pro tools are significantly more costly - either due to infrastructure costs, the complexity of the tool, or a cost imposed by the provider of the tool. Pro tools cost more to execute and have different limits.
+Arcade tools are divided into 2 categories: Standard and Pro. While all tools have some cost for Arcade to run, Pro tools are significantly more costly — either due to infrastructure costs, the complexity of the tool, or a cost imposed by the provider of the tool. Pro tools cost more to execute and have different limits.
 
-Learn more about tool pricing [here](https://www.arcade.dev/pricing).
+#### Standard Tool Executions
+
+Standard tools are the default tier and cover the majority of Arcade's catalog. Each invocation of a Standard tool counts as one Standard Tool Execution against your plan's monthly allowance, with any overage billed per execution at the rate listed on the [pricing page](https://www.arcade.dev/pricing). Provider and infrastructure costs for Standard tools are absorbed by Arcade as part of the platform fee.
+
+#### Pro Tool Executions
+
+Pro tools incur materially higher operational cost than Standard tools due to underlying infrastructure (e.g., compute-intensive sandboxes), provider-imposed fees (e.g., per-call API charges from data providers), or tool complexity. Each invocation of a Pro tool counts as one Pro Tool Execution against your plan's monthly Pro allowance, with any overage billed per execution at the Pro rate listed on the [pricing page](https://www.arcade.dev/pricing). Arcade may reclassify tools between Standard and Pro from time to time as the underlying cost structure of a tool changes; any such reclassification applies prospectively.
+
+As of 04/24, Pro tools include: E2B, Firecrawl, Google Finance, Google Flights, Google Hotels, Google Jobs, Google Maps, Google News, Google Search, Google Shopping, Imgflip, Walmart, and YouTube.
 
 ### Bring Your Own Credentials (BYOC)
 
-Bring Your Own Credentials (BYOC) is a feature that allows you to use your own credentials to certain pro tools. This changes the cost of the tool execution, as you will be charged directly by the provider of the tool, rather than relying on Arcade to pay the bill for you.
+Bring Your Own Credentials (BYOC) is a feature that allows you to use your own credentials to access Pro tools. This changes the cost of the tool execution, as you will be charged directly by the provider of the tool, rather than relying on Arcade to pay the bill for you. In exchange, the tool execution will be billed at the Standard rate. As of 04/26/2026, most credentials required for Pro tools are API Keys specific to the service being accessed.
 
-To set your own credentials, set the requisite secret within the Arcade Dashboard, overwriting the default 'static' credentials.
+To set your own credentials, set the requisite secret(s) within the Arcade Dashboard Secrets page, overwriting the default 'static' credentials. You can also set the secrets using the Arcade CLI.
 
 ## Tool Execution and Tool Development
 


### PR DESCRIPTION
See changes at https://docs-git-vfanelle-glossary-pro-byoc-copy-arcade-ai.vercel.app/en/resources/glossary#standard-and-pro-tool-executions

## Summary

- Expand "Standard and Pro Tool Executions" glossary entry into Standard and Pro sub-sections with allowance, overage, reclassification language, and a current Pro tools list (as of 04/24)
- Tighten "Bring Your Own Credentials (BYOC)" copy to specify Pro tools, Standard-rate billing benefit, and API key credential detail

## Notes

- The static Pro tools list will be replaced with a dynamic link to the integrations page filtered by Pro once a follow-up PR adds filtered URL support to `/en/resources/integrations`
- No other glossary entries were touched
- Existing anchor links (`#standard-and-pro-tool-executions`, `#bring-your-own-credentials-byoc`) still resolve

## Test plan

- [ ] Verify glossary page renders correctly at `/en/resources/glossary`
- [ ] Verify anchor links `#standard-and-pro-tool-executions` and `#bring-your-own-credentials-byoc` resolve
- [ ] Verify no other glossary entries changed

Made with [Cursor](https://cursor.com)