### PR TITLE
revived the changelog agent after stale API key

### DIFF
--- a/agents/changelog/generate.ts
+++ b/agents/changelog/generate.ts
@@ -76,6 +76,21 @@ function getUpcomingFriday(): string {
   return friday.toISOString().split("T")[0];
 }
 
+function parseDateArg(): string | null {
+  const arg = process.argv.find((a) => a.startsWith("--date="));
+  if (!arg) return null;
+  const value = arg.slice("--date=".length);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error(`--date must be YYYY-MM-DD, got: ${value}`);
+  }
+  // Validate it's a Friday (interpret as UTC to avoid TZ drift).
+  const day = new Date(`${value}T00:00:00Z`).getUTCDay();
+  if (day !== 5) {
+    throw new Error(`--date=${value} is not a Friday (got weekday ${day}).`);
+  }
+  return value;
+}
+
 // --- Step 2: Read changelog, extract last entry date ---
 
 function getLastEntryDate(): string {
@@ -91,6 +106,7 @@ async function fetchMergedPRs(
   owner: string,
   repo: string,
   sinceDate: string,
+  untilDate: string,
   isPrivate: boolean,
 ): Promise<PR[]> {
   const token = process.env.GITHUB_TOKEN;
@@ -120,7 +136,7 @@ async function fetchMergedPRs(
     for (const pr of data) {
       if (!pr.merged_at) continue;
       const mergedDate = pr.merged_at.split("T")[0];
-      if (mergedDate > sinceDate) {
+      if (mergedDate > sinceDate && mergedDate <= untilDate) {
         prs.push({
           repo,
           number: pr.number,
@@ -278,8 +294,9 @@ async function main() {
   const openai = new OpenAI();
 
   // Step 1
-  const fridayDate = getUpcomingFriday();
-  console.log(`Changelog date: ${fridayDate}`);
+  const overrideDate = parseDateArg();
+  const fridayDate = overrideDate ?? getUpcomingFriday();
+  console.log(`Changelog date: ${fridayDate}${overrideDate ? " (from --date)" : ""}`);
 
   // Step 2
   const lastEntryDate = getLastEntryDate();
@@ -294,7 +311,7 @@ async function main() {
   console.log("Fetching merged PRs...");
   const allPRs = (
     await Promise.all(
-      REPOS.map((r) => fetchMergedPRs(r.owner, r.repo, lastEntryDate, r.private)),
+      REPOS.map((r) => fetchMergedPRs(r.owner, r.repo, lastEntryDate, fridayDate, r.private)),
     )
   ).flat();
   console.log(`Found ${allPRs.length} merged PRs since ${lastEntryDate}`);

--- a/agents/changelog/readme.md
+++ b/agents/changelog/readme.md
@@ -18,3 +18,11 @@ GITHUB_TOKEN=... OPENAI_API_KEY=... bun run generate
 Or set the env vars in a `.env` file (Bun loads it automatically).
 
 Optionally set `OPENAI_MODEL` to override the default (`gpt-4o-mini`).
+
+To backfill a past Friday, pass `--date=YYYY-MM-DD` (must be a Friday):
+
+```bash
+bun run generate --date=2026-04-24
+```
+
+The script will only include PRs merged after the most recent changelog entry and on or before the target Friday.

--- a/app/en/references/changelog/page.mdx
+++ b/app/en/references/changelog/page.mdx
@@ -9,6 +9,58 @@ import { Callout } from "nextra/components";
 
 _Here's what's new at Arcade.dev!_
 
+## 2026-05-08
+
+
+**Arcade MCP Servers**
+
+- `[feature - 🚀]` Major overhaul of the first-party MCP with new domain modules and tools.
+- `[bugfix - 🐛]` Fix request for Files.ReadWrite scope in SharePoint Excel tools for improved workbook editing.
+- `[documentation - 📝]` Update MCP Servers documentation to reflect new Microsoft OAuth permissions.
+
+**Platform and Engine**
+
+- `[feature - 🚀]` Add OAuth bearer path handling for user_source gateways in MCP AuthMiddleware.
+
+## 2026-05-01
+
+**Arcade MCP Servers**
+
+- `[feature - 🚀]` Improvements to the onboarding flow.
+- `[feature - 🚀]` Add Linear milestone management tools including queries and mutations for project planning workflows.
+- `[feature - 🚀]` Add Telegram toolkit with core messaging tools using Telegram Bot API.
+- `[documentation - 📝]` Updating MCP Servers documentation metadata and OAuth scopes.
+- `[documentation - 📝]` Update documentation to include Telegram in social integrations.
+- `[bugfix - 🐛]` Fix compatibility issue with typing.TypedDict for Python <3.12 in Telegram toolkit.
+- `[bugfix - 🐛]` Fix Gmail WriteDraftReplyEmail to preserve formatting in quoted thread history.
+- `[bugfix - 🐛]` Fix missing scope and behavior for the Gmail_WriteDraftReplyEmail function.
+
+
+**Misc**
+
+- `[feature - 🚀]` Add Partner badge and Tavily as first partner MCP.
+- `[documentation - 📝]` Tightened and expanded glossary entries for Pro Tools and BYOC in documentation.
+
+## 2026-04-24
+
+**Arcade MCP Servers**
+
+- `[feature - 🚀]` Add a `connect` search param to the MCP gateways list route to streamline connecting to gateway instances.
+- `[feature - 🚀]` Revamped GoogleDocs.EditDocument with a more efficient tool and enhanced editing capabilities.
+- `[feature - 🚀]` Add CC support to draft replies and improve handling of email threads.
+- `[feature - 🚀]` Adds permission management tools to the GoogleDrive MCP server.
+- `[feature - 🚀]` Add a tool-feedback survey page for user suggestions and feature requests. (docs PR #943)
+- `[maintenance - 🔧]` Bump first-party-mcp security patches and add constraints to prevent major version updates.
+- `[documentation - 📝]` Add summaries for 5 MCP servers in documentation.
+
+**Platform and Engine**
+
+- `[maintenance - 🔧]` Improves logging for lookup errors to enhance debugging capabilities.
+- `[bugfix - 🐛]` Fix dashboard crash on billing page.
+- `[documentation - 📝]` Document the new NetworkTransportError class and updated HTTP adapter routing.
+- `[feature - 🚀]` Enhance logging for OAuth token exchanges to improve observability.
+- `[feature - 🚀]` Security hardening for .docx/.pptx parsing with stricter limits and subprocess isolation.
+
 ## 2026-04-17
 
 

--- a/app/en/references/changelog/page.mdx
+++ b/app/en/references/changelog/page.mdx
@@ -31,7 +31,7 @@ _Here's what's new at Arcade.dev!_
 - `[feature - 🚀]` Add Telegram toolkit with core messaging tools using Telegram Bot API.
 - `[documentation - 📝]` Updating MCP Servers documentation metadata and OAuth scopes.
 - `[documentation - 📝]` Update documentation to include Telegram in social integrations.
-- `[bugfix - 🐛]` Fix compatibility issue with typing.TypedDict for Python <3.12 in Telegram toolkit.
+- `[bugfix - 🐛]` Fix compatibility issue with typing.TypedDict for Python < 3.12 in Telegram toolkit.
 - `[bugfix - 🐛]` Fix Gmail WriteDraftReplyEmail to preserve formatting in quoted thread history.
 - `[bugfix - 🐛]` Fix missing scope and behavior for the Gmail_WriteDraftReplyEmail function.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts changelog generation logic to bound merged PR selection by an explicit end date and adds a `--date` override, which could change which PRs get included in generated entries if misused or if date handling is off.
> 
> **Overview**
> The changelog generator now supports backfilling by accepting `--date=YYYY-MM-DD` (validated to be a Friday) and uses that date as the changelog entry date.
> 
> Merged PR collection is now bounded to *(last changelog date, target Friday]* via a new `untilDate` filter, preventing PRs after the target week from being included. Documentation was updated to describe the new flag, and the changelog page was updated with new entries for `2026-04-24`, `2026-05-01`, and `2026-05-08`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c253b192f818f8b2488c8a4a75b9a1bfb3164df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->