### PR TITLE
docs: add User Sources overview + add User Source to gateway auth options

### DIFF
--- a/app/en/get-started/mcp-clients/claude-code/page.mdx
+++ b/app/en/get-started/mcp-clients/claude-code/page.mdx
@@ -24,6 +24,10 @@ Connect Claude Code to an Arcade MCP Gateway using the Arcade Headers authentica
   can authenticate via HTTP headers (no browser-based OAuth flow required).
 </Callout>
 
+<Callout type="info">
+  **Production end users with their own identities?** If your end users already sign in to Entra ID, Okta, Auth0, Clerk, or another OIDC provider, configure a [User Source](/guides/user-sources) on your gateway. Arcade redirects each end user to your identity provider on sign-in and identifies them by an OIDC subject claim.
+</Callout>
+
 <Steps>
 
 ### Add your Arcade MCP Gateway

--- a/app/en/get-started/mcp-clients/claude-desktop/page.mdx
+++ b/app/en/get-started/mcp-clients/claude-desktop/page.mdx
@@ -57,6 +57,10 @@ Connect Claude Desktop to an Arcade MCP Gateway.
   be able to use it with Claude Desktop.
 </Callout>
 
+<Callout type="info">
+  **Production end users with their own identities?** If your end users already sign in to Entra ID, Okta, Auth0, Clerk, or another OIDC provider, configure a [User Source](/guides/user-sources) on your gateway. Arcade redirects each end user to your identity provider on sign-in and identifies them by an OIDC subject claim.
+</Callout>
+
 <Steps>
 
 ### Go to your Claude Desktop setting page

--- a/app/en/get-started/mcp-clients/copilot-studio/page.mdx
+++ b/app/en/get-started/mcp-clients/copilot-studio/page.mdx
@@ -1,4 +1,4 @@
-import { Steps } from "nextra/components";
+import { Steps, Callout } from "nextra/components";
 import { SignupLink } from "@/app/_components/analytics";
 import Image from "next/image";
 
@@ -31,6 +31,10 @@ Connect Microsoft Copilot Studio to an Arcade MCP Gateway.
 </GuideOverview.Prerequisites>
 
 </GuideOverview>
+
+<Callout type="info">
+  **Production end users with their own identities?** If your end users already sign in to Entra ID, Okta, Auth0, Clerk, or another OIDC provider, configure a [User Source](/guides/user-sources) on your gateway. Arcade redirects each end user to your identity provider on sign-in and identifies them by an OIDC subject claim.
+</Callout>
 
 <Steps>
 

--- a/app/en/get-started/mcp-clients/cursor/page.mdx
+++ b/app/en/get-started/mcp-clients/cursor/page.mdx
@@ -26,6 +26,10 @@ Connect Cursor to an Arcade MCP Gateway.
   `Authorization` field to "Arcade Headers" in the dashboard.
 </Callout>
 
+<Callout type="info">
+  **Production end users with their own identities?** If your end users already sign in to Entra ID, Okta, Auth0, Clerk, or another OIDC provider, configure a [User Source](/guides/user-sources) on your gateway. Arcade redirects each end user to your identity provider on sign-in and identifies them by an OIDC subject claim.
+</Callout>
+
 ### Set up Cursor
 
 1. Open the Command Palette (`Cmd + Shift + P` on macOS, `Ctrl + Shift + P` on Windows/Linux) and select **Open MCP Settings**

--- a/app/en/get-started/mcp-clients/github-copilot/page.mdx
+++ b/app/en/get-started/mcp-clients/github-copilot/page.mdx
@@ -37,6 +37,10 @@ Connect GitHub Copilot to an Arcade MCP Gateway.
 
 </GuideOverview>
 
+<Callout type="info">
+  **Production end users with their own identities?** If your end users already sign in to Entra ID, Okta, Auth0, Clerk, or another OIDC provider, configure a [User Source](/guides/user-sources) on your gateway. Arcade redirects each end user to your identity provider on sign-in and identifies them by an OIDC subject claim.
+</Callout>
+
 ### Set up GitHub Copilot
 
 <Tabs

--- a/app/en/get-started/mcp-clients/visual-studio-code/page.mdx
+++ b/app/en/get-started/mcp-clients/visual-studio-code/page.mdx
@@ -5,6 +5,10 @@ import { SignupLink } from "@/app/_components/analytics";
 
 In this guide, you'll learn how to connect Visual Studio Code to an Arcade MCP Gateway.
 
+<Callout type="info">
+  **Production end users with their own identities?** If your end users already sign in to Entra ID, Okta, Auth0, Clerk, or another OIDC provider, configure a [User Source](/guides/user-sources) on your gateway. Arcade redirects each end user to your identity provider on sign-in and identifies them by an OIDC subject claim.
+</Callout>
+
 <Steps>
 
 ### Prerequisites

--- a/app/en/guides/_meta.tsx
+++ b/app/en/guides/_meta.tsx
@@ -10,6 +10,9 @@ export const meta: MetaRecord = {
   "mcp-gateways": {
     title: "MCP Gateways",
   },
+  "user-sources": {
+    title: "User Sources",
+  },
   "tool-calling": {
     title: "Call tools",
   },

--- a/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
+++ b/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
@@ -65,8 +65,10 @@ The options available when configuring an MCP Gateway are:
     - **Arcade Headers** (fallback): The client passes an Arcade API key in the `Authorization` header and the end user's ID in the `Arcade-User-ID` header. Pick this for MCP clients that can't run a browser-based OAuth flow.
 - **Allowed Tools**: A selection of tools in the Arcade Tool Catalog that will be available to the MCP Gateway.
 
+See [Skip consent for trusted MCP clients](/guides/mcp-gateways#skip-consent-for-trusted-mcp-clients) for the **Skip consent for trusted clients (optional)** field on this same form.
+
 ## After Creating a Gateway
 
-Once you've created a gateway, you'll need to add it to your chat client. The assistant will provide the MCP URL (for example, `https://api.arcade.dev/mcp/<YOUR-GATEWAY-SLUG>`).
+Once you've created a gateway, you'll need to add it to your chat client. The assistant will provide the MCP URL (for example, `https://api.arcade.dev/mcp/{YOUR-GATEWAY-SLUG}`).
 
 See [Connect to MCP clients](/get-started/mcp-clients) for setup instructions specific to your client.

--- a/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
+++ b/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
@@ -58,9 +58,11 @@ The options available when configuring an MCP Gateway are:
 - **Description**: The description of the MCP Gateway. This is useful for humans and some MCP clients may surface this information to the user.
 - **LLM Instructions**: Optional instructions for the LLM about how to use the MCP Gateway.
 - **Slug**: The slug of the MCP Gateway. This is the URL slug that will be used to access the MCP Gateway. It must be unique.
-- **Authentication**: The authentication mode to use for the MCP Gateway. This determines how the MCP Gateway will authenticate requests to the MCP Servers. Users will still need to authenticate to the tools within the MCP Gateway as normal.
-  - **Arcade Auth**: To access the MCP Gateway, you'll need to authenticate with your Arcade account. This authentication mode is recommended for MCP Gateways in development or testing phase, or for internal use when you know all the users will have Arcade accounts.
-  - **Arcade Headers**: To access the MCP Gateway, you'll need to authenticate with your Arcade account by passing an Arcade API key in the `Authorization` header and the user ID of your end-user in the `Arcade-User-ID` header. This authentication mode is recommended for MCP Gateways in production when your agent or application has users without Arcade accounts.
+- **Authentication**: How end users authenticate to the gateway. Users will still need to authenticate to the tools within the MCP Gateway as normal. The form asks "Who are the users of this Gateway?" with two top-level choices:
+  - **Members of this Project (Arcade Auth)**: End users sign in with Arcade as members of this project. Recommended for development, testing, and internal use when every end user is already a member.
+  - **Non-Arcade Users**: End users come from outside Arcade. Pick one of:
+    - **User Source** (recommended): Arcade redirects end users to your OIDC identity provider to sign in. Pick this for production agents whose end users have identities in your own OIDC identity system. See [User Sources](/guides/user-sources) for how to set one up.
+    - **Arcade Headers** (fallback): The client passes an Arcade API key in the `Authorization` header and the end user's ID in the `Arcade-User-ID` header. Pick this for MCP clients that can't run a browser-based OAuth flow.
 - **Allowed Tools**: A selection of tools in the Arcade Tool Catalog that will be available to the MCP Gateway.
 
 ## After Creating a Gateway

--- a/app/en/guides/mcp-gateways/page.mdx
+++ b/app/en/guides/mcp-gateways/page.mdx
@@ -61,14 +61,15 @@ Learn how to [connect MCP Gateways to your preferred client](/get-started/mcp-cl
 
 ## Authentication
 
-MCP Gateways support two authentication modes:
+When you create a gateway, you choose who its end users are. Arcade groups the options under "Who are the users of this Gateway?":
 
-| Mode | Best For | How It Works |
+| Mode | Best for | How it works |
 |------|----------|--------------|
-| **Arcade Auth (Recommended)** | Development, testing, internal use | Users authenticate with their Arcade account via OAuth |
-| **Arcade Headers** | Production when end-users shouldn't authenticate via Arcade | Pass `Authorization: Bearer {your_api_key}` header and `Arcade-User-ID` header with the end-user identifier |
+| **Arcade Auth** | Development, testing, internal use | End users sign in with Arcade as members of this project |
+| **User Source** (recommended for production) | Production agents whose end users have identities in your OIDC identity provider | Arcade redirects end users to your identity provider, then identifies them by a configured subject claim |
+| **Arcade Headers** (fallback) | MCP clients that can't run a browser-based OAuth flow | The client passes `Authorization: Bearer {your_api_key}` and `Arcade-User-ID: {end_user_id}` on every request |
 
-See [Create via Dashboard](/guides/mcp-gateways/create-via-dashboard) for detailed authentication configuration.
+See [User Sources](/guides/user-sources) for how to set up an OIDC identity provider and attach it to a gateway. See [Create via Dashboard](/guides/mcp-gateways/create-via-dashboard) for the rest of the gateway configuration.
 
 ## Next Steps
 

--- a/app/en/guides/mcp-gateways/page.mdx
+++ b/app/en/guides/mcp-gateways/page.mdx
@@ -54,7 +54,7 @@ Use remote MCP servers when your tools live outside Arcade. Register the server 
 Any MCP client that supports the Streamable HTTP transport can use an Arcade MCP Gateway. Use your gateway URL in the following format:
 
 ```
-https://api.arcade.dev/mcp/<YOUR-GATEWAY-SLUG>
+https://api.arcade.dev/mcp/{YOUR-GATEWAY-SLUG}
 ```
 
 Learn how to [connect MCP Gateways to your preferred client](/get-started/mcp-clients).
@@ -70,6 +70,30 @@ When you create a gateway, you choose who its end users are. Arcade groups the o
 | **Arcade Headers** (fallback) | MCP clients that can't run a browser-based OAuth flow | The client passes `Authorization: Bearer {your_api_key}` and `Arcade-User-ID: {end_user_id}` on every request |
 
 See [User Sources](/guides/user-sources) for how to set up an OIDC identity provider and attach it to a gateway. See [Create via Dashboard](/guides/mcp-gateways/create-via-dashboard) for the rest of the gateway configuration.
+
+## Skip consent for trusted MCP clients
+
+When an end user signs in to a gateway, Arcade shows an OAuth consent screen before issuing a token. This feature lets you allowlist specific MCP client IDs that should bypass that consent screen. End users connecting through an allowlisted client go straight from sign-in to a working session.
+
+The field is available on gateways that use **Arcade Auth** or a **User Source**. It does not apply to Arcade Headers.
+
+A client ID is what the MCP client sends to Arcade during OAuth registration. Clients that publish a [Client ID Metadata Document](https://datatracker.ietf.org/doc/draft-parecki-oauth-client-id-metadata-document/) (CIMD) use their published HTTPS URL as a stable client ID, and that URL is what goes in the allowlist. Clients that rely on [Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591) instead receive a fresh client ID per installation, so they don't have a stable value to allowlist and aren't suitable for this feature.
+
+### Known MCP client IDs
+
+The values below are the literal `client_id` strings these clients send in their OAuth authorize requests to Arcade today.
+
+| MCP client | Client ID |
+|---|---|
+| Claude (Claude Desktop and Claude.ai) | `https://claude.ai/oauth/mcp-oauth-client-metadata` |
+| Claude Code | `https://claude.ai/oauth/claude-code-client-metadata` |
+| Visual Studio Code | `https://vscode.dev/oauth/client-metadata.json` |
+
+### Find the client ID for an unlisted client
+
+If the MCP client publishes a CIMD, its documentation will reference an `https://...client-metadata` URL or similar. That URL is the client ID, so paste it into the allowlist as-is.
+
+If the client uses Dynamic Client Registration, it gets a new client ID per registration and that ID changes any time the client re-registers. Tracking the latest registered ID against your gateway rarely pays back the operational cost.
 
 ## Next Steps
 

--- a/app/en/guides/user-sources/_meta.tsx
+++ b/app/en/guides/user-sources/_meta.tsx
@@ -1,0 +1,5 @@
+import type { MetaRecord } from "nextra";
+
+export const meta: MetaRecord = {};
+
+export default meta;

--- a/app/en/guides/user-sources/page.mdx
+++ b/app/en/guides/user-sources/page.mdx
@@ -1,0 +1,114 @@
+---
+title: "User Sources"
+description: "Connect an OIDC identity provider to an MCP Gateway so your end users sign in with their existing identities"
+---
+
+import { Callout, Steps } from "nextra/components";
+
+# User Sources
+
+A User Source is the connection between an MCP Gateway and your OIDC identity provider. When a gateway uses a User Source, Arcade redirects each end user to your identity provider to sign in and then identifies them by an OIDC subject claim on every gateway request.
+
+## What is a User Source?
+
+Use a User Source when your end users already have identities in your own identity system, such as Entra ID, Okta, Auth0, Clerk, Stytch, or a similar OIDC provider. A User Source plugs that identity directly into your gateway, so Arcade doesn't have to know about your end users ahead of time and you don't have to provision them into Arcade.
+
+A User Source is deliberately separate from any identity provider you use for Arcade admin sign-in. The User Source identifies the **Users** of your gateways (end users), while the Arcade admin sign-in provider identifies the **Arcade Accounts** that manage your projects. Keeping the two distinct means you can govern your administrators and your end users with different identity systems and different policies.
+
+User Sources are project-bound. You create one in a project, then attach it to any MCP Gateway in that project. One User Source can back many gateways, so gateways serving different purposes can share the same end-user identity system without duplicating the configuration.
+
+## When to use a User Source
+
+Arcade MCP Gateways support three ways to authenticate end users:
+
+| Mode | Best for |
+|------|----------|
+| **Arcade Auth** | Development, testing, and internal use, when every end user is a member of your Arcade project |
+| **User Source** (recommended for production) | Production agents whose end users have identities in your OIDC identity provider |
+| **Arcade Headers** (fallback) | MCP clients that can't run a browser-based OAuth flow |
+
+See [MCP Gateway authentication](/guides/mcp-gateways) for the full comparison and for how to pick an authentication mode when creating a gateway.
+
+## Register an OAuth client at your identity provider
+
+Before you create a User Source in Arcade, register a confidential OAuth client at your identity provider. The client must use the Authorization Code flow with PKCE.
+
+<Steps>
+
+### Configure the redirect URL
+
+Set the redirect URL on the OAuth client to `https://cloud.arcade.dev/oauth2/intermediate_callback`.
+
+Your identity provider will redirect end users back to this URL after they sign in, and Arcade exchanges the resulting code for an ID token.
+
+### Copy the client credentials
+
+From your identity provider, copy the **issuer URL**, **client ID**, and **client secret**. You'll provide them to Arcade in the next section.
+
+</Steps>
+
+## Create a User Source
+
+<Steps>
+
+### Open the User Sources dashboard
+
+Go to the [User Sources dashboard](https://cloud.arcade.dev/dashboard/user-sources) for your project and click **Create User Source**.
+
+### Fill in the User Source details
+
+Provide the following:
+
+- **Name**: A short, human-readable name for this connection. For example, `Corporate Identity`.
+- **Description** (optional): Free-form notes about the connection. These notes are visible to other members of your Arcade project and are never shown to end users.
+- **Issuer URL**: The OIDC issuer URL from your identity provider, for example `https://accounts.example.com`. Arcade matches this against the `iss` claim on incoming tokens, so it must exactly match what your identity provider issues.
+- **Client ID**: The client ID of the OAuth client you registered with your identity provider.
+- **Client Secret**: The matching client secret. Arcade stores it encrypted and never returns it through the API or dashboard.
+- **Subject Claim**: The JWT claim Arcade uses as the end user's stable identifier. Defaults to `sub`.
+
+### Save the User Source
+
+Click **Create**. The new User Source appears in the list with **Active** status and is ready to attach to an MCP Gateway.
+
+</Steps>
+
+## Use a User Source on an MCP Gateway
+
+You attach a User Source to an MCP Gateway when you create or edit the gateway. One User Source can back multiple gateways in the same project, so you can reuse the same end-user identity system across every gateway you build for those users.
+
+See [Create via Dashboard](/guides/mcp-gateways/create-via-dashboard) for how to pick a User Source when configuring a gateway's authentication.
+
+## Manage User Sources
+
+### Edit a User Source
+
+You can change a User Source's name, description, issuer URL, client ID, or subject claim at any time from the User Sources dashboard. Saving the changes affects every gateway that uses this User Source on its next request.
+
+### Rotate the client secret
+
+To rotate the client secret:
+
+1. Open the User Source in the dashboard.
+2. Enter the new secret in the **Client Secret** field.
+3. Save.
+
+The field is blank in edit mode and only updates when you fill it in, so editing other fields does not affect the stored secret.
+
+<Callout type="warning">
+Rotate the client secret in your identity provider first, then update it in Arcade. There's a short window where token exchange fails if Arcade's stored secret doesn't match the one your provider expects.
+</Callout>
+
+### Deactivate a User Source
+
+Set a User Source's status to **Inactive** to take it out of rotation. You can only deactivate a User Source after every MCP Gateway that uses it is itself deactivated or deleted. If an active gateway still references the source, the dashboard blocks deactivation and tells you how many gateways still depend on it.
+
+To deactivate a User Source, deactivate or delete the dependent gateways first, then change the User Source's status to **Inactive**.
+
+### Delete a User Source
+
+Deleting a User Source is permanent. As with deactivation, you can only delete a User Source when no active gateway references it. The dashboard blocks the action until you deactivate or remove the dependent gateways.
+
+## Next steps
+
+- [MCP Gateway authentication](/guides/mcp-gateways) for a comparison of Arcade Auth, User Sources, and Arcade Headers
+- [Connect to MCP clients](/get-started/mcp-clients) to point your client at a gateway that uses a User Source

--- a/app/en/resources/glossary/page.mdx
+++ b/app/en/resources/glossary/page.mdx
@@ -160,6 +160,12 @@ An 'auth provider' is a service that your users sign in with to let the agent ac
 
 _Learn more about [auth providers](/references/auth-providers)._
 
+### User Source
+
+A 'User Source' is an OIDC identity provider connection that authenticates the end users of an MCP Gateway. A project can have multiple User Sources, and one User Source can back many gateways. User Sources are intentionally separate from any identity provider used for Arcade Account sign-in, so administrators and end users can be governed independently.
+
+_Learn more about [User Sources](/guides/user-sources)._
+
 ### Authorization Scope
 
 An 'authorization scope' is a permission that a user can grant to an agent. This is used to control what the agent can do with the user's data. Available authorization scopes are defined by the authentication provider, and each tool defines the scopes it requires.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,4 +1,4 @@
-<!-- git-sha: 027403fb15a72f497ccba09bcf6f03e5766dbf3a generation-date: 2026-04-23T01:29:18.671Z -->
+<!-- git-sha: 7bcead9096aa8b8419c1928c5afd40a99d005ac9 generation-date: 2026-05-21T19:48:52.168Z -->
 
 # Arcade
 
@@ -157,6 +157,7 @@ Arcade delivers three core capabilities: Deploy agents even your security team w
 - [Use Arcade in Visual Studio Code](https://docs.arcade.dev/en/get-started/mcp-clients/visual-studio-code): This documentation page provides a step-by-step guide for connecting Visual Studio Code to an Arcade MCP Gateway, enabling users to set up and run their MCP server within the IDE. It outlines prerequisites, setup instructions, and authentication processes to ensure a successful integration.
 - [Use Arcade tools with AG2](https://docs.arcade.dev/en/get-started/agent-frameworks/ag2/use-arcade-tools): Documentation page
 - [Use Arcade tools with CrewAI](https://docs.arcade.dev/en/get-started/agent-frameworks/crewai/use-arcade-tools): This documentation page provides a comprehensive guide for integrating Arcade tools into CrewAI applications, enabling users to build task-oriented multi-agent systems that assist with platforms like Gmail and Slack. It outlines the prerequisites, learning outcomes, and step-by-step instructions for setting up
+- [User Sources](https://docs.arcade.dev/en/guides/user-sources): Documentation page
 - [What are tools?](https://docs.arcade.dev/en/guides/tool-calling): This documentation page provides an overview of tool calling in language models, explaining how users can leverage tools to enhance the capabilities of AI models for tasks such as data retrieval and scheduling. It outlines the process of integrating tools with language models using the Arcade SDK,
 - [Why evaluate tools?](https://docs.arcade.dev/en/guides/create-tools/evaluate-tools/why-evaluate): This documentation page explains the importance of evaluating tools used by AI models to ensure accurate tool selection and parameter accuracy in production environments. It outlines the evaluation process, scoring components, and potential issues that can arise without proper assessments. Users can learn how to create
 - [Windows environment setup](https://docs.arcade.dev/en/get-started/setup/windows-environment): This documentation page provides step-by-step instructions for setting up the Arcade CLI on Windows, emphasizing the use of the `uv` package manager while offering fallback options with `pip`. It includes prerequisites, installation methods, validation steps, and troubleshooting tips to ensure

--- a/styles/config/vocabularies/Arcade/accept.txt
+++ b/styles/config/vocabularies/Arcade/accept.txt
@@ -1,6 +1,8 @@
 # Arcade-specific terms
 Arcade
 MCP
+User Source
+User Sources
 LLM
 SDK
 API


### PR DESCRIPTION
## Summary

- New `/guides/user-sources/` section with a User Sources overview as the index page
- Adds User Source as a third option on the existing MCP Gateway authentication content (folds in GRO-92)
- Adds `User Source` / `User Sources` to the Arcade Vale vocabulary

Closes [GRO-93](https://linear.app/arcadedev/issue/GRO-93/docs-user-sources-overview-guide) and [GRO-92](https://linear.app/arcadedev/issue/GRO-92/docs-update-mcp-gateway-auth-page-add-user-source-as-third-option). Part of the [GRO-75 umbrella](https://linear.app/arcadedev/issue/GRO-75/pre-launch-documentation-user-sources-gateway-auth-umbrella) — sibling per-provider guides and the consent-skip reference are still in flight.

## What's on the User Sources overview page

1. **Concept**: Arcade users vs. end users, what a User Source is, why it's project-bound, 1:N to gateways.
2. **When to use a User Source**: three-row table comparing Arcade Auth, User Source (recommended for production), and Arcade Headers (fallback).
3. **Register an OAuth client at your identity provider**: documents the prod redirect URL `https://cloud.arcade.dev/oauth2/intermediate_callback` and what credentials you'll need to copy out.
4. **Create a User Source**: dashboard walkthrough — Name, Description, Issuer URL, Client ID, Client Secret, Subject Claim (default `sub`, no provider-specific alternatives at this level).
5. **Use a User Source on an MCP Gateway**: short — links to the Gateways doc for the actual auth picker.
6. **Manage**: edit, rotate client secret (with a warning about rotating at the IdP first), deactivate, and delete. Deactivation and deletion are both blocked entirely while any active gateway references the source.

## What's on the gateway auth pages

- `app/en/guides/mcp-gateways/page.mdx` — Authentication table now lists three modes (Arcade Auth, User Source recommended, Arcade Headers fallback), with cross-links to the new User Sources overview.
- `app/en/guides/mcp-gateways/create-via-dashboard/page.mdx` — Authentication bullets now mirror the dashboard's actual two-level radio: "Members of this Project (Arcade Auth)" vs. "Non-Arcade Users → User Source (recommended) / Arcade Headers (fallback)."

## Decisions worth flagging

- **Terminology**: "project-bound" instead of "project-scoped" — avoids overload with OAuth `scope`.
- **Redirect URL**: documented as the prod URL only, per Wils — no staging URL in prod docs.
- **Org-bound binding**: not documented. Data model supports it but there's no CRUD UI today.
- **Feature flag**: not mentioned. Written as if GA.
- **Lifecycle guards**: documented as enforced by the Dashboard (active-gateway check) for both deactivate and delete. The backend API has no guard today — frontend-only.
- **No screenshots yet**: text-only walkthrough; can wire up screenshots before the umbrella ships.
- **Out-of-scope vale findings**: pre-existing `Google.Headings` flags on `mcp-gateways/page.mdx` and a pre-existing `<YOUR-GATEWAY-SLUG>` MDX parser confusion on `create-via-dashboard/page.mdx` are not addressed in this PR.

## Test plan

- [x] `vale` clean on `app/en/guides/user-sources/page.mdx`
- [x] `check-meta-keys` — all `_meta.tsx` keys valid
- [x] `pnpm build` — `/en/guides/user-sources` renders; `/en/guides/mcp-gateways` and `/en/guides/mcp-gateways/create-via-dashboard` still build
- [ ] Reviewer to spot-check the concept overview tone
- [ ] Reviewer to confirm the redirect URL matches what should be public
- [ ] Reviewer to spot-check the gateway auth wording against the dashboard form copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-path impact.
> 
> **Overview**
> Documents **skip consent for trusted MCP clients** on the MCP Gateways guide and ties it to the dashboard create flow.
> 
> The main gateways page adds a section explaining OAuth consent bypass via allowlisted MCP `client_id` values (CIMD vs Dynamic Client Registration), which auth modes support it, a table of known client IDs (Claude, Claude Code, VS Code), and how to find IDs for other clients. The create-via-dashboard page links to that section for the optional **Skip consent for trusted clients** field.
> 
> Gateway URL examples on both pages change from angle-bracket placeholders to `{YOUR-GATEWAY-SLUG}` to avoid MDX parsing issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d60cdf7370a1c704c6338fe50d74fa592a1dad4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->