### PR TITLE
changelogs update

### DIFF
--- a/app/en/references/changelog/page.mdx
+++ b/app/en/references/changelog/page.mdx
@@ -16,7 +16,6 @@ _Here's what's new at Arcade.dev!_
 - `[documentation - 📝]` Updates to MCP Servers documentation including toolkit metadata.
 - `[documentation - 📝]` Updating documentation for MCP Servers following an upgrade.
 
-**Arcade CLI**
 
 
 **Platform and Engine**

--- a/app/en/references/changelog/page.mdx
+++ b/app/en/references/changelog/page.mdx
@@ -9,6 +9,42 @@ import { Callout } from "nextra/components";
 
 _Here's what's new at Arcade.dev!_
 
+## 2026-05-22
+
+**Arcade MCP Servers**
+
+- `[documentation - 📝]` Updates to MCP Servers documentation including toolkit metadata.
+- `[documentation - 📝]` Updating documentation for MCP Servers following an upgrade.
+
+**Arcade CLI**
+
+
+**Platform and Engine**
+
+- `[bugfix - 🐛]` Fix validation error for empty Authorization URL field in MCP Server OAuth configuration.
+- `[bugfix - 🐛]` Fixes middleware handling for HTTPExceptions to improve error responses in FastAPI.
+
+## 2026-05-15
+
+
+**Arcade MCP Servers**
+
+- `[feature - 🚀]` Add default-on filter to exclude automated noise from Gmail search/list results.
+- `[bugfix - 🐛]` Fix missing OAuth scopes for Microsoft Teams toolkit tools to ensure proper authentication.
+- `[bugfix - 🐛]` Fixes the issue of unwanted line breaks in Gmail messages sent as plaintext.
+- `[bugfix - 🐛]` Fix Slack GetMessages tool quality errors related to datetime inputs and user lookup.
+- `[bugfix - 🐛]` Fix Jira tool quality errors including project resolution and optional field handling.
+- `[documentation - 📝]` Adding MCP Servers docs update to reflect new Outlook Mail tools and expanded OAuth scope.
+
+**Platform and Engine**
+
+- `[bugfix - 🐛]` Fix billing graphs on the dashboard by ensuring consistent recharts version usage.
+- `[feature - 🚀]` Make tool-call timeouts configurable for self-hosted deployments.
+
+**Misc**
+
+- `[documentation - 📝]` Add Visual Studio instructions to GitHub Copilot documentation.
+
 ## 2026-05-08
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changelog content with no runtime or application code changes.
> 
> **Overview**
> Adds two new dated sections at the top of the public **Changelog** page (`page.mdx`).
> 
> **2026-05-22** covers MCP Servers doc updates (toolkit metadata and post-upgrade docs) and Platform/Engine fixes (empty OAuth Authorization URL validation, FastAPI HTTPException middleware).
> 
> **2026-05-15** is a broader release note: Gmail noise filtering, Teams OAuth scopes, Gmail/Slack/Jira tool fixes, Outlook Mail docs, dashboard billing graphs (recharts), configurable self-hosted tool-call timeouts, and Visual Studio instructions for GitHub Copilot docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d491d5d71d1da8c3f3ef073c03426d97af81d1e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->