### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/toolkit-docs-generator/data/toolkits/gmail.json
+++ b/toolkit-docs-generator/data/toolkits/gmail.json
@@ -1,7 +1,7 @@
 {
   "id": "Gmail",
   "label": "Gmail",
-  "version": "5.0.0",
+  "version": "5.2.0",
   "description": "Arcade.dev LLM tools for Gmail",
   "metadata": {
     "category": "productivity",
@@ -30,7 +30,7 @@
     {
       "name": "ChangeEmailLabels",
       "qualifiedName": "Gmail.ChangeEmailLabels",
-      "fullyQualifiedName": "Gmail.ChangeEmailLabels@5.0.0",
+      "fullyQualifiedName": "Gmail.ChangeEmailLabels@5.2.0",
       "description": "Add and remove labels from an email using the Gmail API.",
       "parameters": [
         {
@@ -124,7 +124,7 @@
     {
       "name": "CreateLabel",
       "qualifiedName": "Gmail.CreateLabel",
-      "fullyQualifiedName": "Gmail.CreateLabel@5.0.0",
+      "fullyQualifiedName": "Gmail.CreateLabel@5.2.0",
       "description": "Create a new label in the user's mailbox.",
       "parameters": [
         {
@@ -184,7 +184,7 @@
     {
       "name": "DeleteDraftEmail",
       "qualifiedName": "Gmail.DeleteDraftEmail",
-      "fullyQualifiedName": "Gmail.DeleteDraftEmail@5.0.0",
+      "fullyQualifiedName": "Gmail.DeleteDraftEmail@5.2.0",
       "description": "Delete a draft email using the Gmail API.",
       "parameters": [
         {
@@ -244,7 +244,7 @@
     {
       "name": "GetThread",
       "qualifiedName": "Gmail.GetThread",
-      "fullyQualifiedName": "Gmail.GetThread@5.0.0",
+      "fullyQualifiedName": "Gmail.GetThread@5.2.0",
       "description": "Get the specified thread by ID.",
       "parameters": [
         {
@@ -304,7 +304,7 @@
     {
       "name": "ListDraftEmails",
       "qualifiedName": "Gmail.ListDraftEmails",
-      "fullyQualifiedName": "Gmail.ListDraftEmails@5.0.0",
+      "fullyQualifiedName": "Gmail.ListDraftEmails@5.2.0",
       "description": "Lists draft emails in the user's draft mailbox using the Gmail API.",
       "parameters": [
         {
@@ -364,7 +364,7 @@
     {
       "name": "ListEmails",
       "qualifiedName": "Gmail.ListEmails",
-      "fullyQualifiedName": "Gmail.ListEmails@5.0.0",
+      "fullyQualifiedName": "Gmail.ListEmails@5.2.0",
       "description": "Read emails from a Gmail account and extract plain text content.",
       "parameters": [
         {
@@ -424,7 +424,7 @@
     {
       "name": "ListEmailsByHeader",
       "qualifiedName": "Gmail.ListEmailsByHeader",
-      "fullyQualifiedName": "Gmail.ListEmailsByHeader@5.0.0",
+      "fullyQualifiedName": "Gmail.ListEmailsByHeader@5.2.0",
       "description": "Search for emails by header using the Gmail API.",
       "parameters": [
         {
@@ -570,7 +570,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Gmail.ListLabels",
-      "fullyQualifiedName": "Gmail.ListLabels@5.0.0",
+      "fullyQualifiedName": "Gmail.ListLabels@5.2.0",
       "description": "List all the labels in the user's mailbox.",
       "parameters": [],
       "auth": {
@@ -615,7 +615,7 @@
     {
       "name": "ListThreads",
       "qualifiedName": "Gmail.ListThreads",
-      "fullyQualifiedName": "Gmail.ListThreads@5.0.0",
+      "fullyQualifiedName": "Gmail.ListThreads@5.2.0",
       "description": "List threads in the user's mailbox.",
       "parameters": [
         {
@@ -701,7 +701,7 @@
     {
       "name": "ReplyToEmail",
       "qualifiedName": "Gmail.ReplyToEmail",
-      "fullyQualifiedName": "Gmail.ReplyToEmail@5.0.0",
+      "fullyQualifiedName": "Gmail.ReplyToEmail@5.2.0",
       "description": "Send a reply to an email message.",
       "parameters": [
         {
@@ -775,6 +775,49 @@
         "description": "A dictionary containing the sent email details with date in descriptive UTC format"
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Gmail.ReplyToEmail",
+        "parameters": {
+          "body": {
+            "value": "Thank you for reaching out! I have reviewed the details you provided and I'm happy to confirm that everything looks good on our end. Please let me know if you have any further questions.",
+            "type": "string",
+            "required": true
+          },
+          "reply_to_message_id": {
+            "value": "18f3a2b4c5d6e7f8",
+            "type": "string",
+            "required": true
+          },
+          "reply_to_whom": {
+            "value": "GmailReplyToWhom.ONLY_THE_SENDER",
+            "type": "string",
+            "required": false
+          },
+          "cc": {
+            "value": [
+              "manager@example.com",
+              "teamlead@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "bcc": {
+            "value": [
+              "archive@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "content_type": {
+            "value": "plain",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -796,7 +839,7 @@
     {
       "name": "SearchThreads",
       "qualifiedName": "Gmail.SearchThreads",
-      "fullyQualifiedName": "Gmail.SearchThreads@5.0.0",
+      "fullyQualifiedName": "Gmail.SearchThreads@5.2.0",
       "description": "Search for threads in the user's mailbox",
       "parameters": [
         {
@@ -972,7 +1015,7 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "Gmail.SendDraftEmail",
-      "fullyQualifiedName": "Gmail.SendDraftEmail@5.0.0",
+      "fullyQualifiedName": "Gmail.SendDraftEmail@5.2.0",
       "description": "Send a draft email using the Gmail API.",
       "parameters": [
         {
@@ -1032,7 +1075,7 @@
     {
       "name": "SendEmail",
       "qualifiedName": "Gmail.SendEmail",
-      "fullyQualifiedName": "Gmail.SendEmail@5.0.0",
+      "fullyQualifiedName": "Gmail.SendEmail@5.2.0",
       "description": "Send an email using the Gmail API.",
       "parameters": [
         {
@@ -1167,7 +1210,7 @@
     {
       "name": "TrashEmail",
       "qualifiedName": "Gmail.TrashEmail",
-      "fullyQualifiedName": "Gmail.TrashEmail@5.0.0",
+      "fullyQualifiedName": "Gmail.TrashEmail@5.2.0",
       "description": "Move an email to the trash folder using the Gmail API.",
       "parameters": [
         {
@@ -1227,7 +1270,7 @@
     {
       "name": "UpdateDraftEmail",
       "qualifiedName": "Gmail.UpdateDraftEmail",
-      "fullyQualifiedName": "Gmail.UpdateDraftEmail@5.0.0",
+      "fullyQualifiedName": "Gmail.UpdateDraftEmail@5.2.0",
       "description": "Update an existing email draft using the Gmail API.\n\nSingle-part plain drafts support full body replacement. For HTML, attachments, or\nmultipart drafts, the tool fails unless the body is unchanged (metadata-only update),\nin which case the existing MIME tree is preserved. Otherwise edit the draft in Gmail.\n\nFor each of subject, body, recipient, cc, and bcc, omitting the parameter or passing\n``None`` leaves that part of the draft unchanged (for cc/bcc, existing headers are kept;\npass an empty list to clear).",
       "parameters": [
         {
@@ -1295,6 +1338,49 @@
         "description": "A dictionary containing the updated draft email details with date in descriptive UTC format"
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Gmail.UpdateDraftEmail",
+        "parameters": {
+          "draft_email_id": {
+            "value": "r5678901234567890",
+            "type": "string",
+            "required": true
+          },
+          "subject": {
+            "value": "Updated Meeting Agenda for Thursday",
+            "type": "string",
+            "required": false
+          },
+          "body": {
+            "value": "Hi team,\n\nPlease find the updated agenda for our Thursday meeting below:\n\n1. Project status update\n2. Budget review\n3. Q3 planning\n\nLet me know if you have any additions.\n\nBest regards,\nAlex",
+            "type": "string",
+            "required": false
+          },
+          "recipient": {
+            "value": "jane.doe@example.com",
+            "type": "string",
+            "required": false
+          },
+          "cc": {
+            "value": [
+              "manager@example.com",
+              "teamlead@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "bcc": {
+            "value": [
+              "archive@example.com"
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1316,7 +1402,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Gmail.WhoAmI",
-      "fullyQualifiedName": "Gmail.WhoAmI@5.0.0",
+      "fullyQualifiedName": "Gmail.WhoAmI@5.2.0",
       "description": "Get comprehensive user profile and Gmail account information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Gmail account statistics, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1363,7 +1449,7 @@
     {
       "name": "WriteDraftEmail",
       "qualifiedName": "Gmail.WriteDraftEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftEmail@5.0.0",
+      "fullyQualifiedName": "Gmail.WriteDraftEmail@5.2.0",
       "description": "Compose a new email draft using the Gmail API.",
       "parameters": [
         {
@@ -1497,7 +1583,7 @@
     {
       "name": "WriteDraftReplyEmail",
       "qualifiedName": "Gmail.WriteDraftReplyEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@5.0.0",
+      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@5.2.0",
       "description": "Compose a draft reply to an email message.",
       "parameters": [
         {
@@ -1561,7 +1647,8 @@
         "providerId": "google",
         "providerType": "oauth2",
         "scopes": [
-          "https://www.googleapis.com/auth/gmail.compose"
+          "https://www.googleapis.com/auth/gmail.compose",
+          "https://www.googleapis.com/auth/gmail.readonly"
         ]
       },
       "secrets": [],
@@ -1571,6 +1658,49 @@
         "description": "Draft details; use draft_email_id (or id) for update/send/delete—not message.id."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Gmail.WriteDraftReplyEmail",
+        "parameters": {
+          "body": {
+            "value": "Thank you for your message! I have reviewed the details and will get back to you with a full response by end of day tomorrow. Please let me know if you have any urgent questions in the meantime.",
+            "type": "string",
+            "required": true
+          },
+          "reply_to_message_id": {
+            "value": "18e4f2a3b7c91d05",
+            "type": "string",
+            "required": true
+          },
+          "reply_to_whom": {
+            "value": "GmailReplyToWhom.ONLY_THE_SENDER",
+            "type": "string",
+            "required": false
+          },
+          "cc": {
+            "value": [
+              "manager@example.com",
+              "team-lead@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "bcc": {
+            "value": [
+              "records@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "content_type": {
+            "value": "plain",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1579,7 +1709,8 @@
         },
         "behavior": {
           "operations": [
-            "create"
+            "create",
+            "read"
           ],
           "readOnly": false,
           "destructive": false,
@@ -1602,6 +1733,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-04-27T11:41:15.823Z",
-  "summary": "Arcade's Gmail toolkit lets developers read, search, label, draft, send, and reply to Gmail messages through the Gmail API.\n\n**Capabilities**\n- List, search, retrieve, and trash emails and threads.\n- Create, update, send, and delete drafts.\n- Send emails and replies with support for To, Cc, Bcc, and plain or HTML content.\n- Manage Gmail labels and fetch authenticated user profile information.\n- Preserve existing draft fields when optional update parameters are omitted.\n\n**OAuth**\n- **Provider**: Google\n- **Scopes**: Gmail read, compose, modify, send, label access, and Google user profile scopes.\n\n**Secrets**\n- No secret types required for toolkit operation."
+  "generatedAt": "2026-04-29T11:39:18.440Z",
+  "summary": "The Gmail toolkit provides Arcade LLM tools for interacting with a user's Gmail account via the Gmail API. It enables agents to read, compose, send, organize, and manage email on behalf of authenticated users.\n\n## Capabilities\n\n- **Reading & searching:** List emails, threads, and drafts; search threads by query; look up emails by header; retrieve full thread details by ID.\n- **Composing & drafting:** Create new drafts, compose draft replies, update existing drafts (metadata-only for HTML/multipart; full body replacement for plain-text drafts), and delete drafts.\n- **Sending:** Send new emails, send existing drafts, and reply to messages directly.\n- **Organization & labels:** List, create, and apply or remove labels; move emails to trash.\n- **Account info:** Retrieve the authenticated user's profile, email address, display name, profile picture, and Gmail account statistics via `WhoAmI`.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via Google. Arcade handles the OAuth flow automatically. See the [Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for configuration details."
 }

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-27T11:41:16.105Z",
+  "generatedAt": "2026-04-29T11:39:31.900Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -257,7 +257,7 @@
     {
       "id": "Gmail",
       "label": "Gmail",
-      "version": "5.0.0",
+      "version": "5.2.0",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 18,
@@ -509,10 +509,10 @@
     {
       "id": "Linear",
       "label": "Linear",
-      "version": "3.3.3",
+      "version": "3.4.0",
       "category": "productivity",
       "type": "arcade",
-      "toolCount": 39,
+      "toolCount": 42,
       "authType": "oauth2"
     },
     {
@@ -680,7 +680,7 @@
     {
       "id": "Posthog",
       "label": "PostHog",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "development",
       "type": "arcade",
       "toolCount": 41,

--- a/toolkit-docs-generator/data/toolkits/linear.json
+++ b/toolkit-docs-generator/data/toolkits/linear.json
@@ -1,7 +1,7 @@
 {
   "id": "Linear",
   "label": "Linear",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "description": "Arcade tools designed for LLMs to interact with Linear",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "AddComment",
       "qualifiedName": "Linear.AddComment",
-      "fullyQualifiedName": "Linear.AddComment@3.3.3",
+      "fullyQualifiedName": "Linear.AddComment@3.4.0",
       "description": "Add a comment to an issue.",
       "parameters": [
         {
@@ -99,7 +99,7 @@
     {
       "name": "AddProjectComment",
       "qualifiedName": "Linear.AddProjectComment",
-      "fullyQualifiedName": "Linear.AddProjectComment@3.3.3",
+      "fullyQualifiedName": "Linear.AddProjectComment@3.4.0",
       "description": "Add a comment to a project's document content.\n\nIMPORTANT: Due to Linear API limitations, comments created via the API will NOT\nappear visually anchored inline in the document (no yellow highlight on text).\nThe comment will be stored and can be retrieved via list_project_comments, but\nit will appear in the comments panel rather than inline in the document.\n\nFor true inline comments that are visually anchored to text, users should create\nthem directly in the Linear UI by selecting text and adding a comment.\n\nThe quoted_text parameter stores metadata about what text the comment references,\nwhich is useful for context even though the comment won't be visually anchored.",
       "parameters": [
         {
@@ -198,7 +198,7 @@
     {
       "name": "AddProjectToInitiative",
       "qualifiedName": "Linear.AddProjectToInitiative",
-      "fullyQualifiedName": "Linear.AddProjectToInitiative@3.3.3",
+      "fullyQualifiedName": "Linear.AddProjectToInitiative@3.4.0",
       "description": "Link a project to an initiative.\n\nBoth initiative and project can be specified by ID or name.\nIf a name is provided, fuzzy matching is used to resolve it.",
       "parameters": [
         {
@@ -284,7 +284,7 @@
     {
       "name": "ArchiveInitiative",
       "qualifiedName": "Linear.ArchiveInitiative",
-      "fullyQualifiedName": "Linear.ArchiveInitiative@3.3.3",
+      "fullyQualifiedName": "Linear.ArchiveInitiative@3.4.0",
       "description": "Archive an initiative.\n\nArchived initiatives are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -357,7 +357,7 @@
     {
       "name": "ArchiveIssue",
       "qualifiedName": "Linear.ArchiveIssue",
-      "fullyQualifiedName": "Linear.ArchiveIssue@3.3.3",
+      "fullyQualifiedName": "Linear.ArchiveIssue@3.4.0",
       "description": "Archive an issue.\n\nArchived issues are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -417,7 +417,7 @@
     {
       "name": "ArchiveProject",
       "qualifiedName": "Linear.ArchiveProject",
-      "fullyQualifiedName": "Linear.ArchiveProject@3.3.3",
+      "fullyQualifiedName": "Linear.ArchiveProject@3.4.0",
       "description": "Archive a project.\n\nArchived projects are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -490,7 +490,7 @@
     {
       "name": "CreateInitiative",
       "qualifiedName": "Linear.CreateInitiative",
-      "fullyQualifiedName": "Linear.CreateInitiative@3.3.3",
+      "fullyQualifiedName": "Linear.CreateInitiative@3.4.0",
       "description": "Create a new Linear initiative.\n\nInitiatives are high-level strategic goals that group related projects.",
       "parameters": [
         {
@@ -596,7 +596,7 @@
     {
       "name": "CreateIssue",
       "qualifiedName": "Linear.CreateIssue",
-      "fullyQualifiedName": "Linear.CreateIssue@3.3.3",
+      "fullyQualifiedName": "Linear.CreateIssue@3.4.0",
       "description": "Create a new Linear issue with validation.\n\nWhen assignee is None or '@me', the issue is assigned to the authenticated user.\nAll entity references (team, assignee, labels, state, project, cycle, parent)\nare validated before creation. If an entity is not found, suggestions are\nreturned to help correct the input.",
       "parameters": [
         {
@@ -741,6 +741,93 @@
         "description": "Created issue details"
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Linear.CreateIssue",
+        "parameters": {
+          "team": {
+            "value": "Engineering",
+            "type": "string",
+            "required": true
+          },
+          "title": {
+            "value": "Fix null pointer exception in user authentication flow",
+            "type": "string",
+            "required": true
+          },
+          "description": {
+            "value": "## Bug Report\n\nA null pointer exception occurs when a user attempts to log in with an expired token.\n\n**Steps to reproduce:**\n1. Let a session token expire\n2. Attempt to log in again\n3. Observe the error in logs\n\n**Expected:** Graceful re-authentication prompt\n**Actual:** Server returns 500 with NPE",
+            "type": "string",
+            "required": false
+          },
+          "assignee": {
+            "value": "jane.doe@example.com",
+            "type": "string",
+            "required": false
+          },
+          "labels_to_add": {
+            "value": [
+              "bug",
+              "high-impact",
+              "backend"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "priority": {
+            "value": "urgent",
+            "type": "string",
+            "required": false
+          },
+          "state": {
+            "value": "In Progress",
+            "type": "string",
+            "required": false
+          },
+          "project": {
+            "value": "Q3 Platform Stability",
+            "type": "string",
+            "required": false
+          },
+          "cycle": {
+            "value": "Cycle 12",
+            "type": "string",
+            "required": false
+          },
+          "parent_issue": {
+            "value": "ENG-204",
+            "type": "string",
+            "required": false
+          },
+          "estimate": {
+            "value": 3,
+            "type": "integer",
+            "required": false
+          },
+          "due_date": {
+            "value": "2025-08-15",
+            "type": "string",
+            "required": false
+          },
+          "attachment_url": {
+            "value": "https://sentry.io/organizations/example/issues/123456789/",
+            "type": "string",
+            "required": false
+          },
+          "attachment_title": {
+            "value": "Sentry Error Trace – NPE in AuthService",
+            "type": "string",
+            "required": false
+          },
+          "auto_accept_matches": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "linear",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -762,7 +849,7 @@
     {
       "name": "CreateIssueRelation",
       "qualifiedName": "Linear.CreateIssueRelation",
-      "fullyQualifiedName": "Linear.CreateIssueRelation@3.3.3",
+      "fullyQualifiedName": "Linear.CreateIssueRelation@3.4.0",
       "description": "Create a relation between two issues.\n\nRelation types define the relationship from the source issue's perspective:\n- blocks: Source issue blocks the related issue\n- blockedBy: Source issue is blocked by the related issue\n- duplicate: Source issue is a duplicate of the related issue\n- related: Issues are related (bidirectional)",
       "parameters": [
         {
@@ -853,7 +940,7 @@
     {
       "name": "CreateProject",
       "qualifiedName": "Linear.CreateProject",
-      "fullyQualifiedName": "Linear.CreateProject@3.3.3",
+      "fullyQualifiedName": "Linear.CreateProject@3.4.0",
       "description": "Create a new Linear project.\n\nTeam is validated before creation. If team is not found, suggestions are\nreturned to help correct the input. Lead is validated if provided.",
       "parameters": [
         {
@@ -1024,7 +1111,7 @@
     {
       "name": "CreateProjectUpdate",
       "qualifiedName": "Linear.CreateProjectUpdate",
-      "fullyQualifiedName": "Linear.CreateProjectUpdate@3.3.3",
+      "fullyQualifiedName": "Linear.CreateProjectUpdate@3.4.0",
       "description": "Create a project status update.\n\nProject updates are posts that communicate progress, blockers, or status\nchanges to stakeholders. They appear in the project's Updates tab and\ncan include a health status indicator.",
       "parameters": [
         {
@@ -1114,7 +1201,7 @@
     {
       "name": "GetCycle",
       "qualifiedName": "Linear.GetCycle",
-      "fullyQualifiedName": "Linear.GetCycle@3.3.3",
+      "fullyQualifiedName": "Linear.GetCycle@3.4.0",
       "description": "Get detailed information about a specific Linear cycle.",
       "parameters": [
         {
@@ -1174,7 +1261,7 @@
     {
       "name": "GetInitiative",
       "qualifiedName": "Linear.GetInitiative",
-      "fullyQualifiedName": "Linear.GetInitiative@3.3.3",
+      "fullyQualifiedName": "Linear.GetInitiative@3.4.0",
       "description": "Get detailed information about a specific Linear initiative.\n\nSupports lookup by ID or name (with fuzzy matching for name).",
       "parameters": [
         {
@@ -1276,7 +1363,7 @@
     {
       "name": "GetInitiativeDescription",
       "qualifiedName": "Linear.GetInitiativeDescription",
-      "fullyQualifiedName": "Linear.GetInitiativeDescription@3.3.3",
+      "fullyQualifiedName": "Linear.GetInitiativeDescription@3.4.0",
       "description": "Get an initiative's full description with pagination support.\n\nUse this tool when you need the complete description of an initiative that\nwas truncated in the get_initiative response. Supports chunked reading for\nvery large descriptions.",
       "parameters": [
         {
@@ -1362,7 +1449,7 @@
     {
       "name": "GetIssue",
       "qualifiedName": "Linear.GetIssue",
-      "fullyQualifiedName": "Linear.GetIssue@3.3.3",
+      "fullyQualifiedName": "Linear.GetIssue@3.4.0",
       "description": "Get detailed information about a specific Linear issue.\n\nAccepts either the issue UUID or the human-readable identifier (like TOO-123).",
       "parameters": [
         {
@@ -1472,9 +1559,95 @@
       }
     },
     {
+      "name": "GetMilestone",
+      "qualifiedName": "Linear.GetMilestone",
+      "fullyQualifiedName": "Linear.GetMilestone@3.4.0",
+      "description": "Get a milestone by ID or name inside a project.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project ID, slug_id, or name of the project that the milestone is under.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "query",
+          "type": "string",
+          "required": true,
+          "description": "Milestone ID or milestone name.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "auto_accept_matches",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, auto-accept fuzzy project/milestone matches above 90% confidence. Default is False.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "linear",
+        "providerType": "oauth2",
+        "scopes": [
+          "read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Milestone details or fuzzy match suggestions"
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Linear.GetMilestone",
+        "parameters": {
+          "project": {
+            "value": "proj_abc123xyz",
+            "type": "string",
+            "required": true
+          },
+          "query": {
+            "value": "Q3 Launch Milestone",
+            "type": "string",
+            "required": true
+          },
+          "auto_accept_matches": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "linear",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "project_management"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "GetNotifications",
       "qualifiedName": "Linear.GetNotifications",
-      "fullyQualifiedName": "Linear.GetNotifications@3.3.3",
+      "fullyQualifiedName": "Linear.GetNotifications@3.4.0",
       "description": "Get the authenticated user's notifications.\n\nReturns notifications including issue mentions, comments, assignments,\nand state changes.",
       "parameters": [
         {
@@ -1560,7 +1733,7 @@
     {
       "name": "GetProject",
       "qualifiedName": "Linear.GetProject",
-      "fullyQualifiedName": "Linear.GetProject@3.3.3",
+      "fullyQualifiedName": "Linear.GetProject@3.4.0",
       "description": "Get detailed information about a specific Linear project.\n\nSupports lookup by ID, slug_id, or name (with fuzzy matching for name).",
       "parameters": [
         {
@@ -1676,7 +1849,7 @@
     {
       "name": "GetProjectDescription",
       "qualifiedName": "Linear.GetProjectDescription",
-      "fullyQualifiedName": "Linear.GetProjectDescription@3.3.3",
+      "fullyQualifiedName": "Linear.GetProjectDescription@3.4.0",
       "description": "Get a project's full description with pagination support.\n\nUse this tool when you need the complete description of a project that\nwas truncated in the get_project response. Supports chunked reading for\nvery large descriptions.",
       "parameters": [
         {
@@ -1762,7 +1935,7 @@
     {
       "name": "GetRecentActivity",
       "qualifiedName": "Linear.GetRecentActivity",
-      "fullyQualifiedName": "Linear.GetRecentActivity@3.3.3",
+      "fullyQualifiedName": "Linear.GetRecentActivity@3.4.0",
       "description": "Get the authenticated user's recent issue activity.\n\nReturns issues the user has recently created or been assigned to\nwithin the specified time period.",
       "parameters": [
         {
@@ -1835,7 +2008,7 @@
     {
       "name": "GetTeam",
       "qualifiedName": "Linear.GetTeam",
-      "fullyQualifiedName": "Linear.GetTeam@3.3.3",
+      "fullyQualifiedName": "Linear.GetTeam@3.4.0",
       "description": "Get detailed information about a specific Linear team.\n\nSupports lookup by ID, key (like TOO, ENG), or name (with fuzzy matching).",
       "parameters": [
         {
@@ -1925,7 +2098,7 @@
     {
       "name": "LinkGithubToIssue",
       "qualifiedName": "Linear.LinkGithubToIssue",
-      "fullyQualifiedName": "Linear.LinkGithubToIssue@3.3.3",
+      "fullyQualifiedName": "Linear.LinkGithubToIssue@3.4.0",
       "description": "Link a GitHub PR, commit, or issue to a Linear issue.\n\nAutomatically detects the artifact type from the URL and generates\nan appropriate title if not provided.",
       "parameters": [
         {
@@ -2011,7 +2184,7 @@
     {
       "name": "ListComments",
       "qualifiedName": "Linear.ListComments",
-      "fullyQualifiedName": "Linear.ListComments@3.3.3",
+      "fullyQualifiedName": "Linear.ListComments@3.4.0",
       "description": "List comments on an issue.\n\nReturns comments with user info, timestamps, and reply threading info.",
       "parameters": [
         {
@@ -2097,7 +2270,7 @@
     {
       "name": "ListCycles",
       "qualifiedName": "Linear.ListCycles",
-      "fullyQualifiedName": "Linear.ListCycles@3.3.3",
+      "fullyQualifiedName": "Linear.ListCycles@3.4.0",
       "description": "List Linear cycles, optionally filtered by team and status.\n\nCycles are time-boxed iterations (like sprints) for organizing work.",
       "parameters": [
         {
@@ -2209,7 +2382,7 @@
     {
       "name": "ListInitiatives",
       "qualifiedName": "Linear.ListInitiatives",
-      "fullyQualifiedName": "Linear.ListInitiatives@3.3.3",
+      "fullyQualifiedName": "Linear.ListInitiatives@3.4.0",
       "description": "List Linear initiatives, optionally filtered by keywords and other criteria.\n\nReturns all initiatives when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2315,7 +2488,7 @@
     {
       "name": "ListIssues",
       "qualifiedName": "Linear.ListIssues",
-      "fullyQualifiedName": "Linear.ListIssues@3.3.3",
+      "fullyQualifiedName": "Linear.ListIssues@3.4.0",
       "description": "List Linear issues, optionally filtered by keywords and other criteria.\n\nReturns all issues when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2498,7 +2671,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Linear.ListLabels",
-      "fullyQualifiedName": "Linear.ListLabels@3.3.3",
+      "fullyQualifiedName": "Linear.ListLabels@3.4.0",
       "description": "List available issue labels in the workspace.\n\nReturns labels that can be applied to issues. Use label IDs or names\nwhen creating or updating issues.",
       "parameters": [
         {
@@ -2556,9 +2729,108 @@
       }
     },
     {
+      "name": "ListMilestones",
+      "qualifiedName": "Linear.ListMilestones",
+      "fullyQualifiedName": "Linear.ListMilestones@3.4.0",
+      "description": "List milestones in a Linear project.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project ID, slug_id, or name of the project to list milestones from.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum milestones to return. Min 1, max 50. Default is 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "end_cursor",
+          "type": "string",
+          "required": false,
+          "description": "Cursor for pagination. Use 'end_cursor' from previous response. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "auto_accept_matches",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, auto-accept fuzzy project matches above 90% confidence. Default is False.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "linear",
+        "providerType": "oauth2",
+        "scopes": [
+          "read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Milestones for the selected project"
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Linear.ListMilestones",
+        "parameters": {
+          "project": {
+            "value": "mobile-app-redesign",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 10,
+            "type": "integer",
+            "required": false
+          },
+          "end_cursor": {
+            "value": "eyJpZCI6IjEyMyIsInR5cGUiOiJwcm9qZWN0In0=",
+            "type": "string",
+            "required": false
+          },
+          "auto_accept_matches": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "linear",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "project_management"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "ListProjectComments",
       "qualifiedName": "Linear.ListProjectComments",
-      "fullyQualifiedName": "Linear.ListProjectComments@3.3.3",
+      "fullyQualifiedName": "Linear.ListProjectComments@3.4.0",
       "description": "List comments on a project's document content.\n\nReturns comments with user info, timestamps, quoted text for inline comments,\nand reply threading info. Replies are nested under their parent comments.\n\nUse comment_filter to control which comments are returned:\n- only_quoted (default): Only comments attached to a quote in the text\n- only_unquoted: Only comments not attached to a particular quote\n- all: All comments regardless of being attached to a quote or not",
       "parameters": [
         {
@@ -2687,7 +2959,7 @@
     {
       "name": "ListProjects",
       "qualifiedName": "Linear.ListProjects",
-      "fullyQualifiedName": "Linear.ListProjects@3.3.3",
+      "fullyQualifiedName": "Linear.ListProjects@3.4.0",
       "description": "List Linear projects, optionally filtered by keywords and other criteria.\n\nReturns all projects when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2812,7 +3084,7 @@
     {
       "name": "ListTeams",
       "qualifiedName": "Linear.ListTeams",
-      "fullyQualifiedName": "Linear.ListTeams@3.3.3",
+      "fullyQualifiedName": "Linear.ListTeams@3.4.0",
       "description": "List Linear teams, optionally filtered by keywords and other criteria.\n\nReturns all teams when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2924,7 +3196,7 @@
     {
       "name": "ListWorkflowStates",
       "qualifiedName": "Linear.ListWorkflowStates",
-      "fullyQualifiedName": "Linear.ListWorkflowStates@3.3.3",
+      "fullyQualifiedName": "Linear.ListWorkflowStates@3.4.0",
       "description": "List available workflow states in the workspace.\n\nReturns workflow states that can be used for issue transitions.\nStates are team-specific and have different types.",
       "parameters": [
         {
@@ -3017,7 +3289,7 @@
     {
       "name": "ManageIssueSubscription",
       "qualifiedName": "Linear.ManageIssueSubscription",
-      "fullyQualifiedName": "Linear.ManageIssueSubscription@3.3.3",
+      "fullyQualifiedName": "Linear.ManageIssueSubscription@3.4.0",
       "description": "Subscribe to or unsubscribe from an issue's notifications.",
       "parameters": [
         {
@@ -3090,7 +3362,7 @@
     {
       "name": "ReplyToComment",
       "qualifiedName": "Linear.ReplyToComment",
-      "fullyQualifiedName": "Linear.ReplyToComment@3.3.3",
+      "fullyQualifiedName": "Linear.ReplyToComment@3.4.0",
       "description": "Reply to an existing comment on an issue.\n\nCreates a threaded reply to the specified parent comment.",
       "parameters": [
         {
@@ -3176,7 +3448,7 @@
     {
       "name": "ReplyToProjectComment",
       "qualifiedName": "Linear.ReplyToProjectComment",
-      "fullyQualifiedName": "Linear.ReplyToProjectComment@3.3.3",
+      "fullyQualifiedName": "Linear.ReplyToProjectComment@3.4.0",
       "description": "Reply to an existing comment on a project document.\n\nCreates a threaded reply to the specified parent comment.",
       "parameters": [
         {
@@ -3275,7 +3547,7 @@
     {
       "name": "TransitionIssueState",
       "qualifiedName": "Linear.TransitionIssueState",
-      "fullyQualifiedName": "Linear.TransitionIssueState@3.3.3",
+      "fullyQualifiedName": "Linear.TransitionIssueState@3.4.0",
       "description": "Transition a Linear issue to a new workflow state.\n\nThe target state is validated against the team's available states.",
       "parameters": [
         {
@@ -3361,7 +3633,7 @@
     {
       "name": "UpdateComment",
       "qualifiedName": "Linear.UpdateComment",
-      "fullyQualifiedName": "Linear.UpdateComment@3.3.3",
+      "fullyQualifiedName": "Linear.UpdateComment@3.4.0",
       "description": "Update an existing comment.",
       "parameters": [
         {
@@ -3434,7 +3706,7 @@
     {
       "name": "UpdateInitiative",
       "qualifiedName": "Linear.UpdateInitiative",
-      "fullyQualifiedName": "Linear.UpdateInitiative@3.3.3",
+      "fullyQualifiedName": "Linear.UpdateInitiative@3.4.0",
       "description": "Update a Linear initiative with partial updates.\n\nOnly fields that are explicitly provided will be updated.",
       "parameters": [
         {
@@ -3553,7 +3825,7 @@
     {
       "name": "UpdateIssue",
       "qualifiedName": "Linear.UpdateIssue",
-      "fullyQualifiedName": "Linear.UpdateIssue@3.3.3",
+      "fullyQualifiedName": "Linear.UpdateIssue@3.4.0",
       "description": "Update a Linear issue with partial updates.\n\nOnly fields that are explicitly provided will be updated. All entity\nreferences are validated before update.",
       "parameters": [
         {
@@ -3808,7 +4080,7 @@
     {
       "name": "UpdateProject",
       "qualifiedName": "Linear.UpdateProject",
-      "fullyQualifiedName": "Linear.UpdateProject@3.3.3",
+      "fullyQualifiedName": "Linear.UpdateProject@3.4.0",
       "description": "Update a Linear project with partial updates.\n\nOnly fields that are explicitly provided will be updated. All entity\nreferences are validated before update.\n\nIMPORTANT: Updating the 'content' field will break any existing inline\ncomment anchoring. The comments will still exist and be retrievable via\nlist_project_comments, but they will no longer appear visually anchored\nto text in the Linear UI. The 'description' field can be safely updated\nwithout affecting inline comments.",
       "parameters": [
         {
@@ -4010,9 +4282,135 @@
       }
     },
     {
+      "name": "UpsertMilestone",
+      "qualifiedName": "Linear.UpsertMilestone",
+      "fullyQualifiedName": "Linear.UpsertMilestone@3.4.0",
+      "description": "Upsert a project's milestone.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project ID, slug_id, or name of the project that the milestone is under.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "milestone_id",
+          "type": "string",
+          "required": false,
+          "description": "Milestone ID. When provided, the existing milestone with this ID is updated. When omitted, a new milestone is created.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Milestone name. When creating a milestone, this sets the name. When updating a milestone, providing this changes the name; omitting it leaves the existing name unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "required": false,
+          "description": "Milestone description. When creating a milestone, this sets the description. When updating a milestone, providing this changes the description; omitting it leaves the existing description unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "target_date",
+          "type": "string",
+          "required": false,
+          "description": "Target date in YYYY-MM-DD format. When creating a milestone, this sets the target date. When updating a milestone, providing this changes the target date; providing an empty string clears it; omitting it leaves the existing target date unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "auto_accept_matches",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, auto-accept fuzzy project matches above 90% confidence. Default is False.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "linear",
+        "providerType": "oauth2",
+        "scopes": [
+          "write"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Upserted milestone details"
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Linear.UpsertMilestone",
+        "parameters": {
+          "project": {
+            "value": "proj_abc123xyz",
+            "type": "string",
+            "required": true
+          },
+          "milestone_id": {
+            "value": "milestone_7f3d9e21",
+            "type": "string",
+            "required": false
+          },
+          "name": {
+            "value": "Beta Launch",
+            "type": "string",
+            "required": false
+          },
+          "description": {
+            "value": "All features required for the beta release are complete and tested.",
+            "type": "string",
+            "required": false
+          },
+          "target_date": {
+            "value": "2024-09-30",
+            "type": "string",
+            "required": false
+          },
+          "auto_accept_matches": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "linear",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "project_management"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "WhoAmI",
       "qualifiedName": "Linear.WhoAmI",
-      "fullyQualifiedName": "Linear.WhoAmI@3.3.3",
+      "fullyQualifiedName": "Linear.WhoAmI@3.4.0",
       "description": "Get the authenticated user's profile and team memberships.\n\nReturns the current user's information including their name, email,\norganization, and the teams they belong to.",
       "parameters": [],
       "auth": {
@@ -4066,6 +4464,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-04-18T11:20:23.013Z",
-  "summary": "Arcade's Linear toolkit lets LLMs interact with Linear workspaces, enabling programmatic creation, update, archival, and search across issues, projects, initiatives, cycles, and comments. It validates entity references and exposes workspace metadata so agents can plan work without manual lookups.\n\n**Capabilities**\n- Full issue lifecycle: create, update, archive, transition workflow state, relate issues, and link GitHub PRs, commits, or issues.\n- Project and initiative management: create, update, archive, post status updates, link projects to initiatives, and paginate long descriptions.\n- Collaboration: add, list, update, and reply to comments on issues and project documents; manage per-issue notification subscriptions.\n- Discovery and context: list and get cycles, teams, labels, workflow states, notifications, and recent authenticated-user activity; resolve the current user via WhoAmI.\n\n**OAuth**\nRequires Linear OAuth. See the [Arcade Linear auth provider docs](https://docs.arcade.dev/en/references/auth-providers/linear) for configuration."
+  "generatedAt": "2026-04-29T11:39:21.304Z",
+  "summary": "# Linear Toolkit\n\nProvides Arcade tools for LLMs to interact with [Linear](https://linear.app), enabling programmatic management of issues, projects, initiatives, cycles, and team workflows.\n\n## Capabilities\n\n- **Issue management:** Create, update, archive, transition workflow states, manage subscriptions, link GitHub PRs/commits, create issue relations (blocks, blocked-by, duplicate, related), and retrieve detailed issue data with fuzzy-matched entity validation.\n- **Comments & threading:** Add, update, list, and reply to threaded comments on both issues and project documents; project document comments are stored but rendered in the comments panel rather than visually anchored inline (Linear API limitation).\n- **Projects & milestones:** Create, update, archive, and query projects; manage milestones (upsert/get/list); post structured project status updates with health indicators; paginate large project descriptions.\n- **Initiatives & cycles:** Create, update, archive, and query high-level initiatives; link projects to initiatives; list and inspect time-boxed cycles (sprints) with team and status filters.\n- **Workspace & team metadata:** List teams, workflow states, labels, and notifications; retrieve recent user activity; look up team members and user profile via `WhoAmI`.\n- **Flexible lookups:** Most resources support lookup by UUID, human-readable identifier (e.g., `TOO-123`), slug, key, or name with fuzzy matching; suggestions are returned when an entity cannot be resolved.\n\n## OAuth\n\nThis toolkit authenticates via OAuth 2.0 with Linear. See the [Linear auth provider docs](https://docs.arcade.dev/en/references/auth-providers/linear) for setup details."
 }

--- a/toolkit-docs-generator/data/toolkits/posthog.json
+++ b/toolkit-docs-generator/data/toolkits/posthog.json
@@ -1,7 +1,7 @@
 {
   "id": "Posthog",
   "label": "PostHog",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Arcade.dev LLM tools for PostHog analytics",
   "metadata": {
     "category": "development",
@@ -18,7 +18,7 @@
     {
       "name": "AddInsightToDashboard",
       "qualifiedName": "Posthog.AddInsightToDashboard",
-      "fullyQualifiedName": "Posthog.AddInsightToDashboard@1.0.0",
+      "fullyQualifiedName": "Posthog.AddInsightToDashboard@1.0.1",
       "description": "Pin an existing insight as a tile on a dashboard.",
       "parameters": [
         {
@@ -51,12 +51,43 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.AddInsightToDashboard",
+        "parameters": {
+          "insight_id": {
+            "value": 4821,
+            "type": "integer",
+            "required": true
+          },
+          "dashboard_id": {
+            "value": 317,
+            "type": "integer",
+            "required": true
+          },
+          "project_id": {
+            "value": "phc_ABC123xyz456DEF789",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -78,7 +109,7 @@
     {
       "name": "ComparePeriods",
       "qualifiedName": "Posthog.ComparePeriods",
-      "fullyQualifiedName": "Posthog.ComparePeriods@1.0.0",
+      "fullyQualifiedName": "Posthog.ComparePeriods@1.0.1",
       "description": "Compare the same metric across two date ranges side-by-side.",
       "parameters": [
         {
@@ -152,12 +183,63 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.ComparePeriods",
+        "parameters": {
+          "event": {
+            "value": "user_signed_up",
+            "type": "string",
+            "required": true
+          },
+          "current_date_from": {
+            "value": "2024-03-01",
+            "type": "string",
+            "required": true
+          },
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "current_date_to": {
+            "value": "2024-03-31",
+            "type": "string",
+            "required": false
+          },
+          "previous_date_from": {
+            "value": "2024-02-01",
+            "type": "string",
+            "required": false
+          },
+          "time_grouping": {
+            "value": "DAY",
+            "type": "string",
+            "required": false
+          },
+          "math": {
+            "value": "TOTAL",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -179,7 +261,7 @@
     {
       "name": "CreateDashboard",
       "qualifiedName": "Posthog.CreateDashboard",
-      "fullyQualifiedName": "Posthog.CreateDashboard@1.0.0",
+      "fullyQualifiedName": "Posthog.CreateDashboard@1.0.1",
       "description": "Create a new empty dashboard. Insights can be pinned to it as tiles afterward.",
       "parameters": [
         {
@@ -229,12 +311,57 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.CreateDashboard",
+        "parameters": {
+          "name": {
+            "value": "Q3 Marketing Performance",
+            "type": "string",
+            "required": true
+          },
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "description": {
+            "value": "Tracks key marketing KPIs including conversion rates, traffic sources, and campaign ROI for Q3 2024.",
+            "type": "string",
+            "required": false
+          },
+          "pinned": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "tags": {
+            "value": [
+              "marketing",
+              "q3-2024",
+              "kpi"
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -256,7 +383,7 @@
     {
       "name": "CreateExperiment",
       "qualifiedName": "Posthog.CreateExperiment",
-      "fullyQualifiedName": "Posthog.CreateExperiment@1.0.0",
+      "fullyQualifiedName": "Posthog.CreateExperiment@1.0.1",
       "description": "Create an A/B test experiment.\n\nBefore creating, verify the feature_flag_key is not already in\nuse and confirm the event names for metrics are valid.\n\nNote: PostHog does not enforce unique feature_flag_key values\nacross experiments. Duplicate keys will not error but will cause\nunpredictable behavior.",
       "parameters": [
         {
@@ -343,12 +470,96 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.CreateExperiment",
+        "parameters": {
+          "name": {
+            "value": "Homepage CTA Button Color Test",
+            "type": "string",
+            "required": true
+          },
+          "feature_flag_key": {
+            "value": "homepage-cta-button-color",
+            "type": "string",
+            "required": true
+          },
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "description": {
+            "value": "Testing whether a green CTA button increases click-through rate compared to the current blue button. Hypothesis: green color creates stronger visual contrast and urgency, expected to improve CTR by 10-15%.",
+            "type": "string",
+            "required": false
+          },
+          "experiment_type": {
+            "value": "product",
+            "type": "string",
+            "required": false
+          },
+          "primary_metrics": {
+            "value": [
+              {
+                "event": "cta_button_clicked",
+                "type": "conversion"
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
+          "secondary_metrics": {
+            "value": [
+              {
+                "event": "page_bounced",
+                "type": "conversion"
+              },
+              {
+                "event": "signup_completed",
+                "type": "conversion"
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
+          "variants": {
+            "value": [
+              {
+                "key": "control",
+                "rollout_percentage": 50
+              },
+              {
+                "key": "test",
+                "rollout_percentage": 50
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
+          "draft": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -370,7 +581,7 @@
     {
       "name": "CreateExperimentWithFlag",
       "qualifiedName": "Posthog.CreateExperimentWithFlag",
-      "fullyQualifiedName": "Posthog.CreateExperimentWithFlag@1.0.0",
+      "fullyQualifiedName": "Posthog.CreateExperimentWithFlag@1.0.1",
       "description": "Create a feature flag and an experiment in one step.\n\nThe flag is created with the specified rollout_percentage, then\nthe experiment is linked to it.\n\nNote: PostHog does not enforce unique feature_flag_key values\nacross experiments. Duplicate keys will not error but will cause\nunpredictable behavior.",
       "parameters": [
         {
@@ -456,12 +667,83 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.CreateExperimentWithFlag",
+        "parameters": {
+          "name": {
+            "value": "Checkout Button Color Test",
+            "type": "string",
+            "required": true
+          },
+          "feature_flag_key": {
+            "value": "checkout-button-color-test",
+            "type": "string",
+            "required": true
+          },
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "description": {
+            "value": "Testing whether changing the checkout button from grey to green increases conversion rate by at least 5%.",
+            "type": "string",
+            "required": false
+          },
+          "experiment_type": {
+            "value": "product",
+            "type": "string",
+            "required": false
+          },
+          "primary_metrics": {
+            "value": [
+              {
+                "event": "checkout_completed",
+                "type": "conversion"
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
+          "secondary_metrics": {
+            "value": [
+              {
+                "event": "cart_abandoned",
+                "type": "conversion"
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
+          "rollout_percentage": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "draft": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -483,7 +765,7 @@
     {
       "name": "CreateFeatureFlag",
       "qualifiedName": "Posthog.CreateFeatureFlag",
-      "fullyQualifiedName": "Posthog.CreateFeatureFlag@1.0.0",
+      "fullyQualifiedName": "Posthog.CreateFeatureFlag@1.0.1",
       "description": "Create a new feature flag.\n\nVerify the key is not already in use to avoid duplicates. After\ncreation, consult PostHog SDK documentation for the user's\nlanguage/framework to integrate the flag.",
       "parameters": [
         {
@@ -540,12 +822,58 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.CreateFeatureFlag",
+        "parameters": {
+          "key": {
+            "value": "new-dashboard-ui",
+            "type": "string",
+            "required": true
+          },
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "name": {
+            "value": "New Dashboard UI",
+            "type": "string",
+            "required": false
+          },
+          "description": {
+            "value": "Controls the rollout of the redesigned dashboard interface for beta users",
+            "type": "string",
+            "required": false
+          },
+          "active": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "filters": {
+            "value": "{\"groups\":[{\"properties\":[{\"key\":\"email\",\"value\":\"@example.com\",\"operator\":\"icontains\",\"type\":\"person\"}],\"rollout_percentage\":50}]}",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -567,7 +895,7 @@
     {
       "name": "CreateInsightFromQuery",
       "qualifiedName": "Posthog.CreateInsightFromQuery",
-      "fullyQualifiedName": "Posthog.CreateInsightFromQuery@1.0.0",
+      "fullyQualifiedName": "Posthog.CreateInsightFromQuery@1.0.1",
       "description": "Save a tested query as a reusable insight.\n\nAlways verify the query produces expected results before saving\nit as an insight. The query_id is not validated by PostHog —\nensure it is a valid cache_key from a previously executed query.\nPassing an invalid query_id will create a broken insight.",
       "parameters": [
         {
@@ -608,12 +936,48 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.CreateInsightFromQuery",
+        "parameters": {
+          "query_id": {
+            "value": "cache_abc123xyz789def456",
+            "type": "string",
+            "required": true
+          },
+          "name": {
+            "value": "Weekly Active Users by Browser",
+            "type": "string",
+            "required": true
+          },
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "description": {
+            "value": "Measures the number of unique weekly active users segmented by browser type over the last 90 days.",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -635,7 +999,7 @@
     {
       "name": "CreateSurvey",
       "qualifiedName": "Posthog.CreateSurvey",
-      "fullyQualifiedName": "Posthog.CreateSurvey@1.0.0",
+      "fullyQualifiedName": "Posthog.CreateSurvey@1.0.1",
       "description": "Create a new survey.\n\nVerify the name is not already in use to avoid duplicates. After\ncreation, consult PostHog SDK documentation to integrate the\nsurvey into the user's application.",
       "parameters": [
         {
@@ -690,12 +1054,72 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "unknown"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.CreateSurvey",
+        "parameters": {
+          "name": {
+            "value": "User Onboarding Feedback Survey",
+            "type": "string",
+            "required": true
+          },
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "description": {
+            "value": "Collects feedback from users after completing the onboarding flow to identify pain points and improvement areas.",
+            "type": "string",
+            "required": false
+          },
+          "survey_type": {
+            "value": "popover",
+            "type": "string",
+            "required": false
+          },
+          "questions": {
+            "value": [
+              {
+                "type": "open",
+                "question": "How would you describe your onboarding experience?"
+              },
+              {
+                "type": "rating",
+                "question": "How satisfied are you with the onboarding process?",
+                "scale": 10
+              },
+              {
+                "type": "single_choice",
+                "question": "Would you recommend our product to a friend?",
+                "choices": [
+                  "Yes",
+                  "No",
+                  "Maybe"
+                ]
+              }
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -717,7 +1141,7 @@
     {
       "name": "DeleteDashboard",
       "qualifiedName": "Posthog.DeleteDashboard",
-      "fullyQualifiedName": "Posthog.DeleteDashboard@1.0.0",
+      "fullyQualifiedName": "Posthog.DeleteDashboard@1.0.1",
       "description": "Soft-delete a dashboard by ID. The dashboard is marked as deleted but can be restored.",
       "parameters": [
         {
@@ -742,12 +1166,38 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "unknown"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.DeleteDashboard",
+        "parameters": {
+          "dashboard_id": {
+            "value": 42,
+            "type": "integer",
+            "required": true
+          },
+          "project_id": {
+            "value": "phc_abc123XYZ456",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -769,7 +1219,7 @@
     {
       "name": "DeleteExperiment",
       "qualifiedName": "Posthog.DeleteExperiment",
-      "fullyQualifiedName": "Posthog.DeleteExperiment@1.0.0",
+      "fullyQualifiedName": "Posthog.DeleteExperiment@1.0.1",
       "description": "Soft-delete an experiment by ID (marks as archived).\n\nImportant: archiving an experiment does NOT unlink its feature\nflag. PostHog still considers the flag as linked to an \"active\"\nexperiment, blocking flag deletion. To fully clean up, delete\nthe flag separately after the experiment is archived.",
       "parameters": [
         {
@@ -794,12 +1244,38 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.DeleteExperiment",
+        "parameters": {
+          "experiment_id": {
+            "value": 42731,
+            "type": "integer",
+            "required": true
+          },
+          "project_id": {
+            "value": "phc_ABC123xyz789DEF456",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -821,7 +1297,7 @@
     {
       "name": "DeleteFeatureFlag",
       "qualifiedName": "Posthog.DeleteFeatureFlag",
-      "fullyQualifiedName": "Posthog.DeleteFeatureFlag@1.0.0",
+      "fullyQualifiedName": "Posthog.DeleteFeatureFlag@1.0.1",
       "description": "Soft-delete a feature flag by numeric ID or key. Provide one of flag_id or flag_key.\n\nNote: flags linked to an experiment cannot be deleted until the\nexperiment is concluded and deleted first. PostHog considers even\narchived experiments as \"active\" for flag linkage purposes.",
       "parameters": [
         {
@@ -854,12 +1330,43 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.DeleteFeatureFlag",
+        "parameters": {
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "flag_id": {
+            "value": 9876,
+            "type": "integer",
+            "required": false
+          },
+          "flag_key": {
+            "value": "enable-new-dashboard",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -881,7 +1388,7 @@
     {
       "name": "DeleteInsight",
       "qualifiedName": "Posthog.DeleteInsight",
-      "fullyQualifiedName": "Posthog.DeleteInsight@1.0.0",
+      "fullyQualifiedName": "Posthog.DeleteInsight@1.0.1",
       "description": "Soft-delete an insight by ID.",
       "parameters": [
         {
@@ -906,12 +1413,38 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "unknown"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.DeleteInsight",
+        "parameters": {
+          "insight_id": {
+            "value": 42,
+            "type": "integer",
+            "required": true
+          },
+          "project_id": {
+            "value": "phc_abc123XYZ456",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -933,7 +1466,7 @@
     {
       "name": "DeleteSurvey",
       "qualifiedName": "Posthog.DeleteSurvey",
-      "fullyQualifiedName": "Posthog.DeleteSurvey@1.0.0",
+      "fullyQualifiedName": "Posthog.DeleteSurvey@1.0.1",
       "description": "Soft-delete a survey by ID (marks as archived).",
       "parameters": [
         {
@@ -958,12 +1491,38 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "unknown"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.DeleteSurvey",
+        "parameters": {
+          "survey_id": {
+            "value": "a3f7c2d1-84be-4e10-9b2f-123456789abc",
+            "type": "string",
+            "required": true
+          },
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -985,7 +1544,7 @@
     {
       "name": "GetAllSurveyActivity",
       "qualifiedName": "Posthog.GetAllSurveyActivity",
-      "fullyQualifiedName": "Posthog.GetAllSurveyActivity@1.0.0",
+      "fullyQualifiedName": "Posthog.GetAllSurveyActivity@1.0.1",
       "description": "Get the activity log across all surveys.\n\nReturns a chronological list of changes made to any survey\n(created, updated, archived, etc.), not response metrics.",
       "parameters": [
         {
@@ -1002,12 +1561,33 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "unknown"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.GetAllSurveyActivity",
+        "parameters": {
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1029,7 +1609,7 @@
     {
       "name": "GetDashboard",
       "qualifiedName": "Posthog.GetDashboard",
-      "fullyQualifiedName": "Posthog.GetDashboard@1.0.0",
+      "fullyQualifiedName": "Posthog.GetDashboard@1.0.1",
       "description": "Get a dashboard's full configuration including all insight tiles.\n\nProvide dashboard_id or dashboard_name.",
       "parameters": [
         {
@@ -1062,12 +1642,43 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.GetDashboard",
+        "parameters": {
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "dashboard_id": {
+            "value": 42,
+            "type": "integer",
+            "required": false
+          },
+          "dashboard_name": {
+            "value": "Product Analytics Overview",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1089,7 +1700,7 @@
     {
       "name": "GetErrorDetails",
       "qualifiedName": "Posthog.GetErrorDetails",
-      "fullyQualifiedName": "Posthog.GetErrorDetails@1.0.0",
+      "fullyQualifiedName": "Posthog.GetErrorDetails@1.0.1",
       "description": "Get stack trace, occurrence count, and affected users/sessions for a specific error.",
       "parameters": [
         {
@@ -1114,12 +1725,38 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "unknown"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.GetErrorDetails",
+        "parameters": {
+          "issue_id": {
+            "value": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+            "type": "string",
+            "required": true
+          },
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1141,7 +1778,7 @@
     {
       "name": "GetExperiment",
       "qualifiedName": "Posthog.GetExperiment",
-      "fullyQualifiedName": "Posthog.GetExperiment@1.0.0",
+      "fullyQualifiedName": "Posthog.GetExperiment@1.0.1",
       "description": "Get an experiment's full configuration.\n\nIncludes variants, metrics, and current status. Provide either\nthe numeric ID or the name.",
       "parameters": [
         {
@@ -1174,12 +1811,43 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.GetExperiment",
+        "parameters": {
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "experiment_id": {
+            "value": 98765,
+            "type": "integer",
+            "required": false
+          },
+          "experiment_name": {
+            "value": "checkout-button-color-test",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1201,7 +1869,7 @@
     {
       "name": "GetExperimentResults",
       "qualifiedName": "Posthog.GetExperimentResults",
-      "fullyQualifiedName": "Posthog.GetExperimentResults@1.0.0",
+      "fullyQualifiedName": "Posthog.GetExperimentResults@1.0.1",
       "description": "Get experiment results including metric data and exposure counts.\n\nOnly available for launched experiments that have collected data.\nDraft, not-yet-launched, or legacy experiments return 404.",
       "parameters": [
         {
@@ -1226,12 +1894,38 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.GetExperimentResults",
+        "parameters": {
+          "experiment_id": {
+            "value": 42,
+            "type": "integer",
+            "required": true
+          },
+          "project_id": {
+            "value": "project_ABC123xyz",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1253,7 +1947,7 @@
     {
       "name": "GetFeatureFlag",
       "qualifiedName": "Posthog.GetFeatureFlag",
-      "fullyQualifiedName": "Posthog.GetFeatureFlag@1.0.0",
+      "fullyQualifiedName": "Posthog.GetFeatureFlag@1.0.1",
       "description": "Get a feature flag's full definition including rollout rules.\n\nProvide either the numeric ID or the flag key.",
       "parameters": [
         {
@@ -1286,12 +1980,43 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "unknown"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.GetFeatureFlag",
+        "parameters": {
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "flag_id": {
+            "value": 42,
+            "type": "integer",
+            "required": false
+          },
+          "flag_key": {
+            "value": "enable-dark-mode",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1313,7 +2038,7 @@
     {
       "name": "GetFunnel",
       "qualifiedName": "Posthog.GetFunnel",
-      "fullyQualifiedName": "Posthog.GetFunnel@1.0.0",
+      "fullyQualifiedName": "Posthog.GetFunnel@1.0.1",
       "description": "Build a multi-step conversion funnel with optional property breakdowns.",
       "parameters": [
         {
@@ -1392,12 +2117,80 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.GetFunnel",
+        "parameters": {
+          "steps": {
+            "value": [
+              "page_viewed",
+              "sign_up_clicked",
+              "account_created",
+              "subscription_started"
+            ],
+            "type": "array",
+            "required": true
+          },
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "date_from": {
+            "value": "-30d",
+            "type": "string",
+            "required": false
+          },
+          "date_to": {
+            "value": "2024-06-30",
+            "type": "string",
+            "required": false
+          },
+          "breakdown_property": {
+            "value": "$initial_utm_source",
+            "type": "string",
+            "required": false
+          },
+          "breakdown_type": {
+            "value": "EVENT",
+            "type": "string",
+            "required": false
+          },
+          "funnel_window_days": {
+            "value": 7,
+            "type": "integer",
+            "required": false
+          },
+          "property_filters": {
+            "value": [
+              {
+                "key": "$browser",
+                "value": "Chrome",
+                "operator": "exact",
+                "type": "event"
+              }
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1419,7 +2212,7 @@
     {
       "name": "GetInsight",
       "qualifiedName": "Posthog.GetInsight",
-      "fullyQualifiedName": "Posthog.GetInsight@1.0.0",
+      "fullyQualifiedName": "Posthog.GetInsight@1.0.1",
       "description": "Get an insight's full configuration and current query results.\n\nProvide either the numeric ID or the name.",
       "parameters": [
         {
@@ -1452,12 +2245,43 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.GetInsight",
+        "parameters": {
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "insight_id": {
+            "value": 987,
+            "type": "integer",
+            "required": false
+          },
+          "insight_name": {
+            "value": "Weekly Active Users",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1479,7 +2303,7 @@
     {
       "name": "GetRetention",
       "qualifiedName": "Posthog.GetRetention",
-      "fullyQualifiedName": "Posthog.GetRetention@1.0.0",
+      "fullyQualifiedName": "Posthog.GetRetention@1.0.1",
       "description": "Get cohort retention data showing what percentage of users return.\n\nShows return rates after a user's initial event.",
       "parameters": [
         {
@@ -1568,12 +2392,80 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.GetRetention",
+        "parameters": {
+          "start_event": {
+            "value": "signed_up",
+            "type": "string",
+            "required": true
+          },
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "return_event": {
+            "value": "logged_in",
+            "type": "string",
+            "required": false
+          },
+          "date_from": {
+            "value": "-30d",
+            "type": "string",
+            "required": false
+          },
+          "date_to": {
+            "value": "2024-06-30",
+            "type": "string",
+            "required": false
+          },
+          "retention_type": {
+            "value": "FIRST_TIME",
+            "type": "string",
+            "required": false
+          },
+          "period": {
+            "value": "WEEK",
+            "type": "string",
+            "required": false
+          },
+          "total_intervals": {
+            "value": 8,
+            "type": "integer",
+            "required": false
+          },
+          "property_filters": {
+            "value": [
+              {
+                "key": "plan",
+                "value": "pro",
+                "operator": "exact",
+                "type": "person"
+              }
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1595,7 +2487,7 @@
     {
       "name": "GetSurvey",
       "qualifiedName": "Posthog.GetSurvey",
-      "fullyQualifiedName": "Posthog.GetSurvey@1.0.0",
+      "fullyQualifiedName": "Posthog.GetSurvey@1.0.1",
       "description": "Get a survey's full configuration.\n\nIncludes questions, targeting rules, and scheduling. Provide\neither the numeric ID or the name.",
       "parameters": [
         {
@@ -1628,12 +2520,43 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "unknown"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.GetSurvey",
+        "parameters": {
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "survey_id": {
+            "value": "a3f8c2d1-4b7e-4f9a-8c3d-2e1f5a6b7c8d",
+            "type": "string",
+            "required": false
+          },
+          "survey_name": {
+            "value": "Customer Satisfaction Survey",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1655,7 +2578,7 @@
     {
       "name": "GetSurveyActivity",
       "qualifiedName": "Posthog.GetSurveyActivity",
-      "fullyQualifiedName": "Posthog.GetSurveyActivity@1.0.0",
+      "fullyQualifiedName": "Posthog.GetSurveyActivity@1.0.1",
       "description": "Get the activity log for a survey.\n\nReturns a chronological list of changes made to the survey\n(created, updated, archived, etc.), not response metrics.",
       "parameters": [
         {
@@ -1680,12 +2603,38 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.GetSurveyActivity",
+        "parameters": {
+          "survey_id": {
+            "value": "a3f8c2d1-7b45-4e89-b012-9f3e6c1d4a27",
+            "type": "string",
+            "required": true
+          },
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1707,7 +2656,7 @@
     {
       "name": "GetTrend",
       "qualifiedName": "Posthog.GetTrend",
-      "fullyQualifiedName": "Posthog.GetTrend@1.0.0",
+      "fullyQualifiedName": "Posthog.GetTrend@1.0.1",
       "description": "Get a time-series trend for an event over a date range.\n\nOptionally broken down by a property.",
       "parameters": [
         {
@@ -1802,12 +2751,80 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.GetTrend",
+        "parameters": {
+          "event": {
+            "value": "page_view",
+            "type": "string",
+            "required": true
+          },
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "date_from": {
+            "value": "-4w",
+            "type": "string",
+            "required": false
+          },
+          "date_to": {
+            "value": "2024-06-30",
+            "type": "string",
+            "required": false
+          },
+          "time_grouping": {
+            "value": "WEEK",
+            "type": "string",
+            "required": false
+          },
+          "breakdown_property": {
+            "value": "$browser",
+            "type": "string",
+            "required": false
+          },
+          "breakdown_type": {
+            "value": "EVENT",
+            "type": "string",
+            "required": false
+          },
+          "math": {
+            "value": "TOTAL",
+            "type": "string",
+            "required": false
+          },
+          "property_filters": {
+            "value": [
+              {
+                "key": "$os",
+                "value": "Windows",
+                "operator": "exact",
+                "type": "event"
+              }
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1829,7 +2846,7 @@
     {
       "name": "GetTrends",
       "qualifiedName": "Posthog.GetTrends",
-      "fullyQualifiedName": "Posthog.GetTrends@1.0.0",
+      "fullyQualifiedName": "Posthog.GetTrends@1.0.1",
       "description": "Batch trend query: get time-series data for multiple events.\n\nReturns a time-series for each event. Unknown event names return\nzero counts rather than errors.",
       "parameters": [
         {
@@ -1896,12 +2913,63 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "unknown"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.GetTrends",
+        "parameters": {
+          "events": {
+            "value": [
+              "pageview",
+              "signup",
+              "purchase",
+              "button_clicked"
+            ],
+            "type": "array",
+            "required": true
+          },
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "date_from": {
+            "value": "-4w",
+            "type": "string",
+            "required": false
+          },
+          "date_to": {
+            "value": "2024-06-30",
+            "type": "string",
+            "required": false
+          },
+          "time_grouping": {
+            "value": "DAY",
+            "type": "string",
+            "required": false
+          },
+          "math": {
+            "value": "TOTAL",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1923,7 +2991,7 @@
     {
       "name": "ListDashboards",
       "qualifiedName": "Posthog.ListDashboards",
-      "fullyQualifiedName": "Posthog.ListDashboards@1.0.0",
+      "fullyQualifiedName": "Posthog.ListDashboards@1.0.1",
       "description": "List all dashboards in the project.\n\nReturns summaries (id, name, pinned, tags, created_at). Use a\ndashboard's ID to get its full configuration and insight tiles.",
       "parameters": [
         {
@@ -1972,12 +3040,53 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "unknown"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.ListDashboards",
+        "parameters": {
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          },
+          "search": {
+            "value": "marketing",
+            "type": "string",
+            "required": false
+          },
+          "pinned": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1999,7 +3108,7 @@
     {
       "name": "ListErrors",
       "qualifiedName": "Posthog.ListErrors",
-      "fullyQualifiedName": "Posthog.ListErrors@1.0.0",
+      "fullyQualifiedName": "Posthog.ListErrors@1.0.1",
       "description": "List error tracking issues.\n\nReturns summaries (id, fingerprint, status, occurrences, users,\nfirst_seen, last_seen). Use an error's fingerprint with get_error_details\nto get full stack traces.",
       "parameters": [
         {
@@ -2032,12 +3141,43 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "unknown"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.ListErrors",
+        "parameters": {
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -2059,7 +3199,7 @@
     {
       "name": "ListEventDefinitions",
       "qualifiedName": "Posthog.ListEventDefinitions",
-      "fullyQualifiedName": "Posthog.ListEventDefinitions@1.0.0",
+      "fullyQualifiedName": "Posthog.ListEventDefinitions@1.0.1",
       "description": "List all tracked event names in the project.\n\nThis is the discovery starting point -- use it to find valid\nevent names, then look up an event's properties to discover\navailable filters and breakdowns.",
       "parameters": [
         {
@@ -2100,12 +3240,48 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.ListEventDefinitions",
+        "parameters": {
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "search": {
+            "value": "click",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -2127,7 +3303,7 @@
     {
       "name": "ListExperiments",
       "qualifiedName": "Posthog.ListExperiments",
-      "fullyQualifiedName": "Posthog.ListExperiments@1.0.0",
+      "fullyQualifiedName": "Posthog.ListExperiments@1.0.1",
       "description": "List all A/B test experiments.\n\nReturns summaries (id, name, feature_flag_key, start_date,\nend_date). Use an experiment's ID or name to get its full\nconfiguration.",
       "parameters": [
         {
@@ -2160,12 +3336,43 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.ListExperiments",
+        "parameters": {
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -2187,7 +3394,7 @@
     {
       "name": "ListFeatureFlags",
       "qualifiedName": "Posthog.ListFeatureFlags",
-      "fullyQualifiedName": "Posthog.ListFeatureFlags@1.0.0",
+      "fullyQualifiedName": "Posthog.ListFeatureFlags@1.0.1",
       "description": "List all feature flags.\n\nReturns summaries (id, key, name, active). Use a flag's ID or\nkey to get its full rollout rules and targeting detail.",
       "parameters": [
         {
@@ -2220,12 +3427,43 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "unknown"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.ListFeatureFlags",
+        "parameters": {
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -2247,7 +3485,7 @@
     {
       "name": "ListInsights",
       "qualifiedName": "Posthog.ListInsights",
-      "fullyQualifiedName": "Posthog.ListInsights@1.0.0",
+      "fullyQualifiedName": "Posthog.ListInsights@1.0.1",
       "description": "List all saved insights.\n\nReturns summaries (id, name, description, last_modified_at).\nUse an insight's ID or name to get its full configuration and\nquery results.",
       "parameters": [
         {
@@ -2288,12 +3526,48 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.ListInsights",
+        "parameters": {
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "search": {
+            "value": "funnel",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -2315,7 +3589,7 @@
     {
       "name": "ListProperties",
       "qualifiedName": "Posthog.ListProperties",
-      "fullyQualifiedName": "Posthog.ListProperties@1.0.0",
+      "fullyQualifiedName": "Posthog.ListProperties@1.0.1",
       "description": "List property definitions with names, types, and example values.\n\nUse this as a schema exploration step: after identifying tracked\nevent names, query with event_name to discover its properties\nfor use in filters and breakdowns.",
       "parameters": [
         {
@@ -2367,12 +3641,53 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.ListProperties",
+        "parameters": {
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "event_name": {
+            "value": "user_signed_up",
+            "type": "string",
+            "required": false
+          },
+          "property_type": {
+            "value": "event",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -2394,7 +3709,7 @@
     {
       "name": "ListSurveys",
       "qualifiedName": "Posthog.ListSurveys",
-      "fullyQualifiedName": "Posthog.ListSurveys@1.0.0",
+      "fullyQualifiedName": "Posthog.ListSurveys@1.0.1",
       "description": "List all surveys.\n\nReturns summaries (id, name, type, created_at). Use a survey's\nID or name to get its full configuration.",
       "parameters": [
         {
@@ -2435,12 +3750,48 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.ListSurveys",
+        "parameters": {
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "search": {
+            "value": "onboarding",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -2462,7 +3813,7 @@
     {
       "name": "RunQuery",
       "qualifiedName": "Posthog.RunQuery",
-      "fullyQualifiedName": "Posthog.RunQuery@1.0.0",
+      "fullyQualifiedName": "Posthog.RunQuery@1.0.1",
       "description": "Execute a raw PostHog query.\n\nFor common analytics patterns (trends, funnels, retention),\nprefer purpose-built tools if available. Use this for custom\nquery shapes. Discover valid event names before constructing\na query.\n\nFor the full query schema and supported kinds, see\nhttps://posthog.com/docs/api/queries",
       "parameters": [
         {
@@ -2487,12 +3838,45 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.RunQuery",
+        "parameters": {
+          "query": {
+            "value": {
+              "kind": "HogQLQuery",
+              "query": "SELECT event, count() AS total FROM events WHERE timestamp >= '2024-01-01' AND timestamp <= '2024-03-31' GROUP BY event ORDER BY total DESC LIMIT 20",
+              "dateRange": {
+                "date_from": "2024-01-01",
+                "date_to": "2024-03-31"
+              }
+            },
+            "type": "string",
+            "required": true
+          },
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -2514,7 +3898,7 @@
     {
       "name": "UpdateDashboard",
       "qualifiedName": "Posthog.UpdateDashboard",
-      "fullyQualifiedName": "Posthog.UpdateDashboard@1.0.0",
+      "fullyQualifiedName": "Posthog.UpdateDashboard@1.0.1",
       "description": "Update a dashboard's name, description, pinned status, or tags.\n\nReview the dashboard's current values before updating.",
       "parameters": [
         {
@@ -2572,12 +3956,62 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.UpdateDashboard",
+        "parameters": {
+          "dashboard_id": {
+            "value": 42,
+            "type": "integer",
+            "required": true
+          },
+          "project_id": {
+            "value": "proj_abc123XYZ",
+            "type": "string",
+            "required": true
+          },
+          "name": {
+            "value": "Q3 2024 Marketing Overview",
+            "type": "string",
+            "required": false
+          },
+          "description": {
+            "value": "Tracks key marketing KPIs and funnel metrics for Q3 2024.",
+            "type": "string",
+            "required": false
+          },
+          "pinned": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "tags": {
+            "value": [
+              "marketing",
+              "q3-2024",
+              "kpis"
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -2599,7 +4033,7 @@
     {
       "name": "UpdateExperiment",
       "qualifiedName": "Posthog.UpdateExperiment",
-      "fullyQualifiedName": "Posthog.UpdateExperiment@1.0.0",
+      "fullyQualifiedName": "Posthog.UpdateExperiment@1.0.1",
       "description": "Update an experiment's properties or lifecycle state.\n\nReview the experiment's current state before updating.\nTo launch: set launch=true. To conclude: set\nconclude='winning_variant_name'. To restart: set restart=true.",
       "parameters": [
         {
@@ -2682,12 +4116,85 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "unknown"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.UpdateExperiment",
+        "parameters": {
+          "experiment_id": {
+            "value": 42731,
+            "type": "integer",
+            "required": true
+          },
+          "project_id": {
+            "value": "proj_AbCdEf123456",
+            "type": "string",
+            "required": true
+          },
+          "name": {
+            "value": "Homepage CTA Button Color Test",
+            "type": "string",
+            "required": false
+          },
+          "description": {
+            "value": "Testing the impact of button color on conversion rates for the primary call-to-action on the homepage.",
+            "type": "string",
+            "required": false
+          },
+          "primary_metrics": {
+            "value": [
+              {
+                "kind": "ExperimentMetric",
+                "metric_type": "mean",
+                "event_name": "purchase_completed"
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
+          "secondary_metrics": {
+            "value": [
+              {
+                "kind": "ExperimentMetric",
+                "metric_type": "funnel",
+                "event_name": "add_to_cart"
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
+          "launch": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "conclude": {
+            "value": "variant_blue_button",
+            "type": "string",
+            "required": false
+          },
+          "restart": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -2709,7 +4216,7 @@
     {
       "name": "UpdateFeatureFlag",
       "qualifiedName": "Posthog.UpdateFeatureFlag",
-      "fullyQualifiedName": "Posthog.UpdateFeatureFlag@1.0.0",
+      "fullyQualifiedName": "Posthog.UpdateFeatureFlag@1.0.1",
       "description": "Update a feature flag's properties or rollout rules.\n\nProvide one of flag_id or flag_key. Review the flag's current\nstate before updating. To enable: set active=true and\nrollout_percentage=100. To disable: set active=false.",
       "parameters": [
         {
@@ -2774,12 +4281,63 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.UpdateFeatureFlag",
+        "parameters": {
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "flag_id": {
+            "value": 987,
+            "type": "integer",
+            "required": false
+          },
+          "flag_key": {
+            "value": "new-checkout-flow",
+            "type": "string",
+            "required": false
+          },
+          "name": {
+            "value": "New Checkout Flow",
+            "type": "string",
+            "required": false
+          },
+          "description": {
+            "value": "Enables the redesigned checkout experience for targeted users.",
+            "type": "string",
+            "required": false
+          },
+          "active": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "filters": {
+            "value": "{\"groups\":[{\"properties\":[{\"key\":\"email\",\"value\":\"@example.com\",\"operator\":\"icontains\",\"type\":\"person\"}],\"rollout_percentage\":50}],\"multivariate\":null}",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -2801,7 +4359,7 @@
     {
       "name": "UpdateInsight",
       "qualifiedName": "Posthog.UpdateInsight",
-      "fullyQualifiedName": "Posthog.UpdateInsight@1.0.0",
+      "fullyQualifiedName": "Posthog.UpdateInsight@1.0.1",
       "description": "Update an insight's name, description, or query filters.\n\nReview the insight's current query structure first and only\nmodify the parts you need to change.",
       "parameters": [
         {
@@ -2850,12 +4408,65 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "api_key"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.UpdateInsight",
+        "parameters": {
+          "insight_id": {
+            "value": 4821,
+            "type": "integer",
+            "required": true
+          },
+          "project_id": {
+            "value": "phc_ABC123xyz789",
+            "type": "string",
+            "required": true
+          },
+          "name": {
+            "value": "Weekly Active Users Trend",
+            "type": "string",
+            "required": false
+          },
+          "description": {
+            "value": "Tracks the number of unique active users on a weekly basis for Q1 2024",
+            "type": "string",
+            "required": false
+          },
+          "filters": {
+            "value": {
+              "events": [
+                {
+                  "id": "$pageview",
+                  "type": "events",
+                  "order": 0
+                }
+              ],
+              "date_from": "-30d",
+              "interval": "week",
+              "display": "ActionsLineGraph",
+              "insight": "TRENDS"
+            },
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -2877,7 +4488,7 @@
     {
       "name": "UpdateSurvey",
       "qualifiedName": "Posthog.UpdateSurvey",
-      "fullyQualifiedName": "Posthog.UpdateSurvey@1.0.0",
+      "fullyQualifiedName": "Posthog.UpdateSurvey@1.0.1",
       "description": "Update a survey's name, description, or questions.\n\nReview the survey's current configuration before updating.",
       "parameters": [
         {
@@ -2927,12 +4538,77 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "unknown"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.UpdateSurvey",
+        "parameters": {
+          "survey_id": {
+            "value": "a3f7c2d1-84b6-4e29-93f1-7d5a0b2c6e38",
+            "type": "string",
+            "required": true
+          },
+          "project_id": {
+            "value": "12345",
+            "type": "string",
+            "required": true
+          },
+          "name": {
+            "value": "Customer Satisfaction Survey Q1 2024",
+            "type": "string",
+            "required": false
+          },
+          "description": {
+            "value": "A survey to measure customer satisfaction and gather feedback on our product experience.",
+            "type": "string",
+            "required": false
+          },
+          "questions": {
+            "value": [
+              {
+                "type": "rating",
+                "question": "How satisfied are you with our product overall?",
+                "scale": 10,
+                "display": "number",
+                "lowerBoundLabel": "Not satisfied",
+                "upperBoundLabel": "Extremely satisfied"
+              },
+              {
+                "type": "open",
+                "question": "What could we do to improve your experience?"
+              },
+              {
+                "type": "single_choice",
+                "question": "How did you hear about us?",
+                "choices": [
+                  "Social Media",
+                  "Word of Mouth",
+                  "Search Engine",
+                  "Advertisement",
+                  "Other"
+                ]
+              }
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -2954,7 +4630,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Posthog.WhoAmI",
-      "fullyQualifiedName": "Posthog.WhoAmI@1.0.0",
+      "fullyQualifiedName": "Posthog.WhoAmI@1.0.1",
       "description": "Return the authenticated user's identity, organizations, and projects.\n\nCall this first to confirm credentials and discover available\norganization and project IDs.",
       "parameters": [],
       "auth": null,
@@ -2962,12 +4638,27 @@
         "POSTHOG_SERVER_URL",
         "POSTHOG_PERSONAL_API_KEY"
       ],
-      "secretsInfo": [],
+      "secretsInfo": [
+        {
+          "name": "POSTHOG_SERVER_URL",
+          "type": "unknown"
+        },
+        {
+          "name": "POSTHOG_PERSONAL_API_KEY",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Posthog.WhoAmI",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -2990,6 +4681,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-04-10T11:26:08.921Z",
+  "generatedAt": "2026-04-29T11:39:26.339Z",
   "summary": "PostHog is a product analytics and experimentation platform. The Arcade PostHog toolkit lets agents query analytics, manage experiments, and curate insights directly from a PostHog project.\n\n**Capabilities**\n\n- Build and manage dashboards, insights, funnels, trends, and retention views.\n- Create and iterate on experiments, feature flags, and surveys with full CRUD support.\n- Inspect event and property definitions, investigate errors, and compare time periods.\n- Run ad-hoc HogQL or insight queries and retrieve results for downstream analysis.\n\n**OAuth**\n\nNo OAuth — authentication uses a PostHog personal API key passed as a secret.\n\n**Secrets**\n\n- `POSTHOG_PERSONAL_API_KEY` — PostHog personal API key created under Account Settings → Personal API Keys.\n- `POSTHOG_SERVER_URL` — target PostHog region or self-hosted instance URL (e.g. `https://us.posthog.com`).\n\nConfigure both in the [Arcade Dashboard](https://api.arcade.dev/dashboard/auth/secrets) per the [Arcade secret setup guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets)."
 }


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/25106518532

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly regenerated documentation metadata, but it changes surfaced OAuth scopes (Gmail) and adds new Linear tools, which may affect auth prompts and downstream consumers of these JSON schemas.
> 
> **Overview**
> Updates generated toolkit docs/metadata JSON across several integrations.
> 
> **Gmail** is bumped to `5.2.0`, adds `codeExample` blocks for `ReplyToEmail`, `UpdateDraftEmail`, and `WriteDraftReplyEmail`, expands `WriteDraftReplyEmail` OAuth scopes to include `gmail.readonly`, and refreshes the generated toolkit summary text.
> 
> **Linear** is bumped to `3.4.0`, adds milestone support via new tools `GetMilestone`, `ListMilestones`, and `UpsertMilestone`, and includes a new `codeExample` for `CreateIssue`; the toolkit index is updated accordingly (version/toolCount).
> 
> **PostHog** is bumped to `1.0.1`, populates `secretsInfo` for required secrets, and adds `codeExample` blocks across many tools to improve call documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a400e5c425e54be803bb1898f4aa628519b34814. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->