### PR TITLE
Fix proxy matcher regex breaking python-named paths

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -83,6 +83,6 @@ export function proxy(request: NextRequest) {
 
 export const config = {
   matcher: [
-    "/((?!api|_next/static|_next/image|favicon.ico|manifest|public|.*.svg|.*.png|.*.jpg|.*.jpeg|.*.gif|.*.webp|.*.ico|.*.webmanifest|.*.css|.*.js|.*.woff|.*.woff2|.*.ttf|.*.eot|.*.otf|.*.pdf|.*.txt|.*.xml|.*.json|.*.py|.*.mp4).*)",
+    "/((?!api|_next/static|_next/image|favicon\\.ico|manifest|public|.*\\.svg$|.*\\.png$|.*\\.jpg$|.*\\.jpeg$|.*\\.gif$|.*\\.webp$|.*\\.ico$|.*\\.webmanifest$|.*\\.css$|.*\\.js$|.*\\.woff$|.*\\.woff2$|.*\\.ttf$|.*\\.eot$|.*\\.otf$|.*\\.pdf$|.*\\.txt$|.*\\.xml$|.*\\.json$|.*\\.py$|.*\\.mp4$).*)",
   ],
 };


### PR DESCRIPTION
TL;DR from a human: https://arcade-ai.slack.com/archives/C07PDCYFUCE/p1777578118603199 all links with `py` in them (or any of the other strings!) were not redirecting because of this regex error


## Summary

The locale-redirect proxy at `proxy.ts` uses a Next.js matcher to skip static files (`.svg`, `.png`, `.py`, etc.). The exclusion patterns were written as unanchored, unescaped regexes like `.*.py` — where `.` means "any character" — so they matched a prefix of any path containing `<char>py`, not just paths ending in `.py`.

That caused locale-less URLs with "python" or "-py" in the path to be excluded from the proxy and never get the `/en/` redirect, returning 404. Reported example: `/get-started/agent-frameworks/openai-agents/setup-python` (linked from the OpenAI Agents overview page).

The fix: escape the literal dot and anchor each extension to end-of-path with `$`.

### Verification (live, before fix)

Of 100 unique locale-less internal links found in MDX source, 96 redirected 307 → `/en/...` correctly. The 4 that 404'd were exactly the python-named paths:

- `/get-started/agent-frameworks/openai-agents/setup-python`
- `/get-started/agent-frameworks/langchain/use-arcade-with-langchain-py`
- `/references/mcp/python`
- `/references/mcp/python/resources`

### Verification (local, after fix)

All 4 now 307 redirect to their `/en/` equivalents. `favicon.ico` still serves directly; non-existent `.png`/`.js` paths fall through to Next.js's 404 (not redirected).

## Test plan

- [ ] Visit the previously-broken URLs in production after merge and confirm 307 → `/en/...`
- [ ] Confirm static assets (favicon, images, JS bundles) still serve normally
- [ ] Spot-check a few `/en/`-prefixed URLs to make sure they still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the Next.js `matcher` regex used by the locale-redirect proxy, which affects which requests pass through redirect logic; a mistake could inadvertently redirect or bypass static assets site-wide.
> 
> **Overview**
> Fixes the locale-redirect middleware `config.matcher` to stop mistakenly excluding routes that merely contain substrings like `py` (e.g., “python”) from being redirected.
> 
> The static-file exclusion regex now escapes literal dots (e.g., `\.py`) and anchors extensions to end-of-path with `$`, keeping asset paths excluded while allowing content routes with similar substrings to continue through the proxy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9336ec6c5fe67315fb186598bb479733c96194a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->