### PR TITLE
Use Anthropic for toolkit docs generation

### DIFF
--- a/.github/workflows/generate-toolkit-docs.md
+++ b/.github/workflows/generate-toolkit-docs.md
@@ -15,14 +15,15 @@ Required secrets:
 
 - `ENGINE_API_URL`
 - `ENGINE_API_KEY`
-- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
 
 Optional secrets:
 
-- `OPENAI_MODEL` (falls back to `gpt-4o-mini`)
+- `ANTHROPIC_MODEL` (falls back to `claude-sonnet-4-6`)
+- `ANTHROPIC_EDITOR_MODEL` (falls back to `claude-sonnet-4-6`)
 
 ## Where to look
 
-- Workflow: `.github/workflows/generate-toolkit-docs-porter.yml`
+- Workflow: `.github/workflows/generate-toolkit-docs.yml`
 - Sidebar sync script: `toolkit-docs-generator/scripts/sync-toolkit-sidebar.ts`
 - Generator code: `toolkit-docs-generator/src/cli/index.ts`

--- a/.github/workflows/generate-toolkit-docs.yml
+++ b/.github/workflows/generate-toolkit-docs.yml
@@ -58,9 +58,10 @@ jobs:
             --api-source tool-metadata \
             --tool-metadata-url "$ENGINE_API_URL" \
             --tool-metadata-key "$ENGINE_API_KEY" \
-            --llm-provider openai \
-            --llm-model "$OPENAI_MODEL" \
-            --llm-api-key "$OPENAI_API_KEY" \
+            --llm-provider anthropic \
+            --llm-model "$ANTHROPIC_MODEL" \
+            --llm-api-key "$ANTHROPIC_API_KEY" \
+            --llm-max-tokens 8192 \
             --llm-editor-provider anthropic \
             --llm-editor-model "$ANTHROPIC_EDITOR_MODEL" \
             --llm-editor-api-key "$ANTHROPIC_API_KEY" \
@@ -73,12 +74,11 @@ jobs:
         env:
           ENGINE_API_URL: ${{ secrets.ENGINE_API_URL }}
           ENGINE_API_KEY: ${{ secrets.ENGINE_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_MODEL: ${{ secrets.OPENAI_MODEL || 'gpt-4o-mini' }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_MODEL: ${{ secrets.ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
           # Stronger model for the secret-coherence editor. Keeps
           # stale-secret cleanup precise instead of re-summarizing the whole
-          # artifact (which gpt-4o-mini tends to do).
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # artifact.
           ANTHROPIC_EDITOR_MODEL: ${{ secrets.ANTHROPIC_EDITOR_MODEL || 'claude-sonnet-4-6' }}
 
       - name: Sync toolkit sidebar navigation

--- a/toolkit-docs-generator/tests/workflows/generate-toolkit-docs.test.ts
+++ b/toolkit-docs-generator/tests/workflows/generate-toolkit-docs.test.ts
@@ -27,9 +27,10 @@ test("porter workflow generates docs and opens a PR", () => {
   expect(workflowContents).toContain("--api-source tool-metadata");
   expect(workflowContents).toContain("--tool-metadata-url");
   expect(workflowContents).toContain("--tool-metadata-key");
-  expect(workflowContents).toContain("--llm-provider openai");
+  expect(workflowContents).toContain("--llm-provider anthropic");
   expect(workflowContents).toContain("--llm-model");
   expect(workflowContents).toContain("--llm-api-key");
+  expect(workflowContents).toContain("--llm-max-tokens 8192");
   expect(workflowContents).toContain("--remove-empty-sections=false");
   expect(workflowContents).toContain("peter-evans/create-pull-request");
   expect(workflowContents).toContain("HUSKY: 0");


### PR DESCRIPTION
## Summary
- Switch toolkit docs summary and example generation from OpenAI to Anthropic, matching the existing secret-coherence editor provider.
- Set an explicit 8192 token budget for Anthropic generation so long toolkit summaries are not constrained by the client default.
- Update the workflow docs and workflow assertion test for the new provider configuration.

## Test plan
- pnpm vitest --run toolkit-docs-generator/tests/workflows/generate-toolkit-docs.test.ts --exclude '.worktrees/**' --exclude '.claude/**'


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow/config-only changes that swap the LLM provider and update secrets; main risk is CI failure if Anthropic secrets/models aren’t configured correctly.
> 
> **Overview**
> **Switches toolkit docs generation from OpenAI to Anthropic** in the `generate-toolkit-docs` GitHub workflow, wiring `ANTHROPIC_API_KEY`/model env vars and adding `--llm-max-tokens 8192` to avoid truncation.
> 
> Updates the workflow documentation to reflect the new required/optional secrets and adjusts the workflow assertion test to expect the Anthropic flags and token budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae61bc53eadacb444020bb3ccaac3ff9c02d5f00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->