### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-30T11:39:15.774Z",
+  "generatedAt": "2026-05-06T11:42:34.447Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -599,7 +599,7 @@
     {
       "id": "MicrosoftSharepoint",
       "label": "Microsoft SharePoint",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 36,

--- a/toolkit-docs-generator/data/toolkits/microsoftsharepoint.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftsharepoint.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftSharepoint",
   "label": "Microsoft SharePoint",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Arcade.dev LLM tools for Microsoft SharePoint",
   "metadata": {
     "category": "productivity",
@@ -17,6 +17,7 @@
     "type": "oauth2",
     "providerId": "microsoft",
     "allScopes": [
+      "Files.ReadWrite",
       "Sites.Read.All",
       "Sites.ReadWrite.All",
       "User.Read"
@@ -26,7 +27,7 @@
     {
       "name": "AddWorksheet",
       "qualifiedName": "MicrosoftSharepoint.AddWorksheet",
-      "fullyQualifiedName": "MicrosoftSharepoint.AddWorksheet@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.AddWorksheet@0.1.2",
       "description": "Add a new worksheet to a SharePoint Excel workbook.\n\nNote: The new worksheet name may not be immediately visible to other\ntools due to a brief Graph API propagation delay (up to ~10 s). Pass\nthe returned ``session_id`` to subsequent calls that reference the new\nworksheet to mitigate this.",
       "parameters": [
         {
@@ -66,7 +67,8 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "Sites.ReadWrite.All"
+          "Sites.ReadWrite.All",
+          "Files.ReadWrite"
         ]
       },
       "secrets": [],
@@ -80,22 +82,22 @@
         "toolName": "MicrosoftSharepoint.AddWorksheet",
         "parameters": {
           "drive_id": {
-            "value": "b!a1b2c3d4-e5f6-7890-ab12-cd34ef56gh78",
+            "value": "b!3xK9mNpQrT2vLwZdYfGhJk8sUiOeAcBnDlEvHtMqRpWx1yCz4",
             "type": "string",
             "required": true
           },
           "item_id": {
-            "value": "01ABCD2345EF67890!123",
+            "value": "01ABCDE23FGHIJ4KLMNOP5QRSTUVWXYZ67890",
             "type": "string",
             "required": true
           },
           "name": {
-            "value": "Q2 2026 Financials",
+            "value": "Q3 Sales Report",
             "type": "string",
             "required": false
           },
           "session_id": {
-            "value": "9f8e7d6c-5b4a-3210-ffe0-1234567890ab",
+            "value": "cluster=EU1&session=7a2f91bc-3d4e-4a8f-b6c1-e2d3f4a5b6c7",
             "type": "string",
             "required": false
           }
@@ -126,7 +128,7 @@
     {
       "name": "CopyItem",
       "qualifiedName": "MicrosoftSharepoint.CopyItem",
-      "fullyQualifiedName": "MicrosoftSharepoint.CopyItem@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.CopyItem@0.1.2",
       "description": "Copy a file or folder. Returns a completed item or an operation id.",
       "parameters": [
         {
@@ -226,7 +228,7 @@
     {
       "name": "CreateFolder",
       "qualifiedName": "MicrosoftSharepoint.CreateFolder",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateFolder@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateFolder@0.1.2",
       "description": "Create a new folder in a SharePoint drive.",
       "parameters": [
         {
@@ -313,7 +315,7 @@
     {
       "name": "CreatePresentation",
       "qualifiedName": "MicrosoftSharepoint.CreatePresentation",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreatePresentation@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreatePresentation@0.1.2",
       "description": "Create a new PowerPoint presentation in a SharePoint drive.\n\nThe presentation will be created with a title slide containing the specified title.",
       "parameters": [
         {
@@ -400,7 +402,7 @@
     {
       "name": "CreateShareLink",
       "qualifiedName": "MicrosoftSharepoint.CreateShareLink",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateShareLink@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateShareLink@0.1.2",
       "description": "Create a share link for a SharePoint drive item.",
       "parameters": [
         {
@@ -474,7 +476,7 @@
     {
       "name": "CreateSlide",
       "qualifiedName": "MicrosoftSharepoint.CreateSlide",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateSlide@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateSlide@0.1.2",
       "description": "Append a new slide to the end of an existing PowerPoint presentation in a SharePoint drive.\n\nThe slide will be added at the end of the presentation. Both title and body\nare optional to support layouts like BLANK or TITLE_ONLY.\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -597,7 +599,7 @@
     {
       "name": "CreateTwoContentSlide",
       "qualifiedName": "MicrosoftSharepoint.CreateTwoContentSlide",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateTwoContentSlide@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateTwoContentSlide@0.1.2",
       "description": "Append a TWO_CONTENT slide with side-by-side content areas to a SharePoint PowerPoint.\n\nThis layout is useful for comparisons, pros/cons lists, or any content that\nbenefits from a two-column layout.\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -710,7 +712,7 @@
     {
       "name": "CreateWordDocument",
       "qualifiedName": "MicrosoftSharepoint.CreateWordDocument",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateWordDocument@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateWordDocument@0.1.2",
       "description": "Create a new Word document in a SharePoint drive.\n\n4MB upload limit. Optionally include text content.",
       "parameters": [
         {
@@ -823,7 +825,7 @@
     {
       "name": "CreateWorkbook",
       "qualifiedName": "MicrosoftSharepoint.CreateWorkbook",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateWorkbook@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateWorkbook@0.1.2",
       "description": "Create a new Excel workbook (.xlsx) in a SharePoint drive.\n\nOnly .xlsx files are supported.",
       "parameters": [
         {
@@ -863,7 +865,8 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "Sites.ReadWrite.All"
+          "Sites.ReadWrite.All",
+          "Files.ReadWrite"
         ]
       },
       "secrets": [],
@@ -877,22 +880,22 @@
         "toolName": "MicrosoftSharepoint.CreateWorkbook",
         "parameters": {
           "drive_id": {
-            "value": "b!qZx7Yv9u1Lk2P3m",
+            "value": "b!3kT9mN2pQEy7vXsLdR4hFg",
             "type": "string",
             "required": true
           },
           "filename": {
-            "value": "Employees",
+            "value": "Q3_Sales_Report",
             "type": "string",
             "required": true
           },
           "parent_folder_id": {
-            "value": "01A2B3C4D5E6F7G8H9I",
+            "value": "01ABCDE23F4GHIJKLMNOPQR",
             "type": "string",
             "required": false
           },
           "initial_data": {
-            "value": "{\"1\":{\"A\":\"Name\",\"B\":\"Age\",\"C\":\"Active\"},\"2\":{\"A\":\"Alice\",\"B\":30,\"C\":true},\"3\":{\"A\":\"Bob\",\"B\":25,\"C\":false},\"4\":{\"A\":\"Eve\",\"B\":null,\"C\":false}}",
+            "value": "{\"1\": {\"A\": \"Product\", \"B\": \"Units Sold\", \"C\": \"Revenue\"}, \"2\": {\"A\": \"Widget A\", \"B\": 150, \"C\": 4500.00}, \"3\": {\"A\": \"Widget B\", \"B\": 85, \"C\": 2975.50}, \"4\": {\"A\": \"Widget C\", \"B\": 200, \"C\": 6000.00}}",
             "type": "string",
             "required": false
           }
@@ -923,7 +926,7 @@
     {
       "name": "DeleteItem",
       "qualifiedName": "MicrosoftSharepoint.DeleteItem",
-      "fullyQualifiedName": "MicrosoftSharepoint.DeleteItem@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.DeleteItem@0.1.2",
       "description": "Delete a file or folder from a SharePoint drive.",
       "parameters": [
         {
@@ -997,7 +1000,7 @@
     {
       "name": "DeleteWorksheet",
       "qualifiedName": "MicrosoftSharepoint.DeleteWorksheet",
-      "fullyQualifiedName": "MicrosoftSharepoint.DeleteWorksheet@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.DeleteWorksheet@0.1.2",
       "description": "Delete a worksheet from a SharePoint Excel workbook.\n\nCannot delete the last worksheet in a workbook.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -1037,7 +1040,8 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "Sites.ReadWrite.All"
+          "Sites.ReadWrite.All",
+          "Files.ReadWrite"
         ]
       },
       "secrets": [],
@@ -1051,22 +1055,22 @@
         "toolName": "MicrosoftSharepoint.DeleteWorksheet",
         "parameters": {
           "drive_id": {
-            "value": "b!a1B2c3D4e5F6g7H8i9J0kLmNoPqRsTuV",
+            "value": "b!aB3cD4eF5gH6iJ7kL8mN9oP0qR1sT2uV3wX4yZ5",
             "type": "string",
             "required": true
           },
           "item_id": {
-            "value": "01ab23cd-45ef-67gh-89ij-0123klmnopqr",
+            "value": "01ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
             "type": "string",
             "required": true
           },
           "worksheet": {
-            "value": "Expenses Q1 2026",
+            "value": "Q3_Summary",
             "type": "string",
             "required": true
           },
           "session_id": {
-            "value": "b6f7e8d9-0123-4567-89ab-cdef01234567",
+            "value": "cluster=EU1&session=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc123",
             "type": "string",
             "required": false
           }
@@ -1097,7 +1101,7 @@
     {
       "name": "GetAllSlideNotes",
       "qualifiedName": "MicrosoftSharepoint.GetAllSlideNotes",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetAllSlideNotes@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetAllSlideNotes@0.1.2",
       "description": "Get all speaker notes from every slide in a SharePoint PowerPoint presentation.\n\nReturns notes for all slides in one call, which is more efficient than\ncalling get_slide_notes for each slide individually. Notes are returned\nin markdown format.",
       "parameters": [
         {
@@ -1171,7 +1175,7 @@
     {
       "name": "GetCopyStatus",
       "qualifiedName": "MicrosoftSharepoint.GetCopyStatus",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetCopyStatus@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetCopyStatus@0.1.2",
       "description": "Check status of an async copy operation using the token returned by copy_item.",
       "parameters": [
         {
@@ -1245,7 +1249,7 @@
     {
       "name": "GetDrivesFromSite",
       "qualifiedName": "MicrosoftSharepoint.GetDrivesFromSite",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetDrivesFromSite@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetDrivesFromSite@0.1.2",
       "description": "Retrieve drives / document libraries from a SharePoint site.\n\nIf you have a site name, it is not necessary to call Sharepoint.SearchSites first.\nYou can simply call this tool with the site name / keywords.",
       "parameters": [
         {
@@ -1306,7 +1310,7 @@
     {
       "name": "GetItemsFromList",
       "qualifiedName": "MicrosoftSharepoint.GetItemsFromList",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetItemsFromList@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetItemsFromList@0.1.2",
       "description": "Retrieve items from a list in a SharePoint site.\n\nNote: The Microsoft Graph API does not offer endpoints to retrieve list item attachments.\nBecause of that, the only information we can get is whether the item has attachments or not.",
       "parameters": [
         {
@@ -1380,7 +1384,7 @@
     {
       "name": "GetListsFromSite",
       "qualifiedName": "MicrosoftSharepoint.GetListsFromSite",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetListsFromSite@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetListsFromSite@0.1.2",
       "description": "Retrieve lists from a SharePoint site.",
       "parameters": [
         {
@@ -1441,7 +1445,7 @@
     {
       "name": "GetPage",
       "qualifiedName": "MicrosoftSharepoint.GetPage",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetPage@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetPage@0.1.2",
       "description": "Retrieve metadata and the contents of a page in a SharePoint site.\n\nPage content is a list of Microsoft Sharepoint web part objects, such as text, images, banners,\nbuttons, etc.\n\nIf `include_page_content` is set to False, the tool will return only the page metadata.",
       "parameters": [
         {
@@ -1528,7 +1532,7 @@
     {
       "name": "GetPresentationAsMarkdown",
       "qualifiedName": "MicrosoftSharepoint.GetPresentationAsMarkdown",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetPresentationAsMarkdown@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetPresentationAsMarkdown@0.1.2",
       "description": "Get the content of a PowerPoint presentation stored in a SharePoint drive as markdown.\n\nThis tool downloads the presentation and converts it to a markdown representation,\npreserving text content, tables, and chart data. Images and other media are\nrepresented as placeholders.",
       "parameters": [
         {
@@ -1602,7 +1606,7 @@
     {
       "name": "GetSite",
       "qualifiedName": "MicrosoftSharepoint.GetSite",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetSite@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetSite@0.1.2",
       "description": "Retrieve information about a specific SharePoint site by its ID, URL, or name.",
       "parameters": [
         {
@@ -1663,7 +1667,7 @@
     {
       "name": "GetSlideNotes",
       "qualifiedName": "MicrosoftSharepoint.GetSlideNotes",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetSlideNotes@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetSlideNotes@0.1.2",
       "description": "Get the speaker notes from a specific slide in a SharePoint PowerPoint presentation.\n\nSpeaker notes are returned in markdown format, preserving basic formatting\nlike bold, italic, and bullet points.",
       "parameters": [
         {
@@ -1750,7 +1754,7 @@
     {
       "name": "GetWordDocument",
       "qualifiedName": "MicrosoftSharepoint.GetWordDocument",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetWordDocument@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetWordDocument@0.1.2",
       "description": "Get a Word document's metadata and content from a SharePoint drive. Supports only `.docx`.\n\nReturns the document content as Markdown by default.\nReturns only metadata when metadata_only is True.",
       "parameters": [
         {
@@ -1837,7 +1841,7 @@
     {
       "name": "GetWorkbookMetadata",
       "qualifiedName": "MicrosoftSharepoint.GetWorkbookMetadata",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetWorkbookMetadata@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetWorkbookMetadata@0.1.2",
       "description": "Get metadata about an Excel workbook in a SharePoint drive, including worksheet list.",
       "parameters": [
         {
@@ -1869,7 +1873,8 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "Sites.Read.All"
+          "Sites.Read.All",
+          "Files.ReadWrite"
         ]
       },
       "secrets": [],
@@ -1883,17 +1888,17 @@
         "toolName": "MicrosoftSharepoint.GetWorkbookMetadata",
         "parameters": {
           "drive_id": {
-            "value": "b!xYz12AbC3dEfGhIJKlMnOpQRstuVwXyZ",
+            "value": "b!3kT9Lmx2QU6yVfPwNjR8cA1234567890abcdefghij",
             "type": "string",
             "required": true
           },
           "item_id": {
-            "value": "01a2b3c4-5d6e-7f89-0abc-def123456789",
+            "value": "01ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567",
             "type": "string",
             "required": true
           },
           "session_id": {
-            "value": "session-9f1b2c3d-4e5f-6789-abcd-0123456789ab",
+            "value": "cluster=EU&session=7d8a2f1e-4b3c-4d9e-a1b2-c3d4e5f67890",
             "type": "string",
             "required": false
           }
@@ -1924,7 +1929,7 @@
     {
       "name": "GetWorksheetData",
       "qualifiedName": "MicrosoftSharepoint.GetWorksheetData",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetWorksheetData@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetWorksheetData@0.1.2",
       "description": "Read cell values from a worksheet in a SharePoint Excel workbook.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -1996,7 +2001,8 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "Sites.Read.All"
+          "Sites.Read.All",
+          "Files.ReadWrite"
         ]
       },
       "secrets": [],
@@ -2010,17 +2016,17 @@
         "toolName": "MicrosoftSharepoint.GetWorksheetData",
         "parameters": {
           "drive_id": {
-            "value": "b!7d9f2a3b-4c6d-11ec-9d26-0242ac120002",
+            "value": "b!3kT9Lmx2R0eQpZvNcWdYuA1fGhJKlMnOpQrStUvWxYz",
             "type": "string",
             "required": true
           },
           "item_id": {
-            "value": "01234567-89ab-cdef-0123-456789abcdef",
+            "value": "01ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
             "type": "string",
             "required": true
           },
           "worksheet": {
-            "value": "Sales Q1 2026",
+            "value": "Sales Data",
             "type": "string",
             "required": false
           },
@@ -2040,12 +2046,12 @@
             "required": false
           },
           "max_cols": {
-            "value": 20,
+            "value": 10,
             "type": "integer",
             "required": false
           },
           "session_id": {
-            "value": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "value": "cluster=EU&session=eyJhbGciOiJIUzI1NiJ9.abc123xyz",
             "type": "string",
             "required": false
           }
@@ -2076,7 +2082,7 @@
     {
       "name": "InsertTextAtEndOfWordDocument",
       "qualifiedName": "MicrosoftSharepoint.InsertTextAtEndOfWordDocument",
-      "fullyQualifiedName": "MicrosoftSharepoint.InsertTextAtEndOfWordDocument@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.InsertTextAtEndOfWordDocument@0.1.2",
       "description": "Append text to the end of an existing Word document.\n\nThis tool only supports files with the `.docx` extension and enforces the 4MB limit.",
       "parameters": [
         {
@@ -2163,7 +2169,7 @@
     {
       "name": "ListItemsInFolder",
       "qualifiedName": "MicrosoftSharepoint.ListItemsInFolder",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListItemsInFolder@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListItemsInFolder@0.1.2",
       "description": "Retrieve items from a folder in a drive in a SharePoint site.\n\nNote: The Microsoft Graph API requires retrieving all items,\nincluding those skipped by offset.\nExecution time increases with higher offset values.",
       "parameters": [
         {
@@ -2263,7 +2269,7 @@
     {
       "name": "ListPages",
       "qualifiedName": "MicrosoftSharepoint.ListPages",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListPages@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListPages@0.1.2",
       "description": "Retrieve pages from a SharePoint site.\n\nThe Microsoft Graph API does not support pagination on this endpoint.",
       "parameters": [
         {
@@ -2337,7 +2343,7 @@
     {
       "name": "ListRootItemsInDrive",
       "qualifiedName": "MicrosoftSharepoint.ListRootItemsInDrive",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListRootItemsInDrive@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListRootItemsInDrive@0.1.2",
       "description": "Retrieve items from the root of a drive in a SharePoint site.\n\nNote: The Microsoft Graph API requires retrieving all items,\nincluding those skipped by offset.\nExecution time increases with higher offset values.",
       "parameters": [
         {
@@ -2424,7 +2430,7 @@
     {
       "name": "ListSites",
       "qualifiedName": "MicrosoftSharepoint.ListSites",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListSites@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListSites@0.1.2",
       "description": "List all SharePoint sites accessible to the current user.",
       "parameters": [
         {
@@ -2498,7 +2504,7 @@
     {
       "name": "MoveItem",
       "qualifiedName": "MicrosoftSharepoint.MoveItem",
-      "fullyQualifiedName": "MicrosoftSharepoint.MoveItem@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.MoveItem@0.1.2",
       "description": "Move a file or folder to a new location in a SharePoint drive.",
       "parameters": [
         {
@@ -2585,7 +2591,7 @@
     {
       "name": "RenameWorksheet",
       "qualifiedName": "MicrosoftSharepoint.RenameWorksheet",
-      "fullyQualifiedName": "MicrosoftSharepoint.RenameWorksheet@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.RenameWorksheet@0.1.2",
       "description": "Rename an existing worksheet in a SharePoint Excel workbook.\n\nNote: The new name may not be immediately visible to other tools due\nto a brief Graph API propagation delay (up to ~10 s). Pass the returned\n``session_id`` to subsequent calls that reference the renamed worksheet\nto mitigate this. If referencing a recently added worksheet as the source,\nthe same delay applies; retry with the ``session_id`` if a\nWorksheetNotFoundError occurs.",
       "parameters": [
         {
@@ -2633,7 +2639,8 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "Sites.ReadWrite.All"
+          "Sites.ReadWrite.All",
+          "Files.ReadWrite"
         ]
       },
       "secrets": [],
@@ -2647,12 +2654,12 @@
         "toolName": "MicrosoftSharepoint.RenameWorksheet",
         "parameters": {
           "drive_id": {
-            "value": "b!a1B2c3D4e5F6g7H8i9J0K_lMnOpQrSt",
+            "value": "b!aBcDeFgHiJkLmNoPqRsTuV1234567890",
             "type": "string",
             "required": true
           },
           "item_id": {
-            "value": "01ABCDXYZlmnopQRstuVwxyZ1234567890",
+            "value": "01ABCDEFGHIJKLMNOPQRSTUVWXYZ1234",
             "type": "string",
             "required": true
           },
@@ -2662,12 +2669,12 @@
             "required": true
           },
           "new_name": {
-            "value": "Quarterly Report 2026",
+            "value": "Q1 Sales Summary",
             "type": "string",
             "required": true
           },
           "session_id": {
-            "value": "session_9f8e7d6c5b4a3f2e1d0c",
+            "value": "cluster=US4A&session=eyJhbGciOiJIUzI1NiJ9.abc123xyz",
             "type": "string",
             "required": false
           }
@@ -2698,7 +2705,7 @@
     {
       "name": "SearchDriveItems",
       "qualifiedName": "MicrosoftSharepoint.SearchDriveItems",
-      "fullyQualifiedName": "MicrosoftSharepoint.SearchDriveItems@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.SearchDriveItems@0.1.2",
       "description": "Search for items in one or more Sharepoint drives.\n\nNote: When searching a single Drive and/or Folder,\nthe API must retrieve all items including those skipped by offset.\nExecution time increases with higher offset values.",
       "parameters": [
         {
@@ -2811,7 +2818,7 @@
     {
       "name": "SearchSites",
       "qualifiedName": "MicrosoftSharepoint.SearchSites",
-      "fullyQualifiedName": "MicrosoftSharepoint.SearchSites@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.SearchSites@0.1.2",
       "description": "Search for SharePoint sites by name or description.\n\nIn case you need to retrieve a specific site by its name, ID or SharePoint URL, use the\n`Sharepoint.GetSite` tool instead, passing the ID, name or SharePoint URL to it. If you use\nthe `Sharepoint.SearchSites` tool to retrieve a single site by its name, too much CO2 will be\nreleased in the atmosphere and you will contribute to catastrophic climate change.",
       "parameters": [
         {
@@ -2898,7 +2905,7 @@
     {
       "name": "SetSlideNotes",
       "qualifiedName": "MicrosoftSharepoint.SetSlideNotes",
-      "fullyQualifiedName": "MicrosoftSharepoint.SetSlideNotes@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.SetSlideNotes@0.1.2",
       "description": "Set or update the speaker notes on a specific slide in a SharePoint PowerPoint.\n\nNotes can be formatted using markdown:\n- **bold** for bold text\n- *italic* for italic text\n- __underline__ for underlined text\n- Lines starting with - or * become bullet points\n- Indent with spaces for nested bullets\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -2998,7 +3005,7 @@
     {
       "name": "UpdateCell",
       "qualifiedName": "MicrosoftSharepoint.UpdateCell",
-      "fullyQualifiedName": "MicrosoftSharepoint.UpdateCell@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.UpdateCell@0.1.2",
       "description": "Update a single cell value in a SharePoint Excel workbook.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -3062,7 +3069,8 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "Sites.ReadWrite.All"
+          "Sites.ReadWrite.All",
+          "Files.ReadWrite"
         ]
       },
       "secrets": [],
@@ -3076,37 +3084,37 @@
         "toolName": "MicrosoftSharepoint.UpdateCell",
         "parameters": {
           "drive_id": {
-            "value": "b!a1B2c3D4eF5g6H7I8J9K0lmnOPQRstUV",
+            "value": "b!3dKj8Lmn2UexQr7yVwPzNtFhGcXoAiBs1YeD4kMp0uRvCn5wJqT6iHlZ9sOaEf",
             "type": "string",
             "required": true
           },
           "item_id": {
-            "value": "01A2BC3D4EFGH5IJKL6MNOP7QRST8UVW9",
+            "value": "01ABCDE2F3GH4IJ5KLMNOPQR6STUVWXYZ78",
             "type": "string",
             "required": true
           },
           "column": {
-            "value": "BC",
+            "value": "C",
             "type": "string",
             "required": true
           },
           "row": {
-            "value": 12,
+            "value": 5,
             "type": "integer",
             "required": true
           },
           "value": {
-            "value": "=SUM(BC1:BC10)",
+            "value": "=SUM(C1:C4)",
             "type": "string",
             "required": true
           },
           "worksheet": {
-            "value": "Sales Data",
+            "value": "Q1 Sales",
             "type": "string",
             "required": false
           },
           "session_id": {
-            "value": "session_3f5b9f8a-9d3e-4c2a-b6f7-1e2d3c4b5a6f",
+            "value": "cluster=EU1&session=eyJhbGciOiJIUzI1NiJ9.abc123",
             "type": "string",
             "required": false
           }
@@ -3137,7 +3145,7 @@
     {
       "name": "UpdateRange",
       "qualifiedName": "MicrosoftSharepoint.UpdateRange",
-      "fullyQualifiedName": "MicrosoftSharepoint.UpdateRange@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.UpdateRange@0.1.2",
       "description": "Update multiple cells in a SharePoint Excel worksheet using sparse dict format.\n\nOnly specified cells are updated; unspecified cells remain unchanged.\n\nInternally, a single PATCH request is sent covering the bounding box\nof all specified cells.  Cells within the box that are not in the\ninput are sent as ``null``, which the Graph API treats as \"skip\".\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -3185,7 +3193,8 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "Sites.ReadWrite.All"
+          "Sites.ReadWrite.All",
+          "Files.ReadWrite"
         ]
       },
       "secrets": [],
@@ -3199,27 +3208,27 @@
         "toolName": "MicrosoftSharepoint.UpdateRange",
         "parameters": {
           "drive_id": {
-            "value": "b0a1c2d3-e4f5-6789-abcd-ef0123456789",
+            "value": "b!3Kx9mNpQrT2vYwZaLdFhJu8eRcOiXnVkMsPtGbHyAqDlEfCw1o7I6j5N4mU0sP",
             "type": "string",
             "required": true
           },
           "item_id": {
-            "value": "f1e2d3c4-b5a6-7890-cdef-0123456789ab",
+            "value": "01ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
             "type": "string",
             "required": true
           },
           "data": {
-            "value": "{\"1\": {\"A\": \"Name\", \"B\": \"Age\", \"C\": \"Active\"}, \"2\": {\"A\": \"Alice\", \"B\": 30, \"C\": true}, \"3\": {\"A\": \"Bob\", \"B\": null, \"C\": false}, \"10\": {\"D\": 123.45, \"E\": \"Notes\"}}",
+            "value": "{\"1\": {\"A\": \"Product Name\", \"B\": \"Quantity\", \"C\": \"Price\"}, \"2\": {\"A\": \"Widget Alpha\", \"B\": 150, \"C\": 29.99}, \"3\": {\"A\": \"Widget Beta\", \"B\": 75, \"C\": 49.99}, \"5\": {\"C\": 19.99}}",
             "type": "string",
             "required": true
           },
           "worksheet": {
-            "value": "Employees",
+            "value": "Sales Data",
             "type": "string",
             "required": false
           },
           "session_id": {
-            "value": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "value": "cluster=EU001&session=s!AbCdEfGhIjKlMnOpQrStUvWxYz.0123456789",
             "type": "string",
             "required": false
           }
@@ -3250,7 +3259,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftSharepoint.WhoAmI",
-      "fullyQualifiedName": "MicrosoftSharepoint.WhoAmI@0.1.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.WhoAmI@0.1.2",
       "description": "Get information about the current user and their SharePoint environment.",
       "parameters": [],
       "auth": {
@@ -3297,6 +3306,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-04-27T11:41:15.684Z",
-  "summary": "Arcade's Microsoft SharePoint toolkit lets developers manage SharePoint sites, drives, files, Office documents, and Excel workbooks through Microsoft Graph.\n\n**Capabilities**\n- Create, read, update, delete, copy, move, search, and share drive items, folders, pages, lists, and site metadata.\n- Create and edit Office files, including Word documents, PowerPoint presentations, slides, speaker notes, and workbook content.\n- Use Excel worksheet tools for worksheet lifecycle, cell updates, range updates, and session-aware handling for Graph propagation delays.\n- List sites, drives, folders, root items, pages, lists, and async operation status.\n- Fetch authenticated user profile and SharePoint environment information.\n\n**OAuth**\n- **Provider**: Microsoft\n- **Scopes**: Sites.Read.All, Sites.ReadWrite.All, User.Read\n\n**Secrets**\n- No secret types required for toolkit operation."
+  "generatedAt": "2026-05-06T11:42:23.738Z",
+  "summary": "# Microsoft SharePoint Toolkit\n\nThe Microsoft SharePoint toolkit connects Arcade to SharePoint via the Microsoft Graph API, enabling LLM agents to read, write, and manage SharePoint content including files, lists, sites, and Office documents.\n\n## Capabilities\n\n- **Site & drive navigation** — list, search, and retrieve sites, drives/document libraries, folders, and files; look up the current user's SharePoint context.\n- **File operations** — create folders, copy/move/delete items, generate share links, check async copy operation status, and search across drives.\n- **Excel workbook management** — create workbooks, add/rename/delete worksheets, read cell ranges, update individual cells or sparse multi-cell ranges; session IDs mitigate Graph API propagation delays on recently modified worksheets.\n- **Word document management** — create `.docx` files with optional content, read document text and metadata as Markdown, and append text to existing documents (4 MB limit enforced).\n- **PowerPoint management** — create presentations, append standard or two-column slides, get the full presentation as Markdown, and get/set/update per-slide speaker notes (with Markdown formatting support); resumable uploads handle files over 4 MB.\n- **SharePoint lists & pages** — retrieve site lists and list items (attachment presence detected but not downloadable), and read or enumerate site pages including web-part content.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 delegated auth via the **Microsoft** provider. See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for setup details, required tenant configuration, and token handling."
 }


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/25432962300

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low code risk (generated JSON/docs only), but it expands required Microsoft OAuth permissions to include `Files.ReadWrite`, which can impact integrations and user consent flows.
> 
> **Overview**
> Updates the generated toolkit registry to reflect `MicrosoftSharepoint` **v0.1.2** (and refreshes `generatedAt` timestamps).
> 
> For the Microsoft SharePoint toolkit definition, this refresh updates all `fullyQualifiedName` versions, **adds `Files.ReadWrite` to the toolkit’s OAuth scopes** (and to several Excel-related tool scopes), and rewrites the toolkit `summary` into a new Markdown/sectioned format with updated examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a7b77ab34a8eab8f2a0bfdd0b5c213474889469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->