### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/toolkit-docs-generator/data/toolkits/gmail.json
+++ b/toolkit-docs-generator/data/toolkits/gmail.json
@@ -1,7 +1,7 @@
 {
   "id": "Gmail",
   "label": "Gmail",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "description": "Arcade.dev LLM tools for Gmail",
   "metadata": {
     "category": "productivity",
@@ -30,7 +30,7 @@
     {
       "name": "ChangeEmailLabels",
       "qualifiedName": "Gmail.ChangeEmailLabels",
-      "fullyQualifiedName": "Gmail.ChangeEmailLabels@5.2.0",
+      "fullyQualifiedName": "Gmail.ChangeEmailLabels@6.0.0",
       "description": "Add and remove labels from an email using the Gmail API.",
       "parameters": [
         {
@@ -124,7 +124,7 @@
     {
       "name": "CreateLabel",
       "qualifiedName": "Gmail.CreateLabel",
-      "fullyQualifiedName": "Gmail.CreateLabel@5.2.0",
+      "fullyQualifiedName": "Gmail.CreateLabel@6.0.0",
       "description": "Create a new label in the user's mailbox.",
       "parameters": [
         {
@@ -184,7 +184,7 @@
     {
       "name": "DeleteDraftEmail",
       "qualifiedName": "Gmail.DeleteDraftEmail",
-      "fullyQualifiedName": "Gmail.DeleteDraftEmail@5.2.0",
+      "fullyQualifiedName": "Gmail.DeleteDraftEmail@6.0.0",
       "description": "Delete a draft email using the Gmail API.",
       "parameters": [
         {
@@ -244,7 +244,7 @@
     {
       "name": "GetThread",
       "qualifiedName": "Gmail.GetThread",
-      "fullyQualifiedName": "Gmail.GetThread@5.2.0",
+      "fullyQualifiedName": "Gmail.GetThread@6.0.0",
       "description": "Get the specified thread by ID.",
       "parameters": [
         {
@@ -304,7 +304,7 @@
     {
       "name": "ListDraftEmails",
       "qualifiedName": "Gmail.ListDraftEmails",
-      "fullyQualifiedName": "Gmail.ListDraftEmails@5.2.0",
+      "fullyQualifiedName": "Gmail.ListDraftEmails@6.0.0",
       "description": "Lists draft emails in the user's draft mailbox using the Gmail API.",
       "parameters": [
         {
@@ -364,7 +364,7 @@
     {
       "name": "ListEmails",
       "qualifiedName": "Gmail.ListEmails",
-      "fullyQualifiedName": "Gmail.ListEmails@5.2.0",
+      "fullyQualifiedName": "Gmail.ListEmails@6.0.0",
       "description": "Read emails from a Gmail account and extract plain text content.",
       "parameters": [
         {
@@ -424,7 +424,7 @@
     {
       "name": "ListEmailsByHeader",
       "qualifiedName": "Gmail.ListEmailsByHeader",
-      "fullyQualifiedName": "Gmail.ListEmailsByHeader@5.2.0",
+      "fullyQualifiedName": "Gmail.ListEmailsByHeader@6.0.0",
       "description": "Search for emails by header using the Gmail API.",
       "parameters": [
         {
@@ -570,7 +570,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Gmail.ListLabels",
-      "fullyQualifiedName": "Gmail.ListLabels@5.2.0",
+      "fullyQualifiedName": "Gmail.ListLabels@6.0.0",
       "description": "List all the labels in the user's mailbox.",
       "parameters": [],
       "auth": {
@@ -615,7 +615,7 @@
     {
       "name": "ListThreads",
       "qualifiedName": "Gmail.ListThreads",
-      "fullyQualifiedName": "Gmail.ListThreads@5.2.0",
+      "fullyQualifiedName": "Gmail.ListThreads@6.0.0",
       "description": "List threads in the user's mailbox.",
       "parameters": [
         {
@@ -701,14 +701,14 @@
     {
       "name": "ReplyToEmail",
       "qualifiedName": "Gmail.ReplyToEmail",
-      "fullyQualifiedName": "Gmail.ReplyToEmail@5.2.0",
+      "fullyQualifiedName": "Gmail.ReplyToEmail@6.0.0",
       "description": "Send a reply to an email message.",
       "parameters": [
         {
           "name": "body",
           "type": "string",
           "required": true,
-          "description": "The body of the email",
+          "description": "The body of the email, as plain text or HTML.",
           "enum": null,
           "inferrable": true
         },
@@ -753,10 +753,11 @@
           "name": "content_type",
           "type": "string",
           "required": false,
-          "description": "The content type of the email body. Defaults to 'plain'",
+          "description": "How the body is encoded on the wire. `auto` (default) sends as HTML and auto-converts plain-text input to paragraphs. `html` sends the body verbatim as HTML (use this when it contains entities or non-allow-listed tags); `plain` is plain text.",
           "enum": [
             "plain",
-            "html"
+            "html",
+            "auto"
           ],
           "inferrable": true
         }
@@ -765,7 +766,8 @@
         "providerId": "google",
         "providerType": "oauth2",
         "scopes": [
-          "https://www.googleapis.com/auth/gmail.send"
+          "https://www.googleapis.com/auth/gmail.send",
+          "https://www.googleapis.com/auth/gmail.readonly"
         ]
       },
       "secrets": [],
@@ -779,12 +781,12 @@
         "toolName": "Gmail.ReplyToEmail",
         "parameters": {
           "body": {
-            "value": "Thank you for reaching out! I have reviewed the details you provided and I'm happy to confirm that everything looks good on our end. Please let me know if you have any further questions.",
+            "value": "<p>Thank you for reaching out! I will get back to you with more details shortly.</p>",
             "type": "string",
             "required": true
           },
           "reply_to_message_id": {
-            "value": "18f3a2b4c5d6e7f8",
+            "value": "18e4f2a3b7c91d05",
             "type": "string",
             "required": true
           },
@@ -796,7 +798,7 @@
           "cc": {
             "value": [
               "manager@example.com",
-              "teamlead@example.com"
+              "team-lead@example.com"
             ],
             "type": "array",
             "required": false
@@ -809,7 +811,7 @@
             "required": false
           },
           "content_type": {
-            "value": "plain",
+            "value": "auto",
             "type": "string",
             "required": false
           }
@@ -839,7 +841,7 @@
     {
       "name": "SearchThreads",
       "qualifiedName": "Gmail.SearchThreads",
-      "fullyQualifiedName": "Gmail.SearchThreads@5.2.0",
+      "fullyQualifiedName": "Gmail.SearchThreads@6.0.0",
       "description": "Search for threads in the user's mailbox",
       "parameters": [
         {
@@ -1015,7 +1017,7 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "Gmail.SendDraftEmail",
-      "fullyQualifiedName": "Gmail.SendDraftEmail@5.2.0",
+      "fullyQualifiedName": "Gmail.SendDraftEmail@6.0.0",
       "description": "Send a draft email using the Gmail API.",
       "parameters": [
         {
@@ -1075,7 +1077,7 @@
     {
       "name": "SendEmail",
       "qualifiedName": "Gmail.SendEmail",
-      "fullyQualifiedName": "Gmail.SendEmail@5.2.0",
+      "fullyQualifiedName": "Gmail.SendEmail@6.0.0",
       "description": "Send an email using the Gmail API.",
       "parameters": [
         {
@@ -1090,7 +1092,7 @@
           "name": "body",
           "type": "string",
           "required": true,
-          "description": "The body of the email",
+          "description": "The body of the email, as plain text or HTML.",
           "enum": null,
           "inferrable": true
         },
@@ -1124,10 +1126,11 @@
           "name": "content_type",
           "type": "string",
           "required": false,
-          "description": "The content type of the email body. Defaults to 'plain'",
+          "description": "How the body is encoded on the wire. `auto` (default) sends as HTML and auto-converts plain-text input to paragraphs. `html` sends the body verbatim as HTML (use this when it contains entities or non-allow-listed tags); `plain` is plain text.",
           "enum": [
             "plain",
-            "html"
+            "html",
+            "auto"
           ],
           "inferrable": true
         }
@@ -1150,37 +1153,37 @@
         "toolName": "Gmail.SendEmail",
         "parameters": {
           "subject": {
-            "value": "Meeting Reminder",
+            "value": "Meeting Reminder: Project Kickoff Tomorrow at 10 AM",
             "type": "string",
             "required": true
           },
           "body": {
-            "value": "Don't forget our meeting tomorrow at 10 AM.",
+            "value": "<p>Hi Jane,</p><p>Just a friendly reminder that our project kickoff meeting is scheduled for <strong>tomorrow at 10:00 AM</strong> in Conference Room B.</p><p>Please bring your project outlines and any questions you may have.</p><p>Best regards,<br>John</p>",
             "type": "string",
             "required": true
           },
           "recipient": {
-            "value": "example@example.com",
+            "value": "jane.doe@example.com",
             "type": "string",
             "required": true
           },
           "cc": {
             "value": [
               "manager@example.com",
-              "assistant@example.com"
+              "teamlead@example.com"
             ],
             "type": "array",
             "required": false
           },
           "bcc": {
             "value": [
-              "sensitive@example.com"
+              "archive@example.com"
             ],
             "type": "array",
             "required": false
           },
           "content_type": {
-            "value": "plain",
+            "value": "html",
             "type": "string",
             "required": false
           }
@@ -1210,7 +1213,7 @@
     {
       "name": "TrashEmail",
       "qualifiedName": "Gmail.TrashEmail",
-      "fullyQualifiedName": "Gmail.TrashEmail@5.2.0",
+      "fullyQualifiedName": "Gmail.TrashEmail@6.0.0",
       "description": "Move an email to the trash folder using the Gmail API.",
       "parameters": [
         {
@@ -1270,8 +1273,8 @@
     {
       "name": "UpdateDraftEmail",
       "qualifiedName": "Gmail.UpdateDraftEmail",
-      "fullyQualifiedName": "Gmail.UpdateDraftEmail@5.2.0",
-      "description": "Update an existing email draft using the Gmail API.\n\nSingle-part plain drafts support full body replacement. For HTML, attachments, or\nmultipart drafts, the tool fails unless the body is unchanged (metadata-only update),\nin which case the existing MIME tree is preserved. Otherwise edit the draft in Gmail.\n\nFor each of subject, body, recipient, cc, and bcc, omitting the parameter or passing\n``None`` leaves that part of the draft unchanged (for cc/bcc, existing headers are kept;\npass an empty list to clear).",
+      "fullyQualifiedName": "Gmail.UpdateDraftEmail@6.0.0",
+      "description": "Update an existing email draft using the Gmail API.\n\nSingle-part ``text/plain`` and single-part ``text/html`` drafts both support full\nbody replacement; the rebuild follows the existing draft's content type, so a\nplain draft stays plain and an HTML draft stays HTML. Plain-text input supplied\nagainst an HTML draft is auto-converted to HTML, and HTML input supplied against\na plain draft is stored verbatim as ``text/plain``. Reply drafts preserve their\nreply-quote tail (``> `` lines for plain, ``<blockquote>`` for HTML) when the\nbody is supplied as a top-only update.\n\nMultipart drafts and drafts with attachments still fail when the body changes;\nin those cases the tool succeeds only when the effective body is unchanged\n(metadata-only update preserving the existing MIME tree). Edit those drafts in\nGmail directly.\n\nFor each of subject, body, recipient, cc, and bcc, omitting the parameter or passing\n``None`` leaves that part of the draft unchanged (for cc/bcc, existing headers are kept;\npass an empty list to clear).",
       "parameters": [
         {
           "name": "draft_email_id",
@@ -1293,7 +1296,7 @@
           "name": "body",
           "type": "string",
           "required": false,
-          "description": "Plain text for merge and rebuild. Omit or pass None to use the existing draft body (plain text, or single-part HTML decoded as text for comparison). Unsupported MIME (HTML with attachments, multipart) is rejected unless the effective body is unchanged so a headers-only update applies.",
+          "description": "Updated body for the draft. There is no `content_type` argument — the body is encoded to match the existing draft, and reply drafts re-attach their existing reply-quote tail. Omit or pass None to leave the body unchanged.",
           "enum": null,
           "inferrable": true
         },
@@ -1402,7 +1405,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Gmail.WhoAmI",
-      "fullyQualifiedName": "Gmail.WhoAmI@5.2.0",
+      "fullyQualifiedName": "Gmail.WhoAmI@6.0.0",
       "description": "Get comprehensive user profile and Gmail account information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Gmail account statistics, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1449,7 +1452,7 @@
     {
       "name": "WriteDraftEmail",
       "qualifiedName": "Gmail.WriteDraftEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftEmail@5.2.0",
+      "fullyQualifiedName": "Gmail.WriteDraftEmail@6.0.0",
       "description": "Compose a new email draft using the Gmail API.",
       "parameters": [
         {
@@ -1464,7 +1467,7 @@
           "name": "body",
           "type": "string",
           "required": true,
-          "description": "The body of the draft email",
+          "description": "The body of the email, as plain text or HTML.",
           "enum": null,
           "inferrable": true
         },
@@ -1498,10 +1501,11 @@
           "name": "content_type",
           "type": "string",
           "required": false,
-          "description": "The content type of the email body. Defaults to 'plain'",
+          "description": "How the body is encoded on the wire. `auto` (default) sends as HTML and auto-converts plain-text input to paragraphs. `html` sends the body verbatim as HTML (use this when it contains entities or non-allow-listed tags); `plain` is plain text.",
           "enum": [
             "plain",
-            "html"
+            "html",
+            "auto"
           ],
           "inferrable": true
         }
@@ -1524,36 +1528,37 @@
         "toolName": "Gmail.WriteDraftEmail",
         "parameters": {
           "subject": {
-            "value": "Meeting Reminder",
+            "value": "Project Update: Q3 Milestones Review",
             "type": "string",
             "required": true
           },
           "body": {
-            "value": "This is a reminder for our meeting scheduled for tomorrow at 10 AM.",
+            "value": "<p>Hi Sarah,</p><p>I wanted to follow up on our discussion from last week regarding the Q3 milestones. Please find the summary below:</p><ul><li>Feature A: Completed</li><li>Feature B: In Progress</li><li>Feature C: Pending Review</li></ul><p>Let me know if you have any questions.</p><p>Best regards,<br>John</p>",
             "type": "string",
             "required": true
           },
           "recipient": {
-            "value": "john.doe@example.com",
+            "value": "sarah.johnson@example.com",
             "type": "string",
             "required": true
           },
           "cc": {
             "value": [
-              "jane.smith@example.com"
+              "manager@example.com",
+              "teamlead@example.com"
             ],
             "type": "array",
             "required": false
           },
           "bcc": {
             "value": [
-              "manager@example.com"
+              "archive@example.com"
             ],
             "type": "array",
             "required": false
           },
           "content_type": {
-            "value": "plain",
+            "value": "html",
             "type": "string",
             "required": false
           }
@@ -1583,14 +1588,14 @@
     {
       "name": "WriteDraftReplyEmail",
       "qualifiedName": "Gmail.WriteDraftReplyEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@5.2.0",
+      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@6.0.0",
       "description": "Compose a draft reply to an email message.",
       "parameters": [
         {
           "name": "body",
           "type": "string",
           "required": true,
-          "description": "The body of the draft reply email",
+          "description": "The body of the email, as plain text or HTML.",
           "enum": null,
           "inferrable": true
         },
@@ -1635,10 +1640,11 @@
           "name": "content_type",
           "type": "string",
           "required": false,
-          "description": "The content type of the email body. Defaults to 'plain'",
+          "description": "How the body is encoded on the wire. `auto` (default) sends as HTML and auto-converts plain-text input to paragraphs. `html` sends the body verbatim as HTML (use this when it contains entities or non-allow-listed tags); `plain` is plain text.",
           "enum": [
             "plain",
-            "html"
+            "html",
+            "auto"
           ],
           "inferrable": true
         }
@@ -1662,12 +1668,12 @@
         "toolName": "Gmail.WriteDraftReplyEmail",
         "parameters": {
           "body": {
-            "value": "Thank you for your message! I have reviewed the details and will get back to you with a full response by end of day tomorrow. Please let me know if you have any urgent questions in the meantime.",
+            "value": "<p>Thank you for reaching out! I have reviewed your message and I am happy to confirm that we can proceed with the proposed timeline. Please let me know if you need any additional information.</p>",
             "type": "string",
             "required": true
           },
           "reply_to_message_id": {
-            "value": "18e4f2a3b7c91d05",
+            "value": "18e4f2a3b1c9d705",
             "type": "string",
             "required": true
           },
@@ -1679,20 +1685,20 @@
           "cc": {
             "value": [
               "manager@example.com",
-              "team-lead@example.com"
+              "teamlead@example.com"
             ],
             "type": "array",
             "required": false
           },
           "bcc": {
             "value": [
-              "records@example.com"
+              "archive@example.com"
             ],
             "type": "array",
             "required": false
           },
           "content_type": {
-            "value": "plain",
+            "value": "auto",
             "type": "string",
             "required": false
           }
@@ -1733,6 +1739,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-04-29T11:39:18.440Z",
-  "summary": "The Gmail toolkit provides Arcade LLM tools for interacting with a user's Gmail account via the Gmail API. It enables agents to read, compose, send, organize, and manage email on behalf of authenticated users.\n\n## Capabilities\n\n- **Reading & searching:** List emails, threads, and drafts; search threads by query; look up emails by header; retrieve full thread details by ID.\n- **Composing & drafting:** Create new drafts, compose draft replies, update existing drafts (metadata-only for HTML/multipart; full body replacement for plain-text drafts), and delete drafts.\n- **Sending:** Send new emails, send existing drafts, and reply to messages directly.\n- **Organization & labels:** List, create, and apply or remove labels; move emails to trash.\n- **Account info:** Retrieve the authenticated user's profile, email address, display name, profile picture, and Gmail account statistics via `WhoAmI`.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via Google. Arcade handles the OAuth flow automatically. See the [Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for configuration details."
+  "generatedAt": "2026-05-13T11:50:30.114Z",
+  "summary": "Gmail toolkit provides LLM-callable tools for interacting with Gmail via the Arcade platform, enabling agents to read, compose, send, organize, and manage email on behalf of authenticated users.\n\n## Capabilities\n\n- **Reading & searching**: List emails, threads, and drafts; search threads; retrieve a thread by ID; search by header fields.\n- **Sending & replying**: Send new emails, send existing drafts, reply to messages, and send draft replies.\n- **Composing & drafting**: Write new drafts, compose draft replies, update existing drafts (subject, body, recipients, cc, bcc — with smart plain/HTML handling and reply-quote preservation), and delete drafts.\n- **Label management**: List all labels, create new labels, and add or remove labels on individual emails.\n- **Mailbox actions**: Move emails to trash, retrieve full thread content, and fetch user profile and account statistics.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via the **Google** provider. Arcade handles the authorization flow automatically. See the [Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for configuration details.\n\n## Draft Update Behavior\n\nKey constraints to be aware of when using `Gmail.UpdateDraftEmail`:\n\n- Single-part `text/plain` and `text/html` drafts support full body replacement; the rebuild preserves the draft's existing content type.\n- Plain-text input against an HTML draft is auto-converted to HTML; HTML input against a plain draft is stored verbatim as `text/plain`.\n- Reply drafts preserve their reply-quote tail (`> ` lines for plain, `<blockquote>` for HTML) on top-only body updates.\n- Multipart drafts and drafts with attachments fail on body changes; only metadata-only updates succeed for those — edit them in Gmail directly.\n- Omitting a parameter or passing `None` leaves that field unchanged; pass an empty list for `cc`/`bcc` to clear those headers."
 }

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-08T11:39:04.763Z",
+  "generatedAt": "2026-05-13T11:50:41.664Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -257,7 +257,7 @@
     {
       "id": "Gmail",
       "label": "Gmail",
-      "version": "5.2.0",
+      "version": "6.0.0",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 18,
@@ -572,7 +572,7 @@
     {
       "id": "MicrosoftOutlookCalendar",
       "label": "Microsoft Outlook Calendar",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 7,
@@ -581,10 +581,10 @@
     {
       "id": "MicrosoftOutlookMail",
       "label": "Microsoft Outlook Mail",
-      "version": "0.2.3",
+      "version": "0.3.1",
       "category": "productivity",
       "type": "arcade",
-      "toolCount": 13,
+      "toolCount": 26,
       "authType": "oauth2"
     },
     {
@@ -608,7 +608,7 @@
     {
       "id": "MicrosoftTeams",
       "label": "Microsoft Teams",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "category": "social",
       "type": "arcade",
       "toolCount": 25,

--- a/toolkit-docs-generator/data/toolkits/microsoftoutlookcalendar.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftoutlookcalendar.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftOutlookCalendar",
   "label": "Microsoft Outlook Calendar",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Arcade.dev LLM tools for Outlook Calendar",
   "metadata": {
     "category": "productivity",
@@ -28,7 +28,7 @@
     {
       "name": "CreateEvent",
       "qualifiedName": "MicrosoftOutlookCalendar.CreateEvent",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.CreateEvent@0.2.0",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.CreateEvent@0.3.0",
       "description": "Create an event in the authenticated user's default calendar.\n\nIgnores timezone offsets provided in the start_date_time and end_date_time parameters.\nInstead, uses the user's default calendar timezone to filter events.\nIf the user has not set a timezone for their calendar, then the timezone will be UTC.",
       "parameters": [
         {
@@ -112,6 +112,58 @@
         "description": "A dictionary containing the created event details"
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookCalendar.CreateEvent",
+        "parameters": {
+          "subject": {
+            "value": "Q3 Project Kickoff Meeting",
+            "type": "string",
+            "required": true
+          },
+          "body": {
+            "value": "Please join us for the Q3 project kickoff. We will review goals, assign responsibilities, and outline the timeline for the upcoming quarter.",
+            "type": "string",
+            "required": true
+          },
+          "start_date_time": {
+            "value": "2025-07-15T10:00:00",
+            "type": "string",
+            "required": true
+          },
+          "end_date_time": {
+            "value": "2025-07-15T11:00:00",
+            "type": "string",
+            "required": true
+          },
+          "location": {
+            "value": "Conference Room B, 3rd Floor",
+            "type": "string",
+            "required": false
+          },
+          "attendee_emails": {
+            "value": [
+              "alice.johnson@example.com",
+              "bob.smith@example.com",
+              "carol.white@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "is_online_meeting": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "custom_meeting_url": {
+            "value": "https://teams.microsoft.com/l/meetup-join/example-meeting-id",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -133,7 +185,7 @@
     {
       "name": "GetEvent",
       "qualifiedName": "MicrosoftOutlookCalendar.GetEvent",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.GetEvent@0.2.0",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.GetEvent@0.3.0",
       "description": "Get an event by its ID from the user's calendar.",
       "parameters": [
         {
@@ -160,6 +212,19 @@
         "description": "A dictionary containing the event details"
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookCalendar.GetEvent",
+        "parameters": {
+          "event_id": {
+            "value": "AAMkADI5NmY2OWE4LTRkZjMtNGQzZC1hYmNkLTEyMzQ1Njc4OTAxMg==",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -181,7 +246,7 @@
     {
       "name": "ListCalendars",
       "qualifiedName": "MicrosoftOutlookCalendar.ListCalendars",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListCalendars@0.2.0",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListCalendars@0.3.0",
       "description": "List all calendars the user has access to.\n\nReturns the user's own calendars plus any shared or delegated calendars.\nEach calendar includes its ID, name, owner, and permissions.\n\nUse a calendar_id from the results to target a specific calendar\nin other calendar tools.",
       "parameters": [
         {
@@ -215,6 +280,24 @@
         "description": "A dictionary containing a list of available calendars."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookCalendar.ListCalendars",
+        "parameters": {
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "pagination_token": {
+            "value": "eyJza2lwVG9rZW4iOiIlMjRza2lwJTNENTAifQ==",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -236,7 +319,7 @@
     {
       "name": "ListEventAttachments",
       "qualifiedName": "MicrosoftOutlookCalendar.ListEventAttachments",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListEventAttachments@0.2.0",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListEventAttachments@0.3.0",
       "description": "List attachment metadata for a calendar event.\n\nReturns metadata only (name, size, type, etc.). Attachment content is not included.\nUse this tool when the user wants to know what files are attached to a calendar event\nor meeting.\n\nPass a calendar_id to list attachments on events in shared or delegated calendars.",
       "parameters": [
         {
@@ -287,6 +370,34 @@
         "description": "A dictionary containing a list of attachment metadata objects."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookCalendar.ListEventAttachments",
+        "parameters": {
+          "event_id": {
+            "value": "AAMkAGI2TG93AAA=",
+            "type": "string",
+            "required": true
+          },
+          "calendar_id": {
+            "value": "AQMkADAwATM0MDAAMS1iNTQ5LTBhZjQtMDACLTAwCgBGAAADyW3X",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 10,
+            "type": "integer",
+            "required": false
+          },
+          "pagination_token": {
+            "value": "eyJza2lwVG9rZW4iOiIxMjM0NTY3ODkwIn0=",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -308,7 +419,7 @@
     {
       "name": "ListEventsInTimeRange",
       "qualifiedName": "MicrosoftOutlookCalendar.ListEventsInTimeRange",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListEventsInTimeRange@0.2.0",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListEventsInTimeRange@0.3.0",
       "description": "List events in the user's calendar in a specific time range.\n\nIgnores timezone offsets provided in the start_date_time and end_date_time parameters.\nInstead, uses the user's default calendar timezone to filter events.\nIf the user has not set a timezone for their calendar, then the timezone will be UTC.",
       "parameters": [
         {
@@ -351,6 +462,29 @@
         "description": "A dictionary containing a list of events"
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookCalendar.ListEventsInTimeRange",
+        "parameters": {
+          "start_date_time": {
+            "value": "2025-06-01T08:00:00",
+            "type": "string",
+            "required": true
+          },
+          "end_date_time": {
+            "value": "2025-06-07T23:59:59",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -372,8 +506,8 @@
     {
       "name": "SearchEvents",
       "qualifiedName": "MicrosoftOutlookCalendar.SearchEvents",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.SearchEvents@0.2.0",
-      "description": "Search calendar events within a time range with optional filters.\n\nReturns events filtered by subject keyword, attendee, organizer,\nimportance, or online-meeting status. Results are in chronological order.\n\nBy default, searches the user's primary calendar. Pass a calendar_id\nto search a shared or delegated calendar.\n\nEvent bodies are truncated to 200 characters for efficient skimming.\nUse the event_id from the results to retrieve full event details.",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.SearchEvents@0.3.0",
+      "description": "Search calendar events within a time range with optional filters.\n\nResults are in chronological order.\n\nEvent bodies are truncated to 200 characters for efficient skimming.\nUse the event_id from the results to retrieve full event details.",
       "parameters": [
         {
           "name": "subject",
@@ -396,7 +530,15 @@
           "name": "organizer_name",
           "type": "string",
           "required": false,
-          "description": "Filter events organized by this person's display name. Note: filtering by organizer email address is not supported by the Microsoft Graph API. Use the organizer's display name instead. Defaults to None (no organizer filter).",
+          "description": "Filter events organized by another specific person by their display name. Matching is case-insensitive substring against the organizer's display name. Do not use this to filter for events organized by the current authenticated user — use organized_by_me=True instead, which does not depend on knowing your own display name. Defaults to None (no organizer filter).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "organized_by_me",
+          "type": "boolean",
+          "required": false,
+          "description": "Filter for events the current authenticated user organized (True) vs. events the current user was invited to but did not organize (False). Defaults to None (no filter). Prefer this over organizer_name when the user asks about their own events — it does not require knowing the user's display name in the tenant's format.",
           "enum": null,
           "inferrable": true
         },
@@ -456,7 +598,7 @@
           "name": "limit",
           "type": "integer",
           "required": false,
-          "description": "Maximum number of events to return. Max is 200. Defaults to 25.",
+          "description": "Maximum number of matching events to return. Max is 200. Defaults to 25. When client-side filters are active, the tool may scan multiple pages to accumulate matches.",
           "enum": null,
           "inferrable": true
         },
@@ -464,7 +606,7 @@
           "name": "pagination_token",
           "type": "string",
           "required": false,
-          "description": "The pagination token to continue a previous request.",
+          "description": "Encoded pagination token to continue a previous request. Preserves client-side filter state (attendee_emails, organizer_name, organized_by_me, is_online_meeting) across continuation calls.",
           "enum": null,
           "inferrable": true
         }
@@ -484,6 +626,77 @@
         "description": "A dictionary containing a list of matching calendar events."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookCalendar.SearchEvents",
+        "parameters": {
+          "subject": {
+            "value": "quarterly review",
+            "type": "string",
+            "required": false
+          },
+          "attendee_emails": {
+            "value": [
+              "alice@example.com",
+              "bob@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "organizer_name": {
+            "value": "Jane Smith",
+            "type": "string",
+            "required": false
+          },
+          "organized_by_me": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "importance": {
+            "value": "high",
+            "type": "string",
+            "required": false
+          },
+          "is_online_meeting": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "start_date_time": {
+            "value": "2024-06-01T08:00:00",
+            "type": "string",
+            "required": false
+          },
+          "end_date_time": {
+            "value": "2024-09-01T18:00:00",
+            "type": "string",
+            "required": false
+          },
+          "calendar_id": {
+            "value": "AQMkADAwATM0MDAAMS1hYjcd==",
+            "type": "string",
+            "required": false
+          },
+          "include_cancelled": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "pagination_token": {
+            "value": "eyJza2lwVG9rZW4iOiIlMjRza2lwdG9rZW49MTAifQ==",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -505,7 +718,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftOutlookCalendar.WhoAmI",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.WhoAmI@0.2.0",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.WhoAmI@0.3.0",
       "description": "Get information about the current user and their Outlook Calendar environment.",
       "parameters": [],
       "auth": {
@@ -524,6 +737,13 @@
         "description": "Get comprehensive user profile and Outlook Calendar information."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookCalendar.WhoAmI",
+        "parameters": {},
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -546,6 +766,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-04-02T11:25:02.800Z",
-  "summary": "Microsoft Outlook Calendar is Microsoft's calendaring service, accessed through the Microsoft Graph API. The Arcade Outlook Calendar toolkit lets agents read and manage events across a user's primary and shared calendars.\n\n**Capabilities**\n\n- Create events with attendees, locations, and optional online-meeting links.\n- List and search events in a time range with filters for subject, attendees, organizer, importance, and online-meeting status.\n- Retrieve individual events and list event attachment metadata.\n- Enumerate calendars (including shared and delegated) and fetch profile details via WhoAmI.\n\n**OAuth**\n\nRequires Microsoft OAuth. See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration."
+  "generatedAt": "2026-05-13T11:50:27.729Z",
+  "summary": "## Microsoft Outlook Calendar Toolkit\n\nThe Microsoft Outlook Calendar toolkit lets Arcade-powered LLMs interact with a user's Outlook Calendar via the Microsoft Graph API, enabling calendar reads, writes, and queries on behalf of authenticated users.\n\n## Capabilities\n\n- **Calendar discovery & context:** List all calendars the user owns, shares, or has delegated access to; retrieve current user identity and calendar environment details.\n- **Event creation:** Create events in the user's default calendar; timezone handling defers to the calendar's configured timezone (falls back to UTC if unset).\n- **Event retrieval & listing:** Fetch a specific event by ID, or list all events within a defined time range using the calendar's native timezone.\n- **Search & filtering:** Search events across a time range with optional filters; results are chronologically ordered with body content truncated to 200 characters for efficiency — use the returned event ID to fetch full details.\n- **Attachment inspection:** List attachment metadata (name, size, type) for any calendar event, including events on shared or delegated calendars; attachment content is not returned.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 delegated auth via **Microsoft**. Arcade handles the OAuth flow automatically. See the [Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration details."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftoutlookmail.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftoutlookmail.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftOutlookMail",
   "label": "Microsoft Outlook Mail",
-  "version": "0.2.3",
+  "version": "0.3.1",
   "description": "Arcade.dev LLM tools for Outlook Mail",
   "metadata": {
     "category": "productivity",
@@ -18,8 +18,11 @@
     "providerId": "microsoft",
     "allScopes": [
       "Mail.Read",
+      "Mail.Read.Shared",
       "Mail.ReadWrite",
+      "Mail.ReadWrite.Shared",
       "Mail.Send",
+      "Mail.Send.Shared",
       "MailboxSettings.Read",
       "User.Read"
     ]
@@ -28,7 +31,7 @@
     {
       "name": "CreateAndSendEmail",
       "qualifiedName": "MicrosoftOutlookMail.CreateAndSendEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.CreateAndSendEmail@0.2.3",
+      "fullyQualifiedName": "MicrosoftOutlookMail.CreateAndSendEmail@0.3.1",
       "description": "Create and immediately send a new email in Outlook to the specified recipients.\n\nReturns the sent message's ``message_id`` and ``conversation_id`` so callers\ncan immediately chain follow-ups (e.g. reply to what they just sent) without\nhaving to search Sent Items.",
       "parameters": [
         {
@@ -167,7 +170,7 @@
     {
       "name": "CreateDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.CreateDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.CreateDraftEmail@0.2.3",
+      "fullyQualifiedName": "MicrosoftOutlookMail.CreateDraftEmail@0.3.1",
       "description": "Compose a new draft email in Outlook",
       "parameters": [
         {
@@ -306,7 +309,7 @@
     {
       "name": "GetEmail",
       "qualifiedName": "MicrosoftOutlookMail.GetEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.GetEmail@0.2.3",
+      "fullyQualifiedName": "MicrosoftOutlookMail.GetEmail@0.3.1",
       "description": "Retrieve a single email message by its ID.\n\nReturns email metadata and body content. By default, the body is returned\nas plain text (HTML tags stripped) and capped at 5000 characters. Set\nbody_format to HTML to get the original markup. Use body_offset to\ncontinue reading long emails, or set max_body_characters to None for the\nfull body.\n\nUse this tool to read the full content of an email after finding it via\nsearch_emails or any listing tool.",
       "parameters": [
         {
@@ -409,7 +412,7 @@
     {
       "name": "ListEmailAttachments",
       "qualifiedName": "MicrosoftOutlookMail.ListEmailAttachments",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailAttachments@0.2.3",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailAttachments@0.3.1",
       "description": "List attachment metadata for an email message.\n\nReturns metadata only (name, size, type, etc.). Attachment content is not included.\nUse this tool when the user wants to know what files are attached to an email.",
       "parameters": [
         {
@@ -496,7 +499,7 @@
     {
       "name": "ListEmails",
       "qualifiedName": "MicrosoftOutlookMail.ListEmails",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmails@0.2.3",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmails@0.3.1",
       "description": "List emails in the user's mailbox across all folders.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).\n\nSince this tool lists email across all folders, it may return sent items,\ndrafts, and other items that are not in the inbox.",
       "parameters": [
         {
@@ -604,7 +607,7 @@
     {
       "name": "ListEmailsByProperty",
       "qualifiedName": "MicrosoftOutlookMail.ListEmailsByProperty",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsByProperty@0.2.3",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsByProperty@0.3.1",
       "description": "List emails in the user's mailbox across all folders filtering by a property.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).\n\nSorting by RECEIVED_DATE_TIME works with any filter property. Sorting by\na different property (SUBJECT, SENDER, IMPORTANCE) while filtering by an\nunrelated property may fail due to a Microsoft Graph API restriction. If\nthis happens, either sort by RECEIVED_DATE_TIME, or use list_emails (no\nfilter) with the desired sort_by.",
       "parameters": [
         {
@@ -770,7 +773,7 @@
     {
       "name": "ListEmailsInFolder",
       "qualifiedName": "MicrosoftOutlookMail.ListEmailsInFolder",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsInFolder@0.2.3",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsInFolder@0.3.1",
       "description": "List the user's emails in the specified folder.\n\nExactly one of `well_known_folder_name` or `folder_id` MUST be provided.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
       "parameters": [
         {
@@ -912,7 +915,7 @@
     {
       "name": "ListMailFolders",
       "qualifiedName": "MicrosoftOutlookMail.ListMailFolders",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListMailFolders@0.2.3",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListMailFolders@0.3.1",
       "description": "List mail folders in the user's mailbox.\n\nReturns folder names, IDs, unread counts, and total item counts.\nUse the folder ID in follow-up calls to list_emails_in_folder.\nOmit parent_folder_id to list top-level folders, or provide a folder ID\nto list its child folders.",
       "parameters": [
         {
@@ -1011,7 +1014,7 @@
     {
       "name": "ReplyToEmail",
       "qualifiedName": "MicrosoftOutlookMail.ReplyToEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ReplyToEmail@0.2.3",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ReplyToEmail@0.3.1",
       "description": "Reply to an existing email in Outlook.\n\nUse this tool to reply to the sender or all recipients of the email.\nSpecify the reply_type to determine the scope of the reply.",
       "parameters": [
         {
@@ -1101,7 +1104,7 @@
     {
       "name": "SearchEmails",
       "qualifiedName": "MicrosoftOutlookMail.SearchEmails",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SearchEmails@0.2.3",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SearchEmails@0.3.1",
       "description": "Search emails across the user's entire mailbox.\n\nCombines full-text keyword search with structured filters for sender,\nread status, attachments, importance, and more. All provided parameters\nare combined with AND. Results are ordered by date sent (most recent first).\n\nEmail bodies are truncated to 255 characters for efficient skimming.\nUse get_email with the message_id to retrieve the full email content.\n\nUse this tool when the user wants to find emails by content, topic, sender,\nor a combination of criteria. For exact property filtering (e.g., by\nconversationId or flag status), use list_emails_by_property instead.\n\n.. note::\n   Microsoft Graph's ``$search`` on messages is backed by the Microsoft\n   Search index, which returns message IDs in the legacy REST-ID format\n   even when the client opts into Immutable IDs (which other tools in\n   this toolkit do by default). Do not directly compare a ``message_id``\n   from ``search_emails`` against one from ``list_emails`` /\n   ``get_email`` — the ID shapes differ. To chain from a search hit,\n   pass the returned ID straight back into ``get_email`` (which accepts\n   either format), and use ``conversation_id`` as the deduplication\n   key across result sets.",
       "parameters": [
         {
@@ -1325,7 +1328,7 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.SendDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SendDraftEmail@0.2.3",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SendDraftEmail@0.3.1",
       "description": "Send an existing draft email in Outlook.\n\nSends any un-sent message — draft, reply-draft, reply-all draft, or\nforward draft — and returns the message's ``message_id`` and\n``conversation_id`` so callers can chain follow-ups (e.g. reply to\nthe message they just sent) without searching Sent Items.",
       "parameters": [
         {
@@ -1384,9 +1387,1771 @@
       }
     },
     {
+      "name": "SharedMailboxCheckCapabilities",
+      "qualifiedName": "MicrosoftOutlookMail.SharedMailboxCheckCapabilities",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCheckCapabilities@0.3.1",
+      "description": "Check which provided mailboxes are reachable via shared mailbox APIs.\n\nThis is a capability checker, not an Exchange permission inventory. It\nverifies whether each provided mailbox can be reached through a cheap,\nread-only Graph call. When checking multiple mailboxes, pass them together\nin one ``owner_emails`` list so results can be deduplicated and rate-limited\nconsistently. Microsoft Graph does not expose exact ``Send As`` vs ``Send\non behalf`` permissions, so the response names that limitation explicitly\ninstead of guessing.",
+      "parameters": [
+        {
+          "name": "owner_emails",
+          "type": "array",
+          "innerType": "string",
+          "required": true,
+          "description": "Mailbox addresses to check. Use exact email addresses or UPNs. Pass all candidate mailboxes in this single list instead of calling the tool once per mailbox. This tool performs read-only Graph probes and returns one result per address.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "Mail.Read.Shared"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SharedMailboxCheckCapabilities",
+        "parameters": {
+          "owner_emails": {
+            "value": [
+              "alice@contoso.com",
+              "bob@fabrikam.org",
+              "support-team@northwindtraders.net"
+            ],
+            "type": "array",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SharedMailboxCreateAndSendEmail",
+      "qualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateAndSendEmail",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateAndSendEmail@0.3.1",
+      "description": "Create and immediately send an email from a shared or delegated mailbox.\n\nUse this when the user wants the email to be sent from a team inbox (like\nsales@ or support@) or from an executive's mailbox they have been\ndelegated access to, rather than from their own address.",
+      "parameters": [
+        {
+          "name": "owner_email",
+          "type": "string",
+          "required": true,
+          "description": "The mailbox address to send from. Can be a team or shared mailbox, or a specific person's mailbox you have been delegated Send-As or Send-On-Behalf permission for. Provide as a Microsoft Graph UPN (local-part@verified-domain).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "subject",
+          "type": "string",
+          "required": true,
+          "description": "The subject of the email to create",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "required": true,
+          "description": "The body of the email to create",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "to_recipients",
+          "type": "array",
+          "innerType": "string",
+          "required": true,
+          "description": "The email addresses that will be the recipients of the email",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cc_recipients",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "The email addresses that will be the CC recipients of the email.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "bcc_recipients",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "The email addresses that will be the BCC recipients of the email.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "body_type",
+          "type": "string",
+          "required": false,
+          "description": "The content type of the email body. Defaults to 'text'",
+          "enum": [
+            "text",
+            "html"
+          ],
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "Mail.ReadWrite.Shared",
+          "Mail.Send.Shared"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SharedMailboxCreateAndSendEmail",
+        "parameters": {
+          "owner_email": {
+            "value": "support@contoso.com",
+            "type": "string",
+            "required": true
+          },
+          "subject": {
+            "value": "Your Support Ticket Has Been Received",
+            "type": "string",
+            "required": true
+          },
+          "body": {
+            "value": "Dear Customer,\n\nThank you for reaching out to our support team. We have received your request and a team member will get back to you within 24 hours.\n\nBest regards,\nContoso Support Team",
+            "type": "string",
+            "required": true
+          },
+          "to_recipients": {
+            "value": [
+              "jane.doe@example.com",
+              "john.smith@example.com"
+            ],
+            "type": "array",
+            "required": true
+          },
+          "cc_recipients": {
+            "value": [
+              "manager@contoso.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "bcc_recipients": {
+            "value": [
+              "ticketing-log@contoso.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "body_type": {
+            "value": "text",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SharedMailboxCreateDraftEmail",
+      "qualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateDraftEmail",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateDraftEmail@0.3.1",
+      "description": "Compose a new draft email in a shared or delegated mailbox.",
+      "parameters": [
+        {
+          "name": "owner_email",
+          "type": "string",
+          "required": true,
+          "description": "The mailbox address to create the draft in. Can be a team or shared mailbox, or a specific person's mailbox you have delegate access to. Provide as a Microsoft Graph UPN (local-part@verified-domain).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "subject",
+          "type": "string",
+          "required": true,
+          "description": "The subject of the draft email to create",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "required": true,
+          "description": "The body of the draft email to create",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "to_recipients",
+          "type": "array",
+          "innerType": "string",
+          "required": true,
+          "description": "The email addresses that will be the recipients of the draft email",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cc_recipients",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "The email addresses that will be the CC recipients of the draft email.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "bcc_recipients",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "The email addresses that will be the BCC recipients of the draft email.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "body_type",
+          "type": "string",
+          "required": false,
+          "description": "The content type of the email body. Defaults to 'text'",
+          "enum": [
+            "text",
+            "html"
+          ],
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "MailboxSettings.Read",
+          "Mail.ReadWrite.Shared"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SharedMailboxCreateDraftEmail",
+        "parameters": {
+          "owner_email": {
+            "value": "sales-team@contoso.com",
+            "type": "string",
+            "required": true
+          },
+          "subject": {
+            "value": "Q3 Budget Review Meeting Follow-Up",
+            "type": "string",
+            "required": true
+          },
+          "body": {
+            "value": "Hi team,\n\nThank you for attending today's Q3 budget review meeting. Please find the action items attached. Let me know if you have any questions.\n\nBest regards,\nThe Sales Team",
+            "type": "string",
+            "required": true
+          },
+          "to_recipients": {
+            "value": [
+              "alice.johnson@contoso.com",
+              "bob.smith@fabrikam.com"
+            ],
+            "type": "array",
+            "required": true
+          },
+          "cc_recipients": {
+            "value": [
+              "manager@contoso.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "bcc_recipients": {
+            "value": [
+              "compliance@contoso.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "body_type": {
+            "value": "text",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SharedMailboxGetEmail",
+      "qualifiedName": "MicrosoftOutlookMail.SharedMailboxGetEmail",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxGetEmail@0.3.1",
+      "description": "Retrieve a single email from a shared or delegated mailbox by message ID.\n\nReturns email metadata and body content. By default, the body is returned\nas plain text (HTML tags stripped) and capped at 5000 characters. Use\nbody_offset to continue reading long emails, or set max_body_characters\nto None for the full body.",
+      "parameters": [
+        {
+          "name": "owner_email",
+          "type": "string",
+          "required": true,
+          "description": "The mailbox address to read from. Can be a team or shared mailbox, or a specific person's mailbox you have delegate access to. Provide as a Microsoft Graph UPN (local-part@verified-domain).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the email message to retrieve.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "body_format",
+          "type": "string",
+          "required": false,
+          "description": "Format for the returned email body. PLAIN_TEXT strips HTML tags for clean reading. HTML returns the original markup. Defaults to PLAIN_TEXT.",
+          "enum": [
+            "plain_text",
+            "html"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "max_body_characters",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of characters to return from the email body. Defaults to 5000. Set to None to return the full body without a cap.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "body_offset",
+          "type": "integer",
+          "required": false,
+          "description": "Character offset to start reading the body from. Use this to continue reading a long email body that was previously capped. Defaults to 0 (start of body).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "MailboxSettings.Read",
+          "Mail.Read.Shared"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SharedMailboxGetEmail",
+        "parameters": {
+          "owner_email": {
+            "value": "support-team@contoso.com",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": "AAMkAGI2TG93AAA=",
+            "type": "string",
+            "required": true
+          },
+          "body_format": {
+            "value": "PLAIN_TEXT",
+            "type": "string",
+            "required": false
+          },
+          "max_body_characters": {
+            "value": 3000,
+            "type": "integer",
+            "required": false
+          },
+          "body_offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SharedMailboxListEmailAttachments",
+      "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailAttachments",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailAttachments@0.3.1",
+      "description": "List attachment metadata for an email in a shared or delegated mailbox.",
+      "parameters": [
+        {
+          "name": "owner_email",
+          "type": "string",
+          "required": true,
+          "description": "The mailbox address that owns the email. Can be a team or shared mailbox, or a specific person's mailbox you have delegate access to. Provide as a Microsoft Graph UPN (local-part@verified-domain).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the email message to list attachments for.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of attachments to return. Max is 100. Defaults to 25.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "pagination_token",
+          "type": "string",
+          "required": false,
+          "description": "The pagination token to continue a previous request",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "MailboxSettings.Read",
+          "Mail.Read.Shared"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SharedMailboxListEmailAttachments",
+        "parameters": {
+          "owner_email": {
+            "value": "sharedmailbox@contoso.com",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": "AAMkAGI2TG93AAA=",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 10,
+            "type": "integer",
+            "required": false
+          },
+          "pagination_token": {
+            "value": "eyJza2lwVG9rZW4iOiIxMDAifQ==",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SharedMailboxListEmails",
+      "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmails",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmails@0.3.1",
+      "description": "List emails in a shared or delegated mailbox, across all folders.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
+      "parameters": [
+        {
+          "name": "owner_email",
+          "type": "string",
+          "required": true,
+          "description": "The mailbox address to read from. Can be a team or shared mailbox, or a specific person's mailbox you have delegate access to. Provide as a Microsoft Graph UPN (local-part@verified-domain).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "sort_by",
+          "type": "string",
+          "required": false,
+          "description": "Property to sort results by. Defaults to received date.",
+          "enum": [
+            "receivedDateTime",
+            "subject",
+            "sender_email_address",
+            "importance"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "sort_order",
+          "type": "string",
+          "required": false,
+          "description": "Sort direction. Defaults to descending.",
+          "enum": [
+            "ascending",
+            "descending"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "The number of messages to return. Max is 100. Defaults to 10.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "pagination_token",
+          "type": "string",
+          "required": false,
+          "description": "The pagination token to continue a previous request",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "MailboxSettings.Read",
+          "Mail.Read.Shared"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SharedMailboxListEmails",
+        "parameters": {
+          "owner_email": {
+            "value": "support-team@contoso.com",
+            "type": "string",
+            "required": true
+          },
+          "sort_by": {
+            "value": "receivedDateTime",
+            "type": "string",
+            "required": false
+          },
+          "sort_order": {
+            "value": "descending",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "pagination_token": {
+            "value": "AQMkADAwATM0MDAAMS1iNmY5LTYwNjktMDACLTAwCgAuAAADqXmCGSjHQEuVapL9V2LZBQEJ7kX2z0aFQpCqW7X8EjsAAAA=",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SharedMailboxListEmailsByProperty",
+      "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsByProperty",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsByProperty@0.3.1",
+      "description": "List emails in a shared or delegated mailbox filtered by a property.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
+      "parameters": [
+        {
+          "name": "owner_email",
+          "type": "string",
+          "required": true,
+          "description": "The mailbox address to read from. Can be a team or shared mailbox, or a specific person's mailbox you have delegate access to. Provide as a Microsoft Graph UPN (local-part@verified-domain).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "mail_property",
+          "type": "string",
+          "required": true,
+          "description": "The property to filter the emails by.",
+          "enum": [
+            "subject",
+            "conversationId",
+            "receivedDateTime",
+            "sender/emailAddress/address",
+            "isRead",
+            "hasAttachments",
+            "importance",
+            "flag/flagStatus"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "operator",
+          "type": "string",
+          "required": true,
+          "description": "The operator to use for the filter.",
+          "enum": [
+            "eq",
+            "ne",
+            "gt",
+            "ge",
+            "lt",
+            "le",
+            "startsWith",
+            "endsWith",
+            "contains"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "value",
+          "type": "string",
+          "required": true,
+          "description": "The value to filter the emails by",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "sort_by",
+          "type": "string",
+          "required": false,
+          "description": "Property to sort results by. Defaults to received date. Sorting by received date works with any filter property.",
+          "enum": [
+            "receivedDateTime",
+            "subject",
+            "sender_email_address",
+            "importance"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "sort_order",
+          "type": "string",
+          "required": false,
+          "description": "Sort direction. Defaults to descending.",
+          "enum": [
+            "ascending",
+            "descending"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "The number of messages to return. Max is 100. Defaults to 10.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "pagination_token",
+          "type": "string",
+          "required": false,
+          "description": "The pagination token to continue a previous request",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "MailboxSettings.Read",
+          "Mail.Read.Shared"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SharedMailboxListEmailsByProperty",
+        "parameters": {
+          "owner_email": {
+            "value": "sharedmailbox@contoso.com",
+            "type": "string",
+            "required": true
+          },
+          "mail_property": {
+            "value": "sender/emailAddress/address",
+            "type": "string",
+            "required": true
+          },
+          "operator": {
+            "value": "eq",
+            "type": "string",
+            "required": true
+          },
+          "value": {
+            "value": "notifications@example.com",
+            "type": "string",
+            "required": true
+          },
+          "sort_by": {
+            "value": "receivedDateTime",
+            "type": "string",
+            "required": false
+          },
+          "sort_order": {
+            "value": "descending",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "pagination_token": {
+            "value": "AQMkADAwATNiZmYAZC1hYjEyLTQ4NzUtMDACLTAwCgAuAAADexample123tokenXYZ==",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SharedMailboxListEmailsInFolder",
+      "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsInFolder",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsInFolder@0.3.1",
+      "description": "List emails in a specific folder of a shared or delegated mailbox.\n\nExactly one of `well_known_folder_name` or `folder_id` MUST be provided.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
+      "parameters": [
+        {
+          "name": "owner_email",
+          "type": "string",
+          "required": true,
+          "description": "The mailbox address to read from. Can be a team or shared mailbox, or a specific person's mailbox you have delegate access to. Provide as a Microsoft Graph UPN (local-part@verified-domain).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "well_known_folder_name",
+          "type": "string",
+          "required": false,
+          "description": "The name of the folder to list emails from. Defaults to None.",
+          "enum": [
+            "deleteditems",
+            "drafts",
+            "inbox",
+            "junkemail",
+            "sentitems",
+            "starred",
+            "tasks"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "folder_id",
+          "type": "string",
+          "required": false,
+          "description": "The ID of the folder to list emails from if the folder is not a well-known folder. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "sort_by",
+          "type": "string",
+          "required": false,
+          "description": "Property to sort results by. Defaults to received date.",
+          "enum": [
+            "receivedDateTime",
+            "subject",
+            "sender_email_address",
+            "importance"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "sort_order",
+          "type": "string",
+          "required": false,
+          "description": "Sort direction. Defaults to descending.",
+          "enum": [
+            "ascending",
+            "descending"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "The number of messages to return. Max is 100. Defaults to 10.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "pagination_token",
+          "type": "string",
+          "required": false,
+          "description": "The pagination token to continue a previous request",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "MailboxSettings.Read",
+          "Mail.Read.Shared"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SharedMailboxListEmailsInFolder",
+        "parameters": {
+          "owner_email": {
+            "value": "support-team@contoso.com",
+            "type": "string",
+            "required": true
+          },
+          "well_known_folder_name": {
+            "value": "inbox",
+            "type": "string",
+            "required": false
+          },
+          "folder_id": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "sort_by": {
+            "value": "receivedDateTime",
+            "type": "string",
+            "required": false
+          },
+          "sort_order": {
+            "value": "descending",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "pagination_token": {
+            "value": "AQMkADAwATNiZmYAZC1hYjEyLTQ5ZjQtMDACLTAwCgBGAAAD",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SharedMailboxListMailFolders",
+      "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListMailFolders",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListMailFolders@0.3.1",
+      "description": "List mail folders in a shared or delegated mailbox.\n\nReturns folder names, IDs, unread counts, and total item counts.\nUse the folder ID when listing emails in a specific folder.",
+      "parameters": [
+        {
+          "name": "owner_email",
+          "type": "string",
+          "required": true,
+          "description": "The mailbox address to read folders from. Can be a team or shared mailbox, or a specific person's mailbox you have delegate access to. Provide as a Microsoft Graph UPN (local-part@verified-domain).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "parent_folder_id",
+          "type": "string",
+          "required": false,
+          "description": "ID of a parent folder to list child folders of. When omitted, lists top-level mailbox folders.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "include_hidden",
+          "type": "boolean",
+          "required": false,
+          "description": "Whether to include hidden folders in the response. Defaults to False.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of folders to return. Max is 100. Defaults to 25.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "pagination_token",
+          "type": "string",
+          "required": false,
+          "description": "The pagination token to continue a previous request.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "Mail.Read.Shared"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SharedMailboxListMailFolders",
+        "parameters": {
+          "owner_email": {
+            "value": "shared-support@contoso.com",
+            "type": "string",
+            "required": true
+          },
+          "parent_folder_id": {
+            "value": "AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY3OTgxODQ5OABGAAAAAAA",
+            "type": "string",
+            "required": false
+          },
+          "include_hidden": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "pagination_token": {
+            "value": "eyJza2lwVG9rZW4iOiIlMjFDQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQSIsInBhZ2VTaXplIjoyNX0=",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SharedMailboxReplyToEmail",
+      "qualifiedName": "MicrosoftOutlookMail.SharedMailboxReplyToEmail",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxReplyToEmail@0.3.1",
+      "description": "Reply to an email in a shared or delegated mailbox.\n\nThe reply is sent from the shared mailbox address, not the signed-in\nuser's personal address. Specify reply_type to reply only to the sender\nor to all recipients.",
+      "parameters": [
+        {
+          "name": "owner_email",
+          "type": "string",
+          "required": true,
+          "description": "The mailbox address to reply from. Can be a team or shared mailbox, or a specific person's mailbox you have delegate access to. Provide as a Microsoft Graph UPN (local-part@verified-domain).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the email to reply to",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "required": true,
+          "description": "The body of the reply to the email",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "reply_type",
+          "type": "string",
+          "required": false,
+          "description": "Specify ReplyType.REPLY to reply only to the sender or ReplyType.REPLY_ALL to reply to all recipients. Defaults to ReplyType.REPLY.",
+          "enum": [
+            "reply",
+            "reply_all"
+          ],
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "Mail.ReadWrite.Shared",
+          "Mail.Send.Shared"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SharedMailboxReplyToEmail",
+        "parameters": {
+          "owner_email": {
+            "value": "support-team@contoso.com",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": "AAMkAGI2TG93AAA=",
+            "type": "string",
+            "required": true
+          },
+          "body": {
+            "value": "Thank you for reaching out! We have received your request and will get back to you within 24 hours. Please let us know if you have any additional questions in the meantime.",
+            "type": "string",
+            "required": true
+          },
+          "reply_type": {
+            "value": "ReplyType.REPLY_ALL",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SharedMailboxSearchEmails",
+      "qualifiedName": "MicrosoftOutlookMail.SharedMailboxSearchEmails",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxSearchEmails@0.3.1",
+      "description": "Search emails in a shared or delegated mailbox.\n\nCombines full-text keyword search with structured filters for sender,\nread status, attachments, importance, and more. All provided parameters\nare combined with AND. Results are ordered by date sent (most recent first).\n\nEmail bodies are truncated to 255 characters. Retrieve a message by its\nmessage ID when the full content is needed.\n\n.. note::\n   Search results may use a different Graph ID shape than list/get\n   results. Use returned message IDs directly for message retrieval and\n   ``conversation_id`` for deduplication across result sets.",
+      "parameters": [
+        {
+          "name": "owner_email",
+          "type": "string",
+          "required": true,
+          "description": "The mailbox address to search. Can be a team or shared mailbox, or a specific person's mailbox you have delegate access to. Provide as a Microsoft Graph UPN (local-part@verified-domain).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "keywords",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Words or phrases to search for across email subject, body, and sender fields. All terms must match (AND operator). Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "sender",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Filter by sender email address, display name, or alias. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "recipient",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Filter by To-recipient email address or display name. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "attachment_name",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Filter by attachment filename. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "has_attachments",
+          "type": "boolean",
+          "required": false,
+          "description": "Filter for emails with or without attachments. Defaults to None (no filter).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "importance",
+          "type": "string",
+          "required": false,
+          "description": "Filter by email importance level. Defaults to None (no filter).",
+          "enum": [
+            "low",
+            "normal",
+            "high"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "is_read",
+          "type": "boolean",
+          "required": false,
+          "description": "Filter by read status. True for read emails, False for unread. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "category",
+          "type": "string",
+          "required": false,
+          "description": "Filter by email category name. Defaults to None (no filter).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "received_after",
+          "type": "string",
+          "required": false,
+          "description": "Filter for emails received on or after this date (YYYY-MM-DD). Dates are interpreted in UTC. Defaults to None (no filter).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "received_before",
+          "type": "string",
+          "required": false,
+          "description": "Filter for emails received on or before this date (YYYY-MM-DD). Dates are interpreted in UTC. Defaults to None (no filter).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of search results to return. Max is 25. Defaults to 10.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "pagination_token",
+          "type": "string",
+          "required": false,
+          "description": "The pagination token to continue a previous request.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "MailboxSettings.Read",
+          "Mail.Read.Shared"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SharedMailboxSearchEmails",
+        "parameters": {
+          "owner_email": {
+            "value": "sharedmailbox@contoso.com",
+            "type": "string",
+            "required": true
+          },
+          "keywords": {
+            "value": [
+              "project update",
+              "Q3 report"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "sender": {
+            "value": [
+              "john.doe@example.com",
+              "Jane Smith"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "recipient": {
+            "value": [
+              "team-leads@contoso.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "attachment_name": {
+            "value": [
+              "Q3_Report.pdf",
+              "budget.xlsx"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "has_attachments": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "importance": {
+            "value": "high",
+            "type": "string",
+            "required": false
+          },
+          "is_read": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "category": {
+            "value": "Finance",
+            "type": "string",
+            "required": false
+          },
+          "received_after": {
+            "value": "2024-01-01",
+            "type": "string",
+            "required": false
+          },
+          "received_before": {
+            "value": "2024-06-30",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 15,
+            "type": "integer",
+            "required": false
+          },
+          "pagination_token": {
+            "value": "AQMkADAwATNiZmYAZC0xMjM0LTU2NzgtOTBhYi1jZGVmMTIzNDU2NzgALgAAA1bX9k2Q3E6TpHw8zLmVoAEAn7RtKp2FxUqJvBcDe4XQAAACBQAAAA==",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SharedMailboxSendDraftEmail",
+      "qualifiedName": "MicrosoftOutlookMail.SharedMailboxSendDraftEmail",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxSendDraftEmail@0.3.1",
+      "description": "Send an existing draft email from a shared or delegated mailbox.\n\nThis tool can send any un-sent email in the shared mailbox:\n    - draft\n    - reply-draft\n    - reply-all draft\n    - forward draft\n\nReturns the message's ``message_id`` and ``conversation_id`` so callers\ncan chain follow-ups (e.g. reply to the message they just sent) without\nsearching Sent Items.",
+      "parameters": [
+        {
+          "name": "owner_email",
+          "type": "string",
+          "required": true,
+          "description": "The mailbox address that owns the draft. Can be a team or shared mailbox, or a specific person's mailbox you have delegate access to. Provide as a Microsoft Graph UPN (local-part@verified-domain).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the draft email to send",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "Mail.Read.Shared",
+          "Mail.Send.Shared"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SharedMailboxSendDraftEmail",
+        "parameters": {
+          "owner_email": {
+            "value": "sales-team@contoso.com",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": "AAMkAGI2NGVhZTVlLTI1OGMtNDI4Mi1iZWYwLTljNGYwZjk1ZGI3MABGAAAAAADUuTJK1K9AfQ6M9FcA",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SharedMailboxUpdateDraftEmail",
+      "qualifiedName": "MicrosoftOutlookMail.SharedMailboxUpdateDraftEmail",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxUpdateDraftEmail@0.3.1",
+      "description": "Update an existing draft email in a shared or delegated mailbox.\n\nOverwrites the subject and body of a draft (if provided) and modifies its\nrecipient lists by selectively adding or removing email addresses.",
+      "parameters": [
+        {
+          "name": "owner_email",
+          "type": "string",
+          "required": true,
+          "description": "The mailbox address that owns the draft. Can be a team or shared mailbox, or a specific person's mailbox you have delegate access to. Provide as a Microsoft Graph UPN (local-part@verified-domain).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the draft email to update",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "subject",
+          "type": "string",
+          "required": false,
+          "description": "The new subject of the draft email. If provided, the existing subject will be overwritten",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "required": false,
+          "description": "The new body of the draft email. If provided, the existing body will be overwritten",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "to_add",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Email addresses to add as 'To' recipients.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "to_remove",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Email addresses to remove from the current 'To' recipients.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cc_add",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Email addresses to add as 'CC' recipients.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cc_remove",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Email addresses to remove from the current 'CC' recipients.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "bcc_add",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Email addresses to add as 'BCC' recipients.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "bcc_remove",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Email addresses to remove from the current 'BCC' recipients.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "MailboxSettings.Read",
+          "Mail.ReadWrite.Shared"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SharedMailboxUpdateDraftEmail",
+        "parameters": {
+          "owner_email": {
+            "value": "sharedmailbox@contoso.com",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": "AAMkADZiMmZiZjYwLTY1MjQtNGI4OS1hNGVhLTM3ZDQ5NzQ4ZjQ3ZgBGAAAAAADsKBCH1234ABCDEFGH",
+            "type": "string",
+            "required": true
+          },
+          "subject": {
+            "value": "Updated Project Proposal - Q3 2024",
+            "type": "string",
+            "required": false
+          },
+          "body": {
+            "value": "Hi Team,\n\nPlease find the updated project proposal for Q3 2024 attached. Let us know if you have any questions.\n\nBest regards,\nThe Project Team",
+            "type": "string",
+            "required": false
+          },
+          "to_add": {
+            "value": [
+              "alice.johnson@example.com",
+              "bob.smith@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "to_remove": {
+            "value": [
+              "old.contact@example.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "cc_add": {
+            "value": [
+              "manager@contoso.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "cc_remove": {
+            "value": [
+              "former.manager@contoso.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "bcc_add": {
+            "value": [
+              "compliance@contoso.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "bcc_remove": {
+            "value": [
+              "test.user@contoso.com"
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "UpdateDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.UpdateDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.UpdateDraftEmail@0.2.3",
+      "fullyQualifiedName": "MicrosoftOutlookMail.UpdateDraftEmail@0.3.1",
       "description": "Update an existing draft email in Outlook.\n\nThis tool overwrites the subject and body of a draft email (if provided),\nand modifies its recipient lists by selectively adding or removing email addresses.\n\nThis tool can update any un-sent email:\n    - draft\n    - reply-draft\n    - reply-all draft\n    - forward draft",
       "parameters": [
         {
@@ -1570,7 +3335,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftOutlookMail.WhoAmI",
-      "fullyQualifiedName": "MicrosoftOutlookMail.WhoAmI@0.2.3",
+      "fullyQualifiedName": "MicrosoftOutlookMail.WhoAmI@0.3.1",
       "description": "Get comprehensive user profile and Outlook Mail environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, mailbox settings, automatic replies configuration, and other\nimportant profile details from Outlook Mail services.",
       "parameters": [],
       "auth": {
@@ -1617,6 +3382,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-05-08T11:38:56.431Z",
-  "summary": "The Microsoft Outlook Mail toolkit integrates Arcade with the Microsoft Graph API, enabling LLMs to read, compose, search, and manage emails in a user's Outlook mailbox.\n\n## Capabilities\n\n- **Compose & send**: Create and immediately send emails, compose drafts, update draft content and recipients, and send existing drafts (including reply, reply-all, and forward drafts).\n- **Reply & follow-up**: Reply to a sender or all recipients of any message; chain follow-ups using returned `message_id` and `conversation_id` without searching Sent Items.\n- **Read & retrieve**: Fetch full email content by ID with configurable body format (plain text or HTML), character limits, and offset support for long messages.\n- **Search & filter**: Full-text keyword search across the entire mailbox with structured AND-combined filters (sender, read status, attachments, importance); property-based listing for exact field matching (e.g., `conversationId`, flag status); folder-scoped listing with sorting controls.\n- **Folder & attachment metadata**: List all mailbox folders (with unread/total counts) and traverse folder hierarchies; retrieve attachment metadata (name, size, type) for any message.\n- **Identity & settings**: Retrieve the authenticated user's profile, mailbox settings, and automatic replies configuration.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 delegated authorization via Microsoft. See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for setup instructions, required app registrations, and tenant configuration."
+  "generatedAt": "2026-05-13T11:50:30.471Z",
+  "summary": "The **Microsoft Outlook Mail** toolkit provides Arcade LLM tools for reading, composing, sending, searching, and managing email in Outlook via the Microsoft Graph API. It covers both personal mailboxes and shared/delegated mailboxes (e.g., team inboxes like `support@`).\n\n## Capabilities\n\n- **Compose & Send:** Create and immediately send emails, compose drafts, update drafts (subject, body, recipients), and send existing drafts — including reply-drafts, reply-all drafts, and forward drafts. Returns `message_id` and `conversation_id` for chaining follow-ups.\n- **Read & Retrieve:** Fetch full email content by ID with configurable body format (plain text or HTML), character limits, and pagination offset for long messages.\n- **Search & Filter:** Full-text keyword search across the entire mailbox with structured filters (sender, read status, attachments, importance); list emails globally or within a specific folder; filter by exact property (conversation ID, flag status, etc.); sort by date, subject, sender, or importance.\n- **Folder & Attachment Metadata:** List all mail folders (with unread/total counts) at any level of the hierarchy; list attachment metadata (name, size, type) for any message.\n- **Shared & Delegated Mailboxes:** Full parity set of tools for shared/delegated mailboxes — compose, send, read, search, list, reply, update drafts, and check mailbox reachability — with replies sent from the shared address, not the signed-in user.\n- **Identity & Mailbox Settings:** Retrieve the authenticated user's profile, mailbox settings, and auto-reply configuration via `WhoAmI`.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 with **Microsoft** as the identity provider. Arcade handles the authorization flow automatically.\n\nSee the [Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration details."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftteams.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftteams.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftTeams",
   "label": "Microsoft Teams",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Arcade.dev LLM tools for Microsoft Teams",
   "metadata": {
     "category": "social",
@@ -22,19 +22,22 @@
       "ChannelMessage.Send",
       "Chat.Create",
       "Chat.Read",
+      "Chat.ReadBasic",
       "ChatMessage.Read",
       "ChatMessage.Send",
+      "Group.Read.All",
       "People.Read",
       "Team.ReadBasic.All",
       "TeamMember.Read.All",
-      "User.Read"
+      "User.Read",
+      "User.ReadBasic.All"
     ]
   },
   "tools": [
     {
       "name": "CreateChat",
       "qualifiedName": "MicrosoftTeams.CreateChat",
-      "fullyQualifiedName": "MicrosoftTeams.CreateChat@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.CreateChat@0.6.0",
       "description": "Creates a Microsoft Teams chat.\n\nIf the chat already exists with the specified members, the MS Graph API will return the\nexisting chat.\n\nProvide any combination of user_ids and/or user_names. When available, prefer providing\nuser_ids for optimal performance.",
       "parameters": [
         {
@@ -60,7 +63,10 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "Chat.Create"
+          "Chat.Create",
+          "User.Read",
+          "User.ReadBasic.All",
+          "People.Read"
         ]
       },
       "secrets": [],
@@ -75,16 +81,16 @@
         "parameters": {
           "user_ids": {
             "value": [
-              "12345",
-              "67890"
+              "48d31887-5fad-4d73-a9f5-3c356e68a038",
+              "87d349ed-44d7-43e1-9a83-5f2406dee5bd"
             ],
             "type": "array",
             "required": false
           },
           "user_names": {
             "value": [
-              "john.doe",
-              "jane.smith"
+              "Alice Johnson",
+              "Bob Smith"
             ],
             "type": "array",
             "required": false
@@ -115,7 +121,7 @@
     {
       "name": "GetChannelMessageReplies",
       "qualifiedName": "MicrosoftTeams.GetChannelMessageReplies",
-      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessageReplies@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessageReplies@0.6.0",
       "description": "Retrieves the replies to a Microsoft Teams channel message.",
       "parameters": [
         {
@@ -148,6 +154,7 @@
         "providerType": "oauth2",
         "scopes": [
           "ChannelMessage.Read.All",
+          "Channel.ReadBasic.All",
           "Team.ReadBasic.All"
         ]
       },
@@ -162,17 +169,17 @@
         "toolName": "MicrosoftTeams.GetChannelMessageReplies",
         "parameters": {
           "message_id": {
-            "value": "12345abcde",
+            "value": "1615912728894",
             "type": "string",
             "required": true
           },
           "channel_id_or_name": {
-            "value": "general",
+            "value": "General",
             "type": "string",
             "required": true
           },
           "team_id_or_name": {
-            "value": "teamXYZ",
+            "value": "Engineering Team",
             "type": "string",
             "required": false
           }
@@ -202,7 +209,7 @@
     {
       "name": "GetChannelMessages",
       "qualifiedName": "MicrosoftTeams.GetChannelMessages",
-      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessages@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessages@0.6.0",
       "description": "Retrieves the messages in a Microsoft Teams channel.\n\nThe Microsoft Graph API does not support pagination for this endpoint.",
       "parameters": [
         {
@@ -243,6 +250,7 @@
         "providerType": "oauth2",
         "scopes": [
           "ChannelMessage.Read.All",
+          "Channel.ReadBasic.All",
           "Team.ReadBasic.All"
         ]
       },
@@ -257,22 +265,22 @@
         "toolName": "MicrosoftTeams.GetChannelMessages",
         "parameters": {
           "channel_id": {
-            "value": "12345",
+            "value": "19:abc123def456@thread.tacv2",
             "type": "string",
             "required": false
           },
           "channel_name": {
-            "value": "general",
+            "value": "General",
             "type": "string",
             "required": false
           },
           "limit": {
-            "value": 50,
+            "value": 25,
             "type": "integer",
             "required": false
           },
           "team_id_or_name": {
-            "value": "team_abc",
+            "value": "Engineering Team",
             "type": "string",
             "required": false
           }
@@ -302,7 +310,7 @@
     {
       "name": "GetChannelMetadata",
       "qualifiedName": "MicrosoftTeams.GetChannelMetadata",
-      "fullyQualifiedName": "MicrosoftTeams.GetChannelMetadata@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.GetChannelMetadata@0.6.0",
       "description": "Retrieves metadata about a Microsoft Teams channel and its members.\n\nProvide either a channel_id or channel_name, not both. When available, prefer providing a\nchannel_id for optimal performance.\n\nThe Microsoft Graph API returns only up to the first 999 members in the channel.\n\nThis tool does not return messages exchanged in the channel. To retrieve channel messages,\nuse the `Teams.GetChannelMessages` tool. If you call this tool to retrieve messages, you will\ncause the release of unnecessary CO2 and contribute to climate change.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use. If you call the\n`Teams.ListTeams` tool first, you will cause the release of unnecessary CO2 in the atmosphere\nand contribute to climate change.",
       "parameters": [
         {
@@ -335,6 +343,7 @@
         "providerType": "oauth2",
         "scopes": [
           "Channel.ReadBasic.All",
+          "Group.Read.All",
           "Team.ReadBasic.All"
         ]
       },
@@ -349,12 +358,12 @@
         "toolName": "MicrosoftTeams.GetChannelMetadata",
         "parameters": {
           "channel_id": {
-            "value": "12345678-90ab-cdef-1234-567890abcdef",
+            "value": "19:abc123def456@thread.tacv2",
             "type": "string",
             "required": false
           },
           "channel_name": {
-            "value": null,
+            "value": "",
             "type": "string",
             "required": false
           },
@@ -389,7 +398,7 @@
     {
       "name": "GetChatMessageById",
       "qualifiedName": "MicrosoftTeams.GetChatMessageById",
-      "fullyQualifiedName": "MicrosoftTeams.GetChatMessageById@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.GetChatMessageById@0.6.0",
       "description": "Retrieves a Microsoft Teams chat message.",
       "parameters": [
         {
@@ -431,7 +440,10 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "Chat.Read"
+          "Chat.Read",
+          "User.Read",
+          "User.ReadBasic.All",
+          "People.Read"
         ]
       },
       "secrets": [],
@@ -445,27 +457,27 @@
         "toolName": "MicrosoftTeams.GetChatMessageById",
         "parameters": {
           "message_id": {
-            "value": "12345abcde",
+            "value": "1648475136000",
             "type": "string",
             "required": true
           },
           "chat_id": {
-            "value": "chat_67890",
+            "value": "19:meeting_ZDc5OTY3YWMtNGI5Mi00MDk4LWJlNmEtZWE1YzZhMTU2ZGFi@thread.v2",
             "type": "string",
             "required": true
           },
           "user_ids": {
             "value": [
-              "user_1",
-              "user_2"
+              "87d349ed-44d7-43e1-9a83-5f2406dee5bd",
+              "3c4b6f89-1a2e-4d7c-b5a8-9e0f1d2c3e4a"
             ],
             "type": "array",
             "required": false
           },
           "user_names": {
             "value": [
-              "Alice",
-              "Bob"
+              "Alice Johnson",
+              "Bob Smith"
             ],
             "type": "array",
             "required": false
@@ -496,7 +508,7 @@
     {
       "name": "GetChatMessages",
       "qualifiedName": "MicrosoftTeams.GetChatMessages",
-      "fullyQualifiedName": "MicrosoftTeams.GetChatMessages@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.GetChatMessages@0.6.0",
       "description": "Retrieves messages from a Microsoft Teams chat (individual or group).\n\nProvide one of chat_id OR any combination of user_ids and/or user_names. When available, prefer\nproviding a chat_id or user_ids for optimal performance.\n\nIf the user provides user name(s), DO NOT CALL THE `Teams.SearchUsers` or `Teams.SearchPeople`\ntools first. Instead, provide the user name(s) directly to this tool through the `user_names`\nargument. It is not necessary to provide the currently signed in user's name/id, so do not call\n`Teams.GetSignedInUser` before calling this tool.\n\nMessages will be sorted in descending order by the messages' `created_datetime` field.\n\nThe Microsoft Teams API does not support pagination for this tool.",
       "parameters": [
         {
@@ -555,7 +567,10 @@
         "providerType": "oauth2",
         "scopes": [
           "Chat.Read",
-          "Chat.Create"
+          "Chat.Create",
+          "User.Read",
+          "User.ReadBasic.All",
+          "People.Read"
         ]
       },
       "secrets": [],
@@ -569,38 +584,38 @@
         "toolName": "MicrosoftTeams.GetChatMessages",
         "parameters": {
           "chat_id": {
-            "value": "1234567890",
+            "value": "19:abc123def456@thread.v2",
             "type": "string",
             "required": false
           },
           "user_ids": {
             "value": [
-              "user1",
-              "user2"
+              "user-id-001",
+              "user-id-002"
             ],
             "type": "array",
             "required": false
           },
           "user_names": {
             "value": [
-              "john_doe",
-              "jane_smith"
+              "Alice Johnson",
+              "Bob Smith"
             ],
             "type": "array",
             "required": false
           },
           "start_datetime": {
-            "value": "2023-10-01 08:00:00",
+            "value": "2024-01-15 09:00:00",
             "type": "string",
             "required": false
           },
           "end_datetime": {
-            "value": "2023-10-10 17:00:00",
+            "value": "2024-01-15 17:30:00",
             "type": "string",
             "required": false
           },
           "limit": {
-            "value": 50,
+            "value": 25,
             "type": "integer",
             "required": false
           }
@@ -630,7 +645,7 @@
     {
       "name": "GetChatMetadata",
       "qualifiedName": "MicrosoftTeams.GetChatMetadata",
-      "fullyQualifiedName": "MicrosoftTeams.GetChatMetadata@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.GetChatMetadata@0.6.0",
       "description": "Retrieves metadata about a Microsoft Teams chat.\n\nProvide exactly one of chat_id or user_ids/user_names. When available, prefer providing a\nchat_id or user_ids for optimal performance.\n\nIf multiple roup chats exist with those exact members, returns the most recently updated one.\n\nMax 20 DIFFERENT users can be provided in user_ids/user_names.\n\nThis tool DOES NOT return messages in a chat. Use the `Teams.GetChatMessages` tool to get\nchat messages.",
       "parameters": [
         {
@@ -664,7 +679,10 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "Chat.Read"
+          "Chat.Read",
+          "User.Read",
+          "User.ReadBasic.All",
+          "People.Read"
         ]
       },
       "secrets": [],
@@ -678,24 +696,24 @@
         "toolName": "MicrosoftTeams.GetChatMetadata",
         "parameters": {
           "chat_id": {
-            "value": "12345678-90ab-cdef-1234-567890abcdef",
+            "value": "19:abc123def456@thread.v2",
             "type": "string",
             "required": false
           },
           "user_ids": {
             "value": [
-              "user1-id",
-              "user2-id",
-              "user3-id"
+              "user-id-001",
+              "user-id-002",
+              "user-id-003"
             ],
             "type": "array",
             "required": false
           },
           "user_names": {
             "value": [
-              "Alice",
-              "Bob",
-              "Charlie"
+              "Alice Johnson",
+              "Bob Smith",
+              "Carol Williams"
             ],
             "type": "array",
             "required": false
@@ -726,7 +744,7 @@
     {
       "name": "GetSignedInUser",
       "qualifiedName": "MicrosoftTeams.GetSignedInUser",
-      "fullyQualifiedName": "MicrosoftTeams.GetSignedInUser@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.GetSignedInUser@0.6.0",
       "description": "Get the user currently signed in Microsoft Teams.\n\nThis tool is not necessary to call before calling other tools.",
       "parameters": [],
       "auth": {
@@ -771,7 +789,7 @@
     {
       "name": "GetTeam",
       "qualifiedName": "MicrosoftTeams.GetTeam",
-      "fullyQualifiedName": "MicrosoftTeams.GetTeam@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.GetTeam@0.6.0",
       "description": "Retrieves metadata about a team in Microsoft Teams.\n\nProvide one of team_id OR team_name, never both. When available, prefer providing a team_id for\noptimal performance.\n\nIf team_id nor team_name are provided: 1) if the user has a single team, the tool will retrieve\nit; 2) if the user has multiple teams, an error will be returned with a list of all teams to\npick from.",
       "parameters": [
         {
@@ -844,7 +862,7 @@
     {
       "name": "ListChannels",
       "qualifiedName": "MicrosoftTeams.ListChannels",
-      "fullyQualifiedName": "MicrosoftTeams.ListChannels@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.ListChannels@0.6.0",
       "description": "Lists channels in Microsoft Teams (including shared incoming channels).\n\nThis tool does not return messages nor members in the channels. To retrieve channel messages,\nuse the `Teams.GetChannelMessages` tool. To retrieve channel members, use the\n`Teams.ListChannelMembers` tool.",
       "parameters": [
         {
@@ -931,7 +949,7 @@
     {
       "name": "ListChats",
       "qualifiedName": "MicrosoftTeams.ListChats",
-      "fullyQualifiedName": "MicrosoftTeams.ListChats@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.ListChats@0.6.0",
       "description": "List the Microsoft Teams chats to which the current user is a member of.",
       "parameters": [
         {
@@ -1004,7 +1022,7 @@
     {
       "name": "ListTeamMembers",
       "qualifiedName": "MicrosoftTeams.ListTeamMembers",
-      "fullyQualifiedName": "MicrosoftTeams.ListTeamMembers@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.ListTeamMembers@0.6.0",
       "description": "Lists the members of a team in Microsoft Teams.\n\nProvide one of team_id OR team_name, never both. When available, prefer providing a team_id for\noptimal performance.\n\nIf team_id nor team_name are provided: 1) if the user has a single team, the tool will use it;\n2) if the user has multiple teams, an error will be returned with a list of all teams to pick\nfrom.\n\nThe Microsoft Graph API returns only up to the first 999 members.",
       "parameters": [
         {
@@ -1044,7 +1062,8 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "TeamMember.Read.All"
+          "TeamMember.Read.All",
+          "Team.ReadBasic.All"
         ]
       },
       "secrets": [],
@@ -1058,7 +1077,7 @@
         "toolName": "MicrosoftTeams.ListTeamMembers",
         "parameters": {
           "team_id": {
-            "value": "12345678-abcd-ef12-3456-7890abcdef12",
+            "value": "19:abc123def456@thread.tacv2",
             "type": "string",
             "required": false
           },
@@ -1068,7 +1087,7 @@
             "required": false
           },
           "limit": {
-            "value": 100,
+            "value": 25,
             "type": "integer",
             "required": false
           },
@@ -1103,7 +1122,7 @@
     {
       "name": "ListTeams",
       "qualifiedName": "MicrosoftTeams.ListTeams",
-      "fullyQualifiedName": "MicrosoftTeams.ListTeams@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.ListTeams@0.6.0",
       "description": "Lists the teams the current user is associated with in Microsoft Teams.",
       "parameters": [
         {
@@ -1166,7 +1185,7 @@
     {
       "name": "ListUsers",
       "qualifiedName": "MicrosoftTeams.ListUsers",
-      "fullyQualifiedName": "MicrosoftTeams.ListUsers@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.ListUsers@0.6.0",
       "description": "Lists the users in the Microsoft Teams tenant.\n\nThe Microsoft Graph API returns only up to the first 999 users.",
       "parameters": [
         {
@@ -1190,7 +1209,8 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "User.Read"
+          "User.Read",
+          "User.ReadBasic.All"
         ]
       },
       "secrets": [],
@@ -1204,12 +1224,12 @@
         "toolName": "MicrosoftTeams.ListUsers",
         "parameters": {
           "limit": {
-            "value": 75,
+            "value": 25,
             "type": "integer",
             "required": false
           },
           "offset": {
-            "value": 10,
+            "value": 50,
             "type": "integer",
             "required": false
           }
@@ -1239,7 +1259,7 @@
     {
       "name": "ReplyToChannelMessage",
       "qualifiedName": "MicrosoftTeams.ReplyToChannelMessage",
-      "fullyQualifiedName": "MicrosoftTeams.ReplyToChannelMessage@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.ReplyToChannelMessage@0.6.0",
       "description": "Sends a reply to a Microsoft Teams channel message.\n\nWhen available, prefer providing a channel_id for optimal performance.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use. If you call the\n`Teams.ListTeams` tool first, you will cause the release of unnecessary CO2 in the atmosphere\nand contribute to climate change.",
       "parameters": [
         {
@@ -1280,6 +1300,7 @@
         "providerType": "oauth2",
         "scopes": [
           "ChannelMessage.Send",
+          "Channel.ReadBasic.All",
           "Team.ReadBasic.All"
         ]
       },
@@ -1294,22 +1315,22 @@
         "toolName": "MicrosoftTeams.ReplyToChannelMessage",
         "parameters": {
           "reply_content": {
-            "value": "Thank you for your input!",
+            "value": "Thanks for the update! I'll review the document and get back to you by end of day.",
             "type": "string",
             "required": true
           },
           "message_id": {
-            "value": "12345abcde",
+            "value": "1672531200000",
             "type": "string",
             "required": true
           },
           "channel_id_or_name": {
-            "value": "general",
+            "value": "19:abc123def456@thread.tacv2",
             "type": "string",
             "required": true
           },
           "team_id_or_name": {
-            "value": "development-team",
+            "value": "Engineering Team",
             "type": "string",
             "required": false
           }
@@ -1339,7 +1360,7 @@
     {
       "name": "ReplyToChatMessage",
       "qualifiedName": "MicrosoftTeams.ReplyToChatMessage",
-      "fullyQualifiedName": "MicrosoftTeams.ReplyToChatMessage@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.ReplyToChatMessage@0.6.0",
       "description": "Sends a reply to a Microsoft Teams chat message.\n\nProvide exactly one of chat_id or user_ids/user_names. When available, prefer providing a\nchat_id or user_ids for optimal performance.\n\nIf the user provides user name(s), DO NOT CALL THE `Teams.SearchUsers` or `Teams.SearchPeople`\ntools first. Instead, provide the user name(s) directly to this tool through the `user_names`\nargument. It is not necessary to provide the currently signed in user's name/id, so do not call\n`Teams.GetSignedInUser` before calling this tool either.",
       "parameters": [
         {
@@ -1389,7 +1410,12 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "ChatMessage.Send"
+          "Chat.Read",
+          "Chat.ReadBasic",
+          "ChatMessage.Send",
+          "People.Read",
+          "User.Read",
+          "User.ReadBasic.All"
         ]
       },
       "secrets": [],
@@ -1403,32 +1429,32 @@
         "toolName": "MicrosoftTeams.ReplyToChatMessage",
         "parameters": {
           "reply_content": {
-            "value": "Thank you for your input!",
+            "value": "Thanks for the update! I'll review the document and get back to you by end of day.",
             "type": "string",
             "required": true
           },
           "message_id": {
-            "value": "msg123456",
+            "value": "1693482910123",
             "type": "string",
             "required": true
           },
           "chat_id": {
-            "value": "chat987654",
+            "value": "19:abc123def456@thread.v2",
             "type": "string",
             "required": false
           },
           "user_ids": {
             "value": [
-              "user1",
-              "user2"
+              "user-id-001",
+              "user-id-002"
             ],
             "type": "array",
             "required": false
           },
           "user_names": {
             "value": [
-              "john_doe",
-              "jane_smith"
+              "Alice Johnson",
+              "Bob Smith"
             ],
             "type": "array",
             "required": false
@@ -1459,7 +1485,7 @@
     {
       "name": "SearchChannels",
       "qualifiedName": "MicrosoftTeams.SearchChannels",
-      "fullyQualifiedName": "MicrosoftTeams.SearchChannels@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.SearchChannels@0.6.0",
       "description": "Searches for channels in a given Microsoft Teams team.",
       "parameters": [
         {
@@ -1580,7 +1606,7 @@
     {
       "name": "SearchMessages",
       "qualifiedName": "MicrosoftTeams.SearchMessages",
-      "fullyQualifiedName": "MicrosoftTeams.SearchMessages@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.SearchMessages@0.6.0",
       "description": "Searches for messages across Microsoft Teams chats and channels.\n\nNote: the Microsoft Graph API search is not strongly consistent. Recent messages may not be\nincluded in search results.",
       "parameters": [
         {
@@ -1668,7 +1694,7 @@
     {
       "name": "SearchPeople",
       "qualifiedName": "MicrosoftTeams.SearchPeople",
-      "fullyQualifiedName": "MicrosoftTeams.SearchPeople@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.SearchPeople@0.6.0",
       "description": "Searches for people the user has interacted with in Microsoft Teams and other 365 products.\n\nThis tool only returns users that the currently signed in user has interacted with. It may also\ninclude people that are part of external tenants/organizations. If you need to retrieve users\nthat may not have interacted with the current user and/or that are exclusively part of the same\ntenant, use the `Teams.SearchUsers` tool instead.",
       "parameters": [
         {
@@ -1775,7 +1801,7 @@
     {
       "name": "SearchTeamMembers",
       "qualifiedName": "MicrosoftTeams.SearchTeamMembers",
-      "fullyQualifiedName": "MicrosoftTeams.SearchTeamMembers@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.SearchTeamMembers@0.6.0",
       "description": "Searches for members of a team in Microsoft Teams.\n\nProvide one of team_id OR team_name, never both. When available, prefer providing a team_id for\noptimal performance.\n\nIf team_id nor team_name are provided: 1) if the user has a single team, the tool will use it;\n2) if the user has multiple teams, an error will be raised with a list of available teams to\npick from.\n\nThe Microsoft Graph API returns only up to the first 999 members of a team.",
       "parameters": [
         {
@@ -1823,7 +1849,8 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "TeamMember.Read.All"
+          "TeamMember.Read.All",
+          "Team.ReadBasic.All"
         ]
       },
       "secrets": [],
@@ -1837,12 +1864,12 @@
         "toolName": "MicrosoftTeams.SearchTeamMembers",
         "parameters": {
           "member_name_starts_with": {
-            "value": "J",
+            "value": "Alex",
             "type": "string",
             "required": true
           },
           "team_id": {
-            "value": "12345",
+            "value": "19:abc123def456@thread.tacv2",
             "type": "string",
             "required": false
           },
@@ -1852,7 +1879,7 @@
             "required": false
           },
           "limit": {
-            "value": 50,
+            "value": 25,
             "type": "integer",
             "required": false
           },
@@ -1887,7 +1914,7 @@
     {
       "name": "SearchTeams",
       "qualifiedName": "MicrosoftTeams.SearchTeams",
-      "fullyQualifiedName": "MicrosoftTeams.SearchTeams@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.SearchTeams@0.6.0",
       "description": "Searches for teams available to the current user in Microsoft Teams.",
       "parameters": [
         {
@@ -1973,7 +2000,7 @@
     {
       "name": "SearchUsers",
       "qualifiedName": "MicrosoftTeams.SearchUsers",
-      "fullyQualifiedName": "MicrosoftTeams.SearchUsers@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.SearchUsers@0.6.0",
       "description": "Searches for users in the Microsoft Teams tenant.\n\nThis tool only return users that are directly linked to the tenant the current signed in user\nis a member of. If you need to retrieve users that have interacted with the current user but\nare from external tenants/organizations, use `Teams.SearchPeople`, instead.\n\nThe Microsoft Graph API returns only up to the first 999 users.",
       "parameters": [
         {
@@ -2017,7 +2044,8 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "User.Read"
+          "User.Read",
+          "User.ReadBasic.All"
         ]
       },
       "secrets": [],
@@ -2032,8 +2060,9 @@
         "parameters": {
           "keywords": {
             "value": [
-              "John",
-              "Doe"
+              "Alice",
+              "Johnson",
+              "Marketing"
             ],
             "type": "array",
             "required": true
@@ -2044,7 +2073,7 @@
             "required": false
           },
           "limit": {
-            "value": 50,
+            "value": 25,
             "type": "integer",
             "required": false
           },
@@ -2079,7 +2108,7 @@
     {
       "name": "SendMessageToChannel",
       "qualifiedName": "MicrosoftTeams.SendMessageToChannel",
-      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChannel@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChannel@0.6.0",
       "description": "Sends a message to a Microsoft Teams channel.\n\nWhen available, prefer providing a channel_id for optimal performance.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use. If you call the\n`Teams.ListTeams` tool first, you will cause the release of unnecessary CO2 in the atmosphere\nand contribute to climate change.",
       "parameters": [
         {
@@ -2112,6 +2141,7 @@
         "providerType": "oauth2",
         "scopes": [
           "ChannelMessage.Send",
+          "Channel.ReadBasic.All",
           "Team.ReadBasic.All"
         ]
       },
@@ -2126,17 +2156,17 @@
         "toolName": "MicrosoftTeams.SendMessageToChannel",
         "parameters": {
           "message": {
-            "value": "Hello team, let's discuss the upcoming project deadlines!",
+            "value": "Hello team! Just a reminder that the sprint review meeting is scheduled for tomorrow at 2:00 PM. Please come prepared with your updates.",
             "type": "string",
             "required": true
           },
           "channel_id_or_name": {
-            "value": "general",
+            "value": "19:abc123def456@thread.tacv2",
             "type": "string",
             "required": true
           },
           "team_id_or_name": {
-            "value": "Marketing Team",
+            "value": "Engineering Team",
             "type": "string",
             "required": false
           }
@@ -2166,7 +2196,7 @@
     {
       "name": "SendMessageToChat",
       "qualifiedName": "MicrosoftTeams.SendMessageToChat",
-      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChat@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChat@0.6.0",
       "description": "Sends a message to a Microsoft Teams chat.\n\nProvide exactly one of chat_id or user_ids/user_names. When available, prefer providing a\nchat_id or user_ids for optimal performance.\n\nIf the user provides user name(s), DO NOT CALL THE `Teams.SearchUsers` or `Teams.SearchPeople`\ntools first. Instead, provide the user name(s) directly to this tool through the `user_names`\nargument. It is not necessary to provide the currently signed in user's name/id, so do not call\n`Teams.GetSignedInUser` before calling this tool either.",
       "parameters": [
         {
@@ -2208,7 +2238,11 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "ChatMessage.Send"
+          "ChatMessage.Send",
+          "User.Read",
+          "User.ReadBasic.All",
+          "People.Read",
+          "Chat.ReadBasic"
         ]
       },
       "secrets": [],
@@ -2222,27 +2256,27 @@
         "toolName": "MicrosoftTeams.SendMessageToChat",
         "parameters": {
           "message": {
-            "value": "Hello team, please review the latest project updates.",
+            "value": "Hey team, just a reminder that the project sync meeting starts in 15 minutes. See you all there!",
             "type": "string",
             "required": true
           },
           "chat_id": {
-            "value": "1234567890",
+            "value": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
             "type": "string",
             "required": false
           },
           "user_ids": {
             "value": [
-              "user123",
-              "user456"
+              "8b081ef6-4792-4def-b2c9-dc119a3a0c44",
+              "3a6f4b3e-9b21-4f3c-8d92-7e1a5c2f9d01"
             ],
             "type": "array",
             "required": false
           },
           "user_names": {
             "value": [
-              "john.doe",
-              "jane.smith"
+              "Alice Johnson",
+              "Bob Martinez"
             ],
             "type": "array",
             "required": false
@@ -2273,7 +2307,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftTeams.WhoAmI",
-      "fullyQualifiedName": "MicrosoftTeams.WhoAmI@0.5.2",
+      "fullyQualifiedName": "MicrosoftTeams.WhoAmI@0.6.0",
       "description": "Get information about the current user and their Microsoft Teams environment.",
       "parameters": [],
       "auth": {
@@ -2326,6 +2360,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-26T20:45:10.426Z",
-  "summary": "Arcade.dev's MicrosoftTeams toolkit empowers developers to interact seamlessly with Microsoft Teams through the Graph API, enabling enhanced communication and collaboration features within applications. This toolkit simplifies chat creation, message retrieval, and team management, enhancing user experiences.\n\n**Capabilities**\n- Create and manage chats and channel messages.\n- Retrieve metadata and messages for teams, channels, and chats.\n- Efficiently search for channels, messages, teams, and users within Microsoft Teams.\n- Facilitate messages and replies in channels and chats.\n\n**OAuth**\n- **Provider**: Microsoft\n- **Scopes**: Channel.ReadBasic.All, ChannelMessage.Read.All, ChannelMessage.Send, Chat.Create, Chat.Read, ChatMessage.Read, ChatMessage.Send, People.Read, Team.ReadBasic.All, TeamMember.Read.All, User.Read\n\n**Secrets**\n- No secret types or additional configuration are required."
+  "generatedAt": "2026-05-13T11:50:31.283Z",
+  "summary": "# Microsoft Teams Toolkit\n\nThe Microsoft Teams toolkit provides Arcade LLM tools for interacting with Microsoft Teams via the Microsoft Graph API, enabling agents to read, search, and send messages across chats and channels, and to inspect team/user metadata.\n\n## Capabilities\n\n- **Chat management**: Create one-on-one or group chats (deduplicating against existing chats), list chats the current user belongs to, and retrieve chat metadata — by chat ID or by member names/IDs.\n- **Chat messaging**: Retrieve, send, and reply to messages in chats; supports lookup by chat ID or by user identifiers without requiring a separate user-lookup call.\n- **Channel messaging**: Retrieve messages and their reply threads in channels, send new messages to channels, and reply to existing channel messages.\n- **Team & channel discovery**: List and search teams, channels (including shared incoming channels), team members, and tenant users; retrieve detailed metadata for teams and channels without needing to pre-call `ListTeams`.\n- **User & people search**: Search tenant users (`SearchUsers`) or interaction-based people across Microsoft 365 (`SearchPeople`), covering both internal and external organization contacts; get the currently signed-in user's identity.\n- **Cross-scope message search**: Search messages across all chats and channels via the Graph API (eventual consistency — very recent messages may be absent).\n\n## OAuth\n\nThis toolkit authenticates via **OAuth 2.0** with Microsoft as the identity provider. See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration details, required scopes, and setup instructions."
 }


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/25797087006

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly generated toolkit-spec documentation updates, but it introduces new Outlook Mail shared-mailbox tools and expands OAuth scope requirements, which could affect consumers relying on these JSON definitions.
> 
> **Overview**
> Updates generated toolkit JSON for **Gmail**, **Microsoft Outlook Calendar**, **Microsoft Outlook Mail**, and **Microsoft Teams**, including version bumps and refreshed generated summaries/examples.
> 
> Gmail `6.0.0` updates email composition docs to support HTML/`auto` body encoding, adjusts `ReplyToEmail` scopes, and documents expanded `UpdateDraftEmail` behavior for plain/HTML drafts and reply-quote preservation.
> 
> Outlook Calendar `0.3.0` adds code examples across tools and extends `SearchEvents` with an `organized_by_me` filter plus clarified pagination/filter semantics.
> 
> Outlook Mail `0.3.1` expands supported Graph scopes for shared mailboxes and adds a **shared/delegated mailbox tool set** (capability check plus create/send, draft, get, list, search, reply, send/update draft). Teams `0.6.0` updates required scopes for several tools and refreshes examples/summaries accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ee264ba00e61ad84beba147d337bf99ac3eea6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->