### PR TITLE
chore: update @arcadeai/design-system to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://arcade.dev/",
   "dependencies": {
-    "@arcadeai/design-system": "3.39.0",
+    "@arcadeai/design-system": "3.39.1",
     "@mdx-js/mdx": "3.1.1",
     "@mdx-js/react": "3.1.1",
     "@next/third-parties": "16.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@arcadeai/design-system':
-        specifier: 3.39.0
-        version: 3.39.0(@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.73.1(react@19.2.5))(react@19.2.5)(recharts@3.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1))(tailwindcss@4.2.4)
+        specifier: 3.39.1
+        version: 3.39.1(@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.73.1(react@19.2.5))(react@19.2.5)(recharts@3.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1))(tailwindcss@4.2.4)
       '@mdx-js/mdx':
         specifier: 3.1.1
         version: 3.1.1
@@ -267,8 +267,8 @@ packages:
       zod:
         optional: true
 
-  '@arcadeai/design-system@3.39.0':
-    resolution: {integrity: sha512-AK/zyN1QIQ8ZHDTZfVh2HtIqjLSvWUyeGt18JfkeAnKRZTQEYG58nqmzoSHzVxStZLqzHT57JFDj6sF+ZIL2ag==}
+  '@arcadeai/design-system@3.39.1':
+    resolution: {integrity: sha512-VlNNyBo7smm2HmcucGpFGgQAjdUpsVcC4cSOzQviBmx3GUoP0BAQnuoNJqK13UZlvbN3CaB5NqT4uAyuGbp8Kg==}
     engines: {bun: '>=1.3.5'}
     peerDependencies:
       '@hookform/resolvers': '>=5.2.1'
@@ -5168,7 +5168,7 @@ snapshots:
     optionalDependencies:
       zod: 4.3.6
 
-  '@arcadeai/design-system@3.39.0(@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.73.1(react@19.2.5))(react@19.2.5)(recharts@3.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1))(tailwindcss@4.2.4)':
+  '@arcadeai/design-system@3.39.1(@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.73.1(react@19.2.5))(react@19.2.5)(recharts@3.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1))(tailwindcss@4.2.4)':
     dependencies:
       '@hookform/resolvers': 5.2.2(react-hook-form@7.73.1(react@19.2.5))
       '@streamdown/code': 1.1.0(react@19.2.5)


### PR DESCRIPTION
This PR updates `@arcadeai/design-system` to the latest published version.

It runs a design-system compatibility test gate before opening this PR.
If that gate fails, the workflow stops and no PR is created.

- Trigger: `workflow_dispatch`
- Run: https://github.com/ArcadeAI/docs/actions/runs/25074310423

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk patch-level dependency bump; main risk is minor UI/styling regressions from the updated design-system package.
> 
> **Overview**
> Bumps `@arcadeai/design-system` from `3.39.0` to `3.39.1` in `package.json`.
> 
> Updates `pnpm-lock.yaml` to reflect the new resolved version and integrity for the design system dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5e73ae949fd8f5ea7f3fc660f213149955df35d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->