### PR TITLE
Add tool feedback button to integrations CTA section

### DIFF
--- a/app/en/resources/integrations/components/toolkits-client.tsx
+++ b/app/en/resources/integrations/components/toolkits-client.tsx
@@ -120,11 +120,11 @@ export default function ToolkitsClient({ toolkits }: ToolkitsClientProps) {
                     Don't see what you need? Use Arcade's SDK to integrate with
                     any service or API.
                   </p>
-                  <div className="mt-3 mb-1 flex flex-nowrap gap-2">
+                  <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:gap-3">
                     <Link
                       className={cn(
-                        buttonVariants({ variant: "default", size: "sm" }),
-                        "bg-blue-600 hover:bg-blue-700 active:bg-blue-700 dark:bg-blue-500 dark:active:bg-blue-600 dark:hover:bg-blue-600"
+                        buttonVariants({ variant: "default", size: "default" }),
+                        "bg-blue-600 hover:bg-blue-700 active:bg-blue-700 dark:bg-blue-500 dark:active:bg-blue-600 dark:hover:bg-blue-600 flex-1"
                       )}
                       href="/guides/create-tools/tool-basics/build-mcp-server"
                     >
@@ -132,7 +132,8 @@ export default function ToolkitsClient({ toolkits }: ToolkitsClientProps) {
                     </Link>
                     <Link
                       className={cn(
-                        buttonVariants({ variant: "outline", size: "sm" })
+                        buttonVariants({ variant: "outline", size: "default" }),
+                        "flex-1"
                       )}
                       href="/resources/integrations/tool-feedback"
                     >

--- a/app/en/resources/integrations/components/toolkits-client.tsx
+++ b/app/en/resources/integrations/components/toolkits-client.tsx
@@ -7,7 +7,7 @@ import {
 } from "@arcadeai/design-system";
 import { Generic as GenericIcon } from "@arcadeai/design-system/components/ui/atoms/icons";
 import { cn } from "@arcadeai/design-system/lib/utils";
-import { Plus, Search } from "lucide-react";
+import { Code2, MessageSquarePlus, Search } from "lucide-react";
 import Link from "next/link";
 import { ComingSoonProvider } from "@/app/_components/coming-soon-context";
 import {
@@ -106,40 +106,51 @@ export default function ToolkitsClient({ toolkits }: ToolkitsClientProps) {
               )}
             </div>
 
-            {/* Custom Integration Call-to-Action */}
+            {/* Don't see what you need? Two paths to fix that. */}
             <div className="mt-4 rounded-lg border border-blue-500/50 border-dashed bg-blue-500/10 p-4 sm:mt-6 sm:p-5 dark:border-blue-400/50 dark:bg-blue-500/20">
-              <div className="flex flex-col items-center gap-3 sm:gap-4 md:flex-row md:gap-6">
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-blue-500/20 dark:bg-blue-400/20">
-                  <Plus className="h-4 w-4 text-blue-600 dark:text-blue-400" />
-                </div>
-                <div className="text-center md:text-left">
-                  <h2 className="font-bold text-base text-gray-900 dark:text-gray-50">
-                    Build your own MCP Server
-                  </h2>
-                  <p className="!mt-1.5 text-gray-700 text-sm dark:text-gray-300">
-                    Don't see what you need? Use Arcade's SDK to integrate with
-                    any service or API.
-                  </p>
-                  <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:gap-3">
-                    <Link
-                      className={cn(
-                        buttonVariants({ variant: "default", size: "default" }),
-                        "bg-blue-600 hover:bg-blue-700 active:bg-blue-700 dark:bg-blue-500 dark:active:bg-blue-600 dark:hover:bg-blue-600 flex-1"
-                      )}
-                      href="/guides/create-tools/tool-basics/build-mcp-server"
-                    >
-                      Learn how to build a MCP Server
-                    </Link>
-                    <Link
-                      className={cn(
-                        buttonVariants({ variant: "outline", size: "default" }),
-                        "flex-1"
-                      )}
-                      href="/resources/integrations/tool-feedback"
-                    >
-                      Submit tool feedback
-                    </Link>
+              <h2 className="text-center font-bold text-base text-gray-900 sm:text-left dark:text-gray-50">
+                Don't see what you need?
+              </h2>
+              <div className="mt-3 grid grid-cols-1 gap-3 sm:mt-4 sm:grid-cols-2 sm:gap-4">
+                <div className="flex flex-col rounded-md border border-blue-500/30 bg-white/70 p-4 dark:border-blue-400/30 dark:bg-gray-900/40">
+                  <div className="flex items-center gap-2">
+                    <Code2 className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                    <h3 className="font-semibold text-gray-900 text-sm dark:text-gray-50">
+                      Build it yourself
+                    </h3>
                   </div>
+                  <p className="!mt-2 flex-1 text-gray-700 text-xs leading-relaxed dark:text-gray-300">
+                    Use Arcade's SDK to integrate with any service or API.
+                  </p>
+                  <Link
+                    className={cn(
+                      buttonVariants({ variant: "default", size: "sm" }),
+                      "mt-3 bg-blue-600 hover:bg-blue-700 active:bg-blue-700 dark:bg-blue-500 dark:active:bg-blue-600 dark:hover:bg-blue-600"
+                    )}
+                    href="/guides/create-tools/tool-basics/build-mcp-server"
+                  >
+                    Learn how to build a MCP Server
+                  </Link>
+                </div>
+                <div className="flex flex-col rounded-md border border-blue-500/30 bg-white/70 p-4 dark:border-blue-400/30 dark:bg-gray-900/40">
+                  <div className="flex items-center gap-2">
+                    <MessageSquarePlus className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                    <h3 className="font-semibold text-gray-900 text-sm dark:text-gray-50">
+                      Tell us what's missing
+                    </h3>
+                  </div>
+                  <p className="!mt-2 flex-1 text-gray-700 text-xs leading-relaxed dark:text-gray-300">
+                    Request a missing tool, suggest a feature, or report a bug.
+                  </p>
+                  <Link
+                    className={cn(
+                      buttonVariants({ variant: "outline", size: "sm" }),
+                      "mt-3"
+                    )}
+                    href="/resources/integrations/tool-feedback"
+                  >
+                    Submit tool feedback
+                  </Link>
                 </div>
               </div>
             </div>

--- a/app/en/resources/integrations/components/toolkits-client.tsx
+++ b/app/en/resources/integrations/components/toolkits-client.tsx
@@ -120,7 +120,7 @@ export default function ToolkitsClient({ toolkits }: ToolkitsClientProps) {
                     Don't see what you need? Use Arcade's SDK to integrate with
                     any service or API.
                   </p>
-                  <div className="mt-3 mb-1">
+                  <div className="mt-3 mb-1 flex flex-wrap justify-center gap-2 md:justify-start">
                     <Link
                       className={cn(
                         buttonVariants({ variant: "default", size: "sm" }),
@@ -129,6 +129,14 @@ export default function ToolkitsClient({ toolkits }: ToolkitsClientProps) {
                       href="/guides/create-tools/tool-basics/build-mcp-server"
                     >
                       Learn how to build a MCP Server
+                    </Link>
+                    <Link
+                      className={cn(
+                        buttonVariants({ variant: "outline", size: "sm" })
+                      )}
+                      href="/resources/integrations/tool-feedback"
+                    >
+                      Submit tool feedback
                     </Link>
                   </div>
                 </div>

--- a/app/en/resources/integrations/components/toolkits-client.tsx
+++ b/app/en/resources/integrations/components/toolkits-client.tsx
@@ -117,10 +117,16 @@ export default function ToolkitsClient({ toolkits }: ToolkitsClientProps) {
                     Build your own MCP Server
                   </h2>
                   <p className="!mt-1.5 text-gray-700 text-sm dark:text-gray-300">
-                    Don't see what you need? Use Arcade's SDK to integrate with
-                    any service or API.
+                    Don't see what you need?{" "}
+                    <Link
+                      href="/resources/integrations/tool-feedback"
+                      className="font-semibold text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      Submit tool feedback
+                    </Link>
+                    {" "}or use Arcade's SDK to integrate with any service or API.
                   </p>
-                  <div className="mt-3 mb-1 flex flex-wrap justify-center gap-2 md:justify-start">
+                  <div className="mt-3 mb-1">
                     <Link
                       className={cn(
                         buttonVariants({ variant: "default", size: "sm" }),
@@ -129,14 +135,6 @@ export default function ToolkitsClient({ toolkits }: ToolkitsClientProps) {
                       href="/guides/create-tools/tool-basics/build-mcp-server"
                     >
                       Learn how to build a MCP Server
-                    </Link>
-                    <Link
-                      className={cn(
-                        buttonVariants({ variant: "outline", size: "sm" })
-                      )}
-                      href="/resources/integrations/tool-feedback"
-                    >
-                      Submit tool feedback
                     </Link>
                   </div>
                 </div>

--- a/app/en/resources/integrations/components/toolkits-client.tsx
+++ b/app/en/resources/integrations/components/toolkits-client.tsx
@@ -117,16 +117,10 @@ export default function ToolkitsClient({ toolkits }: ToolkitsClientProps) {
                     Build your own MCP Server
                   </h2>
                   <p className="!mt-1.5 text-gray-700 text-sm dark:text-gray-300">
-                    Don't see what you need?{" "}
-                    <Link
-                      href="/resources/integrations/tool-feedback"
-                      className="font-semibold text-blue-600 hover:underline dark:text-blue-400"
-                    >
-                      Submit tool feedback
-                    </Link>
-                    {" "}or use Arcade's SDK to integrate with any service or API.
+                    Don't see what you need? Use Arcade's SDK to integrate with
+                    any service or API.
                   </p>
-                  <div className="mt-3 mb-1">
+                  <div className="mt-3 mb-1 flex flex-nowrap gap-2">
                     <Link
                       className={cn(
                         buttonVariants({ variant: "default", size: "sm" }),
@@ -135,6 +129,14 @@ export default function ToolkitsClient({ toolkits }: ToolkitsClientProps) {
                       href="/guides/create-tools/tool-basics/build-mcp-server"
                     >
                       Learn how to build a MCP Server
+                    </Link>
+                    <Link
+                      className={cn(
+                        buttonVariants({ variant: "outline", size: "sm" })
+                      )}
+                      href="/resources/integrations/tool-feedback"
+                    >
+                      Submit tool feedback
                     </Link>
                   </div>
                 </div>


### PR DESCRIPTION
https://docs-git-ericgustin-affectionate-feynman-73635d-arcade-ai.vercel.app/en/resources/integrations

# Before:
<img width="777" height="156" alt="Screenshot 2026-04-29 at 2 21 28 PM" src="https://github.com/user-attachments/assets/bbc340fa-1229-4585-9179-c2c2eb33f72b" />


# After:
<img width="782" height="245" alt="Screenshot 2026-04-29 at 2 21 21 PM" src="https://github.com/user-attachments/assets/2f73e1e3-32b9-4248-a8e7-cb97b4d5e07f" />


Resolves https://linear.app/arcadedev/issue/TOO-793/add-tool-feedback-survey-to-integrations-page-in-docs