### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-06T11:42:34.447Z",
+  "generatedAt": "2026-05-08T11:39:04.763Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -581,7 +581,7 @@
     {
       "id": "MicrosoftOutlookMail",
       "label": "Microsoft Outlook Mail",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 13,

--- a/toolkit-docs-generator/data/toolkits/microsoftoutlookmail.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftoutlookmail.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftOutlookMail",
   "label": "Microsoft Outlook Mail",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "Arcade.dev LLM tools for Outlook Mail",
   "metadata": {
     "category": "productivity",
@@ -28,8 +28,8 @@
     {
       "name": "CreateAndSendEmail",
       "qualifiedName": "MicrosoftOutlookMail.CreateAndSendEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.CreateAndSendEmail@0.2.1",
-      "description": "Create and immediately send a new email in Outlook to the specified recipients",
+      "fullyQualifiedName": "MicrosoftOutlookMail.CreateAndSendEmail@0.2.3",
+      "description": "Create and immediately send a new email in Outlook to the specified recipients.\n\nReturns the sent message's ``message_id`` and ``conversation_id`` so callers\ncan immediately chain follow-ups (e.g. reply to what they just sent) without\nhaving to search Sent Items.",
       "parameters": [
         {
           "name": "subject",
@@ -90,6 +90,7 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
+          "Mail.ReadWrite",
           "Mail.Send"
         ]
       },
@@ -97,9 +98,54 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "A dictionary containing the created email details"
+        "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.CreateAndSendEmail",
+        "parameters": {
+          "subject": {
+            "value": "Project Update: Q3 Milestone Review",
+            "type": "string",
+            "required": true
+          },
+          "body": {
+            "value": "Hi Team,\n\nI wanted to share a quick update on our Q3 milestones. We are on track to meet all deliverables by the end of the month. Please review the attached summary and let me know if you have any questions.\n\nBest regards,\nAlex",
+            "type": "string",
+            "required": true
+          },
+          "to_recipients": {
+            "value": [
+              "jane.doe@example.com",
+              "john.smith@example.com"
+            ],
+            "type": "array",
+            "required": true
+          },
+          "cc_recipients": {
+            "value": [
+              "manager@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "bcc_recipients": {
+            "value": [
+              "records@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "body_type": {
+            "value": "text",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -121,7 +167,7 @@
     {
       "name": "CreateDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.CreateDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.CreateDraftEmail@0.2.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.CreateDraftEmail@0.2.3",
       "description": "Compose a new draft email in Outlook",
       "parameters": [
         {
@@ -194,6 +240,51 @@
         "description": "A dictionary containing the created email details"
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.CreateDraftEmail",
+        "parameters": {
+          "subject": {
+            "value": "Project Update: Q3 Milestones Review",
+            "type": "string",
+            "required": true
+          },
+          "body": {
+            "value": "Hi Team,\n\nI wanted to share the latest updates on our Q3 milestones. Please review the attached report and let me know if you have any questions.\n\nBest regards,\nAlex",
+            "type": "string",
+            "required": true
+          },
+          "to_recipients": {
+            "value": [
+              "john.doe@example.com",
+              "jane.smith@example.com"
+            ],
+            "type": "array",
+            "required": true
+          },
+          "cc_recipients": {
+            "value": [
+              "manager@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "bcc_recipients": {
+            "value": [
+              "compliance@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "body_type": {
+            "value": "text",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -215,7 +306,7 @@
     {
       "name": "GetEmail",
       "qualifiedName": "MicrosoftOutlookMail.GetEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.GetEmail@0.2.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.GetEmail@0.2.3",
       "description": "Retrieve a single email message by its ID.\n\nReturns email metadata and body content. By default, the body is returned\nas plain text (HTML tags stripped) and capped at 5000 characters. Set\nbody_format to HTML to get the original markup. Use body_offset to\ncontinue reading long emails, or set max_body_characters to None for the\nfull body.\n\nUse this tool to read the full content of an email after finding it via\nsearch_emails or any listing tool.",
       "parameters": [
         {
@@ -249,7 +340,7 @@
           "name": "body_offset",
           "type": "integer",
           "required": false,
-          "description": "Character offset to start reading the body from. Use this to continue reading a long email body that was previously capped. Defaults to 0 (start of body).",
+          "description": "Character offset to start reading the body from. Use this to continue reading a long email body that was capped by ``max_body_characters`` on a prior call. Defaults to 0 (start of body).",
           "enum": null,
           "inferrable": true
         }
@@ -269,6 +360,34 @@
         "description": "A dictionary containing the email message."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.GetEmail",
+        "parameters": {
+          "message_id": {
+            "value": "AAMkAGI2TG93AAA=",
+            "type": "string",
+            "required": true
+          },
+          "body_format": {
+            "value": "PLAIN_TEXT",
+            "type": "string",
+            "required": false
+          },
+          "max_body_characters": {
+            "value": 3000,
+            "type": "integer",
+            "required": false
+          },
+          "body_offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -290,7 +409,7 @@
     {
       "name": "ListEmailAttachments",
       "qualifiedName": "MicrosoftOutlookMail.ListEmailAttachments",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailAttachments@0.2.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailAttachments@0.2.3",
       "description": "List attachment metadata for an email message.\n\nReturns metadata only (name, size, type, etc.). Attachment content is not included.\nUse this tool when the user wants to know what files are attached to an email.",
       "parameters": [
         {
@@ -333,6 +452,29 @@
         "description": "A dictionary containing a list of attachment metadata objects."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.ListEmailAttachments",
+        "parameters": {
+          "message_id": {
+            "value": "AAMkAGI2TG93AAA=",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 10,
+            "type": "integer",
+            "required": false
+          },
+          "pagination_token": {
+            "value": "eyJza2lwVG9rZW4iOiIlMjUyQlJDVCUyNTJCY29udGVudCUyNTJCY29udGVudCUyNTJCY29udGVudCUyNTJC",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -354,7 +496,7 @@
     {
       "name": "ListEmails",
       "qualifiedName": "MicrosoftOutlookMail.ListEmails",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmails@0.2.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmails@0.2.3",
       "description": "List emails in the user's mailbox across all folders.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).\n\nSince this tool lists email across all folders, it may return sent items,\ndrafts, and other items that are not in the inbox.",
       "parameters": [
         {
@@ -413,6 +555,34 @@
         "description": "A dictionary containing a list of emails"
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.ListEmails",
+        "parameters": {
+          "sort_by": {
+            "value": "receivedDateTime",
+            "type": "string",
+            "required": false
+          },
+          "sort_order": {
+            "value": "ascending",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "pagination_token": {
+            "value": "AQMkADAwATM0MDAAMS1hNzUwLTQzYjItMDACLTAwCgBGAAAD",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -434,7 +604,7 @@
     {
       "name": "ListEmailsByProperty",
       "qualifiedName": "MicrosoftOutlookMail.ListEmailsByProperty",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsByProperty@0.2.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsByProperty@0.2.3",
       "description": "List emails in the user's mailbox across all folders filtering by a property.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).\n\nSorting by RECEIVED_DATE_TIME works with any filter property. Sorting by\na different property (SUBJECT, SENDER, IMPORTANCE) while filtering by an\nunrelated property may fail due to a Microsoft Graph API restriction. If\nthis happens, either sort by RECEIVED_DATE_TIME, or use list_emails (no\nfilter) with the desired sort_by.",
       "parameters": [
         {
@@ -536,6 +706,49 @@
         "description": "A dictionary containing a list of emails"
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.ListEmailsByProperty",
+        "parameters": {
+          "mail_property": {
+            "value": "subject",
+            "type": "string",
+            "required": true
+          },
+          "operator": {
+            "value": "contains",
+            "type": "string",
+            "required": true
+          },
+          "value": {
+            "value": "Project Update",
+            "type": "string",
+            "required": true
+          },
+          "sort_by": {
+            "value": "RECEIVED_DATE_TIME",
+            "type": "string",
+            "required": false
+          },
+          "sort_order": {
+            "value": "descending",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "pagination_token": {
+            "value": "AQMkADAwATM0MDAAMS1iOGE5LTYwNjMtMDACLTAwCgAuAAADqZ2Xv9GqTkia9bNFWUkBzgEAf5F9HpCqSEiVp2oLt7QAAAI=",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -557,7 +770,7 @@
     {
       "name": "ListEmailsInFolder",
       "qualifiedName": "MicrosoftOutlookMail.ListEmailsInFolder",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsInFolder@0.2.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsInFolder@0.2.3",
       "description": "List the user's emails in the specified folder.\n\nExactly one of `well_known_folder_name` or `folder_id` MUST be provided.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
       "parameters": [
         {
@@ -640,6 +853,44 @@
         "description": "A dictionary containing a list of emails and a pagination token, if applicable"
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.ListEmailsInFolder",
+        "parameters": {
+          "well_known_folder_name": {
+            "value": "inbox",
+            "type": "string",
+            "required": false
+          },
+          "folder_id": {
+            "value": null,
+            "type": "string",
+            "required": false
+          },
+          "sort_by": {
+            "value": "receivedDateTime",
+            "type": "string",
+            "required": false
+          },
+          "sort_order": {
+            "value": "descending",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "pagination_token": {
+            "value": "AQMkADAwATM0MDAAMS1iNGZmLWU4NjktMDACLTAwCgAuAAAD",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -661,7 +912,7 @@
     {
       "name": "ListMailFolders",
       "qualifiedName": "MicrosoftOutlookMail.ListMailFolders",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListMailFolders@0.2.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListMailFolders@0.2.3",
       "description": "List mail folders in the user's mailbox.\n\nReturns folder names, IDs, unread counts, and total item counts.\nUse the folder ID in follow-up calls to list_emails_in_folder.\nOmit parent_folder_id to list top-level folders, or provide a folder ID\nto list its child folders.",
       "parameters": [
         {
@@ -711,6 +962,34 @@
         "description": "A dictionary containing a list of mail folders."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.ListMailFolders",
+        "parameters": {
+          "parent_folder_id": {
+            "value": "AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDMwLWUwYzc1NTBiNDgwNwAuAAAAAAAiQ8W967B7TKBjgx9nVEUrAQCiIsqMbYjsT5e-T7KIlDZMAAAAAAEMAAA=",
+            "type": "string",
+            "required": false
+          },
+          "include_hidden": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "pagination_token": {
+            "value": "eyJza2lwVG9rZW4iOiIlMjRza2lwPTI1IiwidG9wIjoyNX0=",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -732,7 +1011,7 @@
     {
       "name": "ReplyToEmail",
       "qualifiedName": "MicrosoftOutlookMail.ReplyToEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ReplyToEmail@0.2.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ReplyToEmail@0.2.3",
       "description": "Reply to an existing email in Outlook.\n\nUse this tool to reply to the sender or all recipients of the email.\nSpecify the reply_type to determine the scope of the reply.",
       "parameters": [
         {
@@ -767,6 +1046,7 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
+          "Mail.ReadWrite",
           "Mail.Send"
         ]
       },
@@ -774,9 +1054,32 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "A dictionary containing the sent email details"
+        "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.ReplyToEmail",
+        "parameters": {
+          "message_id": {
+            "value": "AAMkAGI2TG93AAA=",
+            "type": "string",
+            "required": true
+          },
+          "body": {
+            "value": "Thank you for reaching out! I have reviewed the details you shared and everything looks good on my end. Let me know if you need anything else.",
+            "type": "string",
+            "required": true
+          },
+          "reply_type": {
+            "value": "ReplyType.REPLY_ALL",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -798,8 +1101,8 @@
     {
       "name": "SearchEmails",
       "qualifiedName": "MicrosoftOutlookMail.SearchEmails",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SearchEmails@0.2.1",
-      "description": "Search emails across the user's entire mailbox.\n\nCombines full-text keyword search with structured filters for sender,\nread status, attachments, importance, and more. All provided parameters\nare combined with AND. Results are ordered by date sent (most recent first).\n\nEmail bodies are truncated to 255 characters for efficient skimming.\nUse get_email with the message_id to retrieve the full email content.\n\nUse this tool when the user wants to find emails by content, topic, sender,\nor a combination of criteria. For exact property filtering (e.g., by\nconversationId or flag status), use list_emails_by_property instead.",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SearchEmails@0.2.3",
+      "description": "Search emails across the user's entire mailbox.\n\nCombines full-text keyword search with structured filters for sender,\nread status, attachments, importance, and more. All provided parameters\nare combined with AND. Results are ordered by date sent (most recent first).\n\nEmail bodies are truncated to 255 characters for efficient skimming.\nUse get_email with the message_id to retrieve the full email content.\n\nUse this tool when the user wants to find emails by content, topic, sender,\nor a combination of criteria. For exact property filtering (e.g., by\nconversationId or flag status), use list_emails_by_property instead.\n\n.. note::\n   Microsoft Graph's ``$search`` on messages is backed by the Microsoft\n   Search index, which returns message IDs in the legacy REST-ID format\n   even when the client opts into Immutable IDs (which other tools in\n   this toolkit do by default). Do not directly compare a ``message_id``\n   from ``search_emails`` against one from ``list_emails`` /\n   ``get_email`` — the ID shapes differ. To chain from a search hit,\n   pass the returned ID straight back into ``get_email`` (which accepts\n   either format), and use ``conversation_id`` as the deduplication\n   key across result sets.",
       "parameters": [
         {
           "name": "keywords",
@@ -921,6 +1224,86 @@
         "description": "A dictionary containing a list of matching emails."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SearchEmails",
+        "parameters": {
+          "keywords": {
+            "value": [
+              "project deadline",
+              "quarterly report"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "sender": {
+            "value": [
+              "alice.johnson@example.com",
+              "bob.smith@contoso.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "recipient": {
+            "value": [
+              "team-leads@example.com",
+              "carol.white@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "attachment_name": {
+            "value": [
+              "Q3_Report.pdf",
+              "budget_2024.xlsx"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "has_attachments": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "importance": {
+            "value": "high",
+            "type": "string",
+            "required": false
+          },
+          "is_read": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "category": {
+            "value": "Work",
+            "type": "string",
+            "required": false
+          },
+          "received_after": {
+            "value": "2024-01-01",
+            "type": "string",
+            "required": false
+          },
+          "received_before": {
+            "value": "2024-06-30",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 15,
+            "type": "integer",
+            "required": false
+          },
+          "pagination_token": {
+            "value": "AQMkADAwATM0MDAAMS1hYjcd==",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -942,8 +1325,8 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.SendDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SendDraftEmail@0.2.1",
-      "description": "Send an existing draft email in Outlook\n\nThis tool can send any un-sent email:\n    - draft\n    - reply-draft\n    - reply-all draft\n    - forward draft",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SendDraftEmail@0.2.3",
+      "description": "Send an existing draft email in Outlook.\n\nSends any un-sent message — draft, reply-draft, reply-all draft, or\nforward draft — and returns the message's ``message_id`` and\n``conversation_id`` so callers can chain follow-ups (e.g. reply to\nthe message they just sent) without searching Sent Items.",
       "parameters": [
         {
           "name": "message_id",
@@ -958,6 +1341,7 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
+          "Mail.Read",
           "Mail.Send"
         ]
       },
@@ -965,9 +1349,22 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "A dictionary containing the sent email details"
+        "description": "No description provided."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SendDraftEmail",
+        "parameters": {
+          "message_id": {
+            "value": "AAMkAGUwNjQ4ZjIxLTQ3Y2YtNDgwOS1hOWYzLWIwNzdhNmU5ZDc4NgBGAAAAAADCNMkgKwRbT5VHmFgCwBp9BwBtL9yFiRvMSoqAzLlMvOqIAAAAAAEPAABtL9yFiRvMSoqAzLlMvOqIAABZ3k7XAAA=",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -989,7 +1386,7 @@
     {
       "name": "UpdateDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.UpdateDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.UpdateDraftEmail@0.2.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.UpdateDraftEmail@0.2.3",
       "description": "Update an existing draft email in Outlook.\n\nThis tool overwrites the subject and body of a draft email (if provided),\nand modifies its recipient lists by selectively adding or removing email addresses.\n\nThis tool can update any un-sent email:\n    - draft\n    - reply-draft\n    - reply-all draft\n    - forward draft",
       "parameters": [
         {
@@ -1086,6 +1483,72 @@
         "description": "A dictionary containing the updated email details"
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.UpdateDraftEmail",
+        "parameters": {
+          "message_id": {
+            "value": "AAMkAGI2TI0MjU3LThmZDAtNDhkNC04ZGFjLTMxYmE1ZWI1ZGQyNgBGAAAAAADUuTJK1K9ER6M",
+            "type": "string",
+            "required": true
+          },
+          "subject": {
+            "value": "Updated: Q3 Budget Review Meeting",
+            "type": "string",
+            "required": false
+          },
+          "body": {
+            "value": "Hi team,\n\nPlease find the updated agenda for our Q3 budget review meeting scheduled for Friday at 2 PM.\n\nBest regards,\nAlex",
+            "type": "string",
+            "required": false
+          },
+          "to_add": {
+            "value": [
+              "jane.doe@example.com",
+              "mark.smith@company.org"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "to_remove": {
+            "value": [
+              "old.contact@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "cc_add": {
+            "value": [
+              "manager@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "cc_remove": {
+            "value": [
+              "former.colleague@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "bcc_add": {
+            "value": [
+              "compliance@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "bcc_remove": {
+            "value": [
+              "temp.observer@example.com"
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1107,7 +1570,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftOutlookMail.WhoAmI",
-      "fullyQualifiedName": "MicrosoftOutlookMail.WhoAmI@0.2.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.WhoAmI@0.2.3",
       "description": "Get comprehensive user profile and Outlook Mail environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, mailbox settings, automatic replies configuration, and other\nimportant profile details from Outlook Mail services.",
       "parameters": [],
       "auth": {
@@ -1125,6 +1588,13 @@
         "description": "Get comprehensive user profile and Outlook Mail environment information."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.WhoAmI",
+        "parameters": {},
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1147,6 +1617,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-04-03T11:23:10.952Z",
-  "summary": "Microsoft Outlook Mail is Microsoft's email service, accessed through the Microsoft Graph API. The Arcade Outlook Mail toolkit gives agents full mailbox control — reading, composing, sending, and organizing messages on behalf of a user.\n\n**Capabilities**\n\n- Send emails immediately or manage drafts through create, update, and send operations.\n- List and search messages across folders, with filters for sender, recipient, attachments, importance, and read status.\n- Reply to a sender or all recipients, and list attachment metadata for any message.\n- Navigate the mailbox by enumerating mail folders and listing messages by folder or property.\n\n**OAuth**\n\nRequires Microsoft OAuth. See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration."
+  "generatedAt": "2026-05-08T11:38:56.431Z",
+  "summary": "The Microsoft Outlook Mail toolkit integrates Arcade with the Microsoft Graph API, enabling LLMs to read, compose, search, and manage emails in a user's Outlook mailbox.\n\n## Capabilities\n\n- **Compose & send**: Create and immediately send emails, compose drafts, update draft content and recipients, and send existing drafts (including reply, reply-all, and forward drafts).\n- **Reply & follow-up**: Reply to a sender or all recipients of any message; chain follow-ups using returned `message_id` and `conversation_id` without searching Sent Items.\n- **Read & retrieve**: Fetch full email content by ID with configurable body format (plain text or HTML), character limits, and offset support for long messages.\n- **Search & filter**: Full-text keyword search across the entire mailbox with structured AND-combined filters (sender, read status, attachments, importance); property-based listing for exact field matching (e.g., `conversationId`, flag status); folder-scoped listing with sorting controls.\n- **Folder & attachment metadata**: List all mailbox folders (with unread/total counts) and traverse folder hierarchies; retrieve attachment metadata (name, size, type) for any message.\n- **Identity & settings**: Retrieve the authenticated user's profile, mailbox settings, and automatic replies configuration.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 delegated authorization via Microsoft. See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for setup instructions, required app registrations, and tenant configuration."
 }


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/25553374074

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to generated JSON metadata/docs, with no runtime code modifications; main risk is downstream consumers relying on updated versions/scopes/output descriptions.
> 
> **Overview**
> Updates the generated toolkit catalog and `MicrosoftOutlookMail` toolkit metadata to version `0.2.3`.
> 
> Enhances the Outlook Mail toolkit docs by adding per-tool `codeExample` blocks, expanding/clarifying tool descriptions (notably around chaining via `message_id`/`conversation_id` and `search_emails` ID format caveats), and adjusting declared OAuth scopes for send/reply/draft-send operations. Also refreshes generated timestamps and rewrites the toolkit summary copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baf7a32e451573f0c38cbaf4ff42e7a6825e7218. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->