### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/toolkit-docs-generator/data/toolkits/gmail.json
+++ b/toolkit-docs-generator/data/toolkits/gmail.json
@@ -1,7 +1,7 @@
 {
   "id": "Gmail",
   "label": "Gmail",
-  "version": "5.0.0",
+  "version": "5.2.0",
   "description": "Arcade.dev LLM tools for Gmail",
   "metadata": {
     "category": "productivity",
@@ -30,7 +30,7 @@
     {
       "name": "ChangeEmailLabels",
       "qualifiedName": "Gmail.ChangeEmailLabels",
-      "fullyQualifiedName": "Gmail.ChangeEmailLabels@5.0.0",
+      "fullyQualifiedName": "Gmail.ChangeEmailLabels@5.2.0",
       "description": "Add and remove labels from an email using the Gmail API.",
       "parameters": [
         {
@@ -124,7 +124,7 @@
     {
       "name": "CreateLabel",
       "qualifiedName": "Gmail.CreateLabel",
-      "fullyQualifiedName": "Gmail.CreateLabel@5.0.0",
+      "fullyQualifiedName": "Gmail.CreateLabel@5.2.0",
       "description": "Create a new label in the user's mailbox.",
       "parameters": [
         {
@@ -184,7 +184,7 @@
     {
       "name": "DeleteDraftEmail",
       "qualifiedName": "Gmail.DeleteDraftEmail",
-      "fullyQualifiedName": "Gmail.DeleteDraftEmail@5.0.0",
+      "fullyQualifiedName": "Gmail.DeleteDraftEmail@5.2.0",
       "description": "Delete a draft email using the Gmail API.",
       "parameters": [
         {
@@ -244,7 +244,7 @@
     {
       "name": "GetThread",
       "qualifiedName": "Gmail.GetThread",
-      "fullyQualifiedName": "Gmail.GetThread@5.0.0",
+      "fullyQualifiedName": "Gmail.GetThread@5.2.0",
       "description": "Get the specified thread by ID.",
       "parameters": [
         {
@@ -304,7 +304,7 @@
     {
       "name": "ListDraftEmails",
       "qualifiedName": "Gmail.ListDraftEmails",
-      "fullyQualifiedName": "Gmail.ListDraftEmails@5.0.0",
+      "fullyQualifiedName": "Gmail.ListDraftEmails@5.2.0",
       "description": "Lists draft emails in the user's draft mailbox using the Gmail API.",
       "parameters": [
         {
@@ -364,7 +364,7 @@
     {
       "name": "ListEmails",
       "qualifiedName": "Gmail.ListEmails",
-      "fullyQualifiedName": "Gmail.ListEmails@5.0.0",
+      "fullyQualifiedName": "Gmail.ListEmails@5.2.0",
       "description": "Read emails from a Gmail account and extract plain text content.",
       "parameters": [
         {
@@ -424,7 +424,7 @@
     {
       "name": "ListEmailsByHeader",
       "qualifiedName": "Gmail.ListEmailsByHeader",
-      "fullyQualifiedName": "Gmail.ListEmailsByHeader@5.0.0",
+      "fullyQualifiedName": "Gmail.ListEmailsByHeader@5.2.0",
       "description": "Search for emails by header using the Gmail API.",
       "parameters": [
         {
@@ -570,7 +570,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Gmail.ListLabels",
-      "fullyQualifiedName": "Gmail.ListLabels@5.0.0",
+      "fullyQualifiedName": "Gmail.ListLabels@5.2.0",
       "description": "List all the labels in the user's mailbox.",
       "parameters": [],
       "auth": {
@@ -615,7 +615,7 @@
     {
       "name": "ListThreads",
       "qualifiedName": "Gmail.ListThreads",
-      "fullyQualifiedName": "Gmail.ListThreads@5.0.0",
+      "fullyQualifiedName": "Gmail.ListThreads@5.2.0",
       "description": "List threads in the user's mailbox.",
       "parameters": [
         {
@@ -701,7 +701,7 @@
     {
       "name": "ReplyToEmail",
       "qualifiedName": "Gmail.ReplyToEmail",
-      "fullyQualifiedName": "Gmail.ReplyToEmail@5.0.0",
+      "fullyQualifiedName": "Gmail.ReplyToEmail@5.2.0",
       "description": "Send a reply to an email message.",
       "parameters": [
         {
@@ -796,7 +796,7 @@
     {
       "name": "SearchThreads",
       "qualifiedName": "Gmail.SearchThreads",
-      "fullyQualifiedName": "Gmail.SearchThreads@5.0.0",
+      "fullyQualifiedName": "Gmail.SearchThreads@5.2.0",
       "description": "Search for threads in the user's mailbox",
       "parameters": [
         {
@@ -972,7 +972,7 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "Gmail.SendDraftEmail",
-      "fullyQualifiedName": "Gmail.SendDraftEmail@5.0.0",
+      "fullyQualifiedName": "Gmail.SendDraftEmail@5.2.0",
       "description": "Send a draft email using the Gmail API.",
       "parameters": [
         {
@@ -1032,7 +1032,7 @@
     {
       "name": "SendEmail",
       "qualifiedName": "Gmail.SendEmail",
-      "fullyQualifiedName": "Gmail.SendEmail@5.0.0",
+      "fullyQualifiedName": "Gmail.SendEmail@5.2.0",
       "description": "Send an email using the Gmail API.",
       "parameters": [
         {
@@ -1167,7 +1167,7 @@
     {
       "name": "TrashEmail",
       "qualifiedName": "Gmail.TrashEmail",
-      "fullyQualifiedName": "Gmail.TrashEmail@5.0.0",
+      "fullyQualifiedName": "Gmail.TrashEmail@5.2.0",
       "description": "Move an email to the trash folder using the Gmail API.",
       "parameters": [
         {
@@ -1227,7 +1227,7 @@
     {
       "name": "UpdateDraftEmail",
       "qualifiedName": "Gmail.UpdateDraftEmail",
-      "fullyQualifiedName": "Gmail.UpdateDraftEmail@5.0.0",
+      "fullyQualifiedName": "Gmail.UpdateDraftEmail@5.2.0",
       "description": "Update an existing email draft using the Gmail API.\n\nSingle-part plain drafts support full body replacement. For HTML, attachments, or\nmultipart drafts, the tool fails unless the body is unchanged (metadata-only update),\nin which case the existing MIME tree is preserved. Otherwise edit the draft in Gmail.\n\nFor each of subject, body, recipient, cc, and bcc, omitting the parameter or passing\n``None`` leaves that part of the draft unchanged (for cc/bcc, existing headers are kept;\npass an empty list to clear).",
       "parameters": [
         {
@@ -1316,7 +1316,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Gmail.WhoAmI",
-      "fullyQualifiedName": "Gmail.WhoAmI@5.0.0",
+      "fullyQualifiedName": "Gmail.WhoAmI@5.2.0",
       "description": "Get comprehensive user profile and Gmail account information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Gmail account statistics, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1363,7 +1363,7 @@
     {
       "name": "WriteDraftEmail",
       "qualifiedName": "Gmail.WriteDraftEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftEmail@5.0.0",
+      "fullyQualifiedName": "Gmail.WriteDraftEmail@5.2.0",
       "description": "Compose a new email draft using the Gmail API.",
       "parameters": [
         {
@@ -1497,7 +1497,7 @@
     {
       "name": "WriteDraftReplyEmail",
       "qualifiedName": "Gmail.WriteDraftReplyEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@5.0.0",
+      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@5.2.0",
       "description": "Compose a draft reply to an email message.",
       "parameters": [
         {
@@ -1561,7 +1561,8 @@
         "providerId": "google",
         "providerType": "oauth2",
         "scopes": [
-          "https://www.googleapis.com/auth/gmail.compose"
+          "https://www.googleapis.com/auth/gmail.compose",
+          "https://www.googleapis.com/auth/gmail.readonly"
         ]
       },
       "secrets": [],
@@ -1579,7 +1580,8 @@
         },
         "behavior": {
           "operations": [
-            "create"
+            "create",
+            "read"
           ],
           "readOnly": false,
           "destructive": false,
@@ -1602,6 +1604,8 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-04-27T11:41:15.823Z",
-  "summary": "Arcade's Gmail toolkit lets developers read, search, label, draft, send, and reply to Gmail messages through the Gmail API.\n\n**Capabilities**\n- List, search, retrieve, and trash emails and threads.\n- Create, update, send, and delete drafts.\n- Send emails and replies with support for To, Cc, Bcc, and plain or HTML content.\n- Manage Gmail labels and fetch authenticated user profile information.\n- Preserve existing draft fields when optional update parameters are omitted.\n\n**OAuth**\n- **Provider**: Google\n- **Scopes**: Gmail read, compose, modify, send, label access, and Google user profile scopes.\n\n**Secrets**\n- No secret types required for toolkit operation."
+  "generatedAt": "2026-04-28T11:41:12.730Z",
+  "summary": "Arcade's Gmail toolkit lets developers read, search, label, draft, send, and reply to Gmail messages through the Gmail API.\n\n**Capabilities**\n- List, search, retrieve, and trash emails and threads.\n- Create, update, send, and delete drafts.\n- Send emails and replies with support for To, Cc, Bcc, and plain or HTML content.\n- Manage Gmail labels and fetch authenticated user profile information.\n- Preserve existing draft fields when optional update parameters are omitted.\n\n**OAuth**\n- **Provider**: Google\n- **Scopes**: Gmail read, compose, modify, send, label access, and Google user profile scopes.\n\n**Secrets**\n- No secret types required for toolkit operation.",
+  "summaryStale": true,
+  "summaryStaleReason": "llm_generation_failed"
 }

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-27T11:41:16.105Z",
+  "generatedAt": "2026-04-28T11:41:16.294Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -257,7 +257,7 @@
     {
       "id": "Gmail",
       "label": "Gmail",
-      "version": "5.0.0",
+      "version": "5.2.0",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 18,
@@ -509,10 +509,10 @@
     {
       "id": "Linear",
       "label": "Linear",
-      "version": "3.3.3",
+      "version": "3.4.0",
       "category": "productivity",
       "type": "arcade",
-      "toolCount": 39,
+      "toolCount": 42,
       "authType": "oauth2"
     },
     {
@@ -680,7 +680,7 @@
     {
       "id": "Posthog",
       "label": "PostHog",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "development",
       "type": "arcade",
       "toolCount": 41,

--- a/toolkit-docs-generator/data/toolkits/linear.json
+++ b/toolkit-docs-generator/data/toolkits/linear.json
@@ -1,7 +1,7 @@
 {
   "id": "Linear",
   "label": "Linear",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "description": "Arcade tools designed for LLMs to interact with Linear",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "AddComment",
       "qualifiedName": "Linear.AddComment",
-      "fullyQualifiedName": "Linear.AddComment@3.3.3",
+      "fullyQualifiedName": "Linear.AddComment@3.4.0",
       "description": "Add a comment to an issue.",
       "parameters": [
         {
@@ -99,7 +99,7 @@
     {
       "name": "AddProjectComment",
       "qualifiedName": "Linear.AddProjectComment",
-      "fullyQualifiedName": "Linear.AddProjectComment@3.3.3",
+      "fullyQualifiedName": "Linear.AddProjectComment@3.4.0",
       "description": "Add a comment to a project's document content.\n\nIMPORTANT: Due to Linear API limitations, comments created via the API will NOT\nappear visually anchored inline in the document (no yellow highlight on text).\nThe comment will be stored and can be retrieved via list_project_comments, but\nit will appear in the comments panel rather than inline in the document.\n\nFor true inline comments that are visually anchored to text, users should create\nthem directly in the Linear UI by selecting text and adding a comment.\n\nThe quoted_text parameter stores metadata about what text the comment references,\nwhich is useful for context even though the comment won't be visually anchored.",
       "parameters": [
         {
@@ -198,7 +198,7 @@
     {
       "name": "AddProjectToInitiative",
       "qualifiedName": "Linear.AddProjectToInitiative",
-      "fullyQualifiedName": "Linear.AddProjectToInitiative@3.3.3",
+      "fullyQualifiedName": "Linear.AddProjectToInitiative@3.4.0",
       "description": "Link a project to an initiative.\n\nBoth initiative and project can be specified by ID or name.\nIf a name is provided, fuzzy matching is used to resolve it.",
       "parameters": [
         {
@@ -284,7 +284,7 @@
     {
       "name": "ArchiveInitiative",
       "qualifiedName": "Linear.ArchiveInitiative",
-      "fullyQualifiedName": "Linear.ArchiveInitiative@3.3.3",
+      "fullyQualifiedName": "Linear.ArchiveInitiative@3.4.0",
       "description": "Archive an initiative.\n\nArchived initiatives are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -357,7 +357,7 @@
     {
       "name": "ArchiveIssue",
       "qualifiedName": "Linear.ArchiveIssue",
-      "fullyQualifiedName": "Linear.ArchiveIssue@3.3.3",
+      "fullyQualifiedName": "Linear.ArchiveIssue@3.4.0",
       "description": "Archive an issue.\n\nArchived issues are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -417,7 +417,7 @@
     {
       "name": "ArchiveProject",
       "qualifiedName": "Linear.ArchiveProject",
-      "fullyQualifiedName": "Linear.ArchiveProject@3.3.3",
+      "fullyQualifiedName": "Linear.ArchiveProject@3.4.0",
       "description": "Archive a project.\n\nArchived projects are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -490,7 +490,7 @@
     {
       "name": "CreateInitiative",
       "qualifiedName": "Linear.CreateInitiative",
-      "fullyQualifiedName": "Linear.CreateInitiative@3.3.3",
+      "fullyQualifiedName": "Linear.CreateInitiative@3.4.0",
       "description": "Create a new Linear initiative.\n\nInitiatives are high-level strategic goals that group related projects.",
       "parameters": [
         {
@@ -596,7 +596,7 @@
     {
       "name": "CreateIssue",
       "qualifiedName": "Linear.CreateIssue",
-      "fullyQualifiedName": "Linear.CreateIssue@3.3.3",
+      "fullyQualifiedName": "Linear.CreateIssue@3.4.0",
       "description": "Create a new Linear issue with validation.\n\nWhen assignee is None or '@me', the issue is assigned to the authenticated user.\nAll entity references (team, assignee, labels, state, project, cycle, parent)\nare validated before creation. If an entity is not found, suggestions are\nreturned to help correct the input.",
       "parameters": [
         {
@@ -762,7 +762,7 @@
     {
       "name": "CreateIssueRelation",
       "qualifiedName": "Linear.CreateIssueRelation",
-      "fullyQualifiedName": "Linear.CreateIssueRelation@3.3.3",
+      "fullyQualifiedName": "Linear.CreateIssueRelation@3.4.0",
       "description": "Create a relation between two issues.\n\nRelation types define the relationship from the source issue's perspective:\n- blocks: Source issue blocks the related issue\n- blockedBy: Source issue is blocked by the related issue\n- duplicate: Source issue is a duplicate of the related issue\n- related: Issues are related (bidirectional)",
       "parameters": [
         {
@@ -853,7 +853,7 @@
     {
       "name": "CreateProject",
       "qualifiedName": "Linear.CreateProject",
-      "fullyQualifiedName": "Linear.CreateProject@3.3.3",
+      "fullyQualifiedName": "Linear.CreateProject@3.4.0",
       "description": "Create a new Linear project.\n\nTeam is validated before creation. If team is not found, suggestions are\nreturned to help correct the input. Lead is validated if provided.",
       "parameters": [
         {
@@ -1024,7 +1024,7 @@
     {
       "name": "CreateProjectUpdate",
       "qualifiedName": "Linear.CreateProjectUpdate",
-      "fullyQualifiedName": "Linear.CreateProjectUpdate@3.3.3",
+      "fullyQualifiedName": "Linear.CreateProjectUpdate@3.4.0",
       "description": "Create a project status update.\n\nProject updates are posts that communicate progress, blockers, or status\nchanges to stakeholders. They appear in the project's Updates tab and\ncan include a health status indicator.",
       "parameters": [
         {
@@ -1114,7 +1114,7 @@
     {
       "name": "GetCycle",
       "qualifiedName": "Linear.GetCycle",
-      "fullyQualifiedName": "Linear.GetCycle@3.3.3",
+      "fullyQualifiedName": "Linear.GetCycle@3.4.0",
       "description": "Get detailed information about a specific Linear cycle.",
       "parameters": [
         {
@@ -1174,7 +1174,7 @@
     {
       "name": "GetInitiative",
       "qualifiedName": "Linear.GetInitiative",
-      "fullyQualifiedName": "Linear.GetInitiative@3.3.3",
+      "fullyQualifiedName": "Linear.GetInitiative@3.4.0",
       "description": "Get detailed information about a specific Linear initiative.\n\nSupports lookup by ID or name (with fuzzy matching for name).",
       "parameters": [
         {
@@ -1276,7 +1276,7 @@
     {
       "name": "GetInitiativeDescription",
       "qualifiedName": "Linear.GetInitiativeDescription",
-      "fullyQualifiedName": "Linear.GetInitiativeDescription@3.3.3",
+      "fullyQualifiedName": "Linear.GetInitiativeDescription@3.4.0",
       "description": "Get an initiative's full description with pagination support.\n\nUse this tool when you need the complete description of an initiative that\nwas truncated in the get_initiative response. Supports chunked reading for\nvery large descriptions.",
       "parameters": [
         {
@@ -1362,7 +1362,7 @@
     {
       "name": "GetIssue",
       "qualifiedName": "Linear.GetIssue",
-      "fullyQualifiedName": "Linear.GetIssue@3.3.3",
+      "fullyQualifiedName": "Linear.GetIssue@3.4.0",
       "description": "Get detailed information about a specific Linear issue.\n\nAccepts either the issue UUID or the human-readable identifier (like TOO-123).",
       "parameters": [
         {
@@ -1472,9 +1472,72 @@
       }
     },
     {
+      "name": "GetMilestone",
+      "qualifiedName": "Linear.GetMilestone",
+      "fullyQualifiedName": "Linear.GetMilestone@3.4.0",
+      "description": "Get a milestone by ID or name inside a project.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project ID, slug_id, or name of the project that the milestone is under.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "query",
+          "type": "string",
+          "required": true,
+          "description": "Milestone ID or milestone name.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "auto_accept_matches",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, auto-accept fuzzy project/milestone matches above 90% confidence. Default is False.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "linear",
+        "providerType": "oauth2",
+        "scopes": [
+          "read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Milestone details or fuzzy match suggestions"
+      },
+      "documentationChunks": [],
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "project_management"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "GetNotifications",
       "qualifiedName": "Linear.GetNotifications",
-      "fullyQualifiedName": "Linear.GetNotifications@3.3.3",
+      "fullyQualifiedName": "Linear.GetNotifications@3.4.0",
       "description": "Get the authenticated user's notifications.\n\nReturns notifications including issue mentions, comments, assignments,\nand state changes.",
       "parameters": [
         {
@@ -1560,7 +1623,7 @@
     {
       "name": "GetProject",
       "qualifiedName": "Linear.GetProject",
-      "fullyQualifiedName": "Linear.GetProject@3.3.3",
+      "fullyQualifiedName": "Linear.GetProject@3.4.0",
       "description": "Get detailed information about a specific Linear project.\n\nSupports lookup by ID, slug_id, or name (with fuzzy matching for name).",
       "parameters": [
         {
@@ -1676,7 +1739,7 @@
     {
       "name": "GetProjectDescription",
       "qualifiedName": "Linear.GetProjectDescription",
-      "fullyQualifiedName": "Linear.GetProjectDescription@3.3.3",
+      "fullyQualifiedName": "Linear.GetProjectDescription@3.4.0",
       "description": "Get a project's full description with pagination support.\n\nUse this tool when you need the complete description of a project that\nwas truncated in the get_project response. Supports chunked reading for\nvery large descriptions.",
       "parameters": [
         {
@@ -1762,7 +1825,7 @@
     {
       "name": "GetRecentActivity",
       "qualifiedName": "Linear.GetRecentActivity",
-      "fullyQualifiedName": "Linear.GetRecentActivity@3.3.3",
+      "fullyQualifiedName": "Linear.GetRecentActivity@3.4.0",
       "description": "Get the authenticated user's recent issue activity.\n\nReturns issues the user has recently created or been assigned to\nwithin the specified time period.",
       "parameters": [
         {
@@ -1835,7 +1898,7 @@
     {
       "name": "GetTeam",
       "qualifiedName": "Linear.GetTeam",
-      "fullyQualifiedName": "Linear.GetTeam@3.3.3",
+      "fullyQualifiedName": "Linear.GetTeam@3.4.0",
       "description": "Get detailed information about a specific Linear team.\n\nSupports lookup by ID, key (like TOO, ENG), or name (with fuzzy matching).",
       "parameters": [
         {
@@ -1925,7 +1988,7 @@
     {
       "name": "LinkGithubToIssue",
       "qualifiedName": "Linear.LinkGithubToIssue",
-      "fullyQualifiedName": "Linear.LinkGithubToIssue@3.3.3",
+      "fullyQualifiedName": "Linear.LinkGithubToIssue@3.4.0",
       "description": "Link a GitHub PR, commit, or issue to a Linear issue.\n\nAutomatically detects the artifact type from the URL and generates\nan appropriate title if not provided.",
       "parameters": [
         {
@@ -2011,7 +2074,7 @@
     {
       "name": "ListComments",
       "qualifiedName": "Linear.ListComments",
-      "fullyQualifiedName": "Linear.ListComments@3.3.3",
+      "fullyQualifiedName": "Linear.ListComments@3.4.0",
       "description": "List comments on an issue.\n\nReturns comments with user info, timestamps, and reply threading info.",
       "parameters": [
         {
@@ -2097,7 +2160,7 @@
     {
       "name": "ListCycles",
       "qualifiedName": "Linear.ListCycles",
-      "fullyQualifiedName": "Linear.ListCycles@3.3.3",
+      "fullyQualifiedName": "Linear.ListCycles@3.4.0",
       "description": "List Linear cycles, optionally filtered by team and status.\n\nCycles are time-boxed iterations (like sprints) for organizing work.",
       "parameters": [
         {
@@ -2209,7 +2272,7 @@
     {
       "name": "ListInitiatives",
       "qualifiedName": "Linear.ListInitiatives",
-      "fullyQualifiedName": "Linear.ListInitiatives@3.3.3",
+      "fullyQualifiedName": "Linear.ListInitiatives@3.4.0",
       "description": "List Linear initiatives, optionally filtered by keywords and other criteria.\n\nReturns all initiatives when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2315,7 +2378,7 @@
     {
       "name": "ListIssues",
       "qualifiedName": "Linear.ListIssues",
-      "fullyQualifiedName": "Linear.ListIssues@3.3.3",
+      "fullyQualifiedName": "Linear.ListIssues@3.4.0",
       "description": "List Linear issues, optionally filtered by keywords and other criteria.\n\nReturns all issues when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2498,7 +2561,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Linear.ListLabels",
-      "fullyQualifiedName": "Linear.ListLabels@3.3.3",
+      "fullyQualifiedName": "Linear.ListLabels@3.4.0",
       "description": "List available issue labels in the workspace.\n\nReturns labels that can be applied to issues. Use label IDs or names\nwhen creating or updating issues.",
       "parameters": [
         {
@@ -2556,9 +2619,80 @@
       }
     },
     {
+      "name": "ListMilestones",
+      "qualifiedName": "Linear.ListMilestones",
+      "fullyQualifiedName": "Linear.ListMilestones@3.4.0",
+      "description": "List milestones in a Linear project.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project ID, slug_id, or name of the project to list milestones from.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum milestones to return. Min 1, max 50. Default is 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "end_cursor",
+          "type": "string",
+          "required": false,
+          "description": "Cursor for pagination. Use 'end_cursor' from previous response. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "auto_accept_matches",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, auto-accept fuzzy project matches above 90% confidence. Default is False.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "linear",
+        "providerType": "oauth2",
+        "scopes": [
+          "read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Milestones for the selected project"
+      },
+      "documentationChunks": [],
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "project_management"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "ListProjectComments",
       "qualifiedName": "Linear.ListProjectComments",
-      "fullyQualifiedName": "Linear.ListProjectComments@3.3.3",
+      "fullyQualifiedName": "Linear.ListProjectComments@3.4.0",
       "description": "List comments on a project's document content.\n\nReturns comments with user info, timestamps, quoted text for inline comments,\nand reply threading info. Replies are nested under their parent comments.\n\nUse comment_filter to control which comments are returned:\n- only_quoted (default): Only comments attached to a quote in the text\n- only_unquoted: Only comments not attached to a particular quote\n- all: All comments regardless of being attached to a quote or not",
       "parameters": [
         {
@@ -2687,7 +2821,7 @@
     {
       "name": "ListProjects",
       "qualifiedName": "Linear.ListProjects",
-      "fullyQualifiedName": "Linear.ListProjects@3.3.3",
+      "fullyQualifiedName": "Linear.ListProjects@3.4.0",
       "description": "List Linear projects, optionally filtered by keywords and other criteria.\n\nReturns all projects when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2812,7 +2946,7 @@
     {
       "name": "ListTeams",
       "qualifiedName": "Linear.ListTeams",
-      "fullyQualifiedName": "Linear.ListTeams@3.3.3",
+      "fullyQualifiedName": "Linear.ListTeams@3.4.0",
       "description": "List Linear teams, optionally filtered by keywords and other criteria.\n\nReturns all teams when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2924,7 +3058,7 @@
     {
       "name": "ListWorkflowStates",
       "qualifiedName": "Linear.ListWorkflowStates",
-      "fullyQualifiedName": "Linear.ListWorkflowStates@3.3.3",
+      "fullyQualifiedName": "Linear.ListWorkflowStates@3.4.0",
       "description": "List available workflow states in the workspace.\n\nReturns workflow states that can be used for issue transitions.\nStates are team-specific and have different types.",
       "parameters": [
         {
@@ -3017,7 +3151,7 @@
     {
       "name": "ManageIssueSubscription",
       "qualifiedName": "Linear.ManageIssueSubscription",
-      "fullyQualifiedName": "Linear.ManageIssueSubscription@3.3.3",
+      "fullyQualifiedName": "Linear.ManageIssueSubscription@3.4.0",
       "description": "Subscribe to or unsubscribe from an issue's notifications.",
       "parameters": [
         {
@@ -3090,7 +3224,7 @@
     {
       "name": "ReplyToComment",
       "qualifiedName": "Linear.ReplyToComment",
-      "fullyQualifiedName": "Linear.ReplyToComment@3.3.3",
+      "fullyQualifiedName": "Linear.ReplyToComment@3.4.0",
       "description": "Reply to an existing comment on an issue.\n\nCreates a threaded reply to the specified parent comment.",
       "parameters": [
         {
@@ -3176,7 +3310,7 @@
     {
       "name": "ReplyToProjectComment",
       "qualifiedName": "Linear.ReplyToProjectComment",
-      "fullyQualifiedName": "Linear.ReplyToProjectComment@3.3.3",
+      "fullyQualifiedName": "Linear.ReplyToProjectComment@3.4.0",
       "description": "Reply to an existing comment on a project document.\n\nCreates a threaded reply to the specified parent comment.",
       "parameters": [
         {
@@ -3275,7 +3409,7 @@
     {
       "name": "TransitionIssueState",
       "qualifiedName": "Linear.TransitionIssueState",
-      "fullyQualifiedName": "Linear.TransitionIssueState@3.3.3",
+      "fullyQualifiedName": "Linear.TransitionIssueState@3.4.0",
       "description": "Transition a Linear issue to a new workflow state.\n\nThe target state is validated against the team's available states.",
       "parameters": [
         {
@@ -3361,7 +3495,7 @@
     {
       "name": "UpdateComment",
       "qualifiedName": "Linear.UpdateComment",
-      "fullyQualifiedName": "Linear.UpdateComment@3.3.3",
+      "fullyQualifiedName": "Linear.UpdateComment@3.4.0",
       "description": "Update an existing comment.",
       "parameters": [
         {
@@ -3434,7 +3568,7 @@
     {
       "name": "UpdateInitiative",
       "qualifiedName": "Linear.UpdateInitiative",
-      "fullyQualifiedName": "Linear.UpdateInitiative@3.3.3",
+      "fullyQualifiedName": "Linear.UpdateInitiative@3.4.0",
       "description": "Update a Linear initiative with partial updates.\n\nOnly fields that are explicitly provided will be updated.",
       "parameters": [
         {
@@ -3553,7 +3687,7 @@
     {
       "name": "UpdateIssue",
       "qualifiedName": "Linear.UpdateIssue",
-      "fullyQualifiedName": "Linear.UpdateIssue@3.3.3",
+      "fullyQualifiedName": "Linear.UpdateIssue@3.4.0",
       "description": "Update a Linear issue with partial updates.\n\nOnly fields that are explicitly provided will be updated. All entity\nreferences are validated before update.",
       "parameters": [
         {
@@ -3808,7 +3942,7 @@
     {
       "name": "UpdateProject",
       "qualifiedName": "Linear.UpdateProject",
-      "fullyQualifiedName": "Linear.UpdateProject@3.3.3",
+      "fullyQualifiedName": "Linear.UpdateProject@3.4.0",
       "description": "Update a Linear project with partial updates.\n\nOnly fields that are explicitly provided will be updated. All entity\nreferences are validated before update.\n\nIMPORTANT: Updating the 'content' field will break any existing inline\ncomment anchoring. The comments will still exist and be retrievable via\nlist_project_comments, but they will no longer appear visually anchored\nto text in the Linear UI. The 'description' field can be safely updated\nwithout affecting inline comments.",
       "parameters": [
         {
@@ -4010,9 +4144,97 @@
       }
     },
     {
+      "name": "UpsertMilestone",
+      "qualifiedName": "Linear.UpsertMilestone",
+      "fullyQualifiedName": "Linear.UpsertMilestone@3.4.0",
+      "description": "Upsert a project's milestone.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project ID, slug_id, or name of the project that the milestone is under.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "milestone_id",
+          "type": "string",
+          "required": false,
+          "description": "Milestone ID. When provided, the existing milestone with this ID is updated. When omitted, a new milestone is created.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Milestone name. When creating a milestone, this sets the name. When updating a milestone, providing this changes the name; omitting it leaves the existing name unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "required": false,
+          "description": "Milestone description. When creating a milestone, this sets the description. When updating a milestone, providing this changes the description; omitting it leaves the existing description unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "target_date",
+          "type": "string",
+          "required": false,
+          "description": "Target date in YYYY-MM-DD format. When creating a milestone, this sets the target date. When updating a milestone, providing this changes the target date; providing an empty string clears it; omitting it leaves the existing target date unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "auto_accept_matches",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, auto-accept fuzzy project matches above 90% confidence. Default is False.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "linear",
+        "providerType": "oauth2",
+        "scopes": [
+          "write"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Upserted milestone details"
+      },
+      "documentationChunks": [],
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "project_management"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "WhoAmI",
       "qualifiedName": "Linear.WhoAmI",
-      "fullyQualifiedName": "Linear.WhoAmI@3.3.3",
+      "fullyQualifiedName": "Linear.WhoAmI@3.4.0",
       "description": "Get the authenticated user's profile and team memberships.\n\nReturns the current user's information including their name, email,\norganization, and the teams they belong to.",
       "parameters": [],
       "auth": {
@@ -4066,6 +4288,8 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-04-18T11:20:23.013Z",
-  "summary": "Arcade's Linear toolkit lets LLMs interact with Linear workspaces, enabling programmatic creation, update, archival, and search across issues, projects, initiatives, cycles, and comments. It validates entity references and exposes workspace metadata so agents can plan work without manual lookups.\n\n**Capabilities**\n- Full issue lifecycle: create, update, archive, transition workflow state, relate issues, and link GitHub PRs, commits, or issues.\n- Project and initiative management: create, update, archive, post status updates, link projects to initiatives, and paginate long descriptions.\n- Collaboration: add, list, update, and reply to comments on issues and project documents; manage per-issue notification subscriptions.\n- Discovery and context: list and get cycles, teams, labels, workflow states, notifications, and recent authenticated-user activity; resolve the current user via WhoAmI.\n\n**OAuth**\nRequires Linear OAuth. See the [Arcade Linear auth provider docs](https://docs.arcade.dev/en/references/auth-providers/linear) for configuration."
+  "generatedAt": "2026-04-28T11:41:15.977Z",
+  "summary": "Arcade's Linear toolkit lets LLMs interact with Linear workspaces, enabling programmatic creation, update, archival, and search across issues, projects, initiatives, cycles, and comments. It validates entity references and exposes workspace metadata so agents can plan work without manual lookups.\n\n**Capabilities**\n- Full issue lifecycle: create, update, archive, transition workflow state, relate issues, and link GitHub PRs, commits, or issues.\n- Project and initiative management: create, update, archive, post status updates, link projects to initiatives, and paginate long descriptions.\n- Collaboration: add, list, update, and reply to comments on issues and project documents; manage per-issue notification subscriptions.\n- Discovery and context: list and get cycles, teams, labels, workflow states, notifications, and recent authenticated-user activity; resolve the current user via WhoAmI.\n\n**OAuth**\nRequires Linear OAuth. See the [Arcade Linear auth provider docs](https://docs.arcade.dev/en/references/auth-providers/linear) for configuration.",
+  "summaryStale": true,
+  "summaryStaleReason": "llm_generation_failed"
 }

--- a/toolkit-docs-generator/data/toolkits/posthog.json
+++ b/toolkit-docs-generator/data/toolkits/posthog.json
@@ -1,7 +1,7 @@
 {
   "id": "Posthog",
   "label": "PostHog",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Arcade.dev LLM tools for PostHog analytics",
   "metadata": {
     "category": "development",
@@ -18,7 +18,7 @@
     {
       "name": "AddInsightToDashboard",
       "qualifiedName": "Posthog.AddInsightToDashboard",
-      "fullyQualifiedName": "Posthog.AddInsightToDashboard@1.0.0",
+      "fullyQualifiedName": "Posthog.AddInsightToDashboard@1.0.1",
       "description": "Pin an existing insight as a tile on a dashboard.",
       "parameters": [
         {
@@ -78,7 +78,7 @@
     {
       "name": "ComparePeriods",
       "qualifiedName": "Posthog.ComparePeriods",
-      "fullyQualifiedName": "Posthog.ComparePeriods@1.0.0",
+      "fullyQualifiedName": "Posthog.ComparePeriods@1.0.1",
       "description": "Compare the same metric across two date ranges side-by-side.",
       "parameters": [
         {
@@ -179,7 +179,7 @@
     {
       "name": "CreateDashboard",
       "qualifiedName": "Posthog.CreateDashboard",
-      "fullyQualifiedName": "Posthog.CreateDashboard@1.0.0",
+      "fullyQualifiedName": "Posthog.CreateDashboard@1.0.1",
       "description": "Create a new empty dashboard. Insights can be pinned to it as tiles afterward.",
       "parameters": [
         {
@@ -256,7 +256,7 @@
     {
       "name": "CreateExperiment",
       "qualifiedName": "Posthog.CreateExperiment",
-      "fullyQualifiedName": "Posthog.CreateExperiment@1.0.0",
+      "fullyQualifiedName": "Posthog.CreateExperiment@1.0.1",
       "description": "Create an A/B test experiment.\n\nBefore creating, verify the feature_flag_key is not already in\nuse and confirm the event names for metrics are valid.\n\nNote: PostHog does not enforce unique feature_flag_key values\nacross experiments. Duplicate keys will not error but will cause\nunpredictable behavior.",
       "parameters": [
         {
@@ -370,7 +370,7 @@
     {
       "name": "CreateExperimentWithFlag",
       "qualifiedName": "Posthog.CreateExperimentWithFlag",
-      "fullyQualifiedName": "Posthog.CreateExperimentWithFlag@1.0.0",
+      "fullyQualifiedName": "Posthog.CreateExperimentWithFlag@1.0.1",
       "description": "Create a feature flag and an experiment in one step.\n\nThe flag is created with the specified rollout_percentage, then\nthe experiment is linked to it.\n\nNote: PostHog does not enforce unique feature_flag_key values\nacross experiments. Duplicate keys will not error but will cause\nunpredictable behavior.",
       "parameters": [
         {
@@ -483,7 +483,7 @@
     {
       "name": "CreateFeatureFlag",
       "qualifiedName": "Posthog.CreateFeatureFlag",
-      "fullyQualifiedName": "Posthog.CreateFeatureFlag@1.0.0",
+      "fullyQualifiedName": "Posthog.CreateFeatureFlag@1.0.1",
       "description": "Create a new feature flag.\n\nVerify the key is not already in use to avoid duplicates. After\ncreation, consult PostHog SDK documentation for the user's\nlanguage/framework to integrate the flag.",
       "parameters": [
         {
@@ -567,7 +567,7 @@
     {
       "name": "CreateInsightFromQuery",
       "qualifiedName": "Posthog.CreateInsightFromQuery",
-      "fullyQualifiedName": "Posthog.CreateInsightFromQuery@1.0.0",
+      "fullyQualifiedName": "Posthog.CreateInsightFromQuery@1.0.1",
       "description": "Save a tested query as a reusable insight.\n\nAlways verify the query produces expected results before saving\nit as an insight. The query_id is not validated by PostHog —\nensure it is a valid cache_key from a previously executed query.\nPassing an invalid query_id will create a broken insight.",
       "parameters": [
         {
@@ -635,7 +635,7 @@
     {
       "name": "CreateSurvey",
       "qualifiedName": "Posthog.CreateSurvey",
-      "fullyQualifiedName": "Posthog.CreateSurvey@1.0.0",
+      "fullyQualifiedName": "Posthog.CreateSurvey@1.0.1",
       "description": "Create a new survey.\n\nVerify the name is not already in use to avoid duplicates. After\ncreation, consult PostHog SDK documentation to integrate the\nsurvey into the user's application.",
       "parameters": [
         {
@@ -717,7 +717,7 @@
     {
       "name": "DeleteDashboard",
       "qualifiedName": "Posthog.DeleteDashboard",
-      "fullyQualifiedName": "Posthog.DeleteDashboard@1.0.0",
+      "fullyQualifiedName": "Posthog.DeleteDashboard@1.0.1",
       "description": "Soft-delete a dashboard by ID. The dashboard is marked as deleted but can be restored.",
       "parameters": [
         {
@@ -769,7 +769,7 @@
     {
       "name": "DeleteExperiment",
       "qualifiedName": "Posthog.DeleteExperiment",
-      "fullyQualifiedName": "Posthog.DeleteExperiment@1.0.0",
+      "fullyQualifiedName": "Posthog.DeleteExperiment@1.0.1",
       "description": "Soft-delete an experiment by ID (marks as archived).\n\nImportant: archiving an experiment does NOT unlink its feature\nflag. PostHog still considers the flag as linked to an \"active\"\nexperiment, blocking flag deletion. To fully clean up, delete\nthe flag separately after the experiment is archived.",
       "parameters": [
         {
@@ -821,7 +821,7 @@
     {
       "name": "DeleteFeatureFlag",
       "qualifiedName": "Posthog.DeleteFeatureFlag",
-      "fullyQualifiedName": "Posthog.DeleteFeatureFlag@1.0.0",
+      "fullyQualifiedName": "Posthog.DeleteFeatureFlag@1.0.1",
       "description": "Soft-delete a feature flag by numeric ID or key. Provide one of flag_id or flag_key.\n\nNote: flags linked to an experiment cannot be deleted until the\nexperiment is concluded and deleted first. PostHog considers even\narchived experiments as \"active\" for flag linkage purposes.",
       "parameters": [
         {
@@ -881,7 +881,7 @@
     {
       "name": "DeleteInsight",
       "qualifiedName": "Posthog.DeleteInsight",
-      "fullyQualifiedName": "Posthog.DeleteInsight@1.0.0",
+      "fullyQualifiedName": "Posthog.DeleteInsight@1.0.1",
       "description": "Soft-delete an insight by ID.",
       "parameters": [
         {
@@ -933,7 +933,7 @@
     {
       "name": "DeleteSurvey",
       "qualifiedName": "Posthog.DeleteSurvey",
-      "fullyQualifiedName": "Posthog.DeleteSurvey@1.0.0",
+      "fullyQualifiedName": "Posthog.DeleteSurvey@1.0.1",
       "description": "Soft-delete a survey by ID (marks as archived).",
       "parameters": [
         {
@@ -985,7 +985,7 @@
     {
       "name": "GetAllSurveyActivity",
       "qualifiedName": "Posthog.GetAllSurveyActivity",
-      "fullyQualifiedName": "Posthog.GetAllSurveyActivity@1.0.0",
+      "fullyQualifiedName": "Posthog.GetAllSurveyActivity@1.0.1",
       "description": "Get the activity log across all surveys.\n\nReturns a chronological list of changes made to any survey\n(created, updated, archived, etc.), not response metrics.",
       "parameters": [
         {
@@ -1029,7 +1029,7 @@
     {
       "name": "GetDashboard",
       "qualifiedName": "Posthog.GetDashboard",
-      "fullyQualifiedName": "Posthog.GetDashboard@1.0.0",
+      "fullyQualifiedName": "Posthog.GetDashboard@1.0.1",
       "description": "Get a dashboard's full configuration including all insight tiles.\n\nProvide dashboard_id or dashboard_name.",
       "parameters": [
         {
@@ -1089,7 +1089,7 @@
     {
       "name": "GetErrorDetails",
       "qualifiedName": "Posthog.GetErrorDetails",
-      "fullyQualifiedName": "Posthog.GetErrorDetails@1.0.0",
+      "fullyQualifiedName": "Posthog.GetErrorDetails@1.0.1",
       "description": "Get stack trace, occurrence count, and affected users/sessions for a specific error.",
       "parameters": [
         {
@@ -1141,7 +1141,7 @@
     {
       "name": "GetExperiment",
       "qualifiedName": "Posthog.GetExperiment",
-      "fullyQualifiedName": "Posthog.GetExperiment@1.0.0",
+      "fullyQualifiedName": "Posthog.GetExperiment@1.0.1",
       "description": "Get an experiment's full configuration.\n\nIncludes variants, metrics, and current status. Provide either\nthe numeric ID or the name.",
       "parameters": [
         {
@@ -1201,7 +1201,7 @@
     {
       "name": "GetExperimentResults",
       "qualifiedName": "Posthog.GetExperimentResults",
-      "fullyQualifiedName": "Posthog.GetExperimentResults@1.0.0",
+      "fullyQualifiedName": "Posthog.GetExperimentResults@1.0.1",
       "description": "Get experiment results including metric data and exposure counts.\n\nOnly available for launched experiments that have collected data.\nDraft, not-yet-launched, or legacy experiments return 404.",
       "parameters": [
         {
@@ -1253,7 +1253,7 @@
     {
       "name": "GetFeatureFlag",
       "qualifiedName": "Posthog.GetFeatureFlag",
-      "fullyQualifiedName": "Posthog.GetFeatureFlag@1.0.0",
+      "fullyQualifiedName": "Posthog.GetFeatureFlag@1.0.1",
       "description": "Get a feature flag's full definition including rollout rules.\n\nProvide either the numeric ID or the flag key.",
       "parameters": [
         {
@@ -1313,7 +1313,7 @@
     {
       "name": "GetFunnel",
       "qualifiedName": "Posthog.GetFunnel",
-      "fullyQualifiedName": "Posthog.GetFunnel@1.0.0",
+      "fullyQualifiedName": "Posthog.GetFunnel@1.0.1",
       "description": "Build a multi-step conversion funnel with optional property breakdowns.",
       "parameters": [
         {
@@ -1419,7 +1419,7 @@
     {
       "name": "GetInsight",
       "qualifiedName": "Posthog.GetInsight",
-      "fullyQualifiedName": "Posthog.GetInsight@1.0.0",
+      "fullyQualifiedName": "Posthog.GetInsight@1.0.1",
       "description": "Get an insight's full configuration and current query results.\n\nProvide either the numeric ID or the name.",
       "parameters": [
         {
@@ -1479,7 +1479,7 @@
     {
       "name": "GetRetention",
       "qualifiedName": "Posthog.GetRetention",
-      "fullyQualifiedName": "Posthog.GetRetention@1.0.0",
+      "fullyQualifiedName": "Posthog.GetRetention@1.0.1",
       "description": "Get cohort retention data showing what percentage of users return.\n\nShows return rates after a user's initial event.",
       "parameters": [
         {
@@ -1595,7 +1595,7 @@
     {
       "name": "GetSurvey",
       "qualifiedName": "Posthog.GetSurvey",
-      "fullyQualifiedName": "Posthog.GetSurvey@1.0.0",
+      "fullyQualifiedName": "Posthog.GetSurvey@1.0.1",
       "description": "Get a survey's full configuration.\n\nIncludes questions, targeting rules, and scheduling. Provide\neither the numeric ID or the name.",
       "parameters": [
         {
@@ -1655,7 +1655,7 @@
     {
       "name": "GetSurveyActivity",
       "qualifiedName": "Posthog.GetSurveyActivity",
-      "fullyQualifiedName": "Posthog.GetSurveyActivity@1.0.0",
+      "fullyQualifiedName": "Posthog.GetSurveyActivity@1.0.1",
       "description": "Get the activity log for a survey.\n\nReturns a chronological list of changes made to the survey\n(created, updated, archived, etc.), not response metrics.",
       "parameters": [
         {
@@ -1707,7 +1707,7 @@
     {
       "name": "GetTrend",
       "qualifiedName": "Posthog.GetTrend",
-      "fullyQualifiedName": "Posthog.GetTrend@1.0.0",
+      "fullyQualifiedName": "Posthog.GetTrend@1.0.1",
       "description": "Get a time-series trend for an event over a date range.\n\nOptionally broken down by a property.",
       "parameters": [
         {
@@ -1829,7 +1829,7 @@
     {
       "name": "GetTrends",
       "qualifiedName": "Posthog.GetTrends",
-      "fullyQualifiedName": "Posthog.GetTrends@1.0.0",
+      "fullyQualifiedName": "Posthog.GetTrends@1.0.1",
       "description": "Batch trend query: get time-series data for multiple events.\n\nReturns a time-series for each event. Unknown event names return\nzero counts rather than errors.",
       "parameters": [
         {
@@ -1923,7 +1923,7 @@
     {
       "name": "ListDashboards",
       "qualifiedName": "Posthog.ListDashboards",
-      "fullyQualifiedName": "Posthog.ListDashboards@1.0.0",
+      "fullyQualifiedName": "Posthog.ListDashboards@1.0.1",
       "description": "List all dashboards in the project.\n\nReturns summaries (id, name, pinned, tags, created_at). Use a\ndashboard's ID to get its full configuration and insight tiles.",
       "parameters": [
         {
@@ -1999,7 +1999,7 @@
     {
       "name": "ListErrors",
       "qualifiedName": "Posthog.ListErrors",
-      "fullyQualifiedName": "Posthog.ListErrors@1.0.0",
+      "fullyQualifiedName": "Posthog.ListErrors@1.0.1",
       "description": "List error tracking issues.\n\nReturns summaries (id, fingerprint, status, occurrences, users,\nfirst_seen, last_seen). Use an error's fingerprint with get_error_details\nto get full stack traces.",
       "parameters": [
         {
@@ -2059,7 +2059,7 @@
     {
       "name": "ListEventDefinitions",
       "qualifiedName": "Posthog.ListEventDefinitions",
-      "fullyQualifiedName": "Posthog.ListEventDefinitions@1.0.0",
+      "fullyQualifiedName": "Posthog.ListEventDefinitions@1.0.1",
       "description": "List all tracked event names in the project.\n\nThis is the discovery starting point -- use it to find valid\nevent names, then look up an event's properties to discover\navailable filters and breakdowns.",
       "parameters": [
         {
@@ -2127,7 +2127,7 @@
     {
       "name": "ListExperiments",
       "qualifiedName": "Posthog.ListExperiments",
-      "fullyQualifiedName": "Posthog.ListExperiments@1.0.0",
+      "fullyQualifiedName": "Posthog.ListExperiments@1.0.1",
       "description": "List all A/B test experiments.\n\nReturns summaries (id, name, feature_flag_key, start_date,\nend_date). Use an experiment's ID or name to get its full\nconfiguration.",
       "parameters": [
         {
@@ -2187,7 +2187,7 @@
     {
       "name": "ListFeatureFlags",
       "qualifiedName": "Posthog.ListFeatureFlags",
-      "fullyQualifiedName": "Posthog.ListFeatureFlags@1.0.0",
+      "fullyQualifiedName": "Posthog.ListFeatureFlags@1.0.1",
       "description": "List all feature flags.\n\nReturns summaries (id, key, name, active). Use a flag's ID or\nkey to get its full rollout rules and targeting detail.",
       "parameters": [
         {
@@ -2247,7 +2247,7 @@
     {
       "name": "ListInsights",
       "qualifiedName": "Posthog.ListInsights",
-      "fullyQualifiedName": "Posthog.ListInsights@1.0.0",
+      "fullyQualifiedName": "Posthog.ListInsights@1.0.1",
       "description": "List all saved insights.\n\nReturns summaries (id, name, description, last_modified_at).\nUse an insight's ID or name to get its full configuration and\nquery results.",
       "parameters": [
         {
@@ -2315,7 +2315,7 @@
     {
       "name": "ListProperties",
       "qualifiedName": "Posthog.ListProperties",
-      "fullyQualifiedName": "Posthog.ListProperties@1.0.0",
+      "fullyQualifiedName": "Posthog.ListProperties@1.0.1",
       "description": "List property definitions with names, types, and example values.\n\nUse this as a schema exploration step: after identifying tracked\nevent names, query with event_name to discover its properties\nfor use in filters and breakdowns.",
       "parameters": [
         {
@@ -2394,7 +2394,7 @@
     {
       "name": "ListSurveys",
       "qualifiedName": "Posthog.ListSurveys",
-      "fullyQualifiedName": "Posthog.ListSurveys@1.0.0",
+      "fullyQualifiedName": "Posthog.ListSurveys@1.0.1",
       "description": "List all surveys.\n\nReturns summaries (id, name, type, created_at). Use a survey's\nID or name to get its full configuration.",
       "parameters": [
         {
@@ -2462,7 +2462,7 @@
     {
       "name": "RunQuery",
       "qualifiedName": "Posthog.RunQuery",
-      "fullyQualifiedName": "Posthog.RunQuery@1.0.0",
+      "fullyQualifiedName": "Posthog.RunQuery@1.0.1",
       "description": "Execute a raw PostHog query.\n\nFor common analytics patterns (trends, funnels, retention),\nprefer purpose-built tools if available. Use this for custom\nquery shapes. Discover valid event names before constructing\na query.\n\nFor the full query schema and supported kinds, see\nhttps://posthog.com/docs/api/queries",
       "parameters": [
         {
@@ -2514,7 +2514,7 @@
     {
       "name": "UpdateDashboard",
       "qualifiedName": "Posthog.UpdateDashboard",
-      "fullyQualifiedName": "Posthog.UpdateDashboard@1.0.0",
+      "fullyQualifiedName": "Posthog.UpdateDashboard@1.0.1",
       "description": "Update a dashboard's name, description, pinned status, or tags.\n\nReview the dashboard's current values before updating.",
       "parameters": [
         {
@@ -2599,7 +2599,7 @@
     {
       "name": "UpdateExperiment",
       "qualifiedName": "Posthog.UpdateExperiment",
-      "fullyQualifiedName": "Posthog.UpdateExperiment@1.0.0",
+      "fullyQualifiedName": "Posthog.UpdateExperiment@1.0.1",
       "description": "Update an experiment's properties or lifecycle state.\n\nReview the experiment's current state before updating.\nTo launch: set launch=true. To conclude: set\nconclude='winning_variant_name'. To restart: set restart=true.",
       "parameters": [
         {
@@ -2709,7 +2709,7 @@
     {
       "name": "UpdateFeatureFlag",
       "qualifiedName": "Posthog.UpdateFeatureFlag",
-      "fullyQualifiedName": "Posthog.UpdateFeatureFlag@1.0.0",
+      "fullyQualifiedName": "Posthog.UpdateFeatureFlag@1.0.1",
       "description": "Update a feature flag's properties or rollout rules.\n\nProvide one of flag_id or flag_key. Review the flag's current\nstate before updating. To enable: set active=true and\nrollout_percentage=100. To disable: set active=false.",
       "parameters": [
         {
@@ -2801,7 +2801,7 @@
     {
       "name": "UpdateInsight",
       "qualifiedName": "Posthog.UpdateInsight",
-      "fullyQualifiedName": "Posthog.UpdateInsight@1.0.0",
+      "fullyQualifiedName": "Posthog.UpdateInsight@1.0.1",
       "description": "Update an insight's name, description, or query filters.\n\nReview the insight's current query structure first and only\nmodify the parts you need to change.",
       "parameters": [
         {
@@ -2877,7 +2877,7 @@
     {
       "name": "UpdateSurvey",
       "qualifiedName": "Posthog.UpdateSurvey",
-      "fullyQualifiedName": "Posthog.UpdateSurvey@1.0.0",
+      "fullyQualifiedName": "Posthog.UpdateSurvey@1.0.1",
       "description": "Update a survey's name, description, or questions.\n\nReview the survey's current configuration before updating.",
       "parameters": [
         {
@@ -2954,7 +2954,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Posthog.WhoAmI",
-      "fullyQualifiedName": "Posthog.WhoAmI@1.0.0",
+      "fullyQualifiedName": "Posthog.WhoAmI@1.0.1",
       "description": "Return the authenticated user's identity, organizations, and projects.\n\nCall this first to confirm credentials and discover available\norganization and project IDs.",
       "parameters": [],
       "auth": null,
@@ -2990,6 +2990,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-04-10T11:26:08.921Z",
+  "generatedAt": "2026-04-28T11:41:12.853Z",
   "summary": "PostHog is a product analytics and experimentation platform. The Arcade PostHog toolkit lets agents query analytics, manage experiments, and curate insights directly from a PostHog project.\n\n**Capabilities**\n\n- Build and manage dashboards, insights, funnels, trends, and retention views.\n- Create and iterate on experiments, feature flags, and surveys with full CRUD support.\n- Inspect event and property definitions, investigate errors, and compare time periods.\n- Run ad-hoc HogQL or insight queries and retrieve results for downstream analysis.\n\n**OAuth**\n\nNo OAuth — authentication uses a PostHog personal API key passed as a secret.\n\n**Secrets**\n\n- `POSTHOG_PERSONAL_API_KEY` — PostHog personal API key created under Account Settings → Personal API Keys.\n- `POSTHOG_SERVER_URL` — target PostHog region or self-hosted instance URL (e.g. `https://us.posthog.com`).\n\nConfigure both in the [Arcade Dashboard](https://api.arcade.dev/dashboard/auth/secrets) per the [Arcade secret setup guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets)."
 }


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/25050554005

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly regenerated JSON docs, but it changes declared OAuth scopes for `Gmail.WriteDraftReplyEmail` (adds `gmail.readonly`) and adds new Linear milestone tools, which may affect consumers relying on these specs.
> 
> **Overview**
> Refreshes generated toolkit JSON for **Gmail**, **Linear**, and **PostHog**, updating versions in `toolkits/index.json` (Linear tool count now `42`).
> 
> Linear `3.4.0` adds milestone support via new tools `Linear.GetMilestone`, `Linear.ListMilestones`, and `Linear.UpsertMilestone`.
> 
> Gmail `5.2.0` updates tool version strings and expands `Gmail.WriteDraftReplyEmail` to require `gmail.readonly` in addition to `gmail.compose`, marking its metadata operations as `create` + `read`; Gmail and Linear now include `summaryStale`/`summaryStaleReason` due to failed LLM summary generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07cb4269df7beb16432498f501785d84e21f363b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->