### PR TITLE
docs: add consent-skip allowlist section to gateway dashboard guide

### DIFF
--- a/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
+++ b/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
@@ -75,10 +75,13 @@ A client ID is what the MCP client sends to Arcade during OAuth registration. Mo
 
 ### Known MCP client IDs
 
+The values below are the literal `client_id` strings these clients send in their OAuth authorize requests to Arcade today.
+
 | MCP client | Client ID |
 |---|---|
 | Claude (Claude Desktop and Claude.ai) | `https://claude.ai/oauth/mcp-oauth-client-metadata` |
 | Claude Code | `https://claude.ai/oauth/claude-code-client-metadata` |
+| Goose | `https://goose-docs.ai/oauth/client-metadata.json` |
 | Visual Studio Code | `https://vscode.dev/oauth/client-metadata.json` |
 
 This list is intentionally short. The CIMD ecosystem is early as of May 2026, so most other MCP clients (Cursor, GitHub Copilot, Codex, and others) do not yet publish a stable client ID that can be allowlisted. We expect this list to grow as those clients add CIMD support.

--- a/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
+++ b/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
@@ -78,9 +78,10 @@ A client ID is what the MCP client sends to Arcade during OAuth registration. Mo
 | MCP client | Client ID |
 |---|---|
 | Claude (Claude Desktop and Claude.ai) | `https://claude.ai/oauth/mcp-oauth-client-metadata` |
+| Claude Code | `https://claude.ai/oauth/claude-code-client-metadata` |
 | Visual Studio Code | `https://vscode.dev/oauth/client-metadata.json` |
 
-This list is intentionally short. The CIMD ecosystem is early as of May 2026, so most MCP clients (Cursor, GitHub Copilot, Codex, Claude Code, and others) do not yet publish a stable client ID that can be allowlisted. We expect this list to grow as those clients add CIMD support.
+This list is intentionally short. The CIMD ecosystem is early as of May 2026, so most other MCP clients (Cursor, GitHub Copilot, Codex, and others) do not yet publish a stable client ID that can be allowlisted. We expect this list to grow as those clients add CIMD support.
 
 ### Find the client ID for an unlisted client
 

--- a/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
+++ b/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
@@ -69,6 +69,6 @@ See [Skip consent for trusted MCP clients](/guides/mcp-gateways#skip-consent-for
 
 ## After Creating a Gateway
 
-Once you've created a gateway, you'll need to add it to your chat client. The assistant will provide the MCP URL (for example, `https://api.arcade.dev/mcp/your-gateway-slug`).
+Once you've created a gateway, you'll need to add it to your chat client. The assistant will provide the MCP URL (for example, `https://api.arcade.dev/mcp/{your-gateway-slug}`).
 
 See [Connect to MCP clients](/get-started/mcp-clients) for setup instructions specific to your client.

--- a/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
+++ b/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
@@ -65,34 +65,10 @@ The options available when configuring an MCP Gateway are:
     - **Arcade Headers** (fallback): The client passes an Arcade API key in the `Authorization` header and the end user's ID in the `Arcade-User-ID` header. Pick this for MCP clients that can't run a browser-based OAuth flow.
 - **Allowed Tools**: A selection of tools in the Arcade Tool Catalog that will be available to the MCP Gateway.
 
-## Skip consent for trusted MCP clients
-
-When an end user signs in to a gateway, Arcade shows an OAuth consent screen before issuing a token. The **Skip consent for trusted clients (optional)** field on the gateway form lets you allowlist specific MCP client IDs that should bypass that consent screen. End users connecting through an allowlisted client go straight from sign-in to a working session.
-
-The field is available on gateways that use **Arcade Auth** or a **User Source**. It does not apply to Arcade Headers.
-
-A client ID is what the MCP client sends to Arcade during OAuth registration. Most MCP clients today perform [Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591), which mints a fresh, per-installation client ID that's not useful for an allowlist. Clients that publish a [Client ID Metadata Document](https://datatracker.ietf.org/doc/draft-parecki-oauth-client-id-metadata-document/) (CIMD) use their published HTTPS URL as a stable client ID — that URL is what goes in the allowlist.
-
-### Known MCP client IDs
-
-The values below are the literal `client_id` strings these clients send in their OAuth authorize requests to Arcade today.
-
-| MCP client | Client ID |
-|---|---|
-| Claude (Claude Desktop and Claude.ai) | `https://claude.ai/oauth/mcp-oauth-client-metadata` |
-| Claude Code | `https://claude.ai/oauth/claude-code-client-metadata` |
-| Visual Studio Code | `https://vscode.dev/oauth/client-metadata.json` |
-
-This list is intentionally short. The CIMD ecosystem is early as of May 2026, so most other MCP clients (Cursor, GitHub Copilot, Codex, and others) do not yet publish a stable client ID that can be allowlisted. We expect this list to grow as those clients add CIMD support.
-
-### Find the client ID for an unlisted client
-
-If the MCP client publishes a CIMD, its documentation will reference an `https://...client-metadata` URL or similar. That URL is the client ID — paste it into the allowlist as-is.
-
-If the client uses Dynamic Client Registration, the client ID is generated per registration and changes any time the client re-registers. You'd need to track the latest registered client ID against your gateway, which usually isn't worth the operational cost. Wait until the client adopts CIMD instead.
+See [Skip consent for trusted MCP clients](/guides/mcp-gateways#skip-consent-for-trusted-mcp-clients) for the **Skip consent for trusted clients (optional)** field on this same form.
 
 ## After Creating a Gateway
 
-Once you've created a gateway, you'll need to add it to your chat client. The assistant will provide the MCP URL (for example, `https://api.arcade.dev/mcp/<YOUR-GATEWAY-SLUG>`).
+Once you've created a gateway, you'll need to add it to your chat client. The assistant will provide the MCP URL (for example, `https://api.arcade.dev/mcp/your-gateway-slug`).
 
 See [Connect to MCP clients](/get-started/mcp-clients) for setup instructions specific to your client.

--- a/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
+++ b/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
@@ -69,6 +69,6 @@ See [Skip consent for trusted MCP clients](/guides/mcp-gateways#skip-consent-for
 
 ## After Creating a Gateway
 
-Once you've created a gateway, you'll need to add it to your chat client. The assistant will provide the MCP URL (for example, `https://api.arcade.dev/mcp/{your-gateway-slug}`).
+Once you've created a gateway, you'll need to add it to your chat client. The assistant will provide the MCP URL (for example, `https://api.arcade.dev/mcp/{YOUR-GATEWAY-SLUG}`).
 
 See [Connect to MCP clients](/get-started/mcp-clients) for setup instructions specific to your client.

--- a/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
+++ b/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
@@ -81,7 +81,6 @@ The values below are the literal `client_id` strings these clients send in their
 |---|---|
 | Claude (Claude Desktop and Claude.ai) | `https://claude.ai/oauth/mcp-oauth-client-metadata` |
 | Claude Code | `https://claude.ai/oauth/claude-code-client-metadata` |
-| Goose | `https://goose-docs.ai/oauth/client-metadata.json` |
 | Visual Studio Code | `https://vscode.dev/oauth/client-metadata.json` |
 
 This list is intentionally short. The CIMD ecosystem is early as of May 2026, so most other MCP clients (Cursor, GitHub Copilot, Codex, and others) do not yet publish a stable client ID that can be allowlisted. We expect this list to grow as those clients add CIMD support.

--- a/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
+++ b/app/en/guides/mcp-gateways/create-via-dashboard/page.mdx
@@ -65,6 +65,29 @@ The options available when configuring an MCP Gateway are:
     - **Arcade Headers** (fallback): The client passes an Arcade API key in the `Authorization` header and the end user's ID in the `Arcade-User-ID` header. Pick this for MCP clients that can't run a browser-based OAuth flow.
 - **Allowed Tools**: A selection of tools in the Arcade Tool Catalog that will be available to the MCP Gateway.
 
+## Skip consent for trusted MCP clients
+
+When an end user signs in to a gateway, Arcade shows an OAuth consent screen before issuing a token. The **Skip consent for trusted clients (optional)** field on the gateway form lets you allowlist specific MCP client IDs that should bypass that consent screen. End users connecting through an allowlisted client go straight from sign-in to a working session.
+
+The field is available on gateways that use **Arcade Auth** or a **User Source**. It does not apply to Arcade Headers.
+
+A client ID is what the MCP client sends to Arcade during OAuth registration. Most MCP clients today perform [Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591), which mints a fresh, per-installation client ID that's not useful for an allowlist. Clients that publish a [Client ID Metadata Document](https://datatracker.ietf.org/doc/draft-parecki-oauth-client-id-metadata-document/) (CIMD) use their published HTTPS URL as a stable client ID — that URL is what goes in the allowlist.
+
+### Known MCP client IDs
+
+| MCP client | Client ID |
+|---|---|
+| Claude (Claude Desktop and Claude.ai) | `https://claude.ai/oauth/mcp-oauth-client-metadata` |
+| Visual Studio Code | `https://vscode.dev/oauth/client-metadata.json` |
+
+This list is intentionally short. The CIMD ecosystem is early as of May 2026, so most MCP clients (Cursor, GitHub Copilot, Codex, Claude Code, and others) do not yet publish a stable client ID that can be allowlisted. We expect this list to grow as those clients add CIMD support.
+
+### Find the client ID for an unlisted client
+
+If the MCP client publishes a CIMD, its documentation will reference an `https://...client-metadata` URL or similar. That URL is the client ID — paste it into the allowlist as-is.
+
+If the client uses Dynamic Client Registration, the client ID is generated per registration and changes any time the client re-registers. You'd need to track the latest registered client ID against your gateway, which usually isn't worth the operational cost. Wait until the client adopts CIMD instead.
+
 ## After Creating a Gateway
 
 Once you've created a gateway, you'll need to add it to your chat client. The assistant will provide the MCP URL (for example, `https://api.arcade.dev/mcp/<YOUR-GATEWAY-SLUG>`).

--- a/app/en/guides/mcp-gateways/page.mdx
+++ b/app/en/guides/mcp-gateways/page.mdx
@@ -73,7 +73,7 @@ See [User Sources](/guides/user-sources) for how to set up an OIDC identity prov
 
 ## Skip consent for trusted MCP clients
 
-When an end user signs in to a gateway, Arcade shows an OAuth consent screen before issuing a token. The **Skip consent for trusted clients (optional)** field on the gateway form lets you allowlist specific MCP client IDs that should bypass that consent screen. End users connecting through an allowlisted client go straight from sign-in to a working session.
+When an end user signs in to a gateway, Arcade shows an OAuth consent screen before issuing a token. This feature lets you allowlist specific MCP client IDs that should bypass that consent screen. End users connecting through an allowlisted client go straight from sign-in to a working session.
 
 The field is available on gateways that use **Arcade Auth** or a **User Source**. It does not apply to Arcade Headers.
 

--- a/app/en/guides/mcp-gateways/page.mdx
+++ b/app/en/guides/mcp-gateways/page.mdx
@@ -54,7 +54,7 @@ Use remote MCP servers when your tools live outside Arcade. Register the server 
 Any MCP client that supports the Streamable HTTP transport can use an Arcade MCP Gateway. Use your gateway URL in the following format:
 
 ```
-https://api.arcade.dev/mcp/<YOUR-GATEWAY-SLUG>
+https://api.arcade.dev/mcp/your-gateway-slug
 ```
 
 Learn how to [connect MCP Gateways to your preferred client](/get-started/mcp-clients).
@@ -70,6 +70,30 @@ When you create a gateway, you choose who its end users are. Arcade groups the o
 | **Arcade Headers** (fallback) | MCP clients that can't run a browser-based OAuth flow | The client passes `Authorization: Bearer {your_api_key}` and `Arcade-User-ID: {end_user_id}` on every request |
 
 See [User Sources](/guides/user-sources) for how to set up an OIDC identity provider and attach it to a gateway. See [Create via Dashboard](/guides/mcp-gateways/create-via-dashboard) for the rest of the gateway configuration.
+
+## Skip consent for trusted MCP clients
+
+When an end user signs in to a gateway, Arcade shows an OAuth consent screen before issuing a token. The **Skip consent for trusted clients (optional)** field on the gateway form lets you allowlist specific MCP client IDs that should bypass that consent screen. End users connecting through an allowlisted client go straight from sign-in to a working session.
+
+The field is available on gateways that use **Arcade Auth** or a **User Source**. It does not apply to Arcade Headers.
+
+A client ID is what the MCP client sends to Arcade during OAuth registration. Most MCP clients today perform [Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591), which mints a fresh, per-installation client ID that's not useful for an allowlist. Clients that publish a [Client ID Metadata Document](https://datatracker.ietf.org/doc/draft-parecki-oauth-client-id-metadata-document/) (CIMD) use their published HTTPS URL as a stable client ID, and that URL is what goes in the allowlist.
+
+### Known MCP client IDs
+
+The values below are the literal `client_id` strings these clients send in their OAuth authorize requests to Arcade today.
+
+| MCP client | Client ID |
+|---|---|
+| Claude (Claude Desktop and Claude.ai) | `https://claude.ai/oauth/mcp-oauth-client-metadata` |
+| Claude Code | `https://claude.ai/oauth/claude-code-client-metadata` |
+| Visual Studio Code | `https://vscode.dev/oauth/client-metadata.json` |
+
+### Find the client ID for an unlisted client
+
+If the MCP client publishes a CIMD, its documentation will reference an `https://...client-metadata` URL or similar. That URL is the client ID, so paste it into the allowlist as-is.
+
+If the client uses Dynamic Client Registration, it gets a new client ID per registration and that ID changes any time the client re-registers. Tracking the latest registered ID against your gateway rarely pays back the operational cost.
 
 ## Next Steps
 

--- a/app/en/guides/mcp-gateways/page.mdx
+++ b/app/en/guides/mcp-gateways/page.mdx
@@ -77,7 +77,7 @@ When an end user signs in to a gateway, Arcade shows an OAuth consent screen bef
 
 The field is available on gateways that use **Arcade Auth** or a **User Source**. It does not apply to Arcade Headers.
 
-A client ID is what the MCP client sends to Arcade during OAuth registration. Most MCP clients today perform [Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591), which mints a fresh, per-installation client ID that's not useful for an allowlist. Clients that publish a [Client ID Metadata Document](https://datatracker.ietf.org/doc/draft-parecki-oauth-client-id-metadata-document/) (CIMD) use their published HTTPS URL as a stable client ID, and that URL is what goes in the allowlist.
+A client ID is what the MCP client sends to Arcade during OAuth registration. Clients that publish a [Client ID Metadata Document](https://datatracker.ietf.org/doc/draft-parecki-oauth-client-id-metadata-document/) (CIMD) use their published HTTPS URL as a stable client ID, and that URL is what goes in the allowlist. Clients that rely on [Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591) instead receive a fresh client ID per installation, so they don't have a stable value to allowlist and aren't suitable for this feature.
 
 ### Known MCP client IDs
 

--- a/app/en/guides/mcp-gateways/page.mdx
+++ b/app/en/guides/mcp-gateways/page.mdx
@@ -54,7 +54,7 @@ Use remote MCP servers when your tools live outside Arcade. Register the server 
 Any MCP client that supports the Streamable HTTP transport can use an Arcade MCP Gateway. Use your gateway URL in the following format:
 
 ```
-https://api.arcade.dev/mcp/your-gateway-slug
+https://api.arcade.dev/mcp/{your-gateway-slug}
 ```
 
 Learn how to [connect MCP Gateways to your preferred client](/get-started/mcp-clients).

--- a/app/en/guides/mcp-gateways/page.mdx
+++ b/app/en/guides/mcp-gateways/page.mdx
@@ -54,7 +54,7 @@ Use remote MCP servers when your tools live outside Arcade. Register the server 
 Any MCP client that supports the Streamable HTTP transport can use an Arcade MCP Gateway. Use your gateway URL in the following format:
 
 ```
-https://api.arcade.dev/mcp/{your-gateway-slug}
+https://api.arcade.dev/mcp/{YOUR-GATEWAY-SLUG}
 ```
 
 Learn how to [connect MCP Gateways to your preferred client](/get-started/mcp-clients).

--- a/app/en/guides/user-sources/page.mdx
+++ b/app/en/guides/user-sources/page.mdx
@@ -76,7 +76,7 @@ Click **Create**. The new User Source appears in the list with **Active** status
 
 You attach a User Source to an MCP Gateway when you create or edit the gateway. One User Source can back multiple gateways in the same project, so you can reuse the same end-user identity system across every gateway you build for those users.
 
-See [Create via Dashboard](/guides/mcp-gateways/create-via-dashboard) for how to pick a User Source when configuring a gateway's authentication. The MCP Gateways guide covers the gateway's [consent-skip allowlist](/guides/mcp-gateways#skip-consent-for-trusted-mcp-clients) if you want trusted MCP clients to bypass the Arcade consent screen.
+See [Create via Dashboard](/guides/mcp-gateways/create-via-dashboard) for how to pick a User Source when configuring a gateway's authentication.
 
 ## Manage User Sources
 

--- a/app/en/guides/user-sources/page.mdx
+++ b/app/en/guides/user-sources/page.mdx
@@ -76,7 +76,7 @@ Click **Create**. The new User Source appears in the list with **Active** status
 
 You attach a User Source to an MCP Gateway when you create or edit the gateway. One User Source can back multiple gateways in the same project, so you can reuse the same end-user identity system across every gateway you build for those users.
 
-See [Create via Dashboard](/guides/mcp-gateways/create-via-dashboard) for how to pick a User Source when configuring a gateway's authentication.
+See [Create via Dashboard](/guides/mcp-gateways/create-via-dashboard) for how to pick a User Source when configuring a gateway's authentication. The same page covers the gateway's [consent-skip allowlist](/guides/mcp-gateways/create-via-dashboard#skip-consent-for-trusted-mcp-clients) if you want trusted MCP clients to bypass the Arcade consent screen.
 
 ## Manage User Sources
 

--- a/app/en/guides/user-sources/page.mdx
+++ b/app/en/guides/user-sources/page.mdx
@@ -76,7 +76,7 @@ Click **Create**. The new User Source appears in the list with **Active** status
 
 You attach a User Source to an MCP Gateway when you create or edit the gateway. One User Source can back multiple gateways in the same project, so you can reuse the same end-user identity system across every gateway you build for those users.
 
-See [Create via Dashboard](/guides/mcp-gateways/create-via-dashboard) for how to pick a User Source when configuring a gateway's authentication. The same page covers the gateway's [consent-skip allowlist](/guides/mcp-gateways/create-via-dashboard#skip-consent-for-trusted-mcp-clients) if you want trusted MCP clients to bypass the Arcade consent screen.
+See [Create via Dashboard](/guides/mcp-gateways/create-via-dashboard) for how to pick a User Source when configuring a gateway's authentication. The MCP Gateways guide covers the gateway's [consent-skip allowlist](/guides/mcp-gateways#skip-consent-for-trusted-mcp-clients) if you want trusted MCP clients to bypass the Arcade consent screen.
 
 ## Manage User Sources
 


### PR DESCRIPTION
## Summary

Adds an inline **Skip consent for trusted MCP clients** section to `app/en/guides/mcp-gateways/create-via-dashboard/page.mdx`, with a starter table of confirmed MCP client IDs and guidance on finding client IDs for unlisted clients. Cross-link added from the User Sources overview.

Closes [GRO-99](https://linear.app/arcadedev/issue/GRO-99/docs-consent-skip-allowlist-section-on-the-mcp-gateway-dashboard-guide). Part of the [GRO-75 umbrella](https://linear.app/arcadedev/issue/GRO-75/pre-launch-documentation-user-sources-gateway-auth-umbrella).

## Targeting

Targets **`wils/gro-93-docs-configuring-user-sources-guide`** (the GRO-75 integration branch), not main. The umbrella PR (#978) is the one that eventually merges to main.

## Rescope vs. original GRO-99

Originally scoped as a standalone reference page. After investigating actual CIMD adoption across the documented MCP clients, the only stable, publicly verifiable client IDs are:

- **Claude (Claude Desktop + Claude.ai)** — `https://claude.ai/oauth/mcp-oauth-client-metadata` (also referenced in the dashboard form's tooltip)
- **Visual Studio Code** — `https://vscode.dev/oauth/client-metadata.json`

Cursor, GitHub Copilot, Codex, and Claude Code all currently rely on Dynamic Client Registration with ephemeral client IDs — no stable value to allowlist. A separate reference page would be too thin to justify. Inline keeps it adjacent to the form field, and the table is easy to extend when more clients adopt CIMD.

## Decisions worth flagging

- Section heading matches the form's label-style wording ("Skip consent for trusted MCP clients") for discoverability.
- Field applicability documented as Arcade Auth or User Source (not Arcade Headers), matching the actual `if (!byoaEnabled || authType === "arcade_header") return null;` visibility check in `consent-skip-client-ids-field.tsx`.
- Cross-linked CIMD and DCR RFC drafts for readers who want to dig in.
- User Sources overview gets a one-line pointer rather than a re-explanation.

## Test plan

- [x] `pnpm build` — `/en/guides/mcp-gateways/create-via-dashboard` and `/en/guides/user-sources` render in route table
- [x] Vale clean on the User Sources page; the pre-existing `<YOUR-GATEWAY-SLUG>` MDX parser issue on `create-via-dashboard/page.mdx` blocks Vale but is out of scope for this PR
- [ ] Reviewer to spot-check the section copy and the two CIMD URLs
- [ ] Reviewer to confirm the field visibility statement (Arcade Auth or User Source, not Arcade Headers) matches the dashboard behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that add guidance for an OAuth consent-skip allowlist and adjust example URL formatting; no runtime behavior is modified.
> 
> **Overview**
> Adds documentation for the **“Skip consent for trusted MCP clients”** gateway setting, explaining when it applies (Arcade Auth/User Source only), how client IDs are determined (CIMD vs Dynamic Client Registration), and providing a starter table of known `client_id` values.
> 
> Updates the dashboard creation guide to link to this new section and standardizes gateway URL examples to use `{YOUR-GATEWAY-SLUG}` formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fab043fb9cd48f90f8f84d7bb124db8aa8c22be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->