### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/toolkit-docs-generator/data/toolkits/github.json
+++ b/toolkit-docs-generator/data/toolkits/github.json
@@ -1,7 +1,7 @@
 {
   "id": "Github",
   "label": "GitHub",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "Arcade.dev LLM tools for Github",
   "metadata": {
     "category": "development",
@@ -22,7 +22,7 @@
     {
       "name": "AssignPullRequestUser",
       "qualifiedName": "Github.AssignPullRequestUser",
-      "fullyQualifiedName": "Github.AssignPullRequestUser@3.1.3",
+      "fullyQualifiedName": "Github.AssignPullRequestUser@3.2.0",
       "description": "Assign a user to a pull request with intelligent search and fuzzy matching.",
       "parameters": [
         {
@@ -157,7 +157,7 @@
     {
       "name": "CheckPullRequestMergeStatus",
       "qualifiedName": "Github.CheckPullRequestMergeStatus",
-      "fullyQualifiedName": "Github.CheckPullRequestMergeStatus@3.1.3",
+      "fullyQualifiedName": "Github.CheckPullRequestMergeStatus@3.2.0",
       "description": "Check if a pull request is ready to merge without attempting the merge.",
       "parameters": [
         {
@@ -261,7 +261,7 @@
     {
       "name": "CountStargazers",
       "qualifiedName": "Github.CountStargazers",
-      "fullyQualifiedName": "Github.CountStargazers@3.1.3",
+      "fullyQualifiedName": "Github.CountStargazers@3.2.0",
       "description": "Count the number of stargazers (stars) for a GitHub repository.",
       "parameters": [
         {
@@ -339,7 +339,7 @@
     {
       "name": "CreateBranch",
       "qualifiedName": "Github.CreateBranch",
-      "fullyQualifiedName": "Github.CreateBranch@3.1.3",
+      "fullyQualifiedName": "Github.CreateBranch@3.2.0",
       "description": "Create a new branch in a repository.",
       "parameters": [
         {
@@ -443,7 +443,7 @@
     {
       "name": "CreateFile",
       "qualifiedName": "Github.CreateFile",
-      "fullyQualifiedName": "Github.CreateFile@3.1.3",
+      "fullyQualifiedName": "Github.CreateFile@3.2.0",
       "description": "Create a new file or overwrite an existing file in a repository.\n\nThe explicit mode parameter reduces accidental data loss: the default CREATE mode refuses to\ntouch existing files, while OVERWRITE must be chosen intentionally.",
       "parameters": [
         {
@@ -589,7 +589,7 @@
     {
       "name": "CreateIssue",
       "qualifiedName": "Github.CreateIssue",
-      "fullyQualifiedName": "Github.CreateIssue@3.1.3",
+      "fullyQualifiedName": "Github.CreateIssue@3.2.0",
       "description": "Create an issue in a GitHub repository.\n\nOptionally add the created issue to a project by specifying add_to_project_number\nand add_to_project_scope.",
       "parameters": [
         {
@@ -784,7 +784,7 @@
     {
       "name": "CreateIssueComment",
       "qualifiedName": "Github.CreateIssueComment",
-      "fullyQualifiedName": "Github.CreateIssueComment@3.1.3",
+      "fullyQualifiedName": "Github.CreateIssueComment@3.2.0",
       "description": "Create a comment on an issue in a GitHub repository.",
       "parameters": [
         {
@@ -888,7 +888,7 @@
     {
       "name": "CreatePullRequest",
       "qualifiedName": "Github.CreatePullRequest",
-      "fullyQualifiedName": "Github.CreatePullRequest@3.1.3",
+      "fullyQualifiedName": "Github.CreatePullRequest@3.2.0",
       "description": "Create a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -1090,7 +1090,7 @@
     {
       "name": "CreateReplyForReviewComment",
       "qualifiedName": "Github.CreateReplyForReviewComment",
-      "fullyQualifiedName": "Github.CreateReplyForReviewComment@3.1.3",
+      "fullyQualifiedName": "Github.CreateReplyForReviewComment@3.2.0",
       "description": "Create a reply to a review comment for a pull request.\n\nOptionally resolve the conversation thread after replying by setting resolve_thread=True\nand providing the thread_id (GraphQL Node ID).",
       "parameters": [
         {
@@ -1233,7 +1233,7 @@
     {
       "name": "CreateReviewComment",
       "qualifiedName": "Github.CreateReviewComment",
-      "fullyQualifiedName": "Github.CreateReviewComment@3.1.3",
+      "fullyQualifiedName": "Github.CreateReviewComment@3.2.0",
       "description": "Create a review comment for a pull request in a GitHub repository.\n\nIMPORTANT: Line numbers must be part of the diff (changed lines only).\nGitHub's API requires line numbers that exist in the pull request diff, not just any line\nin the file. If the line wasn't changed in the PR, the comment will fail with 422 error.\n\nIf the subject_type is not 'file', then the start_line and end_line parameters are required.\nIf the subject_type is 'file', then the start_line and end_line parameters are ignored.\nIf the commit_id is not provided, the latest commit SHA from the PR will be used.\n\nTIP: Use subject_type='file' to comment on the entire file if unsure about line positions.",
       "parameters": [
         {
@@ -1434,7 +1434,7 @@
     {
       "name": "GetFileContents",
       "qualifiedName": "Github.GetFileContents",
-      "fullyQualifiedName": "Github.GetFileContents@3.1.3",
+      "fullyQualifiedName": "Github.GetFileContents@3.2.0",
       "description": "Get the contents of a file in a repository.\n\nReturns the decoded content (if text) along with metadata like SHA, size, and line count.\nFor large files, use start_line and end_line to retrieve specific line ranges.",
       "parameters": [
         {
@@ -1564,7 +1564,7 @@
     {
       "name": "GetIssue",
       "qualifiedName": "Github.GetIssue",
-      "fullyQualifiedName": "Github.GetIssue@3.1.3",
+      "fullyQualifiedName": "Github.GetIssue@3.2.0",
       "description": "Get a specific issue from a GitHub repository.",
       "parameters": [
         {
@@ -1655,7 +1655,7 @@
     {
       "name": "GetPullRequest",
       "qualifiedName": "Github.GetPullRequest",
-      "fullyQualifiedName": "Github.GetPullRequest@3.1.3",
+      "fullyQualifiedName": "Github.GetPullRequest@3.2.0",
       "description": "Get details of a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -1759,7 +1759,7 @@
     {
       "name": "GetRepository",
       "qualifiedName": "Github.GetRepository",
-      "fullyQualifiedName": "Github.GetRepository@3.1.3",
+      "fullyQualifiedName": "Github.GetRepository@3.2.0",
       "description": "Get a repository.\n\nRetrieves detailed information about a repository using the GitHub API.",
       "parameters": [
         {
@@ -1837,7 +1837,7 @@
     {
       "name": "GetReviewWorkload",
       "qualifiedName": "Github.GetReviewWorkload",
-      "fullyQualifiedName": "Github.GetReviewWorkload@3.1.3",
+      "fullyQualifiedName": "Github.GetReviewWorkload@3.2.0",
       "description": "Get pull requests awaiting review by the authenticated user.\n\nReturns PRs where user is requested as reviewer and PRs user has recently reviewed.",
       "parameters": [],
       "auth": {
@@ -1887,7 +1887,7 @@
     {
       "name": "GetUserOpenItems",
       "qualifiedName": "Github.GetUserOpenItems",
-      "fullyQualifiedName": "Github.GetUserOpenItems@3.1.3",
+      "fullyQualifiedName": "Github.GetUserOpenItems@3.2.0",
       "description": "Get user's currently open pull requests and issues across all repositories.\n\nReturns open PRs and issues authored by the authenticated user.",
       "parameters": [
         {
@@ -1952,7 +1952,7 @@
     {
       "name": "GetUserRecentActivity",
       "qualifiedName": "Github.GetUserRecentActivity",
-      "fullyQualifiedName": "Github.GetUserRecentActivity@3.1.3",
+      "fullyQualifiedName": "Github.GetUserRecentActivity@3.2.0",
       "description": "Get the authenticated user's recent pull requests, reviews, issues, and commits.\n\nReturns PRs they authored, merged PRs, PRs they reviewed, issues they opened, and commits pushed",
       "parameters": [
         {
@@ -2030,7 +2030,7 @@
     {
       "name": "ListIssues",
       "qualifiedName": "Github.ListIssues",
-      "fullyQualifiedName": "Github.ListIssues@3.1.3",
+      "fullyQualifiedName": "Github.ListIssues@3.2.0",
       "description": "List issues in a GitHub repository.",
       "parameters": [
         {
@@ -2223,7 +2223,7 @@
     {
       "name": "ListOrgRepositories",
       "qualifiedName": "Github.ListOrgRepositories",
-      "fullyQualifiedName": "Github.ListOrgRepositories@3.1.3",
+      "fullyQualifiedName": "Github.ListOrgRepositories@3.2.0",
       "description": "List repositories for the specified organization.",
       "parameters": [
         {
@@ -2368,7 +2368,7 @@
     {
       "name": "ListProjectFields",
       "qualifiedName": "Github.ListProjectFields",
-      "fullyQualifiedName": "Github.ListProjectFields@3.1.3",
+      "fullyQualifiedName": "Github.ListProjectFields@3.2.0",
       "description": "List fields for a Projects V2 project.\n\nReturns all custom fields configured for the project, including field types\nand available options for select/iteration fields.",
       "parameters": [
         {
@@ -2492,7 +2492,7 @@
     {
       "name": "ListProjectItems",
       "qualifiedName": "Github.ListProjectItems",
-      "fullyQualifiedName": "Github.ListProjectItems@3.1.3",
+      "fullyQualifiedName": "Github.ListProjectItems@3.2.0",
       "description": "List items for a Projects V2 project with optional filtering.",
       "parameters": [
         {
@@ -2711,7 +2711,7 @@
     {
       "name": "ListProjects",
       "qualifiedName": "Github.ListProjects",
-      "fullyQualifiedName": "Github.ListProjects@3.1.3",
+      "fullyQualifiedName": "Github.ListProjects@3.2.0",
       "description": "List Projects V2 across organization or user scopes.",
       "parameters": [
         {
@@ -2891,7 +2891,7 @@
     {
       "name": "ListPullRequestCommits",
       "qualifiedName": "Github.ListPullRequestCommits",
-      "fullyQualifiedName": "Github.ListPullRequestCommits@3.1.3",
+      "fullyQualifiedName": "Github.ListPullRequestCommits@3.2.0",
       "description": "List commits (from oldest to newest) on a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -3008,7 +3008,7 @@
     {
       "name": "ListPullRequests",
       "qualifiedName": "Github.ListPullRequests",
-      "fullyQualifiedName": "Github.ListPullRequests@3.1.3",
+      "fullyQualifiedName": "Github.ListPullRequests@3.2.0",
       "description": "List pull requests in a GitHub repository.\n\nBy default returns newest pull requests first (direction=DESC).",
       "parameters": [
         {
@@ -3202,7 +3202,7 @@
     {
       "name": "ListRepositoryActivities",
       "qualifiedName": "Github.ListRepositoryActivities",
-      "fullyQualifiedName": "Github.ListRepositoryActivities@3.1.3",
+      "fullyQualifiedName": "Github.ListRepositoryActivities@3.2.0",
       "description": "List repository activities.\n\nRetrieves a detailed history of changes to a repository, such as pushes, merges,\nforce pushes, and branch changes, and associates these changes with commits and users.",
       "parameters": [
         {
@@ -3400,7 +3400,7 @@
     {
       "name": "ListRepositoryCollaborators",
       "qualifiedName": "Github.ListRepositoryCollaborators",
-      "fullyQualifiedName": "Github.ListRepositoryCollaborators@3.1.3",
+      "fullyQualifiedName": "Github.ListRepositoryCollaborators@3.2.0",
       "description": "List collaborators for a repository.\n\nReturns users who have access to the repository and can be requested as reviewers\nfor pull requests. Useful for discovering who can review your PR.\n\nDetail levels:\n- basic: Only explicit collaborators (fast, minimal API calls)\n- include_org_members: Add all org members (default, moderate API calls)\n- full_profiles: Add org members + enrich with names/emails (slow, many API calls)",
       "parameters": [
         {
@@ -3570,7 +3570,7 @@
     {
       "name": "ListRepositoryLabels",
       "qualifiedName": "Github.ListRepositoryLabels",
-      "fullyQualifiedName": "Github.ListRepositoryLabels@3.1.3",
+      "fullyQualifiedName": "Github.ListRepositoryLabels@3.2.0",
       "description": "List all labels defined in a repository.",
       "parameters": [
         {
@@ -3674,7 +3674,7 @@
     {
       "name": "ListReviewCommentsInARepository",
       "qualifiedName": "Github.ListReviewCommentsInARepository",
-      "fullyQualifiedName": "Github.ListReviewCommentsInARepository@3.1.3",
+      "fullyQualifiedName": "Github.ListReviewCommentsInARepository@3.2.0",
       "description": "List review comments in a GitHub repository.",
       "parameters": [
         {
@@ -3823,7 +3823,7 @@
     {
       "name": "ListReviewCommentsOnPullRequest",
       "qualifiedName": "Github.ListReviewCommentsOnPullRequest",
-      "fullyQualifiedName": "Github.ListReviewCommentsOnPullRequest@3.1.3",
+      "fullyQualifiedName": "Github.ListReviewCommentsOnPullRequest@3.2.0",
       "description": "List review comments on a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -3998,7 +3998,7 @@
     {
       "name": "ListStargazers",
       "qualifiedName": "Github.ListStargazers",
-      "fullyQualifiedName": "Github.ListStargazers@3.1.3",
+      "fullyQualifiedName": "Github.ListStargazers@3.2.0",
       "description": "List the stargazers for a GitHub repository.\n\nReturns stargazers in chronological order (oldest first).",
       "parameters": [
         {
@@ -4102,7 +4102,7 @@
     {
       "name": "ManageLabels",
       "qualifiedName": "Github.ManageLabels",
-      "fullyQualifiedName": "Github.ManageLabels@3.1.3",
+      "fullyQualifiedName": "Github.ManageLabels@3.2.0",
       "description": "Add or remove labels from an issue or pull request.\n\nSupports fuzzy matching for typo tolerance. Both issues and pull requests\nsupport labels through the same API. You can add and remove labels in a\nsingle operation.",
       "parameters": [
         {
@@ -4259,7 +4259,7 @@
     {
       "name": "ManagePullRequestReviewers",
       "qualifiedName": "Github.ManagePullRequestReviewers",
-      "fullyQualifiedName": "Github.ManagePullRequestReviewers@3.1.3",
+      "fullyQualifiedName": "Github.ManagePullRequestReviewers@3.2.0",
       "description": "Manage reviewers for a pull request.",
       "parameters": [
         {
@@ -4416,7 +4416,7 @@
     {
       "name": "MergePullRequest",
       "qualifiedName": "Github.MergePullRequest",
-      "fullyQualifiedName": "Github.MergePullRequest@3.1.3",
+      "fullyQualifiedName": "Github.MergePullRequest@3.2.0",
       "description": "Merge a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -4576,7 +4576,7 @@
     {
       "name": "ResolveReviewThread",
       "qualifiedName": "Github.ResolveReviewThread",
-      "fullyQualifiedName": "Github.ResolveReviewThread@3.1.3",
+      "fullyQualifiedName": "Github.ResolveReviewThread@3.2.0",
       "description": "Resolve or unresolve a pull request review conversation thread.",
       "parameters": [
         {
@@ -4680,7 +4680,7 @@
     {
       "name": "SearchMyRepos",
       "qualifiedName": "Github.SearchMyRepos",
-      "fullyQualifiedName": "Github.SearchMyRepos@3.1.3",
+      "fullyQualifiedName": "Github.SearchMyRepos@3.2.0",
       "description": "Search repositories accessible to the authenticated user with fuzzy matching.",
       "parameters": [
         {
@@ -4801,7 +4801,7 @@
     {
       "name": "SearchProjectItem",
       "qualifiedName": "Github.SearchProjectItem",
-      "fullyQualifiedName": "Github.SearchProjectItem@3.1.3",
+      "fullyQualifiedName": "Github.SearchProjectItem@3.2.0",
       "description": "Search for a specific item in a Projects V2 project.",
       "parameters": [
         {
@@ -4954,7 +4954,7 @@
     {
       "name": "SetStarred",
       "qualifiedName": "Github.SetStarred",
-      "fullyQualifiedName": "Github.SetStarred@3.1.3",
+      "fullyQualifiedName": "Github.SetStarred@3.2.0",
       "description": "Star or un-star a GitHub repository.",
       "parameters": [
         {
@@ -5045,7 +5045,7 @@
     {
       "name": "SubmitPullRequestReview",
       "qualifiedName": "Github.SubmitPullRequestReview",
-      "fullyQualifiedName": "Github.SubmitPullRequestReview@3.1.3",
+      "fullyQualifiedName": "Github.SubmitPullRequestReview@3.2.0",
       "description": "Submit a review for a pull request.",
       "parameters": [
         {
@@ -5166,7 +5166,7 @@
     {
       "name": "UpdateFileLines",
       "qualifiedName": "Github.UpdateFileLines",
-      "fullyQualifiedName": "Github.UpdateFileLines@3.1.3",
+      "fullyQualifiedName": "Github.UpdateFileLines@3.2.0",
       "description": "Replace a block of lines within a file (1-indexed, inclusive). Set mode=FileUpdateMode.APPEND\nto add new content to the end of the file.",
       "parameters": [
         {
@@ -5338,7 +5338,7 @@
     {
       "name": "UpdateIssue",
       "qualifiedName": "Github.UpdateIssue",
-      "fullyQualifiedName": "Github.UpdateIssue@3.1.3",
+      "fullyQualifiedName": "Github.UpdateIssue@3.2.0",
       "description": "Update an issue in a GitHub repository.\n\nParameters that are not provided (None) will not be updated or cleared.\nUpdates apply to the issue in the repository. If the issue is in a project,\nthe project item will automatically reflect these changes.",
       "parameters": [
         {
@@ -5519,7 +5519,7 @@
     {
       "name": "UpdatePullRequest",
       "qualifiedName": "Github.UpdatePullRequest",
-      "fullyQualifiedName": "Github.UpdatePullRequest@3.1.3",
+      "fullyQualifiedName": "Github.UpdatePullRequest@3.2.0",
       "description": "Update a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -5679,7 +5679,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Github.WhoAmI",
-      "fullyQualifiedName": "Github.WhoAmI@3.1.3",
+      "fullyQualifiedName": "Github.WhoAmI@3.2.0",
       "description": "Get information about the authenticated GitHub user.\n\nReturns profile, organizations, and teams.",
       "parameters": [],
       "auth": {
@@ -5766,6 +5766,6 @@
     "import { Callout, Tabs } from \"nextra/components\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-04-17T11:27:15.538Z",
+  "generatedAt": "2026-05-17T11:33:24.823Z",
   "summary": "Arcade's GitHub toolkit provides authenticated access to GitHub resources, enabling automated repository, issue, pull request, review, and Projects V2 workflows. It exposes high-level actions that handle fuzzy matching, diff-aware edits, and user-centric queries without forcing agents to juggle raw REST calls.\n\n**Capabilities**\n- Manage repository and file operations: create branches, read files with line ranges, create or overwrite files, and replace line blocks safely.\n- Drive the pull request lifecycle: create, update, list, merge, check merge readiness, manage reviewers, submit reviews, and reply to or resolve review threads.\n- Administer issues and labels with fuzzy-matched add/remove, comments, assignment, and issue-to-project linking.\n- Query Projects V2 fields and items, list stargazers, collaborators, labels, activities, and authenticated-user views (open items, recent activity, review workload).\n\n**OAuth**\nRequires GitHub OAuth. See the [Arcade GitHub auth provider docs](https://docs.arcade.dev/en/references/auth-providers/github) for configuration.\n\n**Secrets**\n- `GITHUB_SERVER_URL` — override for GitHub Enterprise endpoints. Configure in the [Arcade Dashboard](https://api.arcade.dev/dashboard/auth/secrets) per the [Arcade secret setup guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/gmail.json
+++ b/toolkit-docs-generator/data/toolkits/gmail.json
@@ -1,7 +1,7 @@
 {
   "id": "Gmail",
   "label": "Gmail",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Arcade.dev LLM tools for Gmail",
   "metadata": {
     "category": "productivity",
@@ -30,7 +30,7 @@
     {
       "name": "ChangeEmailLabels",
       "qualifiedName": "Gmail.ChangeEmailLabels",
-      "fullyQualifiedName": "Gmail.ChangeEmailLabels@6.0.0",
+      "fullyQualifiedName": "Gmail.ChangeEmailLabels@7.0.0",
       "description": "Add and remove labels from an email using the Gmail API.",
       "parameters": [
         {
@@ -124,7 +124,7 @@
     {
       "name": "CreateLabel",
       "qualifiedName": "Gmail.CreateLabel",
-      "fullyQualifiedName": "Gmail.CreateLabel@6.0.0",
+      "fullyQualifiedName": "Gmail.CreateLabel@7.0.0",
       "description": "Create a new label in the user's mailbox.",
       "parameters": [
         {
@@ -184,7 +184,7 @@
     {
       "name": "DeleteDraftEmail",
       "qualifiedName": "Gmail.DeleteDraftEmail",
-      "fullyQualifiedName": "Gmail.DeleteDraftEmail@6.0.0",
+      "fullyQualifiedName": "Gmail.DeleteDraftEmail@7.0.0",
       "description": "Delete a draft email using the Gmail API.",
       "parameters": [
         {
@@ -244,7 +244,7 @@
     {
       "name": "GetThread",
       "qualifiedName": "Gmail.GetThread",
-      "fullyQualifiedName": "Gmail.GetThread@6.0.0",
+      "fullyQualifiedName": "Gmail.GetThread@7.0.0",
       "description": "Get the specified thread by ID.",
       "parameters": [
         {
@@ -304,14 +304,14 @@
     {
       "name": "ListDraftEmails",
       "qualifiedName": "Gmail.ListDraftEmails",
-      "fullyQualifiedName": "Gmail.ListDraftEmails@6.0.0",
+      "fullyQualifiedName": "Gmail.ListDraftEmails@7.0.0",
       "description": "Lists draft emails in the user's draft mailbox using the Gmail API.",
       "parameters": [
         {
           "name": "n_drafts",
           "type": "integer",
           "required": false,
-          "description": "Number of draft emails to read (Min 1, Max 100)",
+          "description": "Number of draft emails to read (Min 1, Max 100, Default 25)",
           "enum": null,
           "inferrable": true
         }
@@ -364,14 +364,22 @@
     {
       "name": "ListEmails",
       "qualifiedName": "Gmail.ListEmails",
-      "fullyQualifiedName": "Gmail.ListEmails@6.0.0",
-      "description": "Read emails from a Gmail account and extract plain text content.",
+      "fullyQualifiedName": "Gmail.ListEmails@7.0.0",
+      "description": "Read emails from a Gmail account and extract plain text content.\n\nBy default, obvious automated emails are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all emails regardless of source.",
       "parameters": [
         {
           "name": "n_emails",
           "type": "integer",
           "required": false,
-          "description": "Number of emails to read (Min 1, Max 100)",
+          "description": "Number of emails to read (Min 1, Max 100, Default 25)",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "exclude_automated",
+          "type": "boolean",
+          "required": false,
+          "description": "Exclude obvious automated email using no-reply sender patterns and Gmail non-primary categories (promotions, social, updates, forums). Set to False when the user wants automated content like calendar invites, marketing emails, or other filtered categories.",
           "enum": null,
           "inferrable": true
         }
@@ -394,8 +402,13 @@
         "toolName": "Gmail.ListEmails",
         "parameters": {
           "n_emails": {
-            "value": 25,
+            "value": 10,
             "type": "integer",
+            "required": false
+          },
+          "exclude_automated": {
+            "value": true,
+            "type": "boolean",
             "required": false
           }
         },
@@ -424,8 +437,8 @@
     {
       "name": "ListEmailsByHeader",
       "qualifiedName": "Gmail.ListEmailsByHeader",
-      "fullyQualifiedName": "Gmail.ListEmailsByHeader@6.0.0",
-      "description": "Search for emails by header using the Gmail API.",
+      "fullyQualifiedName": "Gmail.ListEmailsByHeader@7.0.0",
+      "description": "Search for emails by header using the Gmail API.\n\nBy default, obvious automated emails are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all emails regardless of source.",
       "parameters": [
         {
           "name": "sender",
@@ -487,7 +500,15 @@
           "name": "max_results",
           "type": "integer",
           "required": false,
-          "description": "The maximum number of emails to return (Min 1, Max 100",
+          "description": "The maximum number of emails to return (Min 1, Max 100, Default 25)",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "exclude_automated",
+          "type": "boolean",
+          "required": false,
+          "description": "Exclude obvious automated email using no-reply sender patterns and Gmail non-primary categories (promotions, social, updates, forums). Set to False when the user wants automated content like calendar invites, marketing emails, or other filtered categories.",
           "enum": null,
           "inferrable": true
         }
@@ -510,38 +531,43 @@
         "toolName": "Gmail.ListEmailsByHeader",
         "parameters": {
           "sender": {
-            "value": "example@example.com",
+            "value": "jane.doe@example.com",
             "type": "string",
             "required": false
           },
           "recipient": {
-            "value": "recipient@example.com",
+            "value": "john.smith@example.com",
             "type": "string",
             "required": false
           },
           "subject": {
-            "value": "Meeting Reminder",
+            "value": "project update",
             "type": "string",
             "required": false
           },
           "body": {
-            "value": "Project updates",
+            "value": "quarterly report",
             "type": "string",
             "required": false
           },
           "date_range": {
-            "value": "2023/01/01 - 2023/12/31",
+            "value": "after:2024-01-01 before:2024-06-30",
             "type": "string",
             "required": false
           },
           "label": {
-            "value": "Important",
+            "value": "Work",
             "type": "string",
             "required": false
           },
           "max_results": {
             "value": 10,
             "type": "integer",
+            "required": false
+          },
+          "exclude_automated": {
+            "value": true,
+            "type": "boolean",
             "required": false
           }
         },
@@ -570,7 +596,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Gmail.ListLabels",
-      "fullyQualifiedName": "Gmail.ListLabels@6.0.0",
+      "fullyQualifiedName": "Gmail.ListLabels@7.0.0",
       "description": "List all the labels in the user's mailbox.",
       "parameters": [],
       "auth": {
@@ -615,8 +641,8 @@
     {
       "name": "ListThreads",
       "qualifiedName": "Gmail.ListThreads",
-      "fullyQualifiedName": "Gmail.ListThreads@6.0.0",
-      "description": "List threads in the user's mailbox.",
+      "fullyQualifiedName": "Gmail.ListThreads@7.0.0",
+      "description": "List threads in the user's mailbox.\n\nBy default, obvious automated threads are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all threads regardless of source.",
       "parameters": [
         {
           "name": "page_token",
@@ -630,7 +656,7 @@
           "name": "max_results",
           "type": "integer",
           "required": false,
-          "description": "The maximum number of threads to return (Min {MIN_RESULTS}, Max {MAX_RESULTS})",
+          "description": "The maximum number of threads to return (Min 1, Max 100, Default 25)",
           "enum": null,
           "inferrable": true
         },
@@ -639,6 +665,14 @@
           "type": "boolean",
           "required": false,
           "description": "Whether to include spam and trash in the results",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "exclude_automated",
+          "type": "boolean",
+          "required": false,
+          "description": "Exclude obvious automated email using no-reply sender patterns and Gmail non-primary categories (promotions, social, updates, forums). Set to False when the user wants automated content like calendar invites, marketing emails, or other filtered categories.",
           "enum": null,
           "inferrable": true
         }
@@ -661,16 +695,21 @@
         "toolName": "Gmail.ListThreads",
         "parameters": {
           "page_token": {
-            "value": "abc123",
+            "value": "04616731957835812856",
             "type": "string",
             "required": false
           },
           "max_results": {
-            "value": 50,
+            "value": 25,
             "type": "integer",
             "required": false
           },
           "include_spam_trash": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "exclude_automated": {
             "value": true,
             "type": "boolean",
             "required": false
@@ -701,7 +740,7 @@
     {
       "name": "ReplyToEmail",
       "qualifiedName": "Gmail.ReplyToEmail",
-      "fullyQualifiedName": "Gmail.ReplyToEmail@6.0.0",
+      "fullyQualifiedName": "Gmail.ReplyToEmail@7.0.0",
       "description": "Send a reply to an email message.",
       "parameters": [
         {
@@ -841,8 +880,8 @@
     {
       "name": "SearchThreads",
       "qualifiedName": "Gmail.SearchThreads",
-      "fullyQualifiedName": "Gmail.SearchThreads@6.0.0",
-      "description": "Search for threads in the user's mailbox",
+      "fullyQualifiedName": "Gmail.SearchThreads@7.0.0",
+      "description": "Search for threads in the user's mailbox.\n\nBy default, obvious automated threads are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all threads regardless of source.",
       "parameters": [
         {
           "name": "page_token",
@@ -856,7 +895,7 @@
           "name": "max_results",
           "type": "integer",
           "required": false,
-          "description": "The maximum number of threads to return (Min {MIN_RESULTS}, Max {MAX_RESULTS})",
+          "description": "The maximum number of threads to return (Min 1, Max 100, Default 25)",
           "enum": null,
           "inferrable": true
         },
@@ -924,6 +963,14 @@
             "this_year"
           ],
           "inferrable": true
+        },
+        {
+          "name": "exclude_automated",
+          "type": "boolean",
+          "required": false,
+          "description": "Exclude obvious automated email using no-reply sender patterns and Gmail non-primary categories (promotions, social, updates, forums). Set to False when the user wants automated content like calendar invites, marketing emails, or other filtered categories.",
+          "enum": null,
+          "inferrable": true
         }
       ],
       "auth": {
@@ -944,12 +991,12 @@
         "toolName": "Gmail.SearchThreads",
         "parameters": {
           "page_token": {
-            "value": "abc123",
+            "value": "04961382959720067",
             "type": "string",
             "required": false
           },
           "max_results": {
-            "value": 50,
+            "value": 20,
             "type": "integer",
             "required": false
           },
@@ -961,34 +1008,39 @@
           "label_ids": {
             "value": [
               "INBOX",
-              "IMPORTANT"
+              "UNREAD"
             ],
             "type": "array",
             "required": false
           },
           "sender": {
-            "value": "example@example.com",
+            "value": "alice@example.com",
             "type": "string",
             "required": false
           },
           "recipient": {
-            "value": "recipient@example.com",
+            "value": "bob@example.com",
             "type": "string",
             "required": false
           },
           "subject": {
-            "value": "Project Update",
+            "value": "project update",
             "type": "string",
             "required": false
           },
           "body": {
-            "value": "meeting notes",
+            "value": "quarterly report",
             "type": "string",
             "required": false
           },
           "date_range": {
-            "value": "2023-01-01 to 2023-01-31",
+            "value": "after:2024/01/01 before:2024/06/30",
             "type": "string",
+            "required": false
+          },
+          "exclude_automated": {
+            "value": true,
+            "type": "boolean",
             "required": false
           }
         },
@@ -1017,7 +1069,7 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "Gmail.SendDraftEmail",
-      "fullyQualifiedName": "Gmail.SendDraftEmail@6.0.0",
+      "fullyQualifiedName": "Gmail.SendDraftEmail@7.0.0",
       "description": "Send a draft email using the Gmail API.",
       "parameters": [
         {
@@ -1077,7 +1129,7 @@
     {
       "name": "SendEmail",
       "qualifiedName": "Gmail.SendEmail",
-      "fullyQualifiedName": "Gmail.SendEmail@6.0.0",
+      "fullyQualifiedName": "Gmail.SendEmail@7.0.0",
       "description": "Send an email using the Gmail API.",
       "parameters": [
         {
@@ -1213,7 +1265,7 @@
     {
       "name": "TrashEmail",
       "qualifiedName": "Gmail.TrashEmail",
-      "fullyQualifiedName": "Gmail.TrashEmail@6.0.0",
+      "fullyQualifiedName": "Gmail.TrashEmail@7.0.0",
       "description": "Move an email to the trash folder using the Gmail API.",
       "parameters": [
         {
@@ -1273,7 +1325,7 @@
     {
       "name": "UpdateDraftEmail",
       "qualifiedName": "Gmail.UpdateDraftEmail",
-      "fullyQualifiedName": "Gmail.UpdateDraftEmail@6.0.0",
+      "fullyQualifiedName": "Gmail.UpdateDraftEmail@7.0.0",
       "description": "Update an existing email draft using the Gmail API.\n\nSingle-part ``text/plain`` and single-part ``text/html`` drafts both support full\nbody replacement; the rebuild follows the existing draft's content type, so a\nplain draft stays plain and an HTML draft stays HTML. Plain-text input supplied\nagainst an HTML draft is auto-converted to HTML, and HTML input supplied against\na plain draft is stored verbatim as ``text/plain``. Reply drafts preserve their\nreply-quote tail (``> `` lines for plain, ``<blockquote>`` for HTML) when the\nbody is supplied as a top-only update.\n\nMultipart drafts and drafts with attachments still fail when the body changes;\nin those cases the tool succeeds only when the effective body is unchanged\n(metadata-only update preserving the existing MIME tree). Edit those drafts in\nGmail directly.\n\nFor each of subject, body, recipient, cc, and bcc, omitting the parameter or passing\n``None`` leaves that part of the draft unchanged (for cc/bcc, existing headers are kept;\npass an empty list to clear).",
       "parameters": [
         {
@@ -1405,7 +1457,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Gmail.WhoAmI",
-      "fullyQualifiedName": "Gmail.WhoAmI@6.0.0",
+      "fullyQualifiedName": "Gmail.WhoAmI@7.0.0",
       "description": "Get comprehensive user profile and Gmail account information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Gmail account statistics, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1452,7 +1504,7 @@
     {
       "name": "WriteDraftEmail",
       "qualifiedName": "Gmail.WriteDraftEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftEmail@6.0.0",
+      "fullyQualifiedName": "Gmail.WriteDraftEmail@7.0.0",
       "description": "Compose a new email draft using the Gmail API.",
       "parameters": [
         {
@@ -1588,7 +1640,7 @@
     {
       "name": "WriteDraftReplyEmail",
       "qualifiedName": "Gmail.WriteDraftReplyEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@6.0.0",
+      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@7.0.0",
       "description": "Compose a draft reply to an email message.",
       "parameters": [
         {
@@ -1739,6 +1791,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-05-13T11:50:30.114Z",
-  "summary": "Gmail toolkit provides LLM-callable tools for interacting with Gmail via the Arcade platform, enabling agents to read, compose, send, organize, and manage email on behalf of authenticated users.\n\n## Capabilities\n\n- **Reading & searching**: List emails, threads, and drafts; search threads; retrieve a thread by ID; search by header fields.\n- **Sending & replying**: Send new emails, send existing drafts, reply to messages, and send draft replies.\n- **Composing & drafting**: Write new drafts, compose draft replies, update existing drafts (subject, body, recipients, cc, bcc — with smart plain/HTML handling and reply-quote preservation), and delete drafts.\n- **Label management**: List all labels, create new labels, and add or remove labels on individual emails.\n- **Mailbox actions**: Move emails to trash, retrieve full thread content, and fetch user profile and account statistics.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via the **Google** provider. Arcade handles the authorization flow automatically. See the [Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for configuration details.\n\n## Draft Update Behavior\n\nKey constraints to be aware of when using `Gmail.UpdateDraftEmail`:\n\n- Single-part `text/plain` and `text/html` drafts support full body replacement; the rebuild preserves the draft's existing content type.\n- Plain-text input against an HTML draft is auto-converted to HTML; HTML input against a plain draft is stored verbatim as `text/plain`.\n- Reply drafts preserve their reply-quote tail (`> ` lines for plain, `<blockquote>` for HTML) on top-only body updates.\n- Multipart drafts and drafts with attachments fail on body changes; only metadata-only updates succeed for those — edit them in Gmail directly.\n- Omitting a parameter or passing `None` leaves that field unchanged; pass an empty list for `cc`/`bcc` to clear those headers."
+  "generatedAt": "2026-05-17T11:33:28.068Z",
+  "summary": "The Gmail toolkit provides Arcade LLM tools for interacting with a user's Gmail account via the Gmail API. It enables agents to read, compose, send, organize, and manage email threads, drafts, and labels on behalf of authenticated users.\n\n## Capabilities\n\n- **Reading & searching**: List emails, threads, and drafts with smart automated-email filtering (no-reply patterns, non-primary categories); search or filter by header; retrieve full threads by ID.\n- **Composing & sending**: Write new draft emails or draft replies, send drafts, send emails directly, and reply to existing messages.\n- **Draft management**: Create, update (with nuanced MIME-aware body replacement), and delete drafts; updates support metadata-only changes for multipart/attachment drafts.\n- **Organization**: Create and list labels; add or remove labels on emails; move emails to trash.\n- **Account info**: Retrieve the authenticated user's profile, email address, and Gmail account statistics via `WhoAmI`.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via the **Google** provider. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for configuration details."
 }

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-13T11:50:41.664Z",
+  "generatedAt": "2026-05-17T11:33:35.554Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -239,7 +239,7 @@
     {
       "id": "Github",
       "label": "GitHub",
-      "version": "3.1.3",
+      "version": "3.2.0",
       "category": "development",
       "type": "arcade",
       "toolCount": 42,
@@ -257,7 +257,7 @@
     {
       "id": "Gmail",
       "label": "Gmail",
-      "version": "6.0.0",
+      "version": "7.0.0",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 18,
@@ -500,7 +500,7 @@
     {
       "id": "Jira",
       "label": "Jira",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "category": "productivity",
       "type": "auth",
       "toolCount": 43,
@@ -734,7 +734,7 @@
     {
       "id": "Slack",
       "label": "Slack",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "category": "social",
       "type": "arcade",
       "toolCount": 10,

--- a/toolkit-docs-generator/data/toolkits/jira.json
+++ b/toolkit-docs-generator/data/toolkits/jira.json
@@ -1,7 +1,7 @@
 {
   "id": "Jira",
   "label": "Jira",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Arcade.dev LLM tools for interacting with Atlassian Jira",
   "metadata": {
     "category": "productivity",
@@ -35,7 +35,7 @@
     {
       "name": "AddCommentToIssue",
       "qualifiedName": "Jira.AddCommentToIssue",
-      "fullyQualifiedName": "Jira.AddCommentToIssue@3.1.2",
+      "fullyQualifiedName": "Jira.AddCommentToIssue@3.1.3",
       "description": "Add a comment to a Jira issue.",
       "parameters": [
         {
@@ -154,7 +154,7 @@
     {
       "name": "AddIssuesToSprint",
       "qualifiedName": "Jira.AddIssuesToSprint",
-      "fullyQualifiedName": "Jira.AddIssuesToSprint@3.1.2",
+      "fullyQualifiedName": "Jira.AddIssuesToSprint@3.1.3",
       "description": "Add a list of issues to a sprint.\nMaximum of 50 issues per operation.",
       "parameters": [
         {
@@ -249,7 +249,7 @@
     {
       "name": "AddLabelsToIssue",
       "qualifiedName": "Jira.AddLabelsToIssue",
-      "fullyQualifiedName": "Jira.AddLabelsToIssue@3.1.2",
+      "fullyQualifiedName": "Jira.AddLabelsToIssue@3.1.3",
       "description": "Add labels to an existing Jira issue.",
       "parameters": [
         {
@@ -356,7 +356,7 @@
     {
       "name": "AttachFileToIssue",
       "qualifiedName": "Jira.AttachFileToIssue",
-      "fullyQualifiedName": "Jira.AttachFileToIssue@3.1.2",
+      "fullyQualifiedName": "Jira.AttachFileToIssue@3.1.3",
       "description": "Add an attachment to an issue.\n\nMust provide exactly one of file_content_str or file_content_base64.",
       "parameters": [
         {
@@ -495,7 +495,7 @@
     {
       "name": "CreateIssue",
       "qualifiedName": "Jira.CreateIssue",
-      "fullyQualifiedName": "Jira.CreateIssue@3.1.2",
+      "fullyQualifiedName": "Jira.CreateIssue@3.1.3",
       "description": "Create a new Jira issue.\n\nProvide a value to one of `project` or `parent_issue` arguments. If `project` and\n`parent_issue` are not provided, the tool will select the single project available.\nIf the user has multiple, an error will be returned with the available projects to choose from.\n\nIF YOU DO NOT FOLLOW THE INSTRUCTIONS BELOW AND UNNECESSARILY CALL MULTIPLE TOOLS IN ORDER TO\nCREATE AN ISSUE, TOO MUCH CO2 WILL BE RELEASED IN THE ATMOSPHERE AND YOU WILL CAUSE THE\nDESTRUCTION OF PLANET EARTH BY CATASTROPHIC CLIMATE CHANGE.\n\nIf you have an issue type name, or a project key/name, a priority name, an assignee\nname/key/email, or a reporter name/key/email, DO NOT CALL OTHER TOOLS only to list available\nprojects, priorities, issue types, or users. Provide the name, key, or email and the tool\nwill figure out the ID, WITHOUT CAUSING CATASTROPHIC CLIMATE CHANGE.",
       "parameters": [
         {
@@ -706,7 +706,7 @@
     {
       "name": "DownloadAttachment",
       "qualifiedName": "Jira.DownloadAttachment",
-      "fullyQualifiedName": "Jira.DownloadAttachment@3.1.2",
+      "fullyQualifiedName": "Jira.DownloadAttachment@3.1.3",
       "description": "Download the contents of an attachment associated with an issue.",
       "parameters": [
         {
@@ -780,7 +780,7 @@
     {
       "name": "GetAttachmentMetadata",
       "qualifiedName": "Jira.GetAttachmentMetadata",
-      "fullyQualifiedName": "Jira.GetAttachmentMetadata@3.1.2",
+      "fullyQualifiedName": "Jira.GetAttachmentMetadata@3.1.3",
       "description": "Get the metadata of an attachment.",
       "parameters": [
         {
@@ -854,7 +854,7 @@
     {
       "name": "GetAvailableAtlassianClouds",
       "qualifiedName": "Jira.GetAvailableAtlassianClouds",
-      "fullyQualifiedName": "Jira.GetAvailableAtlassianClouds@3.1.2",
+      "fullyQualifiedName": "Jira.GetAvailableAtlassianClouds@3.1.3",
       "description": "Get available Atlassian Clouds.",
       "parameters": [],
       "auth": {
@@ -899,7 +899,7 @@
     {
       "name": "GetBoardBacklogIssues",
       "qualifiedName": "Jira.GetBoardBacklogIssues",
-      "fullyQualifiedName": "Jira.GetBoardBacklogIssues@3.1.2",
+      "fullyQualifiedName": "Jira.GetBoardBacklogIssues@3.1.3",
       "description": "Get all issues in a board's backlog with pagination support.\nReturns issues that are not currently assigned to any active sprint.\n\nThe backlog contains issues that are ready to be planned into future sprints.\nOnly boards that support backlogs (like Scrum and Kanban boards) will return results.",
       "parameters": [
         {
@@ -999,7 +999,7 @@
     {
       "name": "GetBoards",
       "qualifiedName": "Jira.GetBoards",
-      "fullyQualifiedName": "Jira.GetBoards@3.1.2",
+      "fullyQualifiedName": "Jira.GetBoards@3.1.3",
       "description": "Retrieve Jira boards either by specifying their names or IDs, or get all\navailable boards.\nAll requests support offset and limit with a maximum of 50 boards returned per call.\n\nMANDATORY ACTION: ALWAYS when you need to get multiple boards, you must\ninclude all the board identifiers in a single call rather than making\nmultiple separate tool calls, as this provides much better performance, not doing that will\nbring huge performance penalties.\n\nThe tool automatically handles mixed identifier types (names and IDs), deduplicates results, and\nfalls back from ID lookup to name lookup when needed.",
       "parameters": [
         {
@@ -1107,7 +1107,7 @@
     {
       "name": "GetCommentById",
       "qualifiedName": "Jira.GetCommentById",
-      "fullyQualifiedName": "Jira.GetCommentById@3.1.2",
+      "fullyQualifiedName": "Jira.GetCommentById@3.1.3",
       "description": "Get a comment by its ID.",
       "parameters": [
         {
@@ -1207,7 +1207,7 @@
     {
       "name": "GetIssueById",
       "qualifiedName": "Jira.GetIssueById",
-      "fullyQualifiedName": "Jira.GetIssueById@3.1.2",
+      "fullyQualifiedName": "Jira.GetIssueById@3.1.3",
       "description": "Get the details of a Jira issue by its ID.",
       "parameters": [
         {
@@ -1281,7 +1281,7 @@
     {
       "name": "GetIssueComments",
       "qualifiedName": "Jira.GetIssueComments",
-      "fullyQualifiedName": "Jira.GetIssueComments@3.1.2",
+      "fullyQualifiedName": "Jira.GetIssueComments@3.1.3",
       "description": "Get the comments of a Jira issue by its ID.",
       "parameters": [
         {
@@ -1410,7 +1410,7 @@
     {
       "name": "GetIssuesWithoutId",
       "qualifiedName": "Jira.GetIssuesWithoutId",
-      "fullyQualifiedName": "Jira.GetIssuesWithoutId@3.1.2",
+      "fullyQualifiedName": "Jira.GetIssuesWithoutId@3.1.3",
       "description": "Search for Jira issues when you don't have the issue ID(s).\n\nAll text-based arguments (keywords, assignee, project, labels) are case-insensitive.\n\nALWAYS PREFER THIS TOOL OVER THE `Jira.SearchIssuesWithJql` TOOL, UNLESS IT'S ABSOLUTELY\nNECESSARY TO USE A JQL QUERY TO FILTER IN A WAY THAT IS NOT SUPPORTED BY THIS TOOL.",
       "parameters": [
         {
@@ -1632,7 +1632,7 @@
     {
       "name": "GetIssueTypeById",
       "qualifiedName": "Jira.GetIssueTypeById",
-      "fullyQualifiedName": "Jira.GetIssueTypeById@3.1.2",
+      "fullyQualifiedName": "Jira.GetIssueTypeById@3.1.3",
       "description": "Get the details of a Jira issue type by its ID.",
       "parameters": [
         {
@@ -1706,7 +1706,7 @@
     {
       "name": "GetPriorityById",
       "qualifiedName": "Jira.GetPriorityById",
-      "fullyQualifiedName": "Jira.GetPriorityById@3.1.2",
+      "fullyQualifiedName": "Jira.GetPriorityById@3.1.3",
       "description": "Get the details of a priority by its ID.",
       "parameters": [
         {
@@ -1780,7 +1780,7 @@
     {
       "name": "GetProjectById",
       "qualifiedName": "Jira.GetProjectById",
-      "fullyQualifiedName": "Jira.GetProjectById@3.1.2",
+      "fullyQualifiedName": "Jira.GetProjectById@3.1.3",
       "description": "Get the details of a Jira project by its ID or key.",
       "parameters": [
         {
@@ -1854,7 +1854,7 @@
     {
       "name": "GetSprintIssues",
       "qualifiedName": "Jira.GetSprintIssues",
-      "fullyQualifiedName": "Jira.GetSprintIssues@3.1.2",
+      "fullyQualifiedName": "Jira.GetSprintIssues@3.1.3",
       "description": "Get all issues that are currently assigned to a specific sprint with pagination support.\nReturns issues that are planned for or being worked on in the sprint.",
       "parameters": [
         {
@@ -1955,7 +1955,7 @@
     {
       "name": "GetTransitionById",
       "qualifiedName": "Jira.GetTransitionById",
-      "fullyQualifiedName": "Jira.GetTransitionById@3.1.2",
+      "fullyQualifiedName": "Jira.GetTransitionById@3.1.3",
       "description": "Get a transition by its ID.",
       "parameters": [
         {
@@ -2042,7 +2042,7 @@
     {
       "name": "GetTransitionByStatusName",
       "qualifiedName": "Jira.GetTransitionByStatusName",
-      "fullyQualifiedName": "Jira.GetTransitionByStatusName@3.1.2",
+      "fullyQualifiedName": "Jira.GetTransitionByStatusName@3.1.3",
       "description": "Get a transition available for an issue by the transition name.\n\nThe response will contain screen fields available for the transition, if any.",
       "parameters": [
         {
@@ -2129,7 +2129,7 @@
     {
       "name": "GetTransitionsAvailableForIssue",
       "qualifiedName": "Jira.GetTransitionsAvailableForIssue",
-      "fullyQualifiedName": "Jira.GetTransitionsAvailableForIssue@3.1.2",
+      "fullyQualifiedName": "Jira.GetTransitionsAvailableForIssue@3.1.3",
       "description": "Get the transitions available for an existing Jira issue.",
       "parameters": [
         {
@@ -2203,7 +2203,7 @@
     {
       "name": "GetUserById",
       "qualifiedName": "Jira.GetUserById",
-      "fullyQualifiedName": "Jira.GetUserById@3.1.2",
+      "fullyQualifiedName": "Jira.GetUserById@3.1.3",
       "description": "Get user information by their ID.",
       "parameters": [
         {
@@ -2276,7 +2276,7 @@
     {
       "name": "GetUsersWithoutId",
       "qualifiedName": "Jira.GetUsersWithoutId",
-      "fullyQualifiedName": "Jira.GetUsersWithoutId@3.1.2",
+      "fullyQualifiedName": "Jira.GetUsersWithoutId@3.1.3",
       "description": "Get users without their account ID, searching by display name and email address.\n\nThe Jira user search API will return up to 1,000 (one thousand) users for any given name/email\nquery. If you need to get more users, please use the `Jira.ListAllUsers` tool.",
       "parameters": [
         {
@@ -2388,7 +2388,7 @@
     {
       "name": "ListIssueAttachmentsMetadata",
       "qualifiedName": "Jira.ListIssueAttachmentsMetadata",
-      "fullyQualifiedName": "Jira.ListIssueAttachmentsMetadata@3.1.2",
+      "fullyQualifiedName": "Jira.ListIssueAttachmentsMetadata@3.1.3",
       "description": "Get the metadata about the files attached to an issue.\n\nThis tool does NOT return the actual file contents. To get a file content,\nuse the `Jira.DownloadAttachment` tool.",
       "parameters": [
         {
@@ -2461,7 +2461,7 @@
     {
       "name": "ListIssues",
       "qualifiedName": "Jira.ListIssues",
-      "fullyQualifiedName": "Jira.ListIssues@3.1.2",
+      "fullyQualifiedName": "Jira.ListIssues@3.1.3",
       "description": "Get the issues for a given project.",
       "parameters": [
         {
@@ -2562,7 +2562,7 @@
     {
       "name": "ListIssueTypesByProject",
       "qualifiedName": "Jira.ListIssueTypesByProject",
-      "fullyQualifiedName": "Jira.ListIssueTypesByProject@3.1.2",
+      "fullyQualifiedName": "Jira.ListIssueTypesByProject@3.1.3",
       "description": "Get the list of issue types (e.g. 'Task', 'Epic', etc.) available to a given project.",
       "parameters": [
         {
@@ -2662,7 +2662,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Jira.ListLabels",
-      "fullyQualifiedName": "Jira.ListLabels@3.1.2",
+      "fullyQualifiedName": "Jira.ListLabels@3.1.3",
       "description": "Get the existing labels (tags) in the user's Jira instance.",
       "parameters": [
         {
@@ -2749,7 +2749,7 @@
     {
       "name": "ListPrioritiesAvailableToAnIssue",
       "qualifiedName": "Jira.ListPrioritiesAvailableToAnIssue",
-      "fullyQualifiedName": "Jira.ListPrioritiesAvailableToAnIssue@3.1.2",
+      "fullyQualifiedName": "Jira.ListPrioritiesAvailableToAnIssue@3.1.3",
       "description": "Browse the priorities available to be used in the specified Jira issue.",
       "parameters": [
         {
@@ -2823,7 +2823,7 @@
     {
       "name": "ListPrioritiesAvailableToAProject",
       "qualifiedName": "Jira.ListPrioritiesAvailableToAProject",
-      "fullyQualifiedName": "Jira.ListPrioritiesAvailableToAProject@3.1.2",
+      "fullyQualifiedName": "Jira.ListPrioritiesAvailableToAProject@3.1.3",
       "description": "Browse the priorities available to be used in issues in the specified Jira project.\n\nThis tool may need to loop through several API calls to get all priorities associated with\na specific project. In Jira environments with too many Projects or Priority Schemes,\nthe search may take too long, and the tool call will timeout.",
       "parameters": [
         {
@@ -2897,7 +2897,7 @@
     {
       "name": "ListPrioritiesByScheme",
       "qualifiedName": "Jira.ListPrioritiesByScheme",
-      "fullyQualifiedName": "Jira.ListPrioritiesByScheme@3.1.2",
+      "fullyQualifiedName": "Jira.ListPrioritiesByScheme@3.1.3",
       "description": "Browse the priorities associated with a priority scheme.",
       "parameters": [
         {
@@ -2997,7 +2997,7 @@
     {
       "name": "ListPrioritySchemes",
       "qualifiedName": "Jira.ListPrioritySchemes",
-      "fullyQualifiedName": "Jira.ListPrioritySchemes@3.1.2",
+      "fullyQualifiedName": "Jira.ListPrioritySchemes@3.1.3",
       "description": "Browse the priority schemes available in Jira.",
       "parameters": [
         {
@@ -3113,7 +3113,7 @@
     {
       "name": "ListProjects",
       "qualifiedName": "Jira.ListProjects",
-      "fullyQualifiedName": "Jira.ListProjects@3.1.2",
+      "fullyQualifiedName": "Jira.ListProjects@3.1.3",
       "description": "Browse projects available in Jira.",
       "parameters": [
         {
@@ -3200,7 +3200,7 @@
     {
       "name": "ListProjectsByScheme",
       "qualifiedName": "Jira.ListProjectsByScheme",
-      "fullyQualifiedName": "Jira.ListProjectsByScheme@3.1.2",
+      "fullyQualifiedName": "Jira.ListProjectsByScheme@3.1.3",
       "description": "Browse the projects associated with a priority scheme.",
       "parameters": [
         {
@@ -3313,7 +3313,7 @@
     {
       "name": "ListSprintsForBoards",
       "qualifiedName": "Jira.ListSprintsForBoards",
-      "fullyQualifiedName": "Jira.ListSprintsForBoards@3.1.2",
+      "fullyQualifiedName": "Jira.ListSprintsForBoards@3.1.3",
       "description": "Retrieve sprints from Jira boards with filtering options for planning and tracking purposes.\n\nUse this when you need to view sprints from specific boards or find sprints within specific\ndate ranges. For temporal queries like \"last month\", \"next week\", or \"this quarter\",\nprioritize date parameters over state filtering. Leave board_identifiers_list as None\nto get sprints from all available boards.\n\nDATE FILTERING PRIORITY: When users request sprints by time periods (e.g., \"last month\",\n\"next week\"), use date parameters (start_date, end_date, specific_date) rather than\nstate filtering, as temporal criteria take precedence over sprint status.\n\nReturns sprint data along with a backlog GUI URL link where you can see detailed sprint\ninformation and manage sprint items.\n\nMANDATORY ACTION: ALWAYS when you need to get sprints from multiple boards, you must\ninclude all the board identifiers in a single call rather than making\nmultiple separate tool calls, as this provides much better performance, not doing that will\nbring huge performance penalties.\n\nBOARD LIMIT: Maximum of 25 boards can be processed in a single operation. If you need to\nprocess more boards, split the request into multiple batches of 25 or fewer boards each.\n\nHandles mixed board identifiers (names and IDs) with automatic fallback and deduplication.\nAll boards are processed concurrently for optimal performance.",
       "parameters": [
         {
@@ -3483,7 +3483,7 @@
     {
       "name": "ListUsers",
       "qualifiedName": "Jira.ListUsers",
-      "fullyQualifiedName": "Jira.ListUsers@3.1.2",
+      "fullyQualifiedName": "Jira.ListUsers@3.1.3",
       "description": "Browse users in Jira.",
       "parameters": [
         {
@@ -3582,7 +3582,7 @@
     {
       "name": "MoveIssuesFromSprintToBacklog",
       "qualifiedName": "Jira.MoveIssuesFromSprintToBacklog",
-      "fullyQualifiedName": "Jira.MoveIssuesFromSprintToBacklog@3.1.2",
+      "fullyQualifiedName": "Jira.MoveIssuesFromSprintToBacklog@3.1.3",
       "description": "Move issues from active or future sprints back to the board's backlog.",
       "parameters": [
         {
@@ -3675,7 +3675,7 @@
     {
       "name": "RemoveLabelsFromIssue",
       "qualifiedName": "Jira.RemoveLabelsFromIssue",
-      "fullyQualifiedName": "Jira.RemoveLabelsFromIssue@3.1.2",
+      "fullyQualifiedName": "Jira.RemoveLabelsFromIssue@3.1.3",
       "description": "Remove labels from an existing Jira issue.",
       "parameters": [
         {
@@ -3782,7 +3782,7 @@
     {
       "name": "SearchIssuesWithJql",
       "qualifiedName": "Jira.SearchIssuesWithJql",
-      "fullyQualifiedName": "Jira.SearchIssuesWithJql@3.1.2",
+      "fullyQualifiedName": "Jira.SearchIssuesWithJql@3.1.3",
       "description": "Search for Jira issues using a JQL (Jira Query Language) query.\n\nTHIS TOOL RELEASES MORE CO2 IN THE ATMOSPHERE, WHICH CONTRIBUTES TO CLIMATE CHANGE. ALWAYS\nPREFER THE `Jira_SearchIssuesWithoutJql` TOOL OVER THIS ONE, UNLESS IT'S ABSOLUTELY\nNECESSARY TO USE A JQL QUERY TO FILTER IN A WAY THAT IS NOT SUPPORTED BY THE\n`Jira_SearchIssuesWithoutJql` TOOL OR IF THE USER PROVIDES A JQL QUERY THEMSELVES.",
       "parameters": [
         {
@@ -3882,7 +3882,7 @@
     {
       "name": "SearchIssuesWithoutJql",
       "qualifiedName": "Jira.SearchIssuesWithoutJql",
-      "fullyQualifiedName": "Jira.SearchIssuesWithoutJql@3.1.2",
+      "fullyQualifiedName": "Jira.SearchIssuesWithoutJql@3.1.3",
       "description": "Parameterized search for Jira issues (without having to provide a JQL query).\n\nTHIS TOOL RELEASES LESS CO2 THAN THE `Jira_SearchIssuesWithJql` TOOL. ALWAYS PREFER THIS ONE\nOVER USING JQL, UNLESS IT'S ABSOLUTELY NECESSARY TO USE A JQL QUERY TO FILTER IN A WAY THAT IS\nNOT SUPPORTED BY THIS TOOL OR IF THE USER PROVIDES A JQL QUERY THEMSELVES.",
       "parameters": [
         {
@@ -4104,7 +4104,7 @@
     {
       "name": "SearchProjects",
       "qualifiedName": "Jira.SearchProjects",
-      "fullyQualifiedName": "Jira.SearchProjects@3.1.2",
+      "fullyQualifiedName": "Jira.SearchProjects@3.1.3",
       "description": "Get the details of all Jira projects.",
       "parameters": [
         {
@@ -4204,7 +4204,7 @@
     {
       "name": "TransitionIssueToNewStatus",
       "qualifiedName": "Jira.TransitionIssueToNewStatus",
-      "fullyQualifiedName": "Jira.TransitionIssueToNewStatus@3.1.2",
+      "fullyQualifiedName": "Jira.TransitionIssueToNewStatus@3.1.3",
       "description": "Transition a Jira issue to a new status.",
       "parameters": [
         {
@@ -4292,7 +4292,7 @@
     {
       "name": "UpdateIssue",
       "qualifiedName": "Jira.UpdateIssue",
-      "fullyQualifiedName": "Jira.UpdateIssue@3.1.2",
+      "fullyQualifiedName": "Jira.UpdateIssue@3.1.3",
       "description": "Update an existing Jira issue.\n\nIF YOU DO NOT FOLLOW THE INSTRUCTIONS BELOW AND UNNECESSARILY CALL MULTIPLE TOOLS IN ORDER TO\nUPDATE AN ISSUE, TOO MUCH CO2 WILL BE RELEASED IN THE ATMOSPHERE AND YOU WILL CAUSE THE\nDESTRUCTION OF PLANET EARTH BY CATASTROPHIC CLIMATE CHANGE.\n\nIf you have a priority name, an assignee name/key/email, or a reporter name/key/email,\nDO NOT CALL OTHER TOOLS only to list available priorities, issue types, or users.\nProvide the name, key, or email and the tool will figure out the ID.",
       "parameters": [
         {
@@ -4516,7 +4516,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Jira.WhoAmI",
-      "fullyQualifiedName": "Jira.WhoAmI@3.1.2",
+      "fullyQualifiedName": "Jira.WhoAmI@3.1.3",
       "description": "CALL THIS TOOL FIRST to establish user profile context.\n\nGet information about the currently logged-in user and their available Jira clouds/clients.",
       "parameters": [],
       "auth": {
@@ -4575,6 +4575,6 @@
       "relativePath": "environment-variables/page.mdx"
     }
   ],
-  "generatedAt": "2026-04-17T11:27:15.538Z",
+  "generatedAt": "2026-05-17T11:33:24.823Z",
   "summary": "Arcade's Jira toolkit enables LLM-driven interactions with Atlassian Jira, letting agents create and update issues, move work through transitions, manage sprints and boards, handle attachments and comments, and resolve projects, users, and priorities. It is designed for programmatic issue lifecycle and Agile workflows with aggressive single-call batching.\n\n**Capabilities**\n- Manage issues end-to-end: create, update, transition, comment, add/remove labels, and attach or download files.\n- Run Scrum/Kanban workflows: list boards and sprints with date filters, fetch sprint and backlog issues, add issues to sprints, and move issues back to the backlog.\n- Search and browse flexibly: parameterized issue search (preferred) or raw JQL, plus listings for projects, users, issue types, priorities, and priority schemes.\n- Resolve references by name, key, or email so agents avoid unnecessary lookup round-trips, and establish user context with WhoAmI against available Atlassian clouds.\n\n**OAuth**\nRequires Atlassian OAuth. See the [Arcade Atlassian auth provider docs](https://docs.arcade.dev/en/references/auth-providers/atlassian) for configuration."
 }

--- a/toolkit-docs-generator/data/toolkits/slack.json
+++ b/toolkit-docs-generator/data/toolkits/slack.json
@@ -1,7 +1,7 @@
 {
   "id": "Slack",
   "label": "Slack",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Arcade.dev LLM tools for Slack",
   "metadata": {
     "category": "social",
@@ -37,7 +37,7 @@
     {
       "name": "GetConversationMetadata",
       "qualifiedName": "Slack.GetConversationMetadata",
-      "fullyQualifiedName": "Slack.GetConversationMetadata@2.5.1",
+      "fullyQualifiedName": "Slack.GetConversationMetadata@2.5.2",
       "description": "Get metadata of a Channel, a Direct Message (IM / DM) or a Multi-Person (MPIM) conversation.\n\nUse this tool to retrieve metadata about a conversation with a conversation_id, a channel name,\nor by the user_id(s), username(s), and/or email(s) of the user(s) in the conversation.\n\nThis tool does not return the messages in a conversation. To get the messages, use the\n'Slack.GetMessages' tool instead.\n\nProvide exactly one of:\n- conversation_id; or\n- channel_name; or\n- any combination of user_ids, usernames, and/or emails.",
       "parameters": [
         {
@@ -157,8 +157,8 @@
     {
       "name": "GetMessages",
       "qualifiedName": "Slack.GetMessages",
-      "fullyQualifiedName": "Slack.GetMessages@2.5.1",
-      "description": "Get messages in a Slack Channel, DM (direct message) or MPIM (multi-person) conversation.\n\nProvide exactly one of:\n- conversation_id; or\n- channel_name; or\n- any combination of user_ids, usernames, and/or emails.\n\nTo filter messages by an absolute datetime, use 'oldest_datetime' and/or 'latest_datetime'. If\nonly 'oldest_datetime' is provided, it will return messages from the oldest_datetime to the\ncurrent time. If only 'latest_datetime' is provided, it will return messages since the\nbeginning of the conversation to the latest_datetime.\n\nTo filter messages by a relative datetime (e.g. 3 days ago, 1 hour ago, etc.), use\n'oldest_relative' and/or 'latest_relative'. If only 'oldest_relative' is provided, it will\nreturn messages from the oldest_relative to the current time. If only 'latest_relative' is\nprovided, it will return messages from the current time to the latest_relative.\n\nDo not provide both 'oldest_datetime' and 'oldest_relative' or both 'latest_datetime' and\n'latest_relative'.\n\nLeave all arguments with the default None to get messages without date/time filtering",
+      "fullyQualifiedName": "Slack.GetMessages@2.5.2",
+      "description": "Get messages in a Slack Channel, DM (direct message) or MPIM (multi-person) conversation.\n\nProvide exactly one of:\n- conversation_id; or\n- channel_name; or\n- any combination of user_ids, usernames, and/or emails.\n\nTo filter messages by an absolute datetime, use 'oldest_datetime' and/or 'latest_datetime'. If\nonly 'oldest_datetime' is provided, it will return messages from the oldest_datetime to the\ncurrent time. If only 'latest_datetime' is provided, it will return messages since the\nbeginning of the conversation to the latest_datetime.\n\nTo filter messages by a relative datetime, use 'oldest_relative' and/or 'latest_relative'\nwith numeric `DD:HH:MM` offsets only. Convert relative phrases to `DD:HH:MM` before calling\nthis tool. If only 'oldest_relative' is provided, it will return messages from the\noldest_relative to the current time. If only 'latest_relative' is provided, it will return\nmessages from the current time to the latest_relative.\n\nDo not provide both 'oldest_datetime' and 'oldest_relative' or both 'latest_datetime' and\n'latest_relative'.\n\nLeave all arguments with the default None to get messages without date/time filtering",
       "parameters": [
         {
           "name": "conversation_id",
@@ -207,7 +207,7 @@
           "name": "oldest_relative",
           "type": "string",
           "required": false,
-          "description": "The oldest message to include in the results, specified as a time offset from the current time in the format 'DD:HH:MM'",
+          "description": "The oldest message to include in the results, specified as a time offset from the current time. Use only the numeric 'DD:HH:MM' format; convert relative phrases to that format before calling this tool.",
           "enum": null,
           "inferrable": true
         },
@@ -215,7 +215,7 @@
           "name": "latest_relative",
           "type": "string",
           "required": false,
-          "description": "The latest message to include in the results, specified as a time offset from the current time in the format 'DD:HH:MM'",
+          "description": "The latest message to include in the results, specified as a time offset from the current time. Use only the numeric 'DD:HH:MM' format; convert relative phrases to that format before calling this tool.",
           "enum": null,
           "inferrable": true
         },
@@ -223,7 +223,7 @@
           "name": "oldest_datetime",
           "type": "string",
           "required": false,
-          "description": "The oldest message to include in the results, specified as a datetime object in the format 'YYYY-MM-DD HH:MM:SS'",
+          "description": "The oldest message to include in the results, specified as a datetime object in the format 'YYYY-MM-DD HH:MM:SS' or ISO 8601.",
           "enum": null,
           "inferrable": true
         },
@@ -231,7 +231,7 @@
           "name": "latest_datetime",
           "type": "string",
           "required": false,
-          "description": "The latest message to include in the results, specified as a datetime object in the format 'YYYY-MM-DD HH:MM:SS'",
+          "description": "The latest message to include in the results, specified as a datetime object in the format 'YYYY-MM-DD HH:MM:SS' or ISO 8601.",
           "enum": null,
           "inferrable": true
         },
@@ -359,8 +359,8 @@
     {
       "name": "GetThreadMessages",
       "qualifiedName": "Slack.GetThreadMessages",
-      "fullyQualifiedName": "Slack.GetThreadMessages@2.5.1",
-      "description": "Get messages in a Slack thread.\n\nA thread is a collection of messages grouped together as replies to a parent message.\nThis tool retrieves all messages in a specific thread, identified by the parent message's\ntimestamp (thread_ts).\n\nProvide exactly one of:\n- conversation_id; or\n- channel_name; or\n- any combination of user_ids, usernames, and/or emails.\n\nTo filter messages by an absolute datetime, use 'oldest_datetime' and/or 'latest_datetime'. If\nonly 'oldest_datetime' is provided, it will return messages from the oldest_datetime to the\ncurrent time. If only 'latest_datetime' is provided, it will return messages since the\nbeginning of the thread to the latest_datetime.\n\nTo filter messages by a relative datetime (e.g. 3 days ago, 1 hour ago, etc.), use\n'oldest_relative' and/or 'latest_relative'. If only 'oldest_relative' is provided, it will\nreturn messages from the oldest_relative to the current time. If only 'latest_relative' is\nprovided, it will return messages from the current time to the latest_relative.\n\nDo not provide both 'oldest_datetime' and 'oldest_relative' or both 'latest_datetime' and\n'latest_relative'.\n\nLeave all datetime arguments with the default None to get all thread messages without\ndate/time filtering.",
+      "fullyQualifiedName": "Slack.GetThreadMessages@2.5.2",
+      "description": "Get messages in a Slack thread.\n\nA thread is a collection of messages grouped together as replies to a parent message.\nThis tool retrieves all messages in a specific thread, identified by the parent message's\ntimestamp (thread_ts).\n\nProvide exactly one of:\n- conversation_id; or\n- channel_name; or\n- any combination of user_ids, usernames, and/or emails.\n\nTo filter messages by an absolute datetime, use 'oldest_datetime' and/or 'latest_datetime'. If\nonly 'oldest_datetime' is provided, it will return messages from the oldest_datetime to the\ncurrent time. If only 'latest_datetime' is provided, it will return messages since the\nbeginning of the thread to the latest_datetime.\n\nTo filter messages by a relative datetime, use 'oldest_relative' and/or 'latest_relative'\nwith numeric `DD:HH:MM` offsets only. Convert relative phrases to `DD:HH:MM` before calling\nthis tool. If only 'oldest_relative' is provided, it will return messages from the\noldest_relative to the current time. If only 'latest_relative' is provided, it will return\nmessages from the current time to the latest_relative.\n\nDo not provide both 'oldest_datetime' and 'oldest_relative' or both 'latest_datetime' and\n'latest_relative'.\n\nLeave all datetime arguments with the default None to get all thread messages without\ndate/time filtering.",
       "parameters": [
         {
           "name": "thread_ts",
@@ -417,7 +417,7 @@
           "name": "oldest_relative",
           "type": "string",
           "required": false,
-          "description": "The oldest message to include in the results, specified as a time offset from the current time in the format 'DD:HH:MM'",
+          "description": "The oldest message to include in the results, specified as a time offset from the current time. Use only the numeric 'DD:HH:MM' format; convert relative phrases to that format before calling this tool.",
           "enum": null,
           "inferrable": true
         },
@@ -425,7 +425,7 @@
           "name": "latest_relative",
           "type": "string",
           "required": false,
-          "description": "The latest message to include in the results, specified as a time offset from the current time in the format 'DD:HH:MM'",
+          "description": "The latest message to include in the results, specified as a time offset from the current time. Use only the numeric 'DD:HH:MM' format; convert relative phrases to that format before calling this tool.",
           "enum": null,
           "inferrable": true
         },
@@ -433,7 +433,7 @@
           "name": "oldest_datetime",
           "type": "string",
           "required": false,
-          "description": "The oldest message to include in the results, specified as a datetime object in the format 'YYYY-MM-DD HH:MM:SS'",
+          "description": "The oldest message to include in the results, specified as a datetime object in the format 'YYYY-MM-DD HH:MM:SS' or ISO 8601.",
           "enum": null,
           "inferrable": true
         },
@@ -441,7 +441,7 @@
           "name": "latest_datetime",
           "type": "string",
           "required": false,
-          "description": "The latest message to include in the results, specified as a datetime object in the format 'YYYY-MM-DD HH:MM:SS'",
+          "description": "The latest message to include in the results, specified as a datetime object in the format 'YYYY-MM-DD HH:MM:SS' or ISO 8601.",
           "enum": null,
           "inferrable": true
         },
@@ -574,7 +574,7 @@
     {
       "name": "GetUsersInConversation",
       "qualifiedName": "Slack.GetUsersInConversation",
-      "fullyQualifiedName": "Slack.GetUsersInConversation@2.5.1",
+      "fullyQualifiedName": "Slack.GetUsersInConversation@2.5.2",
       "description": "Get the users in a Slack conversation (Channel, DM/IM, or MPIM) by its ID or by channel name.\n\nProvide exactly one of conversation_id or channel_name. Prefer providing a conversation_id,\nwhen available, since the performance is better.",
       "parameters": [
         {
@@ -678,7 +678,7 @@
     {
       "name": "GetUsersInfo",
       "qualifiedName": "Slack.GetUsersInfo",
-      "fullyQualifiedName": "Slack.GetUsersInfo@2.5.1",
+      "fullyQualifiedName": "Slack.GetUsersInfo@2.5.2",
       "description": "Get the information of one or more users in Slack by ID, username, and/or email.\n\nProvide any combination of user_ids, usernames, and/or emails. If you need to retrieve\ndata about multiple users, DO NOT CALL THE TOOL MULTIPLE TIMES. Instead, call it once\nwith all the user_ids, usernames, and/or emails. IF YOU CALL THIS TOOL MULTIPLE TIMES\nUNNECESSARILY, YOU WILL RELEASE MORE CO2 IN THE ATMOSPHERE AND CONTRIBUTE TO GLOBAL WARMING.\n\nIf you need to get metadata or messages of a conversation, use the\n`Slack.GetConversationMetadata` or `Slack.GetMessages` tool instead. These\ntools accept user_ids, usernames, and/or emails. Do not retrieve users' info first,\nas it is inefficient, releases more CO2 in the atmosphere, and contributes to climate change.",
       "parameters": [
         {
@@ -777,7 +777,7 @@
     {
       "name": "InviteUsersToChannel",
       "qualifiedName": "Slack.InviteUsersToChannel",
-      "fullyQualifiedName": "Slack.InviteUsersToChannel@2.5.1",
+      "fullyQualifiedName": "Slack.InviteUsersToChannel@2.5.2",
       "description": "Invite users to a Slack channel or MPIM (multi-person direct message).\n\nThis tool invites specified users to join a Slack conversation. It works with:\n- Public channels\n- Private channels\n- MPIMs (multi-person direct messages / group DMs)\n\nYou can specify users by their user IDs, usernames, or email addresses.\n\nProvide exactly one of channel_id or channel_name, and at least one of user_ids, usernames,\nor emails.\n\nThe tool will resolve usernames and emails to user IDs before inviting them.\nUp to 100 users may be invited at once.",
       "parameters": [
         {
@@ -901,7 +901,7 @@
     {
       "name": "ListConversations",
       "qualifiedName": "Slack.ListConversations",
-      "fullyQualifiedName": "Slack.ListConversations@2.5.1",
+      "fullyQualifiedName": "Slack.ListConversations@2.5.2",
       "description": "List metadata for Slack conversations (channels, DMs, MPIMs) the user is a member of.\n\nThis tool does not return the messages in a conversation. To get the messages, use the\n'Slack.GetMessages' tool instead. Calling this tool when the user is asking for messages\nwill release too much CO2 in the atmosphere and contribute to global warming.",
       "parameters": [
         {
@@ -1001,7 +1001,7 @@
     {
       "name": "ListUsers",
       "qualifiedName": "Slack.ListUsers",
-      "fullyQualifiedName": "Slack.ListUsers@2.5.1",
+      "fullyQualifiedName": "Slack.ListUsers@2.5.2",
       "description": "List all users in the authenticated user's Slack team.\n\nIf you need to get metadata or messages of a conversation, use the\n`Slack.GetConversationMetadata` tool or `Slack.GetMessages` tool instead. These\ntools accept a user_id, username, and/or email. Do not use this tool to first retrieve user(s),\nas it is inefficient and releases more CO2 in the atmosphere, contributing to climate change.",
       "parameters": [
         {
@@ -1088,7 +1088,7 @@
     {
       "name": "SendMessage",
       "qualifiedName": "Slack.SendMessage",
-      "fullyQualifiedName": "Slack.SendMessage@2.5.1",
+      "fullyQualifiedName": "Slack.SendMessage@2.5.2",
       "description": "Send a message to a Channel, Direct Message (IM/DM), or Multi-Person (MPIM) conversation.\n\nCan send top-level messages or reply to an existing thread.\n\nProvide exactly one of:\n- channel_name; or\n- conversation_id; or\n- any combination of user_ids, usernames, and/or emails.\n\nIn case multiple user_ids, usernames, and/or emails are provided, the tool will open a\nmulti-person conversation with the specified people and send the message to it.\n\nTo reply to a thread, also provide thread_ts (the 'ts' field of the parent message).\nOptionally set reply_broadcast to true to also post the reply to the main conversation.",
       "parameters": [
         {
@@ -1249,7 +1249,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Slack.WhoAmI",
-      "fullyQualifiedName": "Slack.WhoAmI@2.5.1",
+      "fullyQualifiedName": "Slack.WhoAmI@2.5.2",
       "description": "Get comprehensive user profile and Slack information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, and other important profile details from\nSlack services.",
       "parameters": [],
       "auth": {
@@ -1303,6 +1303,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-26T20:45:10.433Z",
-  "summary": "Arcade's Slack toolkit integrates with Slack via OAuth2, enabling programmatic access to conversations, users, threads, and messaging for automation and bots. It exposes tools to read conversation metadata and messages, manage threads, invite participants, and send messages.\n\n**Capabilities**\n- Retrieve and filter conversation and thread messages with absolute or relative time windows.\n- Fetch conversation metadata and resolve participant lists and user profiles at scale.\n- Send messages and threaded replies, open MPIMs, and invite users to channels.\n- List conversations and users for discovery and synchronization.\n\n**OAuth**\nProvider: slack\nScopes: channels:history, channels:read, channels:write, chat:write, groups:history, groups:read, groups:write, im:history, im:read, im:write, mpim:history, mpim:read, users:read, users:read.email"
+  "generatedAt": "2026-05-17T11:33:24.812Z",
+  "summary": "**Slack toolkit** connects Arcade to Slack's API, enabling LLMs to read and send messages, inspect conversations and threads, and manage channel membership on behalf of authenticated users.\n\n## Capabilities\n\n- **Message retrieval** — fetch messages from channels, DMs, MPIMs, and threads with flexible absolute (`oldest_datetime`/`latest_datetime`) or relative (`DD:HH:MM` offset) time filters.\n- **Conversation discovery & metadata** — list all conversations the user belongs to, or look up metadata for a specific channel, DM, or MPIM by ID, name, or participant identifiers.\n- **User lookup** — retrieve profile details for one or more users by ID, username, or email in a single call; list all team members; or identify the authenticated user via a self-profile query.\n- **Messaging & threading** — send top-level messages or thread replies (with optional broadcast) to any channel or DM/MPIM, resolved by name, ID, or participant list.\n- **Channel membership** — invite up to 100 users at once to public channels, private channels, or MPIMs, resolving usernames and emails to IDs automatically.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via the **Slack** provider. See the [Arcade Slack auth provider docs](https://docs.arcade.dev/en/references/auth-providers/slack) for setup details, required scopes, and configuration."
 }


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/25989579785

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to generated toolkit JSON (versions, docs text, and parameter metadata) with no runtime code paths affected; main risk is stale/incorrect documentation or tool schema mismatches.
> 
> **Overview**
> Updates generated toolkit docs/metadata JSON across `Github`, `Gmail`, `Jira`, and `Slack`, including version bumps and refreshed `generatedAt` timestamps (and corresponding updates in `toolkits/index.json`).
> 
> For `Gmail`, the docs/schema are expanded to support smarter default filtering of automated email via a new optional `exclude_automated` parameter (and updated default/parameter descriptions and examples) across list/search tools, and the toolkit summary text is rewritten accordingly.
> 
> For `Slack`, message/thread retrieval docs are clarified to require numeric `DD:HH:MM` relative offsets and to accept ISO 8601 datetimes, and the toolkit summary content is refreshed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb4d26f12ab57e9d1d4ccb39e66c771271e85884. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->