### PR TITLE
fix(sitemap): include statically-generated toolkit pages

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -58,7 +58,7 @@ async function buildSitemap(): Promise<MetadataRoute.Sitemap> {
 
   const seen = new Set<string>(mdxRoutes.map((r) => r.url));
   const uniqueToolkitEntries = toolkitEntries.filter((entry) => {
-    if (seen.has(entry.url)) return false;
+    if (seen.has(entry.url)) { return false; }
     seen.add(entry.url);
     return true;
   });

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { MetadataRoute } from "next";
+import { listToolkitRoutes } from "./_lib/toolkit-static-params";
 
 const SITE_URL = process.env.SITE_URL ?? "https://docs.arcade.dev";
 const NORMALIZED_SITE_URL = SITE_URL.replace(/\/+$/, "");
@@ -43,13 +44,33 @@ async function collectRoutes(dir: string): Promise<MetadataRoute.Sitemap> {
   return entries;
 }
 
+async function buildSitemap(): Promise<MetadataRoute.Sitemap> {
+  const [mdxRoutes, toolkitRoutes] = await Promise.all([
+    collectRoutes(APP_DIR),
+    listToolkitRoutes(),
+  ]);
+
+  const toolkitEntries: MetadataRoute.Sitemap = toolkitRoutes
+    .filter((route) => route.category !== "others")
+    .map((route) => ({
+      url: `${NORMALIZED_SITE_URL}/en/resources/integrations/${route.category}/${route.toolkitId}`,
+    }));
+
+  const seen = new Set<string>(mdxRoutes.map((r) => r.url));
+  const uniqueToolkitEntries = toolkitEntries.filter((entry) => {
+    if (seen.has(entry.url)) return false;
+    seen.add(entry.url);
+    return true;
+  });
+
+  return [...mdxRoutes, ...uniqueToolkitEntries].sort((a, b) =>
+    a.url.localeCompare(b.url)
+  );
+}
+
 export default function sitemap(): Promise<MetadataRoute.Sitemap> {
   if (!cachedRoutes) {
-    cachedRoutes = collectRoutes(APP_DIR).then((routes) => {
-      routes.sort((a, b) => a.url.localeCompare(b.url));
-      return routes;
-    });
+    cachedRoutes = buildSitemap();
   }
-
   return cachedRoutes;
 }

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -19,8 +19,20 @@ test("sitemap lists expected URLs", async () => {
       true
     );
 
-    // Known page should be present
+    // Known static page should be present
     expect(urls).toContain("https://example.test/en/references/changelog");
+
+    // Toolkit pages should be included
+    expect(urls).toContain(
+      "https://example.test/en/resources/integrations/development/github"
+    );
+    const integrationUrls = urls.filter((url) =>
+      url.includes("/en/resources/integrations/")
+    );
+    expect(integrationUrls.length).toBeGreaterThan(10);
+
+    // No dynamic-segment placeholders should leak into output
+    expect(urls.every((url) => !url.includes("["))).toBe(true);
 
     // No duplicates
     const duplicates = urls.filter(


### PR DESCRIPTION
## Summary

Toolkit pages at `/en/resources/integrations/{category}/{toolkitId}` were missing from `sitemap.xml` because the filesystem walk in `app/sitemap.ts` skips directories whose names contain `[`, dropping all `[toolkitId]` dynamic route folders. This means search engines get no direct signal to crawl ~100 toolkit pages.

- Adds a `buildSitemap()` helper that runs the MDX walk and `listToolkitRoutes()` in parallel, then merges, deduplicates, and sorts the results
- Excludes the `others` category (no on-disk route, redirected by `next.config.ts`)
- Updates `tests/sitemap.test.ts` to assert a known toolkit URL is present, >10 integration URLs exist, and no `[` placeholder leaks

## Related

- Closes TOO-736 (partial — the Algolia `attributeForDistinct` config change is being applied separately in the crawler dashboard)
- Revives the fix from closed PR #923 in a simplified form (no per-toolkit `lastModified` lookup to keep it lean)

## Test plan

- [ ] CI green
- [ ] After deploy, confirm `https://docs.arcade.dev/sitemap.xml` contains `/en/resources/integrations/development/github` and other toolkit URLs