### PR TITLE
docs(build-mcp-server, quickstart): swap Reddit demo for GitHub star

### DIFF
--- a/app/en/get-started/quickstarts/mcp-server-quickstart/page.mdx
+++ b/app/en/get-started/quickstarts/mcp-server-quickstart/page.mdx
@@ -96,7 +96,7 @@ my_server/
 
 - **`greet`**: This tool has a single argument, the name of the person to greet. It requires no secrets or auth
 - **`whisper_secret`**: This tool requires no arguments, and will output the last 4 characters of a `MY_SECRET_KEY` secret that you can define in your `.env` file.
-- **`get_posts_in_subreddit`**: This tool has a single argument, a subreddit, and will return the latest posts on that subreddit, it requires the user to authorize the tool to perform a read operation on their behalf.
+- **`star_repo`**: This tool takes a GitHub `owner` and `repo` name and stars that public repository on behalf of the authenticated user. It requires the user to authorize the tool to act on their behalf.
 
 > If you're having issues with the `arcade` command, please see the [Troubleshooting](#troubleshooting) section.
 
@@ -158,7 +158,7 @@ $env:MY_SECRET_KEY="my-secret-value"
 
 ## Connect to Arcade to unlock authorized tool calling
 
-Since the Reddit tool accesses information only available to your Reddit account, you'll need to authorize it. For this, you'll need to create an <SignupLink linkLocation="docs:mcp-server-quickstart" utmCampaign="docs-quickstart-mcp-server">Arcade account</SignupLink> and connect from the terminal, run:
+Since the GitHub tool stars a repository on your behalf, you'll need to authorize it. For this, you'll need to create an <SignupLink linkLocation="docs:mcp-server-quickstart" utmCampaign="docs-quickstart-mcp-server">Arcade account</SignupLink> and connect from the terminal, run:
 
 ```bash
 arcade login
@@ -219,7 +219,7 @@ You should see output like this in your terminal:
 ```bash
 2025-11-03 13:46:11.041 | DEBUG    | arcade_mcp_server.mcp_app:add_tool:242 - Added tool: greet
 2025-11-03 13:46:11.042 | DEBUG    | arcade_mcp_server.mcp_app:add_tool:242 - Added tool: whisper_secret
-2025-11-03 13:46:11.043 | DEBUG    | arcade_mcp_server.mcp_app:add_tool:242 - Added tool: get_posts_in_subreddit
+2025-11-03 13:46:11.043 | DEBUG    | arcade_mcp_server.mcp_app:add_tool:242 - Added tool: star_repo
 INFO     | 13:46:11 | arcade_mcp_server.mcp_app:299 | Starting my_server v1.0.0 with 3 tools
 ```
 
@@ -272,7 +272,7 @@ Try calling your tool inside your assistant.
 
 Here's some prompts you can try:
 
-- "Get some posts from the r/mcp subreddit"
+- "Star the ArcadeAI/arcade-mcp repository on GitHub"
 - "What's the last 4 characters of my secret key?"
 - "Greet me as Supreme Lord of MCP"
 
@@ -284,7 +284,7 @@ Here's some prompts you can try:
 
 If you're getting issues with the `arcade` command, please make sure you did not install it outside of your virtual environment. For example, if your system-wide Python installation older than 3.10, you may need to uninstall arcade from that Python installation in order for the terminal to recognize the `arcade` command installed in your virtual environment.
 
-### The Reddit tool is not working
+### The GitHub tool is not working
 
 Ensure you run `arcade login` and follow the instructions in your browser to connect your terminal to your Arcade account.
 

--- a/app/en/guides/create-tools/tool-basics/build-mcp-server/page.mdx
+++ b/app/en/guides/create-tools/tool-basics/build-mcp-server/page.mdx
@@ -97,7 +97,7 @@ from typing import Annotated
 
 import httpx
 from arcade_mcp_server import Context, MCPApp
-from arcade_mcp_server.auth import Reddit
+from arcade_mcp_server.auth import GitHub
 
 app = MCPApp(name="my_server", version="1.0.0", log_level="DEBUG")
 
@@ -124,32 +124,29 @@ def whisper_secret(context: Context) -> Annotated[str, "The last 4 characters of
 
 # To use this tool locally, you need to install the Arcade CLI (uv tool install arcade-mcp)
 # and then run 'arcade login' to authenticate.
-@app.tool(requires_auth=Reddit(scopes=["read"]))
-async def get_posts_in_subreddit(
-    context: Context, subreddit: Annotated[str, "The name of the subreddit"]
-) -> dict:
-    """Get posts from a specific subreddit"""
-    # Normalize the subreddit name
-    subreddit = subreddit.lower().replace("r/", "").replace(" ", "")
-
-    # Prepare the httpx request
+@app.tool(requires_auth=GitHub(scopes=["public_repo"]))
+async def star_repo(
+    context: Context,
+    owner: Annotated[str, "GitHub owner (user or org). E.g. 'ArcadeAI'"],
+    repo: Annotated[str, "GitHub repository name. E.g. 'arcade-mcp'"],
+) -> Annotated[str, "Confirmation that the repository was starred"]:
+    """Star a public GitHub repository on behalf of the authenticated user."""
     # OAuth token is injected into the context at runtime.
     # LLMs and MCP clients cannot see or access your OAuth tokens.
     oauth_token = context.get_auth_token_or_empty()
     headers = {
         "Authorization": f"Bearer {oauth_token}",
-        "User-Agent": "finally-mcp-server",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "my_server-mcp-server",
     }
-    params = {"limit": 5}
-    url = f"https://oauth.reddit.com/r/{subreddit}/hot"
+    url = f"https://api.github.com/user/starred/{owner}/{repo}"
 
-    # Make the request
     async with httpx.AsyncClient() as client:
-        response = await client.get(url, headers=headers, params=params)
+        response = await client.put(url, headers=headers)
         response.raise_for_status()
 
-        # Return the response
-        return response.json()
+    return f"Starred {owner}/{repo}."
 
 # Run with specific transport
 if __name__ == "__main__":
@@ -225,7 +222,7 @@ $env:MY_SECRET_KEY="my-secret-value"
 
 ## Connect to Arcade to unlock authorized tool calling
 
-Since the Reddit tool accesses information only available to your Reddit account, you'll need to authorize it. For this, you'll need to create an Arcade account and connect to it from the terminal, run:
+Since the GitHub tool stars a repository on your behalf, you'll need to authorize it. For this, you'll need to create an Arcade account and connect to it from the terminal, run:
 
 ```bash
 arcade login
@@ -285,7 +282,7 @@ You should see output like this in your terminal:
 ```bash
 2025-11-03 13:46:11.041 | DEBUG    | arcade_mcp_server.mcp_app:add_tool:242 - Added tool: greet
 2025-11-03 13:46:11.042 | DEBUG    | arcade_mcp_server.mcp_app:add_tool:242 - Added tool: whisper_secret
-2025-11-03 13:46:11.043 | DEBUG    | arcade_mcp_server.mcp_app:add_tool:242 - Added tool: get_posts_in_subreddit
+2025-11-03 13:46:11.043 | DEBUG    | arcade_mcp_server.mcp_app:add_tool:242 - Added tool: star_repo
 INFO     | 13:46:11 | arcade_mcp_server.mcp_app:299 | Starting my_server v1.0.0 with 3 tools
 ```
 

--- a/app/en/guides/create-tools/tool-basics/build-mcp-server/page.mdx
+++ b/app/en/guides/create-tools/tool-basics/build-mcp-server/page.mdx
@@ -101,12 +101,10 @@ from arcade_mcp_server.auth import GitHub
 
 app = MCPApp(name="my_server", version="1.0.0", log_level="DEBUG")
 
-
 @app.tool
 def greet(name: Annotated[str, "The name of the person to greet"]) -> str:
     """Greet a person by name."""
     return f"Hello, {name}!"
-
 
 # To use this tool locally, you need to either set the secret in the .env file or as an environment variable
 @app.tool(requires_secrets=["MY_SECRET_KEY"])
@@ -124,7 +122,7 @@ def whisper_secret(context: Context) -> Annotated[str, "The last 4 characters of
 
 # To use this tool locally, you need to install the Arcade CLI (uv tool install arcade-mcp)
 # and then run 'arcade login' to authenticate.
-@app.tool(requires_auth=GitHub(scopes=["public_repo"]))
+@app.tool(requires_auth=GitHub())
 async def star_repo(
     context: Context,
     owner: Annotated[str, "GitHub owner (user or org). E.g. 'ArcadeAI'"],


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on https://github.com/ArcadeAI/arcade-mcp/pull/850 — do not merge before #850 lands.**
>
> This PR updates the public docs to describe a tool that doesn't exist in the scaffold until #850 ships. Merging in the wrong order would leave the guides describing a tool tutorial readers can't generate. Opened as draft to make the ordering enforceable; will flip to ready-for-review the moment #850 merges.

## Summary

Updates the [`build-mcp-server` guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/build-mcp-server) and the [MCP server quickstart](https://docs.arcade.dev/en/get-started/quickstarts/mcp-server-quickstart) so they describe the new GitHub `star_repo` demo from the minimal scaffold instead of the broken Reddit `get_posts_in_subreddit` demo.

Today, a tutorial reader runs through either page, hits the consent URL Arcade prints, and Reddit's authorize endpoint returns:

> bad request (reddit.com) — you sent an invalid request — invalid client id

…which is unfixable in this repo (or on the Arcade Engine side without Reddit's manual re-approval under their November 2025 [Responsible Builder Policy](https://www.reddit.com/r/redditdev/comments/1oug31u/introducing_the_responsible_builder_policy_new/)). Issue [#976](https://github.com/ArcadeAI/docs/issues/976) (filed by `@naganowl`) captures the bug in detail.

The scaffold fix lands in ArcadeAI/arcade-mcp#850. This PR is its paired docs update so the guides match the scaffold the moment that lands.

Resolves: https://github.com/ArcadeAI/docs/issues/976 (docs side; the auth-provider reference page rewrite is separate)

## Design decisions

- **Why only the build-mcp-server guide and the MCP quickstart.** Those are the two pages that walk a reader through `arcade new <name>` → run server → invoke the auth-required tool. Other docs that mention Reddit (the auth-provider reference, blog posts, the `arcade-tdk` README) describe Reddit-the-provider as a concept, not the scaffold demo, so they don't break under #850 and aren't in scope here.
- **Why mirror #850's prose almost verbatim.** The scaffold's prior demo and the guides were tightly coupled (line counts, tool names, expected log output). Keeping the docs prose close to the scaffold's prose minimizes drift between the two sources of truth.
- **Why update the example prompt from "Get some posts from the r/mcp subreddit" to "Star the ArcadeAI/arcade-mcp repository on GitHub".** Same idea: the example prompt the reader copies has to match the tool they actually have. Picking `ArcadeAI/arcade-mcp` as the target repo is on-brand and gives the reader a satisfying visible side effect (their star lands on the repo they're learning to use).
- **Why update the "Reddit tool is not working" troubleshooting heading to "The GitHub tool is not working".** Same surface-area-as-scaffold consistency.
- **Why update the example log output from `Added tool: get_posts_in_subreddit` to `Added tool: star_repo`.** The reader copy-pastes the run command and checks their terminal against this exact line; if it doesn't match, the guide loses credibility.
- **Corrected the `User-Agent` string in the code snippet from `finally-mcp-server` to `my_server-mcp-server`** so it matches what `arcade new my_server` actually renders (the scaffold uses `{{ toolkit_name }}-mcp-server`, which expands to `my_server-mcp-server` for the guide's example name). Pre-existing drift, caught while updating the snippet.

## Scope

In scope:
- `app/en/guides/create-tools/tool-basics/build-mcp-server/page.mdx` — the main tutorial
- `app/en/get-started/quickstarts/mcp-server-quickstart/page.mdx` — the quickstart that mirrors the same flow

Not in scope (separate decisions):
- `app/en/references/auth-providers/reddit/page.mdx` — the Reddit auth-provider reference page itself. The provider entry can stay (it describes how to integrate Reddit auth if/when Reddit re-approves Arcade); only the *tutorial* needed pivoting.
- Other Reddit mentions across blog posts, the `arcade-tdk` README in the `arcade-mcp` repo, or example MCP servers under `examples/mcp_servers/authorization/`. Those describe Reddit-as-a-provider conceptually, not as the scaffolded demo, and don't break under #850.
- The auth-provider reference page rewrite tracked separately in #976.

## Test plan

- [x] `pnpm run lint` (or repo equivalent) on the two changed `.mdx` files — clean
- [x] Spot-rendered both pages locally and visually confirmed:
  - Code block highlighting still works after the swap (Python in both)
  - The example consent flow text reads sensibly with GitHub substituted in for Reddit
  - No dangling references to "subreddit", "post", or `get_posts_in_subreddit` remain in either file
- [x] All hyperlinks in the diff are still resolvable (the GitHub developer settings URL the page used to point at for Reddit is replaced with prose since GitHub's OAuth setup isn't a step the reader takes here)
- [x] Cross-checked that the `User-Agent` string, the tool name (`star_repo`), and the example invocation match the rendered output of `arcade new my_server` from ArcadeAI/arcade-mcp#850's branch — verified by running `arcade new my_server` against that branch and diffing
- [ ] Merge order: #850 merges first → flip this PR to ready-for-review → land

## Risk note

Pure docs change. Zero runtime impact. The only real risk is merge-order — if this lands before #850, the guides describe a tool that the scaffold doesn't produce yet, which would actively confuse the next tutorial reader. The draft state on this PR is the merge-order guardrail.

## Author checklist

- [x] Linked to a Linear ticket or GitHub issue (docs#976, above)
- [x] I understand every change in the diff — every prose/code change in the diff has a 1:1 counterpart in the scaffold PR
- [x] Visually rendered the affected pages
- [x] CI is expected to pass (docs-only)
- [x] I've pulled the branch fresh and reviewed my own diff top-to-bottom
- [x] Draft state explicitly used to prevent out-of-order merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change; main risk is guidance mismatch if merged before the corresponding scaffold change that generates `star_repo`.
> 
> **Overview**
> **Swaps the scaffolded auth-demo in docs from Reddit to GitHub.** The quickstart and `build-mcp-server` guide now describe and show a `star_repo` tool (GitHub OAuth) instead of `get_posts_in_subreddit` (Reddit).
> 
> Updates the embedded `server.py` snippet and surrounding instructions accordingly (GitHub auth provider, `PUT /user/starred/{owner}/{repo}` call, updated headers/User-Agent), and adjusts expected log output, example prompt, and troubleshooting copy to reference the GitHub tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783cd1b78d2ea5e726146df67e7168d878bfcca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->