### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/toolkit-docs-generator/data/toolkits/github.json
+++ b/toolkit-docs-generator/data/toolkits/github.json
@@ -1,7 +1,7 @@
 {
   "id": "Github",
   "label": "GitHub",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "Arcade.dev LLM tools for Github",
   "metadata": {
     "category": "development",
@@ -22,7 +22,7 @@
     {
       "name": "AssignPullRequestUser",
       "qualifiedName": "Github.AssignPullRequestUser",
-      "fullyQualifiedName": "Github.AssignPullRequestUser@3.2.0",
+      "fullyQualifiedName": "Github.AssignPullRequestUser@4.0.0",
       "description": "Assign a user to a pull request with intelligent search and fuzzy matching.",
       "parameters": [
         {
@@ -157,7 +157,7 @@
     {
       "name": "CheckPullRequestMergeStatus",
       "qualifiedName": "Github.CheckPullRequestMergeStatus",
-      "fullyQualifiedName": "Github.CheckPullRequestMergeStatus@3.2.0",
+      "fullyQualifiedName": "Github.CheckPullRequestMergeStatus@4.0.0",
       "description": "Check if a pull request is ready to merge without attempting the merge.",
       "parameters": [
         {
@@ -261,7 +261,7 @@
     {
       "name": "CountStargazers",
       "qualifiedName": "Github.CountStargazers",
-      "fullyQualifiedName": "Github.CountStargazers@3.2.0",
+      "fullyQualifiedName": "Github.CountStargazers@4.0.0",
       "description": "Count the number of stargazers (stars) for a GitHub repository.",
       "parameters": [
         {
@@ -339,7 +339,7 @@
     {
       "name": "CreateBranch",
       "qualifiedName": "Github.CreateBranch",
-      "fullyQualifiedName": "Github.CreateBranch@3.2.0",
+      "fullyQualifiedName": "Github.CreateBranch@4.0.0",
       "description": "Create a new branch in a repository.",
       "parameters": [
         {
@@ -443,7 +443,7 @@
     {
       "name": "CreateFile",
       "qualifiedName": "Github.CreateFile",
-      "fullyQualifiedName": "Github.CreateFile@3.2.0",
+      "fullyQualifiedName": "Github.CreateFile@4.0.0",
       "description": "Create a new file or overwrite an existing file in a repository.\n\nThe explicit mode parameter reduces accidental data loss: the default CREATE mode refuses to\ntouch existing files, while OVERWRITE must be chosen intentionally.",
       "parameters": [
         {
@@ -589,7 +589,7 @@
     {
       "name": "CreateIssue",
       "qualifiedName": "Github.CreateIssue",
-      "fullyQualifiedName": "Github.CreateIssue@3.2.0",
+      "fullyQualifiedName": "Github.CreateIssue@4.0.0",
       "description": "Create an issue in a GitHub repository.\n\nOptionally add the created issue to a project by specifying add_to_project_number\nand add_to_project_scope.",
       "parameters": [
         {
@@ -784,7 +784,7 @@
     {
       "name": "CreateIssueComment",
       "qualifiedName": "Github.CreateIssueComment",
-      "fullyQualifiedName": "Github.CreateIssueComment@3.2.0",
+      "fullyQualifiedName": "Github.CreateIssueComment@4.0.0",
       "description": "Create a comment on an issue in a GitHub repository.",
       "parameters": [
         {
@@ -888,7 +888,7 @@
     {
       "name": "CreatePullRequest",
       "qualifiedName": "Github.CreatePullRequest",
-      "fullyQualifiedName": "Github.CreatePullRequest@3.2.0",
+      "fullyQualifiedName": "Github.CreatePullRequest@4.0.0",
       "description": "Create a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -1090,7 +1090,7 @@
     {
       "name": "CreateReplyForReviewComment",
       "qualifiedName": "Github.CreateReplyForReviewComment",
-      "fullyQualifiedName": "Github.CreateReplyForReviewComment@3.2.0",
+      "fullyQualifiedName": "Github.CreateReplyForReviewComment@4.0.0",
       "description": "Create a reply to a review comment for a pull request.\n\nOptionally resolve the conversation thread after replying by setting resolve_thread=True\nand providing the thread_id (GraphQL Node ID).",
       "parameters": [
         {
@@ -1233,7 +1233,7 @@
     {
       "name": "CreateReviewComment",
       "qualifiedName": "Github.CreateReviewComment",
-      "fullyQualifiedName": "Github.CreateReviewComment@3.2.0",
+      "fullyQualifiedName": "Github.CreateReviewComment@4.0.0",
       "description": "Create a review comment for a pull request in a GitHub repository.\n\nIMPORTANT: Line numbers must be part of the diff (changed lines only).\nGitHub's API requires line numbers that exist in the pull request diff, not just any line\nin the file. If the line wasn't changed in the PR, the comment will fail with 422 error.\n\nIf the subject_type is not 'file', then the start_line and end_line parameters are required.\nIf the subject_type is 'file', then the start_line and end_line parameters are ignored.\nIf the commit_id is not provided, the latest commit SHA from the PR will be used.\n\nTIP: Use subject_type='file' to comment on the entire file if unsure about line positions.",
       "parameters": [
         {
@@ -1434,7 +1434,7 @@
     {
       "name": "GetFileContents",
       "qualifiedName": "Github.GetFileContents",
-      "fullyQualifiedName": "Github.GetFileContents@3.2.0",
+      "fullyQualifiedName": "Github.GetFileContents@4.0.0",
       "description": "Get the contents of a file in a repository.\n\nReturns the decoded content (if text) along with metadata like SHA, size, and line count.\nFor large files, use start_line and end_line to retrieve specific line ranges.",
       "parameters": [
         {
@@ -1564,7 +1564,7 @@
     {
       "name": "GetIssue",
       "qualifiedName": "Github.GetIssue",
-      "fullyQualifiedName": "Github.GetIssue@3.2.0",
+      "fullyQualifiedName": "Github.GetIssue@4.0.0",
       "description": "Get a specific issue from a GitHub repository.",
       "parameters": [
         {
@@ -1655,7 +1655,7 @@
     {
       "name": "GetPullRequest",
       "qualifiedName": "Github.GetPullRequest",
-      "fullyQualifiedName": "Github.GetPullRequest@3.2.0",
+      "fullyQualifiedName": "Github.GetPullRequest@4.0.0",
       "description": "Get details of a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -1759,7 +1759,7 @@
     {
       "name": "GetRepository",
       "qualifiedName": "Github.GetRepository",
-      "fullyQualifiedName": "Github.GetRepository@3.2.0",
+      "fullyQualifiedName": "Github.GetRepository@4.0.0",
       "description": "Get a repository.\n\nRetrieves detailed information about a repository using the GitHub API.",
       "parameters": [
         {
@@ -1837,7 +1837,7 @@
     {
       "name": "GetReviewWorkload",
       "qualifiedName": "Github.GetReviewWorkload",
-      "fullyQualifiedName": "Github.GetReviewWorkload@3.2.0",
+      "fullyQualifiedName": "Github.GetReviewWorkload@4.0.0",
       "description": "Get pull requests awaiting review by the authenticated user.\n\nReturns PRs where user is requested as reviewer and PRs user has recently reviewed.",
       "parameters": [],
       "auth": {
@@ -1887,7 +1887,7 @@
     {
       "name": "GetUserOpenItems",
       "qualifiedName": "Github.GetUserOpenItems",
-      "fullyQualifiedName": "Github.GetUserOpenItems@3.2.0",
+      "fullyQualifiedName": "Github.GetUserOpenItems@4.0.0",
       "description": "Get user's currently open pull requests and issues across all repositories.\n\nReturns open PRs and issues authored by the authenticated user.",
       "parameters": [
         {
@@ -1952,7 +1952,7 @@
     {
       "name": "GetUserRecentActivity",
       "qualifiedName": "Github.GetUserRecentActivity",
-      "fullyQualifiedName": "Github.GetUserRecentActivity@3.2.0",
+      "fullyQualifiedName": "Github.GetUserRecentActivity@4.0.0",
       "description": "Get the authenticated user's recent pull requests, reviews, issues, and commits.\n\nReturns PRs they authored, merged PRs, PRs they reviewed, issues they opened, and commits pushed",
       "parameters": [
         {
@@ -2030,7 +2030,7 @@
     {
       "name": "ListIssues",
       "qualifiedName": "Github.ListIssues",
-      "fullyQualifiedName": "Github.ListIssues@3.2.0",
+      "fullyQualifiedName": "Github.ListIssues@4.0.0",
       "description": "List issues in a GitHub repository.",
       "parameters": [
         {
@@ -2223,7 +2223,7 @@
     {
       "name": "ListOrgRepositories",
       "qualifiedName": "Github.ListOrgRepositories",
-      "fullyQualifiedName": "Github.ListOrgRepositories@3.2.0",
+      "fullyQualifiedName": "Github.ListOrgRepositories@4.0.0",
       "description": "List repositories for the specified organization.",
       "parameters": [
         {
@@ -2368,7 +2368,7 @@
     {
       "name": "ListProjectFields",
       "qualifiedName": "Github.ListProjectFields",
-      "fullyQualifiedName": "Github.ListProjectFields@3.2.0",
+      "fullyQualifiedName": "Github.ListProjectFields@4.0.0",
       "description": "List fields for a Projects V2 project.\n\nReturns all custom fields configured for the project, including field types\nand available options for select/iteration fields.",
       "parameters": [
         {
@@ -2492,7 +2492,7 @@
     {
       "name": "ListProjectItems",
       "qualifiedName": "Github.ListProjectItems",
-      "fullyQualifiedName": "Github.ListProjectItems@3.2.0",
+      "fullyQualifiedName": "Github.ListProjectItems@4.0.0",
       "description": "List items for a Projects V2 project with optional filtering.",
       "parameters": [
         {
@@ -2711,7 +2711,7 @@
     {
       "name": "ListProjects",
       "qualifiedName": "Github.ListProjects",
-      "fullyQualifiedName": "Github.ListProjects@3.2.0",
+      "fullyQualifiedName": "Github.ListProjects@4.0.0",
       "description": "List Projects V2 across organization or user scopes.",
       "parameters": [
         {
@@ -2891,7 +2891,7 @@
     {
       "name": "ListPullRequestCommits",
       "qualifiedName": "Github.ListPullRequestCommits",
-      "fullyQualifiedName": "Github.ListPullRequestCommits@3.2.0",
+      "fullyQualifiedName": "Github.ListPullRequestCommits@4.0.0",
       "description": "List commits (from oldest to newest) on a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -3008,7 +3008,7 @@
     {
       "name": "ListPullRequests",
       "qualifiedName": "Github.ListPullRequests",
-      "fullyQualifiedName": "Github.ListPullRequests@3.2.0",
+      "fullyQualifiedName": "Github.ListPullRequests@4.0.0",
       "description": "List pull requests in a GitHub repository.\n\nBy default returns newest pull requests first (direction=DESC).",
       "parameters": [
         {
@@ -3202,7 +3202,7 @@
     {
       "name": "ListRepositoryActivities",
       "qualifiedName": "Github.ListRepositoryActivities",
-      "fullyQualifiedName": "Github.ListRepositoryActivities@3.2.0",
+      "fullyQualifiedName": "Github.ListRepositoryActivities@4.0.0",
       "description": "List repository activities.\n\nRetrieves a detailed history of changes to a repository, such as pushes, merges,\nforce pushes, and branch changes, and associates these changes with commits and users.",
       "parameters": [
         {
@@ -3400,7 +3400,7 @@
     {
       "name": "ListRepositoryCollaborators",
       "qualifiedName": "Github.ListRepositoryCollaborators",
-      "fullyQualifiedName": "Github.ListRepositoryCollaborators@3.2.0",
+      "fullyQualifiedName": "Github.ListRepositoryCollaborators@4.0.0",
       "description": "List collaborators for a repository.\n\nReturns users who have access to the repository and can be requested as reviewers\nfor pull requests. Useful for discovering who can review your PR.\n\nDetail levels:\n- basic: Only explicit collaborators (fast, minimal API calls)\n- include_org_members: Add all org members (default, moderate API calls)\n- full_profiles: Add org members + enrich with names/emails (slow, many API calls)",
       "parameters": [
         {
@@ -3570,7 +3570,7 @@
     {
       "name": "ListRepositoryLabels",
       "qualifiedName": "Github.ListRepositoryLabels",
-      "fullyQualifiedName": "Github.ListRepositoryLabels@3.2.0",
+      "fullyQualifiedName": "Github.ListRepositoryLabels@4.0.0",
       "description": "List all labels defined in a repository.",
       "parameters": [
         {
@@ -3674,7 +3674,7 @@
     {
       "name": "ListReviewCommentsInARepository",
       "qualifiedName": "Github.ListReviewCommentsInARepository",
-      "fullyQualifiedName": "Github.ListReviewCommentsInARepository@3.2.0",
+      "fullyQualifiedName": "Github.ListReviewCommentsInARepository@4.0.0",
       "description": "List review comments in a GitHub repository.",
       "parameters": [
         {
@@ -3823,7 +3823,7 @@
     {
       "name": "ListReviewCommentsOnPullRequest",
       "qualifiedName": "Github.ListReviewCommentsOnPullRequest",
-      "fullyQualifiedName": "Github.ListReviewCommentsOnPullRequest@3.2.0",
+      "fullyQualifiedName": "Github.ListReviewCommentsOnPullRequest@4.0.0",
       "description": "List review comments on a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -3998,7 +3998,7 @@
     {
       "name": "ListStargazers",
       "qualifiedName": "Github.ListStargazers",
-      "fullyQualifiedName": "Github.ListStargazers@3.2.0",
+      "fullyQualifiedName": "Github.ListStargazers@4.0.0",
       "description": "List the stargazers for a GitHub repository.\n\nReturns stargazers in chronological order (oldest first).",
       "parameters": [
         {
@@ -4102,7 +4102,7 @@
     {
       "name": "ManageLabels",
       "qualifiedName": "Github.ManageLabels",
-      "fullyQualifiedName": "Github.ManageLabels@3.2.0",
+      "fullyQualifiedName": "Github.ManageLabels@4.0.0",
       "description": "Add or remove labels from an issue or pull request.\n\nSupports fuzzy matching for typo tolerance. Both issues and pull requests\nsupport labels through the same API. You can add and remove labels in a\nsingle operation.",
       "parameters": [
         {
@@ -4259,7 +4259,7 @@
     {
       "name": "ManagePullRequestReviewers",
       "qualifiedName": "Github.ManagePullRequestReviewers",
-      "fullyQualifiedName": "Github.ManagePullRequestReviewers@3.2.0",
+      "fullyQualifiedName": "Github.ManagePullRequestReviewers@4.0.0",
       "description": "Manage reviewers for a pull request.",
       "parameters": [
         {
@@ -4416,7 +4416,7 @@
     {
       "name": "MergePullRequest",
       "qualifiedName": "Github.MergePullRequest",
-      "fullyQualifiedName": "Github.MergePullRequest@3.2.0",
+      "fullyQualifiedName": "Github.MergePullRequest@4.0.0",
       "description": "Merge a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -4576,7 +4576,7 @@
     {
       "name": "ResolveReviewThread",
       "qualifiedName": "Github.ResolveReviewThread",
-      "fullyQualifiedName": "Github.ResolveReviewThread@3.2.0",
+      "fullyQualifiedName": "Github.ResolveReviewThread@4.0.0",
       "description": "Resolve or unresolve a pull request review conversation thread.",
       "parameters": [
         {
@@ -4680,7 +4680,7 @@
     {
       "name": "SearchMyRepos",
       "qualifiedName": "Github.SearchMyRepos",
-      "fullyQualifiedName": "Github.SearchMyRepos@3.2.0",
+      "fullyQualifiedName": "Github.SearchMyRepos@4.0.0",
       "description": "Search repositories accessible to the authenticated user with fuzzy matching.",
       "parameters": [
         {
@@ -4801,7 +4801,7 @@
     {
       "name": "SearchProjectItem",
       "qualifiedName": "Github.SearchProjectItem",
-      "fullyQualifiedName": "Github.SearchProjectItem@3.2.0",
+      "fullyQualifiedName": "Github.SearchProjectItem@4.0.0",
       "description": "Search for a specific item in a Projects V2 project.",
       "parameters": [
         {
@@ -4954,7 +4954,7 @@
     {
       "name": "SetStarred",
       "qualifiedName": "Github.SetStarred",
-      "fullyQualifiedName": "Github.SetStarred@3.2.0",
+      "fullyQualifiedName": "Github.SetStarred@4.0.0",
       "description": "Star or un-star a GitHub repository.",
       "parameters": [
         {
@@ -5045,7 +5045,7 @@
     {
       "name": "SubmitPullRequestReview",
       "qualifiedName": "Github.SubmitPullRequestReview",
-      "fullyQualifiedName": "Github.SubmitPullRequestReview@3.2.0",
+      "fullyQualifiedName": "Github.SubmitPullRequestReview@4.0.0",
       "description": "Submit a review for a pull request.",
       "parameters": [
         {
@@ -5166,7 +5166,7 @@
     {
       "name": "UpdateFileLines",
       "qualifiedName": "Github.UpdateFileLines",
-      "fullyQualifiedName": "Github.UpdateFileLines@3.2.0",
+      "fullyQualifiedName": "Github.UpdateFileLines@4.0.0",
       "description": "Replace a block of lines within a file (1-indexed, inclusive). Set mode=FileUpdateMode.APPEND\nto add new content to the end of the file.",
       "parameters": [
         {
@@ -5338,7 +5338,7 @@
     {
       "name": "UpdateIssue",
       "qualifiedName": "Github.UpdateIssue",
-      "fullyQualifiedName": "Github.UpdateIssue@3.2.0",
+      "fullyQualifiedName": "Github.UpdateIssue@4.0.0",
       "description": "Update an issue in a GitHub repository.\n\nParameters that are not provided (None) will not be updated or cleared.\nUpdates apply to the issue in the repository. If the issue is in a project,\nthe project item will automatically reflect these changes.",
       "parameters": [
         {
@@ -5519,7 +5519,7 @@
     {
       "name": "UpdatePullRequest",
       "qualifiedName": "Github.UpdatePullRequest",
-      "fullyQualifiedName": "Github.UpdatePullRequest@3.2.0",
+      "fullyQualifiedName": "Github.UpdatePullRequest@4.0.0",
       "description": "Update a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -5679,7 +5679,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Github.WhoAmI",
-      "fullyQualifiedName": "Github.WhoAmI@3.2.0",
+      "fullyQualifiedName": "Github.WhoAmI@4.0.0",
       "description": "Get information about the authenticated GitHub user.\n\nReturns profile, organizations, and teams.",
       "parameters": [],
       "auth": {
@@ -5766,6 +5766,6 @@
     "import { Callout, Tabs } from \"nextra/components\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-05-16T11:29:47.551Z",
+  "generatedAt": "2026-05-28T12:15:52.149Z",
   "summary": "Arcade's GitHub toolkit provides authenticated access to GitHub resources, enabling automated repository, issue, pull request, review, and Projects V2 workflows. It exposes high-level actions that handle fuzzy matching, diff-aware edits, and user-centric queries without forcing agents to juggle raw REST calls.\n\n**Capabilities**\n- Manage repository and file operations: create branches, read files with line ranges, create or overwrite files, and replace line blocks safely.\n- Drive the pull request lifecycle: create, update, list, merge, check merge readiness, manage reviewers, submit reviews, and reply to or resolve review threads.\n- Administer issues and labels with fuzzy-matched add/remove, comments, assignment, and issue-to-project linking.\n- Query Projects V2 fields and items, list stargazers, collaborators, labels, activities, and authenticated-user views (open items, recent activity, review workload).\n\n**OAuth**\nRequires GitHub OAuth. See the [Arcade GitHub auth provider docs](https://docs.arcade.dev/en/references/auth-providers/github) for configuration.\n\n**Secrets**\n- `GITHUB_SERVER_URL` — override for GitHub Enterprise endpoints. Configure in the [Arcade Dashboard](https://api.arcade.dev/dashboard/auth/secrets) per the [Arcade secret setup guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/googledocs.json
+++ b/toolkit-docs-generator/data/toolkits/googledocs.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleDocs",
   "label": "Google Docs",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Arcade.dev LLM tools for Google Docs",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "CommentOnDocument",
       "qualifiedName": "GoogleDocs.CommentOnDocument",
-      "fullyQualifiedName": "GoogleDocs.CommentOnDocument@6.0.0",
+      "fullyQualifiedName": "GoogleDocs.CommentOnDocument@7.0.0",
       "description": "Comment on a specific document by its ID.",
       "parameters": [
         {
@@ -53,8 +53,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "The comment's ID, documentId, and documentUrl in a dictionary"
@@ -64,12 +71,12 @@
         "toolName": "GoogleDocs.CommentOnDocument",
         "parameters": {
           "document_id": {
-            "value": "1aBcD2EfGhIJ3klMnOpQrstUVwXyZ67890",
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
           },
           "comment_text": {
-            "value": "Please review the introduction for clarity and confirm that the data in Table 1 is accurate. Suggest any wording changes directly in the doc.",
+            "value": "This section needs more clarity. Please revise the third paragraph to better explain the methodology.",
             "type": "string",
             "required": true
           }
@@ -99,7 +106,7 @@
     {
       "name": "CreateBlankDocument",
       "qualifiedName": "GoogleDocs.CreateBlankDocument",
-      "fullyQualifiedName": "GoogleDocs.CreateBlankDocument@6.0.0",
+      "fullyQualifiedName": "GoogleDocs.CreateBlankDocument@7.0.0",
       "description": "Create a blank Google Docs document with the specified title.",
       "parameters": [
         {
@@ -159,7 +166,7 @@
     {
       "name": "CreateDocumentFromText",
       "qualifiedName": "GoogleDocs.CreateDocumentFromText",
-      "fullyQualifiedName": "GoogleDocs.CreateDocumentFromText@6.0.0",
+      "fullyQualifiedName": "GoogleDocs.CreateDocumentFromText@7.0.0",
       "description": "Create a Google Docs document with the specified title and text content.\n\nWhen input_format is MARKDOWN, the text_content is parsed as Markdown and the resulting\ndocument is formatted with headings, bold, italic, bullet lists, and numbered lists.",
       "parameters": [
         {
@@ -204,6 +211,29 @@
         "description": "The created document's title, documentId, and documentUrl in a dictionary"
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "GoogleDocs.CreateDocumentFromText",
+        "parameters": {
+          "title": {
+            "value": "Project Kickoff Meeting Notes",
+            "type": "string",
+            "required": true
+          },
+          "text_content": {
+            "value": "# Project Kickoff Meeting\n\n**Date:** October 15, 2024\n\n## Agenda\n\n- Introduction and team overview\n- Project goals and timeline\n- Task assignments\n\n## Key Decisions\n\n1. Launch date set for Q1 2025\n2. Weekly syncs every Monday at 10am\n3. Use Slack for daily communication\n\n## Next Steps\n\n*All team members* should review the project brief before the next meeting.\n\n### Action Items\n\n- Alice: Finalize requirements document\n- Bob: Set up the development environment\n- Carol: Schedule stakeholder interviews",
+            "type": "string",
+            "required": true
+          },
+          "input_format": {
+            "value": "MARKDOWN",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -225,7 +255,7 @@
     {
       "name": "EditDocument",
       "qualifiedName": "GoogleDocs.EditDocument",
-      "fullyQualifiedName": "GoogleDocs.EditDocument@6.0.0",
+      "fullyQualifiedName": "GoogleDocs.EditDocument@7.0.0",
       "description": "Read or edit a Google Docs document using structured batchUpdate requests.\n\nWhen called without requests, returns the document content in DocMD format (block IDs,\ncharacter indices, and text styles). When called with requests, applies the edits and\nreturns the updated DocMD. Use the DocMD indices from the response to construct\nrequests for subsequent calls.",
       "parameters": [
         {
@@ -253,10 +283,12 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
       "secretsInfo": [
         {
-          "name": "OPENAI_API_KEY",
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
           "type": "api_key"
         }
       ],
@@ -265,6 +297,129 @@
         "description": "The result including document ID, URL, number of applied edits, and the document content in DocMD format."
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "GoogleDocs.EditDocument",
+        "parameters": {
+          "document_id": {
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
+            "type": "string",
+            "required": true
+          },
+          "requests": {
+            "value": [
+              {
+                "replaceAllText": {
+                  "containsText": {
+                    "text": "Project Title",
+                    "matchCase": true
+                  },
+                  "replaceText": "Q3 Report"
+                }
+              },
+              {
+                "insertText": {
+                  "location": {
+                    "index": 120
+                  },
+                  "text": "This section describes the key findings.\n"
+                }
+              },
+              {
+                "updateTextStyle": {
+                  "range": {
+                    "startIndex": 74,
+                    "endIndex": 86
+                  },
+                  "textStyle": {
+                    "bold": true,
+                    "fontSize": {
+                      "magnitude": 14,
+                      "unit": "PT"
+                    },
+                    "foregroundColor": {
+                      "color": {
+                        "rgbColor": {
+                          "red": 0.2,
+                          "green": 0.4,
+                          "blue": 0.8
+                        }
+                      }
+                    }
+                  },
+                  "fields": "bold,fontSize,foregroundColor"
+                }
+              },
+              {
+                "updateParagraphStyle": {
+                  "range": {
+                    "startIndex": 10,
+                    "endIndex": 50
+                  },
+                  "paragraphStyle": {
+                    "alignment": "CENTER",
+                    "lineSpacing": 150,
+                    "spaceBelow": {
+                      "magnitude": 10,
+                      "unit": "PT"
+                    }
+                  },
+                  "fields": "alignment,lineSpacing,spaceBelow"
+                }
+              },
+              {
+                "createParagraphBullets": {
+                  "range": {
+                    "startIndex": 200,
+                    "endIndex": 350
+                  },
+                  "bulletPreset": "BULLET_DISC_CIRCLE_SQUARE"
+                }
+              },
+              {
+                "insertTable": {
+                  "location": {
+                    "index": 400
+                  },
+                  "rows": 3,
+                  "columns": 4
+                }
+              },
+              {
+                "insertInlineImage": {
+                  "uri": "https://example.com/chart.png",
+                  "location": {
+                    "index": 500
+                  },
+                  "objectSize": {
+                    "width": {
+                      "magnitude": 300,
+                      "unit": "PT"
+                    },
+                    "height": {
+                      "magnitude": 200,
+                      "unit": "PT"
+                    }
+                  }
+                }
+              },
+              {
+                "createNamedRange": {
+                  "name": "summary-section",
+                  "range": {
+                    "startIndex": 60,
+                    "endIndex": 120
+                  }
+                }
+              }
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -287,8 +442,8 @@
     {
       "name": "GenerateGoogleFilePickerUrl",
       "qualifiedName": "GoogleDocs.GenerateGoogleFilePickerUrl",
-      "fullyQualifiedName": "GoogleDocs.GenerateGoogleFilePickerUrl@6.0.0",
-      "description": "Generate a Google File Picker URL for user-driven file selection and authorization.\n\nThis tool generates a URL that directs the end-user to a Google File Picker interface where\nwhere they can select or upload Google Drive files. Users can grant permission to access their\nDrive files, providing a secure and authorized way to interact with their files.\n\nThis is particularly useful when prior tools (e.g., those accessing or modifying\nGoogle Docs, Google Sheets, etc.) encountered failures due to file non-existence\n(Requested entity was not found) or permission errors. Once the user completes the file\npicker flow, the prior tool can be retried.\n\nSuggest this tool to users when they are surprised or confused that the file they are\nsearching for or attempting to access cannot be found.",
+      "fullyQualifiedName": "GoogleDocs.GenerateGoogleFilePickerUrl@7.0.0",
+      "description": "Generate a URL where the user can grant this app access to specific Drive files.\n\nOpens Google's first-party Drive picker. The user selects which files to share\nwith this application — it is not a sign-in or credential prompt.\n\nUse this when a prior tool reported that a file was not found or access was denied,\nand the user expects the file to exist. After the user completes the picker flow,\nretry the prior tool.",
       "parameters": [],
       "auth": {
         "providerId": "google",
@@ -330,7 +485,7 @@
     {
       "name": "GetDocumentAsDocmd",
       "qualifiedName": "GoogleDocs.GetDocumentAsDocmd",
-      "fullyQualifiedName": "GoogleDocs.GetDocumentAsDocmd@6.0.0",
+      "fullyQualifiedName": "GoogleDocs.GetDocumentAsDocmd@7.0.0",
       "description": "Get the latest version of the specified Google Docs document as DocMD.\nThe DocMD output will include tags that can be used to annotate the document with location\ninformation, the type of block, block IDs, and other metadata. If the document has tabs,\nall tabs are included in sequential order unless a specific tab_id is provided.",
       "parameters": [
         {
@@ -357,8 +512,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "string",
         "description": "The document contents as DocMD"
@@ -368,12 +530,12 @@
         "toolName": "GoogleDocs.GetDocumentAsDocmd",
         "parameters": {
           "document_id": {
-            "value": "1a2B3cD4e5FgH6IJ7kLmNoPqR8sTuvWxYz",
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
           },
           "tab_id": {
-            "value": "tab-0",
+            "value": "t.abc123xyz",
             "type": "string",
             "required": false
           }
@@ -403,7 +565,7 @@
     {
       "name": "GetDocumentById",
       "qualifiedName": "GoogleDocs.GetDocumentById",
-      "fullyQualifiedName": "GoogleDocs.GetDocumentById@6.0.0",
+      "fullyQualifiedName": "GoogleDocs.GetDocumentById@7.0.0",
       "description": "DEPRECATED DO NOT USE THIS TOOL\nGet the latest version of the specified Google Docs document.",
       "parameters": [
         {
@@ -422,8 +584,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "The document contents as a dictionary"
@@ -433,7 +602,7 @@
         "toolName": "GoogleDocs.GetDocumentById",
         "parameters": {
           "document_id": {
-            "value": "1aBcD_EfGhIjKlMnOpQrStUvWxYz1234567890",
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
           }
@@ -463,7 +632,7 @@
     {
       "name": "GetDocumentMetadata",
       "qualifiedName": "GoogleDocs.GetDocumentMetadata",
-      "fullyQualifiedName": "GoogleDocs.GetDocumentMetadata@6.0.0",
+      "fullyQualifiedName": "GoogleDocs.GetDocumentMetadata@7.0.0",
       "description": "Get metadata for a Google Docs document including hierarchical tab structure.\nReturns document title, ID, URL, total character count, and nested tab information\nwith character counts for each tab.",
       "parameters": [
         {
@@ -482,8 +651,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "Document metadata including hierarchical tab structure"
@@ -493,7 +669,7 @@
         "toolName": "GoogleDocs.GetDocumentMetadata",
         "parameters": {
           "document_id": {
-            "value": "1a2B3cD4eF5GhI6JkLmNoPqRsTuVwXyZ_12345",
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
           }
@@ -523,7 +699,7 @@
     {
       "name": "InsertTextAtEndOfDocument",
       "qualifiedName": "GoogleDocs.InsertTextAtEndOfDocument",
-      "fullyQualifiedName": "GoogleDocs.InsertTextAtEndOfDocument@6.0.0",
+      "fullyQualifiedName": "GoogleDocs.InsertTextAtEndOfDocument@7.0.0",
       "description": "Updates an existing Google Docs document using the batchUpdate API endpoint.",
       "parameters": [
         {
@@ -550,8 +726,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "The response from the batchUpdate API as a dict."
@@ -561,12 +744,12 @@
         "toolName": "GoogleDocs.InsertTextAtEndOfDocument",
         "parameters": {
           "document_id": {
-            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms",
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
           },
           "text_content": {
-            "value": "This is an example paragraph to append to the end of the document. Replace this sample text with the content you want inserted into the document.",
+            "value": "This is an example paragraph appended to the end of the document.",
             "type": "string",
             "required": true
           }
@@ -596,7 +779,7 @@
     {
       "name": "ListDocumentComments",
       "qualifiedName": "GoogleDocs.ListDocumentComments",
-      "fullyQualifiedName": "GoogleDocs.ListDocumentComments@6.0.0",
+      "fullyQualifiedName": "GoogleDocs.ListDocumentComments@7.0.0",
       "description": "List all comments on the specified Google Docs document.",
       "parameters": [
         {
@@ -623,8 +806,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "A dictionary containing the comments"
@@ -634,7 +824,7 @@
         "toolName": "GoogleDocs.ListDocumentComments",
         "parameters": {
           "document_id": {
-            "value": "1a2B3cD4EfGhIjKlmNoPqRstUvWxYz",
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
           },
@@ -669,7 +859,7 @@
     {
       "name": "SearchAndRetrieveDocuments",
       "qualifiedName": "GoogleDocs.SearchAndRetrieveDocuments",
-      "fullyQualifiedName": "GoogleDocs.SearchAndRetrieveDocuments@6.0.0",
+      "fullyQualifiedName": "GoogleDocs.SearchAndRetrieveDocuments@7.0.0",
       "description": "Searches for documents in the user's Google Drive and returns documents with their main body\ncontent and tab metadata. Excludes documents that are in the trash.\n\nReturns main body content only with metadata about tabs. Use get_document_as_docmd() to retrieve\nfull tab content for specific documents. Use search_documents() for metadata-only searches.",
       "parameters": [
         {
@@ -783,8 +973,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "A dictionary containing document count, list of documents with content and metadata, pagination token, and has_more flag"
@@ -800,9 +997,8 @@
           },
           "document_contains": {
             "value": [
-              "Q2 roadmap",
-              "budget overview",
-              "quarterly goals"
+              "quarterly report",
+              "budget 2024"
             ],
             "type": "array",
             "required": false
@@ -810,13 +1006,13 @@
           "document_not_contains": {
             "value": [
               "draft",
-              "personal notes"
+              "archived"
             ],
             "type": "array",
             "required": false
           },
           "search_only_in_shared_drive_id": {
-            "value": "0A1B2C3D4E5F6gHIJKLMNOP",
+            "value": "0AF1234abcXYZ567",
             "type": "string",
             "required": false
           },
@@ -839,12 +1035,12 @@
             "required": false
           },
           "limit": {
-            "value": 25,
+            "value": 10,
             "type": "integer",
             "required": false
           },
           "pagination_token": {
-            "value": "Cg0KC2RhdGFCbG9iMTIz",
+            "value": "eyJzdGFydEluZGV4IjoyMCwicGFnZVRva2VuIjoiYWJjMTIzIn0=",
             "type": "string",
             "required": false
           }
@@ -874,7 +1070,7 @@
     {
       "name": "SearchDocuments",
       "qualifiedName": "GoogleDocs.SearchDocuments",
-      "fullyQualifiedName": "GoogleDocs.SearchDocuments@6.0.0",
+      "fullyQualifiedName": "GoogleDocs.SearchDocuments@7.0.0",
       "description": "Searches for documents in the user's Google Drive. Excludes documents in trash.\nReturns metadata only. Use get_document_metadata or get_document_as_docmd for content.",
       "parameters": [
         {
@@ -975,8 +1171,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "Document count, list of documents, pagination token, and has_more flag"
@@ -988,8 +1191,7 @@
           "document_contains": {
             "value": [
               "quarterly report",
-              "Q4 revenue",
-              "performance review"
+              "budget 2024"
             ],
             "type": "array",
             "required": false
@@ -997,13 +1199,13 @@
           "document_not_contains": {
             "value": [
               "draft",
-              "confidential"
+              "archived"
             ],
             "type": "array",
             "required": false
           },
           "search_only_in_shared_drive_id": {
-            "value": "0A1b2C3d4E5fGhIjKlmN",
+            "value": "0AFs3hMr6gJQRUk9PVA",
             "type": "string",
             "required": false
           },
@@ -1031,7 +1233,7 @@
             "required": false
           },
           "pagination_token": {
-            "value": "CgkI1a2b3c4d5e6f7g8h",
+            "value": "eyJzdGFydEluZGV4IjoyNX0=",
             "type": "string",
             "required": false
           }
@@ -1061,7 +1263,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleDocs.WhoAmI",
-      "fullyQualifiedName": "GoogleDocs.WhoAmI@6.0.0",
+      "fullyQualifiedName": "GoogleDocs.WhoAmI@7.0.0",
       "description": "Get comprehensive user profile and Google Docs environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Docs access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1132,6 +1334,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-04-27T11:41:15.814Z",
-  "summary": "Arcade's Google Docs toolkit lets developers create, read, edit, comment on, and search Google Docs from LLM workflows.\n\n**Capabilities**\n- Create blank documents or generate documents from plain text and Markdown.\n- Read documents as DocMD, including tab annotations and structured edit indices.\n- Apply batchUpdate-style edits and return updated DocMD for follow-up changes.\n- Search and retrieve Docs content, inspect document metadata, list comments, add comments, and open a Google File Picker URL when file access needs user help.\n- Fetch authenticated user profile and Google Docs environment information.\n\n**OAuth**\n- **Provider**: Google\n- **Scopes**: Google Drive file access and Google user profile scopes.\n\n**Secrets**\n- No secret types required for toolkit operation."
+  "generatedAt": "2026-05-28T12:16:03.702Z",
+  "summary": "## Google Docs Toolkit\n\nThe Google Docs toolkit lets LLM agents create, read, edit, search, and annotate Google Docs documents through the Google Docs and Drive APIs via Arcade.\n\n## Capabilities\n\n- **Document creation:** Create blank documents or populate them from plain text or Markdown (with automatic heading, bold, italic, and list formatting).\n- **Document reading & metadata:** Retrieve full document content in DocMD format (block IDs, character indices, text styles, tab structure) or fetch metadata-only (title, ID, URL, character counts, tab hierarchy).\n- **Structured editing:** Apply batchUpdate requests using DocMD indices for precise in-document edits; append text to document ends.\n- **Search & discovery:** Search Drive for documents by query, with options to return metadata only or include full body content; trash is automatically excluded.\n- **Comments:** Add new comments to a document or list all existing comments.\n- **User & access management:** Retrieve authenticated user profile and permissions; generate a Google Drive inline file picker URL to grant per-file access when a document is not found or access is denied.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 with **Google** as the provider. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details.\n\n## Secrets\n\n- **`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL`** — A flag/URL secret that activates the `GenerateGoogleFilePickerUrl` tool, which opens Google's first-party Drive file picker so users can grant the app access to specific files without a full re-authentication flow. To obtain or configure this value, you set it in your Arcade environment to enable the picker endpoint. Refer to the [Arcade secrets documentation](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to define secrets, and manage them at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/googledrive.json
+++ b/toolkit-docs-generator/data/toolkits/googledrive.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleDrive",
   "label": "Google Drive",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "description": "Arcade.dev LLM tools for Google Drive",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "CreateFolder",
       "qualifiedName": "GoogleDrive.CreateFolder",
-      "fullyQualifiedName": "GoogleDrive.CreateFolder@5.3.0",
+      "fullyQualifiedName": "GoogleDrive.CreateFolder@6.0.0",
       "description": "Create a new folder in Google Drive.\n\nBy default, parent folder paths are resolved in My Drive. For shared drives, use folder IDs\nor provide shared_drive_id.",
       "parameters": [
         {
@@ -61,8 +61,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "Created folder information including ID, name, web view link, and location path"
@@ -72,17 +79,17 @@
         "toolName": "GoogleDrive.CreateFolder",
         "parameters": {
           "folder_name": {
-            "value": "ProjectDocumentation",
+            "value": "Project Reports 2024",
             "type": "string",
             "required": true
           },
           "parent_folder_path_or_id": {
-            "value": "Projects/2023",
+            "value": "Work/Quarterly Reports",
             "type": "string",
             "required": false
           },
           "shared_drive_id": {
-            "value": "abc123xyz",
+            "value": "0AKzTMnXy9B2pUk9PVA",
             "type": "string",
             "required": false
           }
@@ -112,7 +119,7 @@
     {
       "name": "DownloadFile",
       "qualifiedName": "GoogleDrive.DownloadFile",
-      "fullyQualifiedName": "GoogleDrive.DownloadFile@5.3.0",
+      "fullyQualifiedName": "GoogleDrive.DownloadFile@6.0.0",
       "description": "Download a blob file (non-workspace file) from Google Drive as base64 encoded content.\n\nFor small files (under ~5MB raw), returns the file content directly in the response as base64.\nFor large files, returns metadata with requires_chunked_download=True - use download_file_chunk\nto retrieve the file in parts.\n\nBy default, paths are resolved in My Drive. For shared drives, use file IDs or provide\nshared_drive_id.",
       "parameters": [
         {
@@ -139,8 +146,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "For small files (<5MB): file content (base64 encoded) and metadata. For large files: metadata with requires_chunked_download=True and instructions."
@@ -150,12 +164,12 @@
         "toolName": "GoogleDrive.DownloadFile",
         "parameters": {
           "file_path_or_id": {
-            "value": "1234567890abcdef",
+            "value": "Projects/Reports/Q3_Summary.pdf",
             "type": "string",
             "required": true
           },
           "shared_drive_id": {
-            "value": "shared-drive-unique-id",
+            "value": "0ACI7Xe9lJkRpUk9PVA",
             "type": "string",
             "required": false
           }
@@ -185,7 +199,7 @@
     {
       "name": "DownloadFileChunk",
       "qualifiedName": "GoogleDrive.DownloadFileChunk",
-      "fullyQualifiedName": "GoogleDrive.DownloadFileChunk@5.3.0",
+      "fullyQualifiedName": "GoogleDrive.DownloadFileChunk@6.0.0",
       "description": "Download a specific byte range of a file from Google Drive.\n\nUse this for large files that require chunked download (when download_file returns\nrequires_chunked_download=True). Call repeatedly with increasing start_byte values\nto retrieve the complete file.\n\nReturns the chunk content as base64, along with progress information including\nwhether this is the final chunk.",
       "parameters": [
         {
@@ -228,8 +242,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "Chunk content (base64 encoded), byte range info, and progress details"
@@ -239,22 +260,22 @@
         "toolName": "GoogleDrive.DownloadFileChunk",
         "parameters": {
           "file_path_or_id": {
-            "value": "1A2B3C4D5E6F7G8H9I0J",
+            "value": "Projects/Reports/annual_report_2024.pdf",
             "type": "string",
             "required": true
           },
           "start_byte": {
-            "value": 0,
+            "value": 5242880,
             "type": "integer",
             "required": true
           },
           "chunk_size": {
-            "value": 5242880,
+            "value": 2097152,
             "type": "integer",
             "required": false
           },
           "shared_drive_id": {
-            "value": null,
+            "value": "0AEtSWv9kDnKZUk9PVA",
             "type": "string",
             "required": false
           }
@@ -284,8 +305,8 @@
     {
       "name": "GenerateGoogleFilePickerUrl",
       "qualifiedName": "GoogleDrive.GenerateGoogleFilePickerUrl",
-      "fullyQualifiedName": "GoogleDrive.GenerateGoogleFilePickerUrl@5.3.0",
-      "description": "Generate a Google File Picker URL for user-driven file selection and authorization.\n\nThis tool generates a URL that directs the end-user to a Google File Picker interface where\nwhere they can select or upload Google Drive files. Users can grant permission to access their\nDrive files, providing a secure and authorized way to interact with their files.\n\nThis is particularly useful when prior tools (e.g., those accessing or modifying\nGoogle Docs, Google Sheets, etc.) encountered failures due to file non-existence\n(Requested entity was not found) or permission errors. Once the user completes the file\npicker flow, the prior tool can be retried.\n\nSuggest this tool to users when they are surprised or confused that the file they are\nsearching for or attempting to access cannot be found.",
+      "fullyQualifiedName": "GoogleDrive.GenerateGoogleFilePickerUrl@6.0.0",
+      "description": "Generate a URL where the user can grant this app access to specific Drive files.\n\nOpens Google's first-party Drive picker. The user selects which files to share\nwith this application — it is not a sign-in or credential prompt.\n\nUse this when a prior tool reported that a file was not found or access was denied,\nand the user expects the file to exist. After the user completes the picker flow,\nretry the prior tool.",
       "parameters": [],
       "auth": {
         "providerId": "google",
@@ -327,7 +348,7 @@
     {
       "name": "GetFileTreeStructure",
       "qualifiedName": "GoogleDrive.GetFileTreeStructure",
-      "fullyQualifiedName": "GoogleDrive.GetFileTreeStructure@5.3.0",
+      "fullyQualifiedName": "GoogleDrive.GetFileTreeStructure@6.0.0",
       "description": "Get the file/folder tree structure of the user's entire Google Drive.\nVery inefficient for large drives. Use with caution.",
       "parameters": [
         {
@@ -402,8 +423,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "A dictionary containing the file/folder tree structure in the user's Google Drive"
@@ -418,7 +446,7 @@
             "required": false
           },
           "restrict_to_shared_drive_id": {
-            "value": "123abc456def",
+            "value": "0AJ9Ks8dHkGxUUk9PVA",
             "type": "string",
             "required": false
           },
@@ -429,14 +457,14 @@
           },
           "order_by": {
             "value": [
-              "name",
-              "modifiedTime"
+              "modifiedTime desc",
+              "name asc"
             ],
             "type": "array",
             "required": false
           },
           "limit": {
-            "value": 50,
+            "value": 100,
             "type": "integer",
             "required": false
           }
@@ -466,7 +494,7 @@
     {
       "name": "ListFilePermissions",
       "qualifiedName": "GoogleDrive.ListFilePermissions",
-      "fullyQualifiedName": "GoogleDrive.ListFilePermissions@5.3.0",
+      "fullyQualifiedName": "GoogleDrive.ListFilePermissions@6.0.0",
       "description": "List permissions on a Google Drive file or folder.\n\nReturns the individual people (and groups) with access and the current General access\n(link sharing) state. `general_access` is computed across the ENTIRE file regardless of\nfiltering -- so \"is this doc public?\" is always answered authoritatively.\n\nWhen `roles` is provided, `people` and `total_people` reflect only collaborators whose\nrole matches the filter. Truncated collaborators beyond `limit` are not returned;\n`has_more` indicates whether truncation occurred.",
       "parameters": [
         {
@@ -515,13 +543,51 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "File permissions including per-person grants and the current General access (link) state"
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "GoogleDrive.ListFilePermissions",
+        "parameters": {
+          "file_path_or_id": {
+            "value": "Marketing/Campaigns/Q3_Report.pdf",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "roles": {
+            "value": [
+              "owner",
+              "writer"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "shared_drive_id": {
+            "value": "0AFs3mFqBwK2hUk9PVA",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -543,7 +609,7 @@
     {
       "name": "MoveFile",
       "qualifiedName": "GoogleDrive.MoveFile",
-      "fullyQualifiedName": "GoogleDrive.MoveFile@5.3.0",
+      "fullyQualifiedName": "GoogleDrive.MoveFile@6.0.0",
       "description": "Move a file or folder to a different folder within the same Google Drive.\n\nCan move to a folder (keeping name), or move and rename in one operation. By default, paths\nare resolved in My Drive. For shared drives, use file IDs or provide shared_drive_id.",
       "parameters": [
         {
@@ -586,8 +652,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "Confirmation with the file's ID, name, and new location"
@@ -597,22 +670,22 @@
         "toolName": "GoogleDrive.MoveFile",
         "parameters": {
           "source_file_path_or_id": {
-            "value": "folder1/subfolder1/document.txt",
+            "value": "Projects/2024/Q1_Report.docx",
             "type": "string",
             "required": true
           },
           "destination_folder_path_or_id": {
-            "value": "folder2/subfolder2",
+            "value": "Archive/2024",
             "type": "string",
             "required": false
           },
           "new_filename": {
-            "value": "new_document.txt",
+            "value": "Q1_Report_Final.docx",
             "type": "string",
             "required": false
           },
           "shared_drive_id": {
-            "value": null,
+            "value": "0AHv3kqDxyz123UK9PVA",
             "type": "string",
             "required": false
           }
@@ -642,7 +715,7 @@
     {
       "name": "RemoveAllCollaborators",
       "qualifiedName": "GoogleDrive.RemoveAllCollaborators",
-      "fullyQualifiedName": "GoogleDrive.RemoveAllCollaborators@5.3.0",
+      "fullyQualifiedName": "GoogleDrive.RemoveAllCollaborators@6.0.0",
       "description": "Remove all user collaborators (and optionally groups) from a Google Drive file.\n\nThe file owner and the calling user are always preserved. Groups are preserved by default\nbecause the Drive API cannot verify group membership -- pass include_groups=True to opt in.\nInherited shared-drive permissions are never removable from the file level and are skipped.\n\nUse except_people to preserve additional people or groups by email or name. Ambiguous or\nunmatched except_people entries raise an error to avoid accidentally removing someone the\ncaller meant to keep.",
       "parameters": [
         {
@@ -686,13 +759,51 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "Summary of removed and preserved permissions"
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "GoogleDrive.RemoveAllCollaborators",
+        "parameters": {
+          "file_path_or_id": {
+            "value": "Projects/2024/Q3_Report.docx",
+            "type": "string",
+            "required": true
+          },
+          "except_people": {
+            "value": [
+              "alice@example.com",
+              "bob.smith@company.org"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "include_groups": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "shared_drive_id": {
+            "value": "0AKbGFpGVZXSHUk9PVA",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -714,7 +825,7 @@
     {
       "name": "RenameFile",
       "qualifiedName": "GoogleDrive.RenameFile",
-      "fullyQualifiedName": "GoogleDrive.RenameFile@5.3.0",
+      "fullyQualifiedName": "GoogleDrive.RenameFile@6.0.0",
       "description": "Rename a file or folder in Google Drive.\n\nBy default, paths are resolved in My Drive. For files in shared drives, either use the file ID\ndirectly or provide the shared_drive_id parameter.",
       "parameters": [
         {
@@ -749,8 +860,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "Confirmation with the file's new name, ID, and web view link"
@@ -760,17 +878,17 @@
         "toolName": "GoogleDrive.RenameFile",
         "parameters": {
           "file_path_or_id": {
-            "value": "folder/subfolder/old_filename.txt",
+            "value": "Projects/2024/Q1_Report.docx",
             "type": "string",
             "required": true
           },
           "new_filename": {
-            "value": "new_filename.txt",
+            "value": "Q1_Annual_Report_2024.docx",
             "type": "string",
             "required": true
           },
           "shared_drive_id": {
-            "value": "12345abcd",
+            "value": "0AJ1234abcDEFghIJ",
             "type": "string",
             "required": false
           }
@@ -800,7 +918,7 @@
     {
       "name": "RevokeFileAccess",
       "qualifiedName": "GoogleDrive.RevokeFileAccess",
-      "fullyQualifiedName": "GoogleDrive.RevokeFileAccess@5.3.0",
+      "fullyQualifiedName": "GoogleDrive.RevokeFileAccess@6.0.0",
       "description": "Revoke access for specific people or groups on a Google Drive file.\n\nIdentifies matches by email (exact, case-insensitive) or display name. When an input\nmatches multiple people, the clear matches are still revoked and the ambiguous input is\nsurfaced in the `ambiguous` response field with candidate details so the agent can\nre-prompt the user for just the uncertain ones. Inputs that don't match any collaborator\nare returned in `not_found`. Pending-owner matches (mid-ownership-transfer) are skipped\nand surfaced in `skipped_pending_owner` so the clean revokes in the batch still land.\nOwner permissions cannot be revoked -- transfer ownership first.\n\nWhen a grantee has both a direct and an inherited permission (e.g., shared-drive member\nalso granted directly on the file), revoking the direct row leaves the inherited access\nintact. The inherited row is surfaced in `skipped_inherited` so callers don't assume the\ngrantee is fully removed -- inherited access must be adjusted at the shared drive level.",
       "parameters": [
         {
@@ -836,13 +954,47 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "Summary of revoked permissions, including any inputs that could not be matched"
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "GoogleDrive.RevokeFileAccess",
+        "parameters": {
+          "file_path_or_id": {
+            "value": "Projects/Q3_Reports/budget_summary.xlsx",
+            "type": "string",
+            "required": true
+          },
+          "people": {
+            "value": [
+              "alice.johnson@example.com",
+              "bob.smith@example.com",
+              "Carol Williams"
+            ],
+            "type": "array",
+            "required": true
+          },
+          "shared_drive_id": {
+            "value": "0ABCdEfGhIjKlMnOp",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -864,7 +1016,7 @@
     {
       "name": "SearchFiles",
       "qualifiedName": "GoogleDrive.SearchFiles",
-      "fullyQualifiedName": "GoogleDrive.SearchFiles@5.3.0",
+      "fullyQualifiedName": "GoogleDrive.SearchFiles@6.0.0",
       "description": "Search for files in Google Drive.\n\nThe provided 'query' should only contain the search terms.\nThe tool will construct the full search query for you.",
       "parameters": [
         {
@@ -977,8 +1129,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "Search results containing matching files from Google Drive with metadata and file information"
@@ -988,17 +1147,17 @@
         "toolName": "GoogleDrive.SearchFiles",
         "parameters": {
           "query": {
-            "value": "project plan",
+            "value": "quarterly financial report 2024",
             "type": "string",
             "required": true
           },
           "folder_path_or_id": {
-            "value": "2023/ProjectX",
+            "value": "reports/finance",
             "type": "string",
             "required": false
           },
           "shared_drive_id": {
-            "value": "0B12abcDEfgHIJklMNO",
+            "value": "0ABCxyz123456789",
             "type": "string",
             "required": false
           },
@@ -1014,20 +1173,22 @@
           },
           "order_by": {
             "value": [
-              "modifiedTime desc"
+              "modifiedTime desc",
+              "name asc"
             ],
             "type": "array",
             "required": false
           },
           "limit": {
-            "value": 20,
+            "value": 25,
             "type": "integer",
             "required": false
           },
           "file_types": {
             "value": [
-              "application/vnd.google-apps.document",
-              "application/pdf"
+              "document",
+              "spreadsheet",
+              "pdf"
             ],
             "type": "array",
             "required": false
@@ -1058,7 +1219,7 @@
     {
       "name": "SetGeneralAccess",
       "qualifiedName": "GoogleDrive.SetGeneralAccess",
-      "fullyQualifiedName": "GoogleDrive.SetGeneralAccess@5.3.0",
+      "fullyQualifiedName": "GoogleDrive.SetGeneralAccess@6.0.0",
       "description": "Change the 'General access' (link sharing) setting on a Google Drive file.\n\nIdempotent: calling with the same state as the current configuration is a no-op. When access\nis 'domain', the link is scoped to the caller's email domain -- NOT the file owner's domain.\nFor cross-org collaboration (e.g., editing a file owned by another organization), confirm\nwith the user which domain they intend before calling. Google will reject domain sharing\nfor personal accounts (gmail.com, outlook.com, etc.) -- the tool translates that rejection\ninto a friendly error.\n\nThe response's `access` and `role` fields report the EFFECTIVE state after the transition,\nnot the requested state. For files on shared drives, inherited link permissions cannot be\nchanged from the file level -- if the request would have required removing an inherited\npermission, the effective state will reflect the inherited permission that remained. When\n`skipped_inherited` is non-empty, inspect it to understand why effective state may differ\nfrom what was requested.",
       "parameters": [
         {
@@ -1117,13 +1278,53 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "New General access state, including previous state for reference"
       },
       "documentationChunks": [],
+      "codeExample": {
+        "toolName": "GoogleDrive.SetGeneralAccess",
+        "parameters": {
+          "file_path_or_id": {
+            "value": "Projects/Q3Reports/summary_report.pdf",
+            "type": "string",
+            "required": true
+          },
+          "access": {
+            "value": "anyone",
+            "type": "string",
+            "required": false
+          },
+          "role": {
+            "value": "commenter",
+            "type": "string",
+            "required": false
+          },
+          "allow_discovery": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "shared_drive_id": {
+            "value": "0ABCdEfGhIjKlMnO",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
       "metadata": {
         "classification": {
           "serviceDomains": [
@@ -1145,7 +1346,7 @@
     {
       "name": "ShareFile",
       "qualifiedName": "GoogleDrive.ShareFile",
-      "fullyQualifiedName": "GoogleDrive.ShareFile@5.3.0",
+      "fullyQualifiedName": "GoogleDrive.ShareFile@6.0.0",
       "description": "Share a file or folder in Google Drive with specific people by granting them permissions.\n\nIf a user already has permission on the file, their role will be updated to the new role.\nBy default, paths are resolved in My Drive. For shared drives, use file IDs or provide\nshared_drive_id.",
       "parameters": [
         {
@@ -1210,8 +1411,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "Sharing confirmation with list of granted permissions including recipient emails and roles"
@@ -1221,20 +1429,20 @@
         "toolName": "GoogleDrive.ShareFile",
         "parameters": {
           "file_path_or_id": {
-            "value": "folder1/subfolder1/file1.pdf",
+            "value": "Projects/Q3_Reports/sales_summary.xlsx",
             "type": "string",
             "required": true
           },
           "email_addresses": {
             "value": [
-              "user1@example.com",
-              "user2@example.com"
+              "alice@example.com",
+              "bob@company.org"
             ],
             "type": "array",
             "required": true
           },
           "role": {
-            "value": "editor",
+            "value": "reader",
             "type": "string",
             "required": false
           },
@@ -1244,12 +1452,12 @@
             "required": false
           },
           "message": {
-            "value": "Please find the file attached.",
+            "value": "Hi team, I've shared the Q3 sales summary with you. Please review and let me know if you have any questions!",
             "type": "string",
             "required": false
           },
           "shared_drive_id": {
-            "value": "abc123def456",
+            "value": "0AHv3kQKlMqBcUk9PVA",
             "type": "string",
             "required": false
           }
@@ -1279,7 +1487,7 @@
     {
       "name": "UploadFile",
       "qualifiedName": "GoogleDrive.UploadFile",
-      "fullyQualifiedName": "GoogleDrive.UploadFile@5.3.0",
+      "fullyQualifiedName": "GoogleDrive.UploadFile@6.0.0",
       "description": "Upload a file to Google Drive from a URL.\n\nFetches the file content from the provided URL and uploads it to Google Drive.\nSupports files of any size - uses resumable upload internally for large files.\n\nCANNOT upload Google Workspace files (Google Docs, Sheets, Slides)\nCANNOT upload files larger than 25MB",
       "parameters": [
         {
@@ -1342,8 +1550,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "Uploaded file information including ID, name, web view link, and location"
@@ -1353,27 +1568,27 @@
         "toolName": "GoogleDrive.UploadFile",
         "parameters": {
           "file_name": {
-            "value": "example_document.pdf",
+            "value": "quarterly_report_2024.pdf",
             "type": "string",
             "required": true
           },
           "source_url": {
-            "value": "https://example.com/files/example_document.pdf",
+            "value": "https://example.com/files/quarterly_report_2024.pdf",
             "type": "string",
             "required": true
           },
           "mime_type": {
-            "value": "application/pdf",
+            "value": "pdf",
             "type": "string",
             "required": false
           },
           "destination_folder_path_or_id": {
-            "value": "Invoices/2023",
+            "value": "Reports/2024/Q1",
             "type": "string",
             "required": false
           },
           "shared_drive_id": {
-            "value": null,
+            "value": "0AaBbCcDdEeFfGgHh",
             "type": "string",
             "required": false
           }
@@ -1403,7 +1618,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleDrive.WhoAmI",
-      "fullyQualifiedName": "GoogleDrive.WhoAmI@5.3.0",
+      "fullyQualifiedName": "GoogleDrive.WhoAmI@6.0.0",
       "description": "Get comprehensive user profile and Google Drive environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Drive storage information, the shared\ndrives (and their IDs) the user has access to, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1453,6 +1668,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-04-27T11:41:15.827Z",
-  "summary": "Arcade's Google Drive toolkit lets developers manage files, folders, sharing, permissions, and authenticated user context through the Google Drive API.\n\n**Capabilities**\n- Create folders, upload files, download files, and download large files in chunks.\n- Move, rename, search, and inspect Drive files and folder trees.\n- Generate a Google File Picker URL for user-driven file selection and authorization recovery.\n- Share files with specific people, inspect collaborators and general access, remove collaborators, and update link-sharing access.\n- Fetch authenticated user profile and Google Drive environment information.\n\n**OAuth**\n- **Provider**: Google\n- **Scopes**: Google Drive file access and Google user profile scopes.\n\n**Secrets**\n- No secret types required for toolkit operation."
+  "generatedAt": "2026-05-28T12:15:56.126Z",
+  "summary": "# Google Drive Toolkit\n\nThe Google Drive toolkit connects Arcade to Google Drive via OAuth, enabling LLMs to manage files, folders, sharing, and permissions on behalf of authenticated users.\n\n## Capabilities\n\n- **File & folder management:** Create folders, move, rename, and search files across My Drive and shared drives (by path or ID).\n- **Upload & download:** Upload files to Drive from a URL (up to 25 MB, non-Workspace formats); download blob files directly or in byte-range chunks for large files.\n- **Permissions & sharing:** Share files with specific people, revoke or bulk-remove collaborators, set general/link-sharing access (including domain scoping), and list all permissions with role filtering.\n- **Drive introspection:** Retrieve the full file/folder tree, look up authenticated user profile and storage info, and enumerate accessible shared drives and their IDs.\n- **File picker integration:** Generate a Google-hosted Drive Picker URL so users can grant the app access to specific files when a prior tool reports not-found or access-denied.\n\n## OAuth\n\nAuthentication uses OAuth 2.0 via the **Google** provider. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details.\n\n## Secrets\n\n- **`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL`** — Controls whether the `GoogleDrive.GenerateGoogleFilePickerUrl` tool surfaces an inline Google Drive Picker URL. This is an Arcade-side feature flag, not a credential issued by Google. Set its value in the Arcade secrets manager to enable the picker flow. There is no external provider dashboard for this secret; it is configured entirely within Arcade.\n\nSee the [Arcade secrets documentation](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to store and reference secrets, or manage them directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/googlesheets.json
+++ b/toolkit-docs-generator/data/toolkits/googlesheets.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleSheets",
   "label": "Google Sheets",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "description": "Arcade.dev LLM tools for Google Sheets.",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "AddNoteToCell",
       "qualifiedName": "GoogleSheets.AddNoteToCell",
-      "fullyQualifiedName": "GoogleSheets.AddNoteToCell@5.2.0",
+      "fullyQualifiedName": "GoogleSheets.AddNoteToCell@6.0.0",
       "description": "Add a note to a specific cell in a spreadsheet. A note is a small\npiece of text attached to a cell (shown with a black triangle) that\nappears when you hover over the cell.\n\nsheet_id_or_name takes precedence over sheet_position. If a sheet is not mentioned,\nthen always assume the default sheet_position is sufficient.",
       "parameters": [
         {
@@ -85,8 +85,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "The status of the operation"
@@ -96,12 +103,12 @@
         "toolName": "GoogleSheets.AddNoteToCell",
         "parameters": {
           "spreadsheet_id": {
-            "value": "1A2B3C4D5E6F7G8H9I0J",
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
           },
           "column": {
-            "value": "B",
+            "value": "C",
             "type": "string",
             "required": true
           },
@@ -111,7 +118,7 @@
             "required": true
           },
           "note_text": {
-            "value": "This is a note regarding the data in this cell.",
+            "value": "This value was updated on Q3 review — please verify before publishing.",
             "type": "string",
             "required": true
           },
@@ -121,7 +128,7 @@
             "required": false
           },
           "sheet_id_or_name": {
-            "value": "Monthly Report",
+            "value": "Sales Data",
             "type": "string",
             "required": false
           }
@@ -151,7 +158,7 @@
     {
       "name": "CreateSpreadsheet",
       "qualifiedName": "GoogleSheets.CreateSpreadsheet",
-      "fullyQualifiedName": "GoogleSheets.CreateSpreadsheet@5.2.0",
+      "fullyQualifiedName": "GoogleSheets.CreateSpreadsheet@6.0.0",
       "description": "Create a new spreadsheet with the provided title and data in its first sheet\n\nReturns the newly created spreadsheet's id and title",
       "parameters": [
         {
@@ -224,8 +231,8 @@
     {
       "name": "GenerateGoogleFilePickerUrl",
       "qualifiedName": "GoogleSheets.GenerateGoogleFilePickerUrl",
-      "fullyQualifiedName": "GoogleSheets.GenerateGoogleFilePickerUrl@5.2.0",
-      "description": "Generate a Google File Picker URL for user-driven file selection and authorization.\n\nThis tool generates a URL that directs the end-user to a Google File Picker interface where\nwhere they can select or upload Google Drive files. Users can grant permission to access their\nDrive files, providing a secure and authorized way to interact with their files.\n\nThis is particularly useful when prior tools (e.g., those accessing or modifying\nGoogle Docs, Google Sheets, etc.) encountered failures due to file non-existence\n(Requested entity was not found) or permission errors. Once the user completes the file\npicker flow, the prior tool can be retried.\n\nSuggest this tool to users when they are surprised or confused that the file they are\nsearching for or attempting to access cannot be found.",
+      "fullyQualifiedName": "GoogleSheets.GenerateGoogleFilePickerUrl@6.0.0",
+      "description": "Generate a URL where the user can grant this app access to specific Drive files.\n\nOpens Google's first-party Drive picker. The user selects which files to share\nwith this application — it is not a sign-in or credential prompt.\n\nUse this when a prior tool reported that a file was not found or access was denied,\nand the user expects the file to exist. After the user completes the picker flow,\nretry the prior tool.",
       "parameters": [],
       "auth": {
         "providerId": "google",
@@ -267,7 +274,7 @@
     {
       "name": "GetSpreadsheet",
       "qualifiedName": "GoogleSheets.GetSpreadsheet",
-      "fullyQualifiedName": "GoogleSheets.GetSpreadsheet@5.2.0",
+      "fullyQualifiedName": "GoogleSheets.GetSpreadsheet@6.0.0",
       "description": "Gets the specified range of cells from a single sheet in the spreadsheet.\n\nsheet_id_or_name takes precedence over sheet_position. If a sheet is not mentioned,\nthen always assume the default sheet_position is sufficient.",
       "parameters": [
         {
@@ -334,8 +341,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "The spreadsheet properties and data for the specified sheet in the spreadsheet"
@@ -345,22 +359,22 @@
         "toolName": "GoogleSheets.GetSpreadsheet",
         "parameters": {
           "spreadsheet_id": {
-            "value": "12345abcde",
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
           },
           "sheet_position": {
-            "value": 1,
+            "value": 2,
             "type": "integer",
             "required": false
           },
           "sheet_id_or_name": {
-            "value": "SalesData",
+            "value": "Sales Data",
             "type": "string",
             "required": false
           },
           "start_row": {
-            "value": 2,
+            "value": 3,
             "type": "integer",
             "required": false
           },
@@ -370,12 +384,12 @@
             "required": false
           },
           "max_rows": {
-            "value": 50,
+            "value": 500,
             "type": "integer",
             "required": false
           },
           "max_cols": {
-            "value": 10,
+            "value": 20,
             "type": "integer",
             "required": false
           }
@@ -405,7 +419,7 @@
     {
       "name": "GetSpreadsheetMetadata",
       "qualifiedName": "GoogleSheets.GetSpreadsheetMetadata",
-      "fullyQualifiedName": "GoogleSheets.GetSpreadsheetMetadata@5.2.0",
+      "fullyQualifiedName": "GoogleSheets.GetSpreadsheetMetadata@6.0.0",
       "description": "Gets the metadata for a spreadsheet including the metadata for the sheets in the spreadsheet.\n\nUse this tool to get the name, position, ID, and URL of all sheets in a spreadsheet as well as\nthe number of rows and columns in each sheet.\n\nDoes not return the content/data of the sheets in the spreadsheet - only the metadata.\nExcludes spreadsheets that are in the trash.",
       "parameters": [
         {
@@ -424,8 +438,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "The spreadsheet metadata for the specified spreadsheet"
@@ -435,7 +456,7 @@
         "toolName": "GoogleSheets.GetSpreadsheetMetadata",
         "parameters": {
           "spreadsheet_id": {
-            "value": "1BxiMVs0x8gXj8lQySYqE3g5bQs8D_rPG6lXErnKPZsg",
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
           }
@@ -465,7 +486,7 @@
     {
       "name": "SearchSpreadsheets",
       "qualifiedName": "GoogleSheets.SearchSpreadsheets",
-      "fullyQualifiedName": "GoogleSheets.SearchSpreadsheets@5.2.0",
+      "fullyQualifiedName": "GoogleSheets.SearchSpreadsheets@6.0.0",
       "description": "Searches for spreadsheets in the user's Google Drive based on the titles and content and\nreturns the title, ID, and URL for each matching spreadsheet.\n\nDoes not return the content/data of the sheets in the spreadsheets - only the metadata.\nExcludes spreadsheets that are in the trash.",
       "parameters": [
         {
@@ -566,8 +587,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "A dictionary containing the title, ID, and URL for each matching spreadsheet. Also contains a pagination token if there are more spreadsheets to list."
@@ -578,22 +606,22 @@
         "parameters": {
           "spreadsheet_contains": {
             "value": [
-              "financial",
-              "budget"
+              "Q3 Budget",
+              "Finance"
             ],
             "type": "array",
             "required": false
           },
           "spreadsheet_not_contains": {
             "value": [
-              "draft",
-              "old"
+              "Archive",
+              "Draft"
             ],
             "type": "array",
             "required": false
           },
           "search_only_in_shared_drive_id": {
-            "value": "1A2B3C4D5E",
+            "value": "0AHz3pAZmRzXYUk9PVA",
             "type": "string",
             "required": false
           },
@@ -609,18 +637,19 @@
           },
           "order_by": {
             "value": [
-              "lastModifiedTime"
+              "modifiedTime desc",
+              "name asc"
             ],
             "type": "array",
             "required": false
           },
           "limit": {
-            "value": 25,
+            "value": 15,
             "type": "integer",
             "required": false
           },
           "pagination_token": {
-            "value": "abcd1234",
+            "value": "V1*AHRsNm1QZ3h5dGN2ZXJzaW9u",
             "type": "string",
             "required": false
           }
@@ -650,7 +679,7 @@
     {
       "name": "UpdateCells",
       "qualifiedName": "GoogleSheets.UpdateCells",
-      "fullyQualifiedName": "GoogleSheets.UpdateCells@5.2.0",
+      "fullyQualifiedName": "GoogleSheets.UpdateCells@6.0.0",
       "description": "Write values to a Google Sheet using a flexible data format.\n\nsheet_id_or_name takes precedence over sheet_position. If a sheet is not mentioned,\nthen always assume the default sheet_position is sufficient.",
       "parameters": [
         {
@@ -693,8 +722,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "The status of the operation, including updated ranges and counts"
@@ -704,12 +740,12 @@
         "toolName": "GoogleSheets.UpdateCells",
         "parameters": {
           "spreadsheet_id": {
-            "value": "1A2B3C4D5E6F7G8H9I0J",
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
           },
           "data": {
-            "value": "{\"23\":{\"A\":\"Value1\",\"B\":123,\"C\":45.67,\"D\":true}}",
+            "value": "{\"1\": {\"A\": \"Name\", \"B\": \"Age\", \"C\": \"Score\"}, \"2\": {\"A\": \"Alice\", \"B\": 30, \"C\": 95.5}, \"3\": {\"A\": \"Bob\", \"B\": 25, \"C\": 87.0}, \"4\": {\"A\": \"Charlie\", \"B\": 35, \"C\": true}}",
             "type": "string",
             "required": true
           },
@@ -719,7 +755,7 @@
             "required": false
           },
           "sheet_id_or_name": {
-            "value": "SalesData",
+            "value": "Sheet1",
             "type": "string",
             "required": false
           }
@@ -749,7 +785,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleSheets.WhoAmI",
-      "fullyQualifiedName": "GoogleSheets.WhoAmI@5.2.0",
+      "fullyQualifiedName": "GoogleSheets.WhoAmI@6.0.0",
       "description": "Get comprehensive user profile and Google Sheets environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Sheets access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -796,7 +832,7 @@
     {
       "name": "WriteToCell",
       "qualifiedName": "GoogleSheets.WriteToCell",
-      "fullyQualifiedName": "GoogleSheets.WriteToCell@5.2.0",
+      "fullyQualifiedName": "GoogleSheets.WriteToCell@6.0.0",
       "description": "Write a value to a single cell in a spreadsheet.",
       "parameters": [
         {
@@ -847,8 +883,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "The status of the operation"
@@ -858,27 +901,27 @@
         "toolName": "GoogleSheets.WriteToCell",
         "parameters": {
           "spreadsheet_id": {
-            "value": "1aBcD2EfGhIjKlMnOqRsTuVwXyZ",
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
           },
           "column": {
-            "value": "B",
+            "value": "C",
             "type": "string",
             "required": true
           },
           "row": {
-            "value": 10,
+            "value": 7,
             "type": "integer",
             "required": true
           },
           "value": {
-            "value": "Hello, World!",
+            "value": "Q3 Revenue",
             "type": "string",
             "required": true
           },
           "sheet_name": {
-            "value": "Data",
+            "value": "Summary",
             "type": "string",
             "required": false
           }
@@ -911,6 +954,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-02-26T20:45:10.404Z",
-  "summary": "Arcade.dev provides LLM tools for Google Sheets, enabling seamless interactions with spreadsheet data through API integration. This toolkit allows developers to automate tasks, manage files, and enhance user experience in Google Sheets.\n\n### Capabilities\n- Create and manage spreadsheets with flexible data formats.\n- Retrieve and update cell contents efficiently.\n- Access user profile information and permissions.\n- Generate file picker URLs for user-driven file selection and authorization.\n\n### OAuth\n- **Provider**: Google  \n- **Scopes**:  \n  - `https://www.googleapis.com/auth/drive.file`  \n  - `https://www.googleapis.com/auth/userinfo.email`  \n  - `https://www.googleapis.com/auth/userinfo.profile`\n\n### Secrets\n- No secret types or names are specified."
+  "generatedAt": "2026-05-28T12:15:57.058Z",
+  "summary": "The Google Sheets toolkit lets LLM agents create, read, search, and edit Google Sheets spreadsheets through Arcade, using Google OAuth for delegated user access.\n\n## Capabilities\n\n- **Spreadsheet discovery & metadata** — search across a user's Drive for spreadsheets by title/content, retrieve full sheet metadata (names, positions, IDs, URLs, dimensions) without loading cell data.\n- **Reading data** — fetch cell ranges from any sheet within a spreadsheet, with flexible sheet targeting by name, ID, or position.\n- **Writing & editing** — create new spreadsheets with initial data, write a single cell value, bulk-update cell ranges with flexible data formats, and attach hover notes to individual cells.\n- **File access recovery** — generate a Google Drive inline file-picker URL so users can grant the app access to specific files when a prior operation fails due to missing permissions, then retry the original tool.\n- **Identity & permissions inspection** — retrieve the authenticated user's profile, email, and Google Sheets access permissions via `WhoAmI`.\n\n## OAuth\n\nThis toolkit uses **Google OAuth 2.0** to act on behalf of the authenticated user. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for scopes, setup, and configuration details.\n\n## Secrets\n\n- **`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL`** — An API key that enables the `GoogleSheets.GenerateGoogleFilePickerUrl` tool to render Google's first-party Drive file picker. To obtain it, go to the [Google Cloud Console APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials) page for your project, click **Create credentials → API key**, and ensure the Google Picker API is enabled for your project under **APIs & Services → Library**. Restrict the key to the Picker API and to allowed HTTP referrers/origins as appropriate for your deployment. See [Google Picker API documentation](https://developers.google.com/drive/picker/guides/overview) for full setup details.\n\nStore secrets in Arcade via the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) or directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/googleslides.json
+++ b/toolkit-docs-generator/data/toolkits/googleslides.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleSlides",
   "label": "Google Slides",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "description": "Arcade.dev LLM tools for Google Slides",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "CommentOnPresentation",
       "qualifiedName": "GoogleSlides.CommentOnPresentation",
-      "fullyQualifiedName": "GoogleSlides.CommentOnPresentation@1.4.2",
+      "fullyQualifiedName": "GoogleSlides.CommentOnPresentation@2.0.0",
       "description": "Comment on a specific slide by its index in a Google Slides presentation.",
       "parameters": [
         {
@@ -53,8 +53,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "The comment's ID, presentationId, and slideNumber in a dictionary"
@@ -64,12 +71,12 @@
         "toolName": "GoogleSlides.CommentOnPresentation",
         "parameters": {
           "presentation_id": {
-            "value": "1A2b3C4d5E6fG7h8I9jK0lMnOpQrStUvWxYz",
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
           },
           "comment_text": {
-            "value": "Please update the chart data on slide 2 to reflect Q1 numbers and add a citation for the source.",
+            "value": "Please update the font size on this slide to improve readability.",
             "type": "string",
             "required": true
           }
@@ -99,7 +106,7 @@
     {
       "name": "CreatePresentation",
       "qualifiedName": "GoogleSlides.CreatePresentation",
-      "fullyQualifiedName": "GoogleSlides.CreatePresentation@1.4.2",
+      "fullyQualifiedName": "GoogleSlides.CreatePresentation@2.0.0",
       "description": "Create a new Google Slides presentation\nThe first slide will be populated with the specified title and subtitle.",
       "parameters": [
         {
@@ -172,7 +179,7 @@
     {
       "name": "CreateSlide",
       "qualifiedName": "GoogleSlides.CreateSlide",
-      "fullyQualifiedName": "GoogleSlides.CreateSlide@1.4.2",
+      "fullyQualifiedName": "GoogleSlides.CreateSlide@2.0.0",
       "description": "Create a new slide at the end of the specified presentation",
       "parameters": [
         {
@@ -207,8 +214,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "A URL to the created slide"
@@ -218,17 +232,17 @@
         "toolName": "GoogleSlides.CreateSlide",
         "parameters": {
           "presentation_id": {
-            "value": "1A2b3C4d5E6fGhIjKlMnOpQrStUvWxYz",
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
           },
           "slide_title": {
-            "value": "Q2 Sales Overview",
+            "value": "Q3 Sales Performance Overview",
             "type": "string",
             "required": true
           },
           "slide_body": {
-            "value": "Highlights: Revenue up 12% vs Q1. Key drivers: new product launch and expanded distribution channels. Action items: increase marketing spend in top-performing regions and optimize pricing for SKU 1234.",
+            "value": "Revenue increased by 24% compared to Q2, driven by strong performance in the enterprise segment and successful product launches in APAC markets.",
             "type": "string",
             "required": true
           }
@@ -258,8 +272,8 @@
     {
       "name": "GenerateGoogleFilePickerUrl",
       "qualifiedName": "GoogleSlides.GenerateGoogleFilePickerUrl",
-      "fullyQualifiedName": "GoogleSlides.GenerateGoogleFilePickerUrl@1.4.2",
-      "description": "Generate a Google File Picker URL for user-driven file selection and authorization.\n\nThis tool generates a URL that directs the end-user to a Google File Picker interface where\nwhere they can select or upload Google Drive files. Users can grant permission to access their\nDrive files, providing a secure and authorized way to interact with their files.\n\nThis is particularly useful when prior tools (e.g., those accessing or modifying\nGoogle Docs, Google Sheets, etc.) encountered failures due to file non-existence\n(Requested entity was not found) or permission errors. Once the user completes the file\npicker flow, the prior tool can be retried.\n\nSuggest this tool to users when they are surprised or confused that the file they are\nsearching for or attempting to access cannot be found.",
+      "fullyQualifiedName": "GoogleSlides.GenerateGoogleFilePickerUrl@2.0.0",
+      "description": "Generate a URL where the user can grant this app access to specific Drive files.\n\nOpens Google's first-party Drive picker. The user selects which files to share\nwith this application — it is not a sign-in or credential prompt.\n\nUse this when a prior tool reported that a file was not found or access was denied,\nand the user expects the file to exist. After the user completes the picker flow,\nretry the prior tool.",
       "parameters": [],
       "auth": {
         "providerId": "google",
@@ -301,7 +315,7 @@
     {
       "name": "GetPresentationAsMarkdown",
       "qualifiedName": "GoogleSlides.GetPresentationAsMarkdown",
-      "fullyQualifiedName": "GoogleSlides.GetPresentationAsMarkdown@1.4.2",
+      "fullyQualifiedName": "GoogleSlides.GetPresentationAsMarkdown@2.0.0",
       "description": "Get the specified Google Slides presentation and convert it to markdown.\n\nOnly retrieves the text content of the presentation and formats it as markdown.",
       "parameters": [
         {
@@ -320,8 +334,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "unknown"
+        }
+      ],
       "output": {
         "type": "string",
         "description": "The presentation textual content as markdown"
@@ -331,7 +352,7 @@
         "toolName": "GoogleSlides.GetPresentationAsMarkdown",
         "parameters": {
           "presentation_id": {
-            "value": "1a2B3cD4EfG5HijKlmNOPqrsTuvwxYZ6789",
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
           }
@@ -361,7 +382,7 @@
     {
       "name": "ListPresentationComments",
       "qualifiedName": "GoogleSlides.ListPresentationComments",
-      "fullyQualifiedName": "GoogleSlides.ListPresentationComments@1.4.2",
+      "fullyQualifiedName": "GoogleSlides.ListPresentationComments@2.0.0",
       "description": "List all comments on the specified Google Slides presentation.",
       "parameters": [
         {
@@ -388,8 +409,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "A dictionary containing the comments"
@@ -399,7 +427,7 @@
         "toolName": "GoogleSlides.ListPresentationComments",
         "parameters": {
           "presentation_id": {
-            "value": "1A2B3cD4eF5GhIjKlMnOpQrStUvWxYz",
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
           },
@@ -434,7 +462,7 @@
     {
       "name": "SearchPresentations",
       "qualifiedName": "GoogleSlides.SearchPresentations",
-      "fullyQualifiedName": "GoogleSlides.SearchPresentations@1.4.2",
+      "fullyQualifiedName": "GoogleSlides.SearchPresentations@2.0.0",
       "description": "Searches for presentations in the user's Google Drive.\nExcludes presentations that are in the trash.",
       "parameters": [
         {
@@ -535,8 +563,15 @@
           "https://www.googleapis.com/auth/drive.file"
         ]
       },
-      "secrets": [],
-      "secretsInfo": [],
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
       "output": {
         "type": "json",
         "description": "A dictionary containing 'presentations_count' (number of presentations returned) and 'presentations' (a list of presentation details including 'kind', 'mimeType', 'id', and 'name' for each presentation)"
@@ -547,9 +582,8 @@
         "parameters": {
           "presentation_contains": {
             "value": [
-              "annual report",
-              "Q4 sales",
-              "financial summary"
+              "quarterly report",
+              "sales"
             ],
             "type": "array",
             "required": false
@@ -557,14 +591,13 @@
           "presentation_not_contains": {
             "value": [
               "draft",
-              "confidential",
-              "internal only"
+              "archived"
             ],
             "type": "array",
             "required": false
           },
           "search_only_in_shared_drive_id": {
-            "value": "0A1B2C3D4EFGHIJKLMNOP",
+            "value": "0AHv3zDrXYZ123abc456",
             "type": "string",
             "required": false
           },
@@ -587,12 +620,12 @@
             "required": false
           },
           "limit": {
-            "value": 25,
+            "value": 10,
             "type": "integer",
             "required": false
           },
           "pagination_token": {
-            "value": "Cg0KC2V4YW1wbGVfdG9rZW4xMjM",
+            "value": "eyJzdGFydEluZGV4IjoxMCwicGFnZVNpemUiOjEwfQ==",
             "type": "string",
             "required": false
           }
@@ -622,7 +655,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleSlides.WhoAmI",
-      "fullyQualifiedName": "GoogleSlides.WhoAmI@1.4.2",
+      "fullyQualifiedName": "GoogleSlides.WhoAmI@2.0.0",
       "description": "Get comprehensive user profile and Google Slides environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Slides access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -680,6 +713,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-02-26T20:45:10.410Z",
-  "summary": "Arcade.dev provides a powerful toolkit for Google Slides, enabling seamless integration and manipulation of presentations within Google Drive. This toolkit allows developers to automate various tasks related to presentation management, enhancing productivity and collaboration.\n\n**Capabilities**\n- Generate, modify, and comment on slides within presentations.\n- Create new Google Slides presentations with specified content.\n- Retrieve presentations and convert them to markdown format.\n- Search for and list presentations in the user's Google Drive.\n- Access comprehensive user profile information and permissions.\n\n**OAuth**\n- Provider: Google\n- Scopes: [https://www.googleapis.com/auth/drive.file, https://www.googleapis.com/auth/userinfo.email, https://www.googleapis.com/auth/userinfo.profile]"
+  "generatedAt": "2026-05-28T12:15:56.863Z",
+  "summary": "The Google Slides toolkit lets Arcade-powered LLMs create, read, search, and annotate Google Slides presentations on behalf of authenticated users.\n\n## Capabilities\n\n- **Presentation management**: Create new presentations with a title and subtitle, or retrieve the full text content of any accessible presentation as Markdown.\n- **Slide & comment authoring**: Add slides to an existing presentation and post comments on specific slides by index; list all comments on a presentation.\n- **Search & discovery**: Search the authenticated user's Google Drive for presentations (trash excluded) and resolve access issues via the Google Drive inline file picker.\n- **Identity & environment inspection**: Retrieve the authenticated user's profile, email, permissions, and Google Slides environment details.\n\n## OAuth\n\nUses OAuth 2.0 via Google. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details.\n\n## Secrets\n\n- **`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL`**: Controls whether the `GoogleSlides.GenerateGoogleFilePickerUrl` tool is available. This secret is expected to be a URL (or a flag value) that enables the Google Drive inline picker flow — the mechanism that lets a user grant the app access to specific Drive files without a full re-authentication. This is not a standard Google API credential; it is an application-level configuration value specific to your Arcade deployment. Set this in your Arcade secrets store. Consult the [Arcade secrets documentation](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to configure it, and manage your values at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-21T12:10:50.316Z",
+  "generatedAt": "2026-05-28T12:16:15.122Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -239,7 +239,7 @@
     {
       "id": "Github",
       "label": "GitHub",
-      "version": "3.2.0",
+      "version": "4.0.0",
       "category": "development",
       "type": "arcade",
       "toolCount": 42,
@@ -284,7 +284,7 @@
     {
       "id": "GoogleDocs",
       "label": "Google Docs",
-      "version": "6.0.0",
+      "version": "7.0.0",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 13,
@@ -293,7 +293,7 @@
     {
       "id": "GoogleDrive",
       "label": "Google Drive",
-      "version": "5.3.0",
+      "version": "6.0.0",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 15,
@@ -365,7 +365,7 @@
     {
       "id": "GoogleSheets",
       "label": "Google Sheets",
-      "version": "5.2.0",
+      "version": "6.0.0",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 9,
@@ -383,7 +383,7 @@
     {
       "id": "GoogleSlides",
       "label": "Google Slides",
-      "version": "1.4.2",
+      "version": "2.0.0",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 8,
@@ -500,7 +500,7 @@
     {
       "id": "Jira",
       "label": "Jira",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "category": "productivity",
       "type": "auth",
       "toolCount": 43,
@@ -599,7 +599,7 @@
     {
       "id": "MicrosoftSharepoint",
       "label": "Microsoft SharePoint",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 36,
@@ -608,7 +608,7 @@
     {
       "id": "MicrosoftTeams",
       "label": "Microsoft Teams",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "category": "social",
       "type": "arcade",
       "toolCount": 25,
@@ -734,7 +734,7 @@
     {
       "id": "Slack",
       "label": "Slack",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "category": "social",
       "type": "arcade",
       "toolCount": 10,

--- a/toolkit-docs-generator/data/toolkits/jira.json
+++ b/toolkit-docs-generator/data/toolkits/jira.json
@@ -1,7 +1,7 @@
 {
   "id": "Jira",
   "label": "Jira",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Arcade.dev LLM tools for interacting with Atlassian Jira",
   "metadata": {
     "category": "productivity",
@@ -35,7 +35,7 @@
     {
       "name": "AddCommentToIssue",
       "qualifiedName": "Jira.AddCommentToIssue",
-      "fullyQualifiedName": "Jira.AddCommentToIssue@3.1.3",
+      "fullyQualifiedName": "Jira.AddCommentToIssue@3.1.4",
       "description": "Add a comment to a Jira issue.",
       "parameters": [
         {
@@ -154,7 +154,7 @@
     {
       "name": "AddIssuesToSprint",
       "qualifiedName": "Jira.AddIssuesToSprint",
-      "fullyQualifiedName": "Jira.AddIssuesToSprint@3.1.3",
+      "fullyQualifiedName": "Jira.AddIssuesToSprint@3.1.4",
       "description": "Add a list of issues to a sprint.\nMaximum of 50 issues per operation.",
       "parameters": [
         {
@@ -249,7 +249,7 @@
     {
       "name": "AddLabelsToIssue",
       "qualifiedName": "Jira.AddLabelsToIssue",
-      "fullyQualifiedName": "Jira.AddLabelsToIssue@3.1.3",
+      "fullyQualifiedName": "Jira.AddLabelsToIssue@3.1.4",
       "description": "Add labels to an existing Jira issue.",
       "parameters": [
         {
@@ -356,7 +356,7 @@
     {
       "name": "AttachFileToIssue",
       "qualifiedName": "Jira.AttachFileToIssue",
-      "fullyQualifiedName": "Jira.AttachFileToIssue@3.1.3",
+      "fullyQualifiedName": "Jira.AttachFileToIssue@3.1.4",
       "description": "Add an attachment to an issue.\n\nMust provide exactly one of file_content_str or file_content_base64.",
       "parameters": [
         {
@@ -495,8 +495,8 @@
     {
       "name": "CreateIssue",
       "qualifiedName": "Jira.CreateIssue",
-      "fullyQualifiedName": "Jira.CreateIssue@3.1.3",
-      "description": "Create a new Jira issue.\n\nProvide a value to one of `project` or `parent_issue` arguments. If `project` and\n`parent_issue` are not provided, the tool will select the single project available.\nIf the user has multiple, an error will be returned with the available projects to choose from.\n\nIF YOU DO NOT FOLLOW THE INSTRUCTIONS BELOW AND UNNECESSARILY CALL MULTIPLE TOOLS IN ORDER TO\nCREATE AN ISSUE, TOO MUCH CO2 WILL BE RELEASED IN THE ATMOSPHERE AND YOU WILL CAUSE THE\nDESTRUCTION OF PLANET EARTH BY CATASTROPHIC CLIMATE CHANGE.\n\nIf you have an issue type name, or a project key/name, a priority name, an assignee\nname/key/email, or a reporter name/key/email, DO NOT CALL OTHER TOOLS only to list available\nprojects, priorities, issue types, or users. Provide the name, key, or email and the tool\nwill figure out the ID, WITHOUT CAUSING CATASTROPHIC CLIMATE CHANGE.",
+      "fullyQualifiedName": "Jira.CreateIssue@3.1.4",
+      "description": "Create a new Jira issue.\n\nProvide a value to one of `project` or `parent_issue` arguments. If `project` and\n`parent_issue` are not provided, the tool will select the single project available.\nIf the user has multiple, an error will be returned with the available projects to choose from.\n\nIf you have an issue type name, or a project key/name, a priority name, an assignee\nname/key/email, or a reporter name/key/email, DO NOT CALL OTHER TOOLS only to list available\nprojects, priorities, issue types, or users. Provide the name, key, or email and the tool\nwill figure out the ID.",
       "parameters": [
         {
           "name": "title",
@@ -706,7 +706,7 @@
     {
       "name": "DownloadAttachment",
       "qualifiedName": "Jira.DownloadAttachment",
-      "fullyQualifiedName": "Jira.DownloadAttachment@3.1.3",
+      "fullyQualifiedName": "Jira.DownloadAttachment@3.1.4",
       "description": "Download the contents of an attachment associated with an issue.",
       "parameters": [
         {
@@ -780,7 +780,7 @@
     {
       "name": "GetAttachmentMetadata",
       "qualifiedName": "Jira.GetAttachmentMetadata",
-      "fullyQualifiedName": "Jira.GetAttachmentMetadata@3.1.3",
+      "fullyQualifiedName": "Jira.GetAttachmentMetadata@3.1.4",
       "description": "Get the metadata of an attachment.",
       "parameters": [
         {
@@ -854,7 +854,7 @@
     {
       "name": "GetAvailableAtlassianClouds",
       "qualifiedName": "Jira.GetAvailableAtlassianClouds",
-      "fullyQualifiedName": "Jira.GetAvailableAtlassianClouds@3.1.3",
+      "fullyQualifiedName": "Jira.GetAvailableAtlassianClouds@3.1.4",
       "description": "Get available Atlassian Clouds.",
       "parameters": [],
       "auth": {
@@ -899,7 +899,7 @@
     {
       "name": "GetBoardBacklogIssues",
       "qualifiedName": "Jira.GetBoardBacklogIssues",
-      "fullyQualifiedName": "Jira.GetBoardBacklogIssues@3.1.3",
+      "fullyQualifiedName": "Jira.GetBoardBacklogIssues@3.1.4",
       "description": "Get all issues in a board's backlog with pagination support.\nReturns issues that are not currently assigned to any active sprint.\n\nThe backlog contains issues that are ready to be planned into future sprints.\nOnly boards that support backlogs (like Scrum and Kanban boards) will return results.",
       "parameters": [
         {
@@ -999,7 +999,7 @@
     {
       "name": "GetBoards",
       "qualifiedName": "Jira.GetBoards",
-      "fullyQualifiedName": "Jira.GetBoards@3.1.3",
+      "fullyQualifiedName": "Jira.GetBoards@3.1.4",
       "description": "Retrieve Jira boards either by specifying their names or IDs, or get all\navailable boards.\nAll requests support offset and limit with a maximum of 50 boards returned per call.\n\nMANDATORY ACTION: ALWAYS when you need to get multiple boards, you must\ninclude all the board identifiers in a single call rather than making\nmultiple separate tool calls, as this provides much better performance, not doing that will\nbring huge performance penalties.\n\nThe tool automatically handles mixed identifier types (names and IDs), deduplicates results, and\nfalls back from ID lookup to name lookup when needed.",
       "parameters": [
         {
@@ -1107,7 +1107,7 @@
     {
       "name": "GetCommentById",
       "qualifiedName": "Jira.GetCommentById",
-      "fullyQualifiedName": "Jira.GetCommentById@3.1.3",
+      "fullyQualifiedName": "Jira.GetCommentById@3.1.4",
       "description": "Get a comment by its ID.",
       "parameters": [
         {
@@ -1207,7 +1207,7 @@
     {
       "name": "GetIssueById",
       "qualifiedName": "Jira.GetIssueById",
-      "fullyQualifiedName": "Jira.GetIssueById@3.1.3",
+      "fullyQualifiedName": "Jira.GetIssueById@3.1.4",
       "description": "Get the details of a Jira issue by its ID.",
       "parameters": [
         {
@@ -1281,7 +1281,7 @@
     {
       "name": "GetIssueComments",
       "qualifiedName": "Jira.GetIssueComments",
-      "fullyQualifiedName": "Jira.GetIssueComments@3.1.3",
+      "fullyQualifiedName": "Jira.GetIssueComments@3.1.4",
       "description": "Get the comments of a Jira issue by its ID.",
       "parameters": [
         {
@@ -1410,7 +1410,7 @@
     {
       "name": "GetIssuesWithoutId",
       "qualifiedName": "Jira.GetIssuesWithoutId",
-      "fullyQualifiedName": "Jira.GetIssuesWithoutId@3.1.3",
+      "fullyQualifiedName": "Jira.GetIssuesWithoutId@3.1.4",
       "description": "Search for Jira issues when you don't have the issue ID(s).\n\nAll text-based arguments (keywords, assignee, project, labels) are case-insensitive.\n\nALWAYS PREFER THIS TOOL OVER THE `Jira.SearchIssuesWithJql` TOOL, UNLESS IT'S ABSOLUTELY\nNECESSARY TO USE A JQL QUERY TO FILTER IN A WAY THAT IS NOT SUPPORTED BY THIS TOOL.",
       "parameters": [
         {
@@ -1632,7 +1632,7 @@
     {
       "name": "GetIssueTypeById",
       "qualifiedName": "Jira.GetIssueTypeById",
-      "fullyQualifiedName": "Jira.GetIssueTypeById@3.1.3",
+      "fullyQualifiedName": "Jira.GetIssueTypeById@3.1.4",
       "description": "Get the details of a Jira issue type by its ID.",
       "parameters": [
         {
@@ -1706,7 +1706,7 @@
     {
       "name": "GetPriorityById",
       "qualifiedName": "Jira.GetPriorityById",
-      "fullyQualifiedName": "Jira.GetPriorityById@3.1.3",
+      "fullyQualifiedName": "Jira.GetPriorityById@3.1.4",
       "description": "Get the details of a priority by its ID.",
       "parameters": [
         {
@@ -1780,7 +1780,7 @@
     {
       "name": "GetProjectById",
       "qualifiedName": "Jira.GetProjectById",
-      "fullyQualifiedName": "Jira.GetProjectById@3.1.3",
+      "fullyQualifiedName": "Jira.GetProjectById@3.1.4",
       "description": "Get the details of a Jira project by its ID or key.",
       "parameters": [
         {
@@ -1854,7 +1854,7 @@
     {
       "name": "GetSprintIssues",
       "qualifiedName": "Jira.GetSprintIssues",
-      "fullyQualifiedName": "Jira.GetSprintIssues@3.1.3",
+      "fullyQualifiedName": "Jira.GetSprintIssues@3.1.4",
       "description": "Get all issues that are currently assigned to a specific sprint with pagination support.\nReturns issues that are planned for or being worked on in the sprint.",
       "parameters": [
         {
@@ -1955,7 +1955,7 @@
     {
       "name": "GetTransitionById",
       "qualifiedName": "Jira.GetTransitionById",
-      "fullyQualifiedName": "Jira.GetTransitionById@3.1.3",
+      "fullyQualifiedName": "Jira.GetTransitionById@3.1.4",
       "description": "Get a transition by its ID.",
       "parameters": [
         {
@@ -2042,7 +2042,7 @@
     {
       "name": "GetTransitionByStatusName",
       "qualifiedName": "Jira.GetTransitionByStatusName",
-      "fullyQualifiedName": "Jira.GetTransitionByStatusName@3.1.3",
+      "fullyQualifiedName": "Jira.GetTransitionByStatusName@3.1.4",
       "description": "Get a transition available for an issue by the transition name.\n\nThe response will contain screen fields available for the transition, if any.",
       "parameters": [
         {
@@ -2129,7 +2129,7 @@
     {
       "name": "GetTransitionsAvailableForIssue",
       "qualifiedName": "Jira.GetTransitionsAvailableForIssue",
-      "fullyQualifiedName": "Jira.GetTransitionsAvailableForIssue@3.1.3",
+      "fullyQualifiedName": "Jira.GetTransitionsAvailableForIssue@3.1.4",
       "description": "Get the transitions available for an existing Jira issue.",
       "parameters": [
         {
@@ -2203,7 +2203,7 @@
     {
       "name": "GetUserById",
       "qualifiedName": "Jira.GetUserById",
-      "fullyQualifiedName": "Jira.GetUserById@3.1.3",
+      "fullyQualifiedName": "Jira.GetUserById@3.1.4",
       "description": "Get user information by their ID.",
       "parameters": [
         {
@@ -2276,7 +2276,7 @@
     {
       "name": "GetUsersWithoutId",
       "qualifiedName": "Jira.GetUsersWithoutId",
-      "fullyQualifiedName": "Jira.GetUsersWithoutId@3.1.3",
+      "fullyQualifiedName": "Jira.GetUsersWithoutId@3.1.4",
       "description": "Get users without their account ID, searching by display name and email address.\n\nThe Jira user search API will return up to 1,000 (one thousand) users for any given name/email\nquery. If you need to get more users, please use the `Jira.ListAllUsers` tool.",
       "parameters": [
         {
@@ -2388,7 +2388,7 @@
     {
       "name": "ListIssueAttachmentsMetadata",
       "qualifiedName": "Jira.ListIssueAttachmentsMetadata",
-      "fullyQualifiedName": "Jira.ListIssueAttachmentsMetadata@3.1.3",
+      "fullyQualifiedName": "Jira.ListIssueAttachmentsMetadata@3.1.4",
       "description": "Get the metadata about the files attached to an issue.\n\nThis tool does NOT return the actual file contents. To get a file content,\nuse the `Jira.DownloadAttachment` tool.",
       "parameters": [
         {
@@ -2461,7 +2461,7 @@
     {
       "name": "ListIssues",
       "qualifiedName": "Jira.ListIssues",
-      "fullyQualifiedName": "Jira.ListIssues@3.1.3",
+      "fullyQualifiedName": "Jira.ListIssues@3.1.4",
       "description": "Get the issues for a given project.",
       "parameters": [
         {
@@ -2562,7 +2562,7 @@
     {
       "name": "ListIssueTypesByProject",
       "qualifiedName": "Jira.ListIssueTypesByProject",
-      "fullyQualifiedName": "Jira.ListIssueTypesByProject@3.1.3",
+      "fullyQualifiedName": "Jira.ListIssueTypesByProject@3.1.4",
       "description": "Get the list of issue types (e.g. 'Task', 'Epic', etc.) available to a given project.",
       "parameters": [
         {
@@ -2662,7 +2662,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Jira.ListLabels",
-      "fullyQualifiedName": "Jira.ListLabels@3.1.3",
+      "fullyQualifiedName": "Jira.ListLabels@3.1.4",
       "description": "Get the existing labels (tags) in the user's Jira instance.",
       "parameters": [
         {
@@ -2749,7 +2749,7 @@
     {
       "name": "ListPrioritiesAvailableToAnIssue",
       "qualifiedName": "Jira.ListPrioritiesAvailableToAnIssue",
-      "fullyQualifiedName": "Jira.ListPrioritiesAvailableToAnIssue@3.1.3",
+      "fullyQualifiedName": "Jira.ListPrioritiesAvailableToAnIssue@3.1.4",
       "description": "Browse the priorities available to be used in the specified Jira issue.",
       "parameters": [
         {
@@ -2823,7 +2823,7 @@
     {
       "name": "ListPrioritiesAvailableToAProject",
       "qualifiedName": "Jira.ListPrioritiesAvailableToAProject",
-      "fullyQualifiedName": "Jira.ListPrioritiesAvailableToAProject@3.1.3",
+      "fullyQualifiedName": "Jira.ListPrioritiesAvailableToAProject@3.1.4",
       "description": "Browse the priorities available to be used in issues in the specified Jira project.\n\nThis tool may need to loop through several API calls to get all priorities associated with\na specific project. In Jira environments with too many Projects or Priority Schemes,\nthe search may take too long, and the tool call will timeout.",
       "parameters": [
         {
@@ -2897,7 +2897,7 @@
     {
       "name": "ListPrioritiesByScheme",
       "qualifiedName": "Jira.ListPrioritiesByScheme",
-      "fullyQualifiedName": "Jira.ListPrioritiesByScheme@3.1.3",
+      "fullyQualifiedName": "Jira.ListPrioritiesByScheme@3.1.4",
       "description": "Browse the priorities associated with a priority scheme.",
       "parameters": [
         {
@@ -2997,7 +2997,7 @@
     {
       "name": "ListPrioritySchemes",
       "qualifiedName": "Jira.ListPrioritySchemes",
-      "fullyQualifiedName": "Jira.ListPrioritySchemes@3.1.3",
+      "fullyQualifiedName": "Jira.ListPrioritySchemes@3.1.4",
       "description": "Browse the priority schemes available in Jira.",
       "parameters": [
         {
@@ -3113,7 +3113,7 @@
     {
       "name": "ListProjects",
       "qualifiedName": "Jira.ListProjects",
-      "fullyQualifiedName": "Jira.ListProjects@3.1.3",
+      "fullyQualifiedName": "Jira.ListProjects@3.1.4",
       "description": "Browse projects available in Jira.",
       "parameters": [
         {
@@ -3200,7 +3200,7 @@
     {
       "name": "ListProjectsByScheme",
       "qualifiedName": "Jira.ListProjectsByScheme",
-      "fullyQualifiedName": "Jira.ListProjectsByScheme@3.1.3",
+      "fullyQualifiedName": "Jira.ListProjectsByScheme@3.1.4",
       "description": "Browse the projects associated with a priority scheme.",
       "parameters": [
         {
@@ -3313,7 +3313,7 @@
     {
       "name": "ListSprintsForBoards",
       "qualifiedName": "Jira.ListSprintsForBoards",
-      "fullyQualifiedName": "Jira.ListSprintsForBoards@3.1.3",
+      "fullyQualifiedName": "Jira.ListSprintsForBoards@3.1.4",
       "description": "Retrieve sprints from Jira boards with filtering options for planning and tracking purposes.\n\nUse this when you need to view sprints from specific boards or find sprints within specific\ndate ranges. For temporal queries like \"last month\", \"next week\", or \"this quarter\",\nprioritize date parameters over state filtering. Leave board_identifiers_list as None\nto get sprints from all available boards.\n\nDATE FILTERING PRIORITY: When users request sprints by time periods (e.g., \"last month\",\n\"next week\"), use date parameters (start_date, end_date, specific_date) rather than\nstate filtering, as temporal criteria take precedence over sprint status.\n\nReturns sprint data along with a backlog GUI URL link where you can see detailed sprint\ninformation and manage sprint items.\n\nMANDATORY ACTION: ALWAYS when you need to get sprints from multiple boards, you must\ninclude all the board identifiers in a single call rather than making\nmultiple separate tool calls, as this provides much better performance, not doing that will\nbring huge performance penalties.\n\nBOARD LIMIT: Maximum of 25 boards can be processed in a single operation. If you need to\nprocess more boards, split the request into multiple batches of 25 or fewer boards each.\n\nHandles mixed board identifiers (names and IDs) with automatic fallback and deduplication.\nAll boards are processed concurrently for optimal performance.",
       "parameters": [
         {
@@ -3483,7 +3483,7 @@
     {
       "name": "ListUsers",
       "qualifiedName": "Jira.ListUsers",
-      "fullyQualifiedName": "Jira.ListUsers@3.1.3",
+      "fullyQualifiedName": "Jira.ListUsers@3.1.4",
       "description": "Browse users in Jira.",
       "parameters": [
         {
@@ -3582,7 +3582,7 @@
     {
       "name": "MoveIssuesFromSprintToBacklog",
       "qualifiedName": "Jira.MoveIssuesFromSprintToBacklog",
-      "fullyQualifiedName": "Jira.MoveIssuesFromSprintToBacklog@3.1.3",
+      "fullyQualifiedName": "Jira.MoveIssuesFromSprintToBacklog@3.1.4",
       "description": "Move issues from active or future sprints back to the board's backlog.",
       "parameters": [
         {
@@ -3675,7 +3675,7 @@
     {
       "name": "RemoveLabelsFromIssue",
       "qualifiedName": "Jira.RemoveLabelsFromIssue",
-      "fullyQualifiedName": "Jira.RemoveLabelsFromIssue@3.1.3",
+      "fullyQualifiedName": "Jira.RemoveLabelsFromIssue@3.1.4",
       "description": "Remove labels from an existing Jira issue.",
       "parameters": [
         {
@@ -3782,8 +3782,8 @@
     {
       "name": "SearchIssuesWithJql",
       "qualifiedName": "Jira.SearchIssuesWithJql",
-      "fullyQualifiedName": "Jira.SearchIssuesWithJql@3.1.3",
-      "description": "Search for Jira issues using a JQL (Jira Query Language) query.\n\nTHIS TOOL RELEASES MORE CO2 IN THE ATMOSPHERE, WHICH CONTRIBUTES TO CLIMATE CHANGE. ALWAYS\nPREFER THE `Jira_SearchIssuesWithoutJql` TOOL OVER THIS ONE, UNLESS IT'S ABSOLUTELY\nNECESSARY TO USE A JQL QUERY TO FILTER IN A WAY THAT IS NOT SUPPORTED BY THE\n`Jira_SearchIssuesWithoutJql` TOOL OR IF THE USER PROVIDES A JQL QUERY THEMSELVES.",
+      "fullyQualifiedName": "Jira.SearchIssuesWithJql@3.1.4",
+      "description": "Search for Jira issues using a JQL (Jira Query Language) query.\n\nALWAYS PREFER THE `Jira_SearchIssuesWithoutJql` TOOL OVER THIS ONE, UNLESS IT'S ABSOLUTELY\nNECESSARY TO USE A JQL QUERY TO FILTER IN A WAY THAT IS NOT SUPPORTED BY THE\n`Jira_SearchIssuesWithoutJql` TOOL OR IF THE USER PROVIDES A JQL QUERY THEMSELVES.",
       "parameters": [
         {
           "name": "jql",
@@ -3882,8 +3882,8 @@
     {
       "name": "SearchIssuesWithoutJql",
       "qualifiedName": "Jira.SearchIssuesWithoutJql",
-      "fullyQualifiedName": "Jira.SearchIssuesWithoutJql@3.1.3",
-      "description": "Parameterized search for Jira issues (without having to provide a JQL query).\n\nTHIS TOOL RELEASES LESS CO2 THAN THE `Jira_SearchIssuesWithJql` TOOL. ALWAYS PREFER THIS ONE\nOVER USING JQL, UNLESS IT'S ABSOLUTELY NECESSARY TO USE A JQL QUERY TO FILTER IN A WAY THAT IS\nNOT SUPPORTED BY THIS TOOL OR IF THE USER PROVIDES A JQL QUERY THEMSELVES.",
+      "fullyQualifiedName": "Jira.SearchIssuesWithoutJql@3.1.4",
+      "description": "Parameterized search for Jira issues (without having to provide a JQL query).\n\nALWAYS PREFER THIS TOOL OVER USING JQL, UNLESS IT'S ABSOLUTELY NECESSARY TO USE A JQL QUERY\nTO FILTER IN A WAY THAT IS NOT SUPPORTED BY THIS TOOL OR IF THE USER PROVIDES A JQL QUERY\nTHEMSELVES.",
       "parameters": [
         {
           "name": "keywords",
@@ -4104,7 +4104,7 @@
     {
       "name": "SearchProjects",
       "qualifiedName": "Jira.SearchProjects",
-      "fullyQualifiedName": "Jira.SearchProjects@3.1.3",
+      "fullyQualifiedName": "Jira.SearchProjects@3.1.4",
       "description": "Get the details of all Jira projects.",
       "parameters": [
         {
@@ -4204,7 +4204,7 @@
     {
       "name": "TransitionIssueToNewStatus",
       "qualifiedName": "Jira.TransitionIssueToNewStatus",
-      "fullyQualifiedName": "Jira.TransitionIssueToNewStatus@3.1.3",
+      "fullyQualifiedName": "Jira.TransitionIssueToNewStatus@3.1.4",
       "description": "Transition a Jira issue to a new status.",
       "parameters": [
         {
@@ -4292,8 +4292,8 @@
     {
       "name": "UpdateIssue",
       "qualifiedName": "Jira.UpdateIssue",
-      "fullyQualifiedName": "Jira.UpdateIssue@3.1.3",
-      "description": "Update an existing Jira issue.\n\nIF YOU DO NOT FOLLOW THE INSTRUCTIONS BELOW AND UNNECESSARILY CALL MULTIPLE TOOLS IN ORDER TO\nUPDATE AN ISSUE, TOO MUCH CO2 WILL BE RELEASED IN THE ATMOSPHERE AND YOU WILL CAUSE THE\nDESTRUCTION OF PLANET EARTH BY CATASTROPHIC CLIMATE CHANGE.\n\nIf you have a priority name, an assignee name/key/email, or a reporter name/key/email,\nDO NOT CALL OTHER TOOLS only to list available priorities, issue types, or users.\nProvide the name, key, or email and the tool will figure out the ID.",
+      "fullyQualifiedName": "Jira.UpdateIssue@3.1.4",
+      "description": "Update an existing Jira issue.\n\nIf you have a priority name, an assignee name/key/email, or a reporter name/key/email,\nDO NOT CALL OTHER TOOLS only to list available priorities, issue types, or users.\nProvide the name, key, or email and the tool will figure out the ID.",
       "parameters": [
         {
           "name": "issue",
@@ -4516,7 +4516,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Jira.WhoAmI",
-      "fullyQualifiedName": "Jira.WhoAmI@3.1.3",
+      "fullyQualifiedName": "Jira.WhoAmI@3.1.4",
       "description": "CALL THIS TOOL FIRST to establish user profile context.\n\nGet information about the currently logged-in user and their available Jira clouds/clients.",
       "parameters": [],
       "auth": {
@@ -4575,6 +4575,6 @@
       "relativePath": "environment-variables/page.mdx"
     }
   ],
-  "generatedAt": "2026-05-16T11:29:47.551Z",
-  "summary": "Arcade's Jira toolkit enables LLM-driven interactions with Atlassian Jira, letting agents create and update issues, move work through transitions, manage sprints and boards, handle attachments and comments, and resolve projects, users, and priorities. It is designed for programmatic issue lifecycle and Agile workflows with aggressive single-call batching.\n\n**Capabilities**\n- Manage issues end-to-end: create, update, transition, comment, add/remove labels, and attach or download files.\n- Run Scrum/Kanban workflows: list boards and sprints with date filters, fetch sprint and backlog issues, add issues to sprints, and move issues back to the backlog.\n- Search and browse flexibly: parameterized issue search (preferred) or raw JQL, plus listings for projects, users, issue types, priorities, and priority schemes.\n- Resolve references by name, key, or email so agents avoid unnecessary lookup round-trips, and establish user context with WhoAmI against available Atlassian clouds.\n\n**OAuth**\nRequires Atlassian OAuth. See the [Arcade Atlassian auth provider docs](https://docs.arcade.dev/en/references/auth-providers/atlassian) for configuration."
+  "generatedAt": "2026-05-28T12:15:52.149Z",
+  "summary": "The Jira toolkit integrates Arcade with Atlassian Jira, enabling LLMs to manage issues, sprints, boards, users, attachments, and project metadata across Jira Cloud instances.\n\n## Capabilities\n\n- **Issue lifecycle management** — Create, update, transition, search (parameterized or JQL), comment on, label, and attach files to issues; move issues between sprints and backlogs.\n- **Sprint & board operations** — List boards and their sprints (with date-range filtering), retrieve backlog and sprint issues, add/move issues to sprints, and access backlog GUI URLs.\n- **Project & metadata discovery** — Browse projects, issue types, priority schemes, labels, and available transitions; resolve names/keys/emails to IDs automatically without requiring pre-lookup calls.\n- **User & identity management** — Look up users by ID, name, or email; list all users; retrieve the authenticated user's profile and available Atlassian Cloud instances.\n- **Attachment handling** — List attachment metadata, download attachment contents, and upload files (string or base64) to issues.\n\n## OAuth\n\nAuthentication uses OAuth 2.0 via the **Atlassian** provider. See the [Atlassian auth provider docs](https://docs.arcade.dev/en/references/auth-providers/atlassian) for setup details, required scopes, and configuration steps."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftsharepoint.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftsharepoint.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftSharepoint",
   "label": "Microsoft SharePoint",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Arcade.dev LLM tools for Microsoft SharePoint",
   "metadata": {
     "category": "productivity",
@@ -27,7 +27,7 @@
     {
       "name": "AddWorksheet",
       "qualifiedName": "MicrosoftSharepoint.AddWorksheet",
-      "fullyQualifiedName": "MicrosoftSharepoint.AddWorksheet@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.AddWorksheet@0.1.3",
       "description": "Add a new worksheet to a SharePoint Excel workbook.\n\nNote: The new worksheet name may not be immediately visible to other\ntools due to a brief Graph API propagation delay (up to ~10 s). Pass\nthe returned ``session_id`` to subsequent calls that reference the new\nworksheet to mitigate this.",
       "parameters": [
         {
@@ -128,7 +128,7 @@
     {
       "name": "CopyItem",
       "qualifiedName": "MicrosoftSharepoint.CopyItem",
-      "fullyQualifiedName": "MicrosoftSharepoint.CopyItem@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.CopyItem@0.1.3",
       "description": "Copy a file or folder. Returns a completed item or an operation id.",
       "parameters": [
         {
@@ -228,7 +228,7 @@
     {
       "name": "CreateFolder",
       "qualifiedName": "MicrosoftSharepoint.CreateFolder",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateFolder@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateFolder@0.1.3",
       "description": "Create a new folder in a SharePoint drive.",
       "parameters": [
         {
@@ -315,7 +315,7 @@
     {
       "name": "CreatePresentation",
       "qualifiedName": "MicrosoftSharepoint.CreatePresentation",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreatePresentation@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreatePresentation@0.1.3",
       "description": "Create a new PowerPoint presentation in a SharePoint drive.\n\nThe presentation will be created with a title slide containing the specified title.",
       "parameters": [
         {
@@ -402,7 +402,7 @@
     {
       "name": "CreateShareLink",
       "qualifiedName": "MicrosoftSharepoint.CreateShareLink",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateShareLink@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateShareLink@0.1.3",
       "description": "Create a share link for a SharePoint drive item.",
       "parameters": [
         {
@@ -476,7 +476,7 @@
     {
       "name": "CreateSlide",
       "qualifiedName": "MicrosoftSharepoint.CreateSlide",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateSlide@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateSlide@0.1.3",
       "description": "Append a new slide to the end of an existing PowerPoint presentation in a SharePoint drive.\n\nThe slide will be added at the end of the presentation. Both title and body\nare optional to support layouts like BLANK or TITLE_ONLY.\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -599,7 +599,7 @@
     {
       "name": "CreateTwoContentSlide",
       "qualifiedName": "MicrosoftSharepoint.CreateTwoContentSlide",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateTwoContentSlide@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateTwoContentSlide@0.1.3",
       "description": "Append a TWO_CONTENT slide with side-by-side content areas to a SharePoint PowerPoint.\n\nThis layout is useful for comparisons, pros/cons lists, or any content that\nbenefits from a two-column layout.\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -712,7 +712,7 @@
     {
       "name": "CreateWordDocument",
       "qualifiedName": "MicrosoftSharepoint.CreateWordDocument",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateWordDocument@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateWordDocument@0.1.3",
       "description": "Create a new Word document in a SharePoint drive.\n\n4MB upload limit. Optionally include text content.",
       "parameters": [
         {
@@ -825,7 +825,7 @@
     {
       "name": "CreateWorkbook",
       "qualifiedName": "MicrosoftSharepoint.CreateWorkbook",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateWorkbook@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateWorkbook@0.1.3",
       "description": "Create a new Excel workbook (.xlsx) in a SharePoint drive.\n\nOnly .xlsx files are supported.",
       "parameters": [
         {
@@ -926,7 +926,7 @@
     {
       "name": "DeleteItem",
       "qualifiedName": "MicrosoftSharepoint.DeleteItem",
-      "fullyQualifiedName": "MicrosoftSharepoint.DeleteItem@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.DeleteItem@0.1.3",
       "description": "Delete a file or folder from a SharePoint drive.",
       "parameters": [
         {
@@ -1000,7 +1000,7 @@
     {
       "name": "DeleteWorksheet",
       "qualifiedName": "MicrosoftSharepoint.DeleteWorksheet",
-      "fullyQualifiedName": "MicrosoftSharepoint.DeleteWorksheet@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.DeleteWorksheet@0.1.3",
       "description": "Delete a worksheet from a SharePoint Excel workbook.\n\nCannot delete the last worksheet in a workbook.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -1101,7 +1101,7 @@
     {
       "name": "GetAllSlideNotes",
       "qualifiedName": "MicrosoftSharepoint.GetAllSlideNotes",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetAllSlideNotes@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetAllSlideNotes@0.1.3",
       "description": "Get all speaker notes from every slide in a SharePoint PowerPoint presentation.\n\nReturns notes for all slides in one call, which is more efficient than\ncalling get_slide_notes for each slide individually. Notes are returned\nin markdown format.",
       "parameters": [
         {
@@ -1175,7 +1175,7 @@
     {
       "name": "GetCopyStatus",
       "qualifiedName": "MicrosoftSharepoint.GetCopyStatus",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetCopyStatus@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetCopyStatus@0.1.3",
       "description": "Check status of an async copy operation using the token returned by copy_item.",
       "parameters": [
         {
@@ -1249,7 +1249,7 @@
     {
       "name": "GetDrivesFromSite",
       "qualifiedName": "MicrosoftSharepoint.GetDrivesFromSite",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetDrivesFromSite@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetDrivesFromSite@0.1.3",
       "description": "Retrieve drives / document libraries from a SharePoint site.\n\nIf you have a site name, it is not necessary to call Sharepoint.SearchSites first.\nYou can simply call this tool with the site name / keywords.",
       "parameters": [
         {
@@ -1310,7 +1310,7 @@
     {
       "name": "GetItemsFromList",
       "qualifiedName": "MicrosoftSharepoint.GetItemsFromList",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetItemsFromList@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetItemsFromList@0.1.3",
       "description": "Retrieve items from a list in a SharePoint site.\n\nNote: The Microsoft Graph API does not offer endpoints to retrieve list item attachments.\nBecause of that, the only information we can get is whether the item has attachments or not.",
       "parameters": [
         {
@@ -1384,7 +1384,7 @@
     {
       "name": "GetListsFromSite",
       "qualifiedName": "MicrosoftSharepoint.GetListsFromSite",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetListsFromSite@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetListsFromSite@0.1.3",
       "description": "Retrieve lists from a SharePoint site.",
       "parameters": [
         {
@@ -1445,7 +1445,7 @@
     {
       "name": "GetPage",
       "qualifiedName": "MicrosoftSharepoint.GetPage",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetPage@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetPage@0.1.3",
       "description": "Retrieve metadata and the contents of a page in a SharePoint site.\n\nPage content is a list of Microsoft Sharepoint web part objects, such as text, images, banners,\nbuttons, etc.\n\nIf `include_page_content` is set to False, the tool will return only the page metadata.",
       "parameters": [
         {
@@ -1532,7 +1532,7 @@
     {
       "name": "GetPresentationAsMarkdown",
       "qualifiedName": "MicrosoftSharepoint.GetPresentationAsMarkdown",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetPresentationAsMarkdown@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetPresentationAsMarkdown@0.1.3",
       "description": "Get the content of a PowerPoint presentation stored in a SharePoint drive as markdown.\n\nThis tool downloads the presentation and converts it to a markdown representation,\npreserving text content, tables, and chart data. Images and other media are\nrepresented as placeholders.",
       "parameters": [
         {
@@ -1606,7 +1606,7 @@
     {
       "name": "GetSite",
       "qualifiedName": "MicrosoftSharepoint.GetSite",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetSite@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetSite@0.1.3",
       "description": "Retrieve information about a specific SharePoint site by its ID, URL, or name.",
       "parameters": [
         {
@@ -1667,7 +1667,7 @@
     {
       "name": "GetSlideNotes",
       "qualifiedName": "MicrosoftSharepoint.GetSlideNotes",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetSlideNotes@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetSlideNotes@0.1.3",
       "description": "Get the speaker notes from a specific slide in a SharePoint PowerPoint presentation.\n\nSpeaker notes are returned in markdown format, preserving basic formatting\nlike bold, italic, and bullet points.",
       "parameters": [
         {
@@ -1754,7 +1754,7 @@
     {
       "name": "GetWordDocument",
       "qualifiedName": "MicrosoftSharepoint.GetWordDocument",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetWordDocument@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetWordDocument@0.1.3",
       "description": "Get a Word document's metadata and content from a SharePoint drive. Supports only `.docx`.\n\nReturns the document content as Markdown by default.\nReturns only metadata when metadata_only is True.",
       "parameters": [
         {
@@ -1841,7 +1841,7 @@
     {
       "name": "GetWorkbookMetadata",
       "qualifiedName": "MicrosoftSharepoint.GetWorkbookMetadata",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetWorkbookMetadata@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetWorkbookMetadata@0.1.3",
       "description": "Get metadata about an Excel workbook in a SharePoint drive, including worksheet list.",
       "parameters": [
         {
@@ -1929,7 +1929,7 @@
     {
       "name": "GetWorksheetData",
       "qualifiedName": "MicrosoftSharepoint.GetWorksheetData",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetWorksheetData@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetWorksheetData@0.1.3",
       "description": "Read cell values from a worksheet in a SharePoint Excel workbook.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -2082,7 +2082,7 @@
     {
       "name": "InsertTextAtEndOfWordDocument",
       "qualifiedName": "MicrosoftSharepoint.InsertTextAtEndOfWordDocument",
-      "fullyQualifiedName": "MicrosoftSharepoint.InsertTextAtEndOfWordDocument@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.InsertTextAtEndOfWordDocument@0.1.3",
       "description": "Append text to the end of an existing Word document.\n\nThis tool only supports files with the `.docx` extension and enforces the 4MB limit.",
       "parameters": [
         {
@@ -2169,7 +2169,7 @@
     {
       "name": "ListItemsInFolder",
       "qualifiedName": "MicrosoftSharepoint.ListItemsInFolder",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListItemsInFolder@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListItemsInFolder@0.1.3",
       "description": "Retrieve items from a folder in a drive in a SharePoint site.\n\nNote: The Microsoft Graph API requires retrieving all items,\nincluding those skipped by offset.\nExecution time increases with higher offset values.",
       "parameters": [
         {
@@ -2269,7 +2269,7 @@
     {
       "name": "ListPages",
       "qualifiedName": "MicrosoftSharepoint.ListPages",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListPages@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListPages@0.1.3",
       "description": "Retrieve pages from a SharePoint site.\n\nThe Microsoft Graph API does not support pagination on this endpoint.",
       "parameters": [
         {
@@ -2343,7 +2343,7 @@
     {
       "name": "ListRootItemsInDrive",
       "qualifiedName": "MicrosoftSharepoint.ListRootItemsInDrive",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListRootItemsInDrive@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListRootItemsInDrive@0.1.3",
       "description": "Retrieve items from the root of a drive in a SharePoint site.\n\nNote: The Microsoft Graph API requires retrieving all items,\nincluding those skipped by offset.\nExecution time increases with higher offset values.",
       "parameters": [
         {
@@ -2430,7 +2430,7 @@
     {
       "name": "ListSites",
       "qualifiedName": "MicrosoftSharepoint.ListSites",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListSites@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListSites@0.1.3",
       "description": "List all SharePoint sites accessible to the current user.",
       "parameters": [
         {
@@ -2504,7 +2504,7 @@
     {
       "name": "MoveItem",
       "qualifiedName": "MicrosoftSharepoint.MoveItem",
-      "fullyQualifiedName": "MicrosoftSharepoint.MoveItem@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.MoveItem@0.1.3",
       "description": "Move a file or folder to a new location in a SharePoint drive.",
       "parameters": [
         {
@@ -2591,7 +2591,7 @@
     {
       "name": "RenameWorksheet",
       "qualifiedName": "MicrosoftSharepoint.RenameWorksheet",
-      "fullyQualifiedName": "MicrosoftSharepoint.RenameWorksheet@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.RenameWorksheet@0.1.3",
       "description": "Rename an existing worksheet in a SharePoint Excel workbook.\n\nNote: The new name may not be immediately visible to other tools due\nto a brief Graph API propagation delay (up to ~10 s). Pass the returned\n``session_id`` to subsequent calls that reference the renamed worksheet\nto mitigate this. If referencing a recently added worksheet as the source,\nthe same delay applies; retry with the ``session_id`` if a\nWorksheetNotFoundError occurs.",
       "parameters": [
         {
@@ -2705,7 +2705,7 @@
     {
       "name": "SearchDriveItems",
       "qualifiedName": "MicrosoftSharepoint.SearchDriveItems",
-      "fullyQualifiedName": "MicrosoftSharepoint.SearchDriveItems@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.SearchDriveItems@0.1.3",
       "description": "Search for items in one or more Sharepoint drives.\n\nNote: When searching a single Drive and/or Folder,\nthe API must retrieve all items including those skipped by offset.\nExecution time increases with higher offset values.",
       "parameters": [
         {
@@ -2818,8 +2818,8 @@
     {
       "name": "SearchSites",
       "qualifiedName": "MicrosoftSharepoint.SearchSites",
-      "fullyQualifiedName": "MicrosoftSharepoint.SearchSites@0.1.2",
-      "description": "Search for SharePoint sites by name or description.\n\nIn case you need to retrieve a specific site by its name, ID or SharePoint URL, use the\n`Sharepoint.GetSite` tool instead, passing the ID, name or SharePoint URL to it. If you use\nthe `Sharepoint.SearchSites` tool to retrieve a single site by its name, too much CO2 will be\nreleased in the atmosphere and you will contribute to catastrophic climate change.",
+      "fullyQualifiedName": "MicrosoftSharepoint.SearchSites@0.1.3",
+      "description": "Search for SharePoint sites by name or description.\n\nIn case you need to retrieve a specific site by its name, ID or SharePoint URL, use the\n`Sharepoint.GetSite` tool instead, passing the ID, name or SharePoint URL to it.",
       "parameters": [
         {
           "name": "keywords",
@@ -2905,7 +2905,7 @@
     {
       "name": "SetSlideNotes",
       "qualifiedName": "MicrosoftSharepoint.SetSlideNotes",
-      "fullyQualifiedName": "MicrosoftSharepoint.SetSlideNotes@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.SetSlideNotes@0.1.3",
       "description": "Set or update the speaker notes on a specific slide in a SharePoint PowerPoint.\n\nNotes can be formatted using markdown:\n- **bold** for bold text\n- *italic* for italic text\n- __underline__ for underlined text\n- Lines starting with - or * become bullet points\n- Indent with spaces for nested bullets\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -3005,7 +3005,7 @@
     {
       "name": "UpdateCell",
       "qualifiedName": "MicrosoftSharepoint.UpdateCell",
-      "fullyQualifiedName": "MicrosoftSharepoint.UpdateCell@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.UpdateCell@0.1.3",
       "description": "Update a single cell value in a SharePoint Excel workbook.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -3145,7 +3145,7 @@
     {
       "name": "UpdateRange",
       "qualifiedName": "MicrosoftSharepoint.UpdateRange",
-      "fullyQualifiedName": "MicrosoftSharepoint.UpdateRange@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.UpdateRange@0.1.3",
       "description": "Update multiple cells in a SharePoint Excel worksheet using sparse dict format.\n\nOnly specified cells are updated; unspecified cells remain unchanged.\n\nInternally, a single PATCH request is sent covering the bounding box\nof all specified cells.  Cells within the box that are not in the\ninput are sent as ``null``, which the Graph API treats as \"skip\".\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -3259,7 +3259,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftSharepoint.WhoAmI",
-      "fullyQualifiedName": "MicrosoftSharepoint.WhoAmI@0.1.2",
+      "fullyQualifiedName": "MicrosoftSharepoint.WhoAmI@0.1.3",
       "description": "Get information about the current user and their SharePoint environment.",
       "parameters": [],
       "auth": {
@@ -3306,6 +3306,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-05-06T11:42:23.738Z",
-  "summary": "# Microsoft SharePoint Toolkit\n\nThe Microsoft SharePoint toolkit connects Arcade to SharePoint via the Microsoft Graph API, enabling LLM agents to read, write, and manage SharePoint content including files, lists, sites, and Office documents.\n\n## Capabilities\n\n- **Site & drive navigation** — list, search, and retrieve sites, drives/document libraries, folders, and files; look up the current user's SharePoint context.\n- **File operations** — create folders, copy/move/delete items, generate share links, check async copy operation status, and search across drives.\n- **Excel workbook management** — create workbooks, add/rename/delete worksheets, read cell ranges, update individual cells or sparse multi-cell ranges; session IDs mitigate Graph API propagation delays on recently modified worksheets.\n- **Word document management** — create `.docx` files with optional content, read document text and metadata as Markdown, and append text to existing documents (4 MB limit enforced).\n- **PowerPoint management** — create presentations, append standard or two-column slides, get the full presentation as Markdown, and get/set/update per-slide speaker notes (with Markdown formatting support); resumable uploads handle files over 4 MB.\n- **SharePoint lists & pages** — retrieve site lists and list items (attachment presence detected but not downloadable), and read or enumerate site pages including web-part content.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 delegated auth via the **Microsoft** provider. See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for setup details, required tenant configuration, and token handling."
+  "generatedAt": "2026-05-28T12:15:52.149Z",
+  "summary": "The Microsoft SharePoint toolkit connects Arcade to Microsoft SharePoint via the Microsoft Graph API, enabling LLMs to read, write, and manage SharePoint sites, drives, lists, pages, and Office documents programmatically.\n\n## Capabilities\n\n- **Site & drive navigation** — list, search, and inspect SharePoint sites, document libraries, drives, folders, pages, and lists; retrieve the current user's context.\n- **File operations** — copy, move, delete, rename, and create share links for files and folders; check async copy status; search across drives.\n- **Excel workbook management** — create workbooks, add/rename/delete worksheets, read cell ranges, update individual cells or sparse multi-cell ranges, and retrieve workbook metadata. Session IDs mitigate Graph API propagation delays after structural changes.\n- **PowerPoint authoring** — create presentations, append single-content or two-column slides, set or retrieve per-slide speaker notes, get full presentation content as Markdown.\n- **Word document handling** — create `.docx` files, read content as Markdown, append text to existing documents (4 MB limit enforced).\n- **Lists and pages** — retrieve SharePoint list items (attachment presence noted but not downloadable via Graph), list and read site pages including web part content.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 delegated auth via the **Microsoft** provider. Arcade manages the token flow; see the [Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for setup details."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftteams.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftteams.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftTeams",
   "label": "Microsoft Teams",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Arcade.dev LLM tools for Microsoft Teams",
   "metadata": {
     "category": "social",
@@ -37,7 +37,7 @@
     {
       "name": "CreateChat",
       "qualifiedName": "MicrosoftTeams.CreateChat",
-      "fullyQualifiedName": "MicrosoftTeams.CreateChat@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.CreateChat@0.6.1",
       "description": "Creates a Microsoft Teams chat.\n\nIf the chat already exists with the specified members, the MS Graph API will return the\nexisting chat.\n\nProvide any combination of user_ids and/or user_names. When available, prefer providing\nuser_ids for optimal performance.",
       "parameters": [
         {
@@ -121,7 +121,7 @@
     {
       "name": "GetChannelMessageReplies",
       "qualifiedName": "MicrosoftTeams.GetChannelMessageReplies",
-      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessageReplies@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessageReplies@0.6.1",
       "description": "Retrieves the replies to a Microsoft Teams channel message.",
       "parameters": [
         {
@@ -209,7 +209,7 @@
     {
       "name": "GetChannelMessages",
       "qualifiedName": "MicrosoftTeams.GetChannelMessages",
-      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessages@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessages@0.6.1",
       "description": "Retrieves the messages in a Microsoft Teams channel.\n\nThe Microsoft Graph API does not support pagination for this endpoint.",
       "parameters": [
         {
@@ -310,8 +310,8 @@
     {
       "name": "GetChannelMetadata",
       "qualifiedName": "MicrosoftTeams.GetChannelMetadata",
-      "fullyQualifiedName": "MicrosoftTeams.GetChannelMetadata@0.6.0",
-      "description": "Retrieves metadata about a Microsoft Teams channel and its members.\n\nProvide either a channel_id or channel_name, not both. When available, prefer providing a\nchannel_id for optimal performance.\n\nThe Microsoft Graph API returns only up to the first 999 members in the channel.\n\nThis tool does not return messages exchanged in the channel. To retrieve channel messages,\nuse the `Teams.GetChannelMessages` tool. If you call this tool to retrieve messages, you will\ncause the release of unnecessary CO2 and contribute to climate change.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use. If you call the\n`Teams.ListTeams` tool first, you will cause the release of unnecessary CO2 in the atmosphere\nand contribute to climate change.",
+      "fullyQualifiedName": "MicrosoftTeams.GetChannelMetadata@0.6.1",
+      "description": "Retrieves metadata about a Microsoft Teams channel and its members.\n\nProvide either a channel_id or channel_name, not both. When available, prefer providing a\nchannel_id for optimal performance.\n\nThe Microsoft Graph API returns only up to the first 999 members in the channel.\n\nThis tool does not return messages exchanged in the channel. To retrieve channel messages,\nuse the `Teams.GetChannelMessages` tool.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use.",
       "parameters": [
         {
           "name": "channel_id",
@@ -398,7 +398,7 @@
     {
       "name": "GetChatMessageById",
       "qualifiedName": "MicrosoftTeams.GetChatMessageById",
-      "fullyQualifiedName": "MicrosoftTeams.GetChatMessageById@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.GetChatMessageById@0.6.1",
       "description": "Retrieves a Microsoft Teams chat message.",
       "parameters": [
         {
@@ -508,7 +508,7 @@
     {
       "name": "GetChatMessages",
       "qualifiedName": "MicrosoftTeams.GetChatMessages",
-      "fullyQualifiedName": "MicrosoftTeams.GetChatMessages@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.GetChatMessages@0.6.1",
       "description": "Retrieves messages from a Microsoft Teams chat (individual or group).\n\nProvide one of chat_id OR any combination of user_ids and/or user_names. When available, prefer\nproviding a chat_id or user_ids for optimal performance.\n\nIf the user provides user name(s), DO NOT CALL THE `Teams.SearchUsers` or `Teams.SearchPeople`\ntools first. Instead, provide the user name(s) directly to this tool through the `user_names`\nargument. It is not necessary to provide the currently signed in user's name/id, so do not call\n`Teams.GetSignedInUser` before calling this tool.\n\nMessages will be sorted in descending order by the messages' `created_datetime` field.\n\nThe Microsoft Teams API does not support pagination for this tool.",
       "parameters": [
         {
@@ -645,7 +645,7 @@
     {
       "name": "GetChatMetadata",
       "qualifiedName": "MicrosoftTeams.GetChatMetadata",
-      "fullyQualifiedName": "MicrosoftTeams.GetChatMetadata@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.GetChatMetadata@0.6.1",
       "description": "Retrieves metadata about a Microsoft Teams chat.\n\nProvide exactly one of chat_id or user_ids/user_names. When available, prefer providing a\nchat_id or user_ids for optimal performance.\n\nIf multiple roup chats exist with those exact members, returns the most recently updated one.\n\nMax 20 DIFFERENT users can be provided in user_ids/user_names.\n\nThis tool DOES NOT return messages in a chat. Use the `Teams.GetChatMessages` tool to get\nchat messages.",
       "parameters": [
         {
@@ -744,7 +744,7 @@
     {
       "name": "GetSignedInUser",
       "qualifiedName": "MicrosoftTeams.GetSignedInUser",
-      "fullyQualifiedName": "MicrosoftTeams.GetSignedInUser@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.GetSignedInUser@0.6.1",
       "description": "Get the user currently signed in Microsoft Teams.\n\nThis tool is not necessary to call before calling other tools.",
       "parameters": [],
       "auth": {
@@ -789,7 +789,7 @@
     {
       "name": "GetTeam",
       "qualifiedName": "MicrosoftTeams.GetTeam",
-      "fullyQualifiedName": "MicrosoftTeams.GetTeam@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.GetTeam@0.6.1",
       "description": "Retrieves metadata about a team in Microsoft Teams.\n\nProvide one of team_id OR team_name, never both. When available, prefer providing a team_id for\noptimal performance.\n\nIf team_id nor team_name are provided: 1) if the user has a single team, the tool will retrieve\nit; 2) if the user has multiple teams, an error will be returned with a list of all teams to\npick from.",
       "parameters": [
         {
@@ -862,7 +862,7 @@
     {
       "name": "ListChannels",
       "qualifiedName": "MicrosoftTeams.ListChannels",
-      "fullyQualifiedName": "MicrosoftTeams.ListChannels@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.ListChannels@0.6.1",
       "description": "Lists channels in Microsoft Teams (including shared incoming channels).\n\nThis tool does not return messages nor members in the channels. To retrieve channel messages,\nuse the `Teams.GetChannelMessages` tool. To retrieve channel members, use the\n`Teams.ListChannelMembers` tool.",
       "parameters": [
         {
@@ -949,7 +949,7 @@
     {
       "name": "ListChats",
       "qualifiedName": "MicrosoftTeams.ListChats",
-      "fullyQualifiedName": "MicrosoftTeams.ListChats@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.ListChats@0.6.1",
       "description": "List the Microsoft Teams chats to which the current user is a member of.",
       "parameters": [
         {
@@ -1022,7 +1022,7 @@
     {
       "name": "ListTeamMembers",
       "qualifiedName": "MicrosoftTeams.ListTeamMembers",
-      "fullyQualifiedName": "MicrosoftTeams.ListTeamMembers@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.ListTeamMembers@0.6.1",
       "description": "Lists the members of a team in Microsoft Teams.\n\nProvide one of team_id OR team_name, never both. When available, prefer providing a team_id for\noptimal performance.\n\nIf team_id nor team_name are provided: 1) if the user has a single team, the tool will use it;\n2) if the user has multiple teams, an error will be returned with a list of all teams to pick\nfrom.\n\nThe Microsoft Graph API returns only up to the first 999 members.",
       "parameters": [
         {
@@ -1122,7 +1122,7 @@
     {
       "name": "ListTeams",
       "qualifiedName": "MicrosoftTeams.ListTeams",
-      "fullyQualifiedName": "MicrosoftTeams.ListTeams@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.ListTeams@0.6.1",
       "description": "Lists the teams the current user is associated with in Microsoft Teams.",
       "parameters": [
         {
@@ -1185,7 +1185,7 @@
     {
       "name": "ListUsers",
       "qualifiedName": "MicrosoftTeams.ListUsers",
-      "fullyQualifiedName": "MicrosoftTeams.ListUsers@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.ListUsers@0.6.1",
       "description": "Lists the users in the Microsoft Teams tenant.\n\nThe Microsoft Graph API returns only up to the first 999 users.",
       "parameters": [
         {
@@ -1259,8 +1259,8 @@
     {
       "name": "ReplyToChannelMessage",
       "qualifiedName": "MicrosoftTeams.ReplyToChannelMessage",
-      "fullyQualifiedName": "MicrosoftTeams.ReplyToChannelMessage@0.6.0",
-      "description": "Sends a reply to a Microsoft Teams channel message.\n\nWhen available, prefer providing a channel_id for optimal performance.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use. If you call the\n`Teams.ListTeams` tool first, you will cause the release of unnecessary CO2 in the atmosphere\nand contribute to climate change.",
+      "fullyQualifiedName": "MicrosoftTeams.ReplyToChannelMessage@0.6.1",
+      "description": "Sends a reply to a Microsoft Teams channel message.\n\nWhen available, prefer providing a channel_id for optimal performance.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use.",
       "parameters": [
         {
           "name": "reply_content",
@@ -1360,7 +1360,7 @@
     {
       "name": "ReplyToChatMessage",
       "qualifiedName": "MicrosoftTeams.ReplyToChatMessage",
-      "fullyQualifiedName": "MicrosoftTeams.ReplyToChatMessage@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.ReplyToChatMessage@0.6.1",
       "description": "Sends a reply to a Microsoft Teams chat message.\n\nProvide exactly one of chat_id or user_ids/user_names. When available, prefer providing a\nchat_id or user_ids for optimal performance.\n\nIf the user provides user name(s), DO NOT CALL THE `Teams.SearchUsers` or `Teams.SearchPeople`\ntools first. Instead, provide the user name(s) directly to this tool through the `user_names`\nargument. It is not necessary to provide the currently signed in user's name/id, so do not call\n`Teams.GetSignedInUser` before calling this tool either.",
       "parameters": [
         {
@@ -1485,7 +1485,7 @@
     {
       "name": "SearchChannels",
       "qualifiedName": "MicrosoftTeams.SearchChannels",
-      "fullyQualifiedName": "MicrosoftTeams.SearchChannels@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.SearchChannels@0.6.1",
       "description": "Searches for channels in a given Microsoft Teams team.",
       "parameters": [
         {
@@ -1606,7 +1606,7 @@
     {
       "name": "SearchMessages",
       "qualifiedName": "MicrosoftTeams.SearchMessages",
-      "fullyQualifiedName": "MicrosoftTeams.SearchMessages@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.SearchMessages@0.6.1",
       "description": "Searches for messages across Microsoft Teams chats and channels.\n\nNote: the Microsoft Graph API search is not strongly consistent. Recent messages may not be\nincluded in search results.",
       "parameters": [
         {
@@ -1694,7 +1694,7 @@
     {
       "name": "SearchPeople",
       "qualifiedName": "MicrosoftTeams.SearchPeople",
-      "fullyQualifiedName": "MicrosoftTeams.SearchPeople@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.SearchPeople@0.6.1",
       "description": "Searches for people the user has interacted with in Microsoft Teams and other 365 products.\n\nThis tool only returns users that the currently signed in user has interacted with. It may also\ninclude people that are part of external tenants/organizations. If you need to retrieve users\nthat may not have interacted with the current user and/or that are exclusively part of the same\ntenant, use the `Teams.SearchUsers` tool instead.",
       "parameters": [
         {
@@ -1801,7 +1801,7 @@
     {
       "name": "SearchTeamMembers",
       "qualifiedName": "MicrosoftTeams.SearchTeamMembers",
-      "fullyQualifiedName": "MicrosoftTeams.SearchTeamMembers@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.SearchTeamMembers@0.6.1",
       "description": "Searches for members of a team in Microsoft Teams.\n\nProvide one of team_id OR team_name, never both. When available, prefer providing a team_id for\noptimal performance.\n\nIf team_id nor team_name are provided: 1) if the user has a single team, the tool will use it;\n2) if the user has multiple teams, an error will be raised with a list of available teams to\npick from.\n\nThe Microsoft Graph API returns only up to the first 999 members of a team.",
       "parameters": [
         {
@@ -1914,7 +1914,7 @@
     {
       "name": "SearchTeams",
       "qualifiedName": "MicrosoftTeams.SearchTeams",
-      "fullyQualifiedName": "MicrosoftTeams.SearchTeams@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.SearchTeams@0.6.1",
       "description": "Searches for teams available to the current user in Microsoft Teams.",
       "parameters": [
         {
@@ -2000,7 +2000,7 @@
     {
       "name": "SearchUsers",
       "qualifiedName": "MicrosoftTeams.SearchUsers",
-      "fullyQualifiedName": "MicrosoftTeams.SearchUsers@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.SearchUsers@0.6.1",
       "description": "Searches for users in the Microsoft Teams tenant.\n\nThis tool only return users that are directly linked to the tenant the current signed in user\nis a member of. If you need to retrieve users that have interacted with the current user but\nare from external tenants/organizations, use `Teams.SearchPeople`, instead.\n\nThe Microsoft Graph API returns only up to the first 999 users.",
       "parameters": [
         {
@@ -2108,8 +2108,8 @@
     {
       "name": "SendMessageToChannel",
       "qualifiedName": "MicrosoftTeams.SendMessageToChannel",
-      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChannel@0.6.0",
-      "description": "Sends a message to a Microsoft Teams channel.\n\nWhen available, prefer providing a channel_id for optimal performance.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use. If you call the\n`Teams.ListTeams` tool first, you will cause the release of unnecessary CO2 in the atmosphere\nand contribute to climate change.",
+      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChannel@0.6.1",
+      "description": "Sends a message to a Microsoft Teams channel.\n\nWhen available, prefer providing a channel_id for optimal performance.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use.",
       "parameters": [
         {
           "name": "message",
@@ -2196,7 +2196,7 @@
     {
       "name": "SendMessageToChat",
       "qualifiedName": "MicrosoftTeams.SendMessageToChat",
-      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChat@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChat@0.6.1",
       "description": "Sends a message to a Microsoft Teams chat.\n\nProvide exactly one of chat_id or user_ids/user_names. When available, prefer providing a\nchat_id or user_ids for optimal performance.\n\nIf the user provides user name(s), DO NOT CALL THE `Teams.SearchUsers` or `Teams.SearchPeople`\ntools first. Instead, provide the user name(s) directly to this tool through the `user_names`\nargument. It is not necessary to provide the currently signed in user's name/id, so do not call\n`Teams.GetSignedInUser` before calling this tool either.",
       "parameters": [
         {
@@ -2307,7 +2307,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftTeams.WhoAmI",
-      "fullyQualifiedName": "MicrosoftTeams.WhoAmI@0.6.0",
+      "fullyQualifiedName": "MicrosoftTeams.WhoAmI@0.6.1",
       "description": "Get information about the current user and their Microsoft Teams environment.",
       "parameters": [],
       "auth": {
@@ -2360,6 +2360,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-05-13T11:50:31.283Z",
-  "summary": "# Microsoft Teams Toolkit\n\nThe Microsoft Teams toolkit provides Arcade LLM tools for interacting with Microsoft Teams via the Microsoft Graph API, enabling agents to read, search, and send messages across chats and channels, and to inspect team/user metadata.\n\n## Capabilities\n\n- **Chat management**: Create one-on-one or group chats (deduplicating against existing chats), list chats the current user belongs to, and retrieve chat metadata — by chat ID or by member names/IDs.\n- **Chat messaging**: Retrieve, send, and reply to messages in chats; supports lookup by chat ID or by user identifiers without requiring a separate user-lookup call.\n- **Channel messaging**: Retrieve messages and their reply threads in channels, send new messages to channels, and reply to existing channel messages.\n- **Team & channel discovery**: List and search teams, channels (including shared incoming channels), team members, and tenant users; retrieve detailed metadata for teams and channels without needing to pre-call `ListTeams`.\n- **User & people search**: Search tenant users (`SearchUsers`) or interaction-based people across Microsoft 365 (`SearchPeople`), covering both internal and external organization contacts; get the currently signed-in user's identity.\n- **Cross-scope message search**: Search messages across all chats and channels via the Graph API (eventual consistency — very recent messages may be absent).\n\n## OAuth\n\nThis toolkit authenticates via **OAuth 2.0** with Microsoft as the identity provider. See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration details, required scopes, and setup instructions."
+  "generatedAt": "2026-05-28T12:15:52.129Z",
+  "summary": "## Microsoft Teams Toolkit\n\nThe Microsoft Teams toolkit provides Arcade LLM tools for interacting with Microsoft Teams via the Microsoft Graph API, enabling agents to read and send messages, manage chats and channels, and look up users and teams.\n\n## Capabilities\n\n- **Messaging — chats:** Create chats, retrieve chat metadata and messages, send messages, and reply to messages in one-on-one or group chats; addressable by chat ID or user names/IDs.\n- **Messaging — channels:** Retrieve channel messages and their replies, send messages to channels, and reply to channel messages; addressable by channel ID or name.\n- **Chat & channel discovery:** List all chats the current user belongs to, list channels within a team (including shared incoming channels), and search for channels by name.\n- **Team & member management:** List teams the user belongs to, retrieve team metadata, list or search team members (up to 999 per Graph API limit), and list all tenant users.\n- **User & people search:** Search users within the signed-in user's tenant (`SearchUsers`), search people the user has previously interacted with across Microsoft 365 — including external tenants (`SearchPeople`), and retrieve the currently signed-in user's profile.\n- **Cross-scope search:** Search messages across chats and channels tenant-wide (note: Graph API search is not strongly consistent; very recent messages may be absent).\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via Microsoft (Entra ID / Azure AD). See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for setup details, required permissions, and configuration."
 }

--- a/toolkit-docs-generator/data/toolkits/slack.json
+++ b/toolkit-docs-generator/data/toolkits/slack.json
@@ -1,7 +1,7 @@
 {
   "id": "Slack",
   "label": "Slack",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Arcade.dev LLM tools for Slack",
   "metadata": {
     "category": "social",
@@ -37,7 +37,7 @@
     {
       "name": "GetConversationMetadata",
       "qualifiedName": "Slack.GetConversationMetadata",
-      "fullyQualifiedName": "Slack.GetConversationMetadata@2.5.2",
+      "fullyQualifiedName": "Slack.GetConversationMetadata@2.5.3",
       "description": "Get metadata of a Channel, a Direct Message (IM / DM) or a Multi-Person (MPIM) conversation.\n\nUse this tool to retrieve metadata about a conversation with a conversation_id, a channel name,\nor by the user_id(s), username(s), and/or email(s) of the user(s) in the conversation.\n\nThis tool does not return the messages in a conversation. To get the messages, use the\n'Slack.GetMessages' tool instead.\n\nProvide exactly one of:\n- conversation_id; or\n- channel_name; or\n- any combination of user_ids, usernames, and/or emails.",
       "parameters": [
         {
@@ -157,7 +157,7 @@
     {
       "name": "GetMessages",
       "qualifiedName": "Slack.GetMessages",
-      "fullyQualifiedName": "Slack.GetMessages@2.5.2",
+      "fullyQualifiedName": "Slack.GetMessages@2.5.3",
       "description": "Get messages in a Slack Channel, DM (direct message) or MPIM (multi-person) conversation.\n\nProvide exactly one of:\n- conversation_id; or\n- channel_name; or\n- any combination of user_ids, usernames, and/or emails.\n\nTo filter messages by an absolute datetime, use 'oldest_datetime' and/or 'latest_datetime'. If\nonly 'oldest_datetime' is provided, it will return messages from the oldest_datetime to the\ncurrent time. If only 'latest_datetime' is provided, it will return messages since the\nbeginning of the conversation to the latest_datetime.\n\nTo filter messages by a relative datetime, use 'oldest_relative' and/or 'latest_relative'\nwith numeric `DD:HH:MM` offsets only. Convert relative phrases to `DD:HH:MM` before calling\nthis tool. If only 'oldest_relative' is provided, it will return messages from the\noldest_relative to the current time. If only 'latest_relative' is provided, it will return\nmessages from the current time to the latest_relative.\n\nDo not provide both 'oldest_datetime' and 'oldest_relative' or both 'latest_datetime' and\n'latest_relative'.\n\nLeave all arguments with the default None to get messages without date/time filtering",
       "parameters": [
         {
@@ -359,7 +359,7 @@
     {
       "name": "GetThreadMessages",
       "qualifiedName": "Slack.GetThreadMessages",
-      "fullyQualifiedName": "Slack.GetThreadMessages@2.5.2",
+      "fullyQualifiedName": "Slack.GetThreadMessages@2.5.3",
       "description": "Get messages in a Slack thread.\n\nA thread is a collection of messages grouped together as replies to a parent message.\nThis tool retrieves all messages in a specific thread, identified by the parent message's\ntimestamp (thread_ts).\n\nProvide exactly one of:\n- conversation_id; or\n- channel_name; or\n- any combination of user_ids, usernames, and/or emails.\n\nTo filter messages by an absolute datetime, use 'oldest_datetime' and/or 'latest_datetime'. If\nonly 'oldest_datetime' is provided, it will return messages from the oldest_datetime to the\ncurrent time. If only 'latest_datetime' is provided, it will return messages since the\nbeginning of the thread to the latest_datetime.\n\nTo filter messages by a relative datetime, use 'oldest_relative' and/or 'latest_relative'\nwith numeric `DD:HH:MM` offsets only. Convert relative phrases to `DD:HH:MM` before calling\nthis tool. If only 'oldest_relative' is provided, it will return messages from the\noldest_relative to the current time. If only 'latest_relative' is provided, it will return\nmessages from the current time to the latest_relative.\n\nDo not provide both 'oldest_datetime' and 'oldest_relative' or both 'latest_datetime' and\n'latest_relative'.\n\nLeave all datetime arguments with the default None to get all thread messages without\ndate/time filtering.",
       "parameters": [
         {
@@ -574,7 +574,7 @@
     {
       "name": "GetUsersInConversation",
       "qualifiedName": "Slack.GetUsersInConversation",
-      "fullyQualifiedName": "Slack.GetUsersInConversation@2.5.2",
+      "fullyQualifiedName": "Slack.GetUsersInConversation@2.5.3",
       "description": "Get the users in a Slack conversation (Channel, DM/IM, or MPIM) by its ID or by channel name.\n\nProvide exactly one of conversation_id or channel_name. Prefer providing a conversation_id,\nwhen available, since the performance is better.",
       "parameters": [
         {
@@ -678,8 +678,8 @@
     {
       "name": "GetUsersInfo",
       "qualifiedName": "Slack.GetUsersInfo",
-      "fullyQualifiedName": "Slack.GetUsersInfo@2.5.2",
-      "description": "Get the information of one or more users in Slack by ID, username, and/or email.\n\nProvide any combination of user_ids, usernames, and/or emails. If you need to retrieve\ndata about multiple users, DO NOT CALL THE TOOL MULTIPLE TIMES. Instead, call it once\nwith all the user_ids, usernames, and/or emails. IF YOU CALL THIS TOOL MULTIPLE TIMES\nUNNECESSARILY, YOU WILL RELEASE MORE CO2 IN THE ATMOSPHERE AND CONTRIBUTE TO GLOBAL WARMING.\n\nIf you need to get metadata or messages of a conversation, use the\n`Slack.GetConversationMetadata` or `Slack.GetMessages` tool instead. These\ntools accept user_ids, usernames, and/or emails. Do not retrieve users' info first,\nas it is inefficient, releases more CO2 in the atmosphere, and contributes to climate change.",
+      "fullyQualifiedName": "Slack.GetUsersInfo@2.5.3",
+      "description": "Get the information of one or more users in Slack by ID, username, and/or email.\n\nProvide any combination of user_ids, usernames, and/or emails. If you need to retrieve\ndata about multiple users, DO NOT CALL THE TOOL MULTIPLE TIMES. Instead, call it once\nwith all the user_ids, usernames, and/or emails.\n\nIf you need to get metadata or messages of a conversation, use the\n`Slack.GetConversationMetadata` or `Slack.GetMessages` tool instead. These\ntools accept user_ids, usernames, and/or emails. Do not retrieve users' info first,\nas it is inefficient.",
       "parameters": [
         {
           "name": "user_ids",
@@ -777,7 +777,7 @@
     {
       "name": "InviteUsersToChannel",
       "qualifiedName": "Slack.InviteUsersToChannel",
-      "fullyQualifiedName": "Slack.InviteUsersToChannel@2.5.2",
+      "fullyQualifiedName": "Slack.InviteUsersToChannel@2.5.3",
       "description": "Invite users to a Slack channel or MPIM (multi-person direct message).\n\nThis tool invites specified users to join a Slack conversation. It works with:\n- Public channels\n- Private channels\n- MPIMs (multi-person direct messages / group DMs)\n\nYou can specify users by their user IDs, usernames, or email addresses.\n\nProvide exactly one of channel_id or channel_name, and at least one of user_ids, usernames,\nor emails.\n\nThe tool will resolve usernames and emails to user IDs before inviting them.\nUp to 100 users may be invited at once.",
       "parameters": [
         {
@@ -901,8 +901,8 @@
     {
       "name": "ListConversations",
       "qualifiedName": "Slack.ListConversations",
-      "fullyQualifiedName": "Slack.ListConversations@2.5.2",
-      "description": "List metadata for Slack conversations (channels, DMs, MPIMs) the user is a member of.\n\nThis tool does not return the messages in a conversation. To get the messages, use the\n'Slack.GetMessages' tool instead. Calling this tool when the user is asking for messages\nwill release too much CO2 in the atmosphere and contribute to global warming.",
+      "fullyQualifiedName": "Slack.ListConversations@2.5.3",
+      "description": "List metadata for Slack conversations (channels, DMs, MPIMs) the user is a member of.\n\nThis tool does not return the messages in a conversation. To get the messages, use the\n'Slack.GetMessages' tool instead.",
       "parameters": [
         {
           "name": "conversation_types",
@@ -1001,8 +1001,8 @@
     {
       "name": "ListUsers",
       "qualifiedName": "Slack.ListUsers",
-      "fullyQualifiedName": "Slack.ListUsers@2.5.2",
-      "description": "List all users in the authenticated user's Slack team.\n\nIf you need to get metadata or messages of a conversation, use the\n`Slack.GetConversationMetadata` tool or `Slack.GetMessages` tool instead. These\ntools accept a user_id, username, and/or email. Do not use this tool to first retrieve user(s),\nas it is inefficient and releases more CO2 in the atmosphere, contributing to climate change.",
+      "fullyQualifiedName": "Slack.ListUsers@2.5.3",
+      "description": "List all users in the authenticated user's Slack team.\n\nIf you need to get metadata or messages of a conversation, use the\n`Slack.GetConversationMetadata` tool or `Slack.GetMessages` tool instead. These\ntools accept a user_id, username, and/or email. Do not use this tool to first retrieve user(s),\nas it is inefficient.",
       "parameters": [
         {
           "name": "exclude_bots",
@@ -1088,7 +1088,7 @@
     {
       "name": "SendMessage",
       "qualifiedName": "Slack.SendMessage",
-      "fullyQualifiedName": "Slack.SendMessage@2.5.2",
+      "fullyQualifiedName": "Slack.SendMessage@2.5.3",
       "description": "Send a message to a Channel, Direct Message (IM/DM), or Multi-Person (MPIM) conversation.\n\nCan send top-level messages or reply to an existing thread.\n\nProvide exactly one of:\n- channel_name; or\n- conversation_id; or\n- any combination of user_ids, usernames, and/or emails.\n\nIn case multiple user_ids, usernames, and/or emails are provided, the tool will open a\nmulti-person conversation with the specified people and send the message to it.\n\nTo reply to a thread, also provide thread_ts (the 'ts' field of the parent message).\nOptionally set reply_broadcast to true to also post the reply to the main conversation.",
       "parameters": [
         {
@@ -1249,7 +1249,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Slack.WhoAmI",
-      "fullyQualifiedName": "Slack.WhoAmI@2.5.2",
+      "fullyQualifiedName": "Slack.WhoAmI@2.5.3",
       "description": "Get comprehensive user profile and Slack information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, and other important profile details from\nSlack services.",
       "parameters": [],
       "auth": {
@@ -1303,6 +1303,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-05-16T11:29:47.541Z",
-  "summary": "The Slack toolkit connects LLMs to Slack via Arcade, enabling agents to read, write, and manage Slack conversations, threads, channels, and users on behalf of an authenticated user.\n\n## Capabilities\n\n- **Reading conversations & messages:** Fetch metadata for channels, DMs, and MPIMs by ID, name, or participant identifiers; retrieve paginated messages with flexible absolute (`oldest_datetime`/`latest_datetime`) or relative (`DD:HH:MM` offsets) time filters; read full thread reply chains with the same filtering options.\n- **User lookup & identity:** Resolve users by ID, username, or email in a single batched call; list all team members; retrieve the authenticated user's own profile and Slack metadata.\n- **Channel membership:** List all conversations the authenticated user belongs to; get the member list for any channel or group DM; invite up to 100 users at once to public channels, private channels, or MPIMs.\n- **Sending messages:** Post top-level messages or threaded replies to any channel, DM, or MPIM, identified by name, ID, or participant list; optionally broadcast thread replies to the parent channel.\n\n## OAuth\n\nAuthentication uses OAuth 2.0 with **Slack** as the provider. See the [Arcade Slack auth provider docs](https://docs.arcade.dev/en/references/auth-providers/slack) for setup details, required scopes, and configuration steps."
+  "generatedAt": "2026-05-28T12:15:52.160Z",
+  "summary": "The Slack toolkit integrates Arcade with Slack's API, enabling LLM agents to read, send, and manage Slack conversations, messages, and users on behalf of an authenticated user.\n\n## Capabilities\n\n- **Conversation discovery & metadata**: List all conversations the user belongs to (channels, DMs, MPIMs) and retrieve detailed metadata for any conversation by ID, channel name, or participant identifiers.\n- **Message reading**: Fetch top-level messages from any conversation or drill into a specific thread, with flexible absolute (`oldest_datetime`/`latest_datetime`) or relative (`DD:HH:MM` offset) time filtering.\n- **Sending & replying**: Post messages to channels, DMs, or multi-person conversations; reply to existing threads with optional broadcast to the main channel.\n- **User lookup & management**: Resolve and retrieve profile information for one or more users by ID, username, or email in a single call; list all team members; invite users (up to 100 at once) to channels or MPIMs.\n- **Identity**: Retrieve the authenticated user's full Slack profile (name, email, avatar, and other profile fields).\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 with **Slack** as the provider. See the [Slack auth provider docs](https://docs.arcade.dev/en/references/auth-providers/slack) for setup details."
 }


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/26573886584

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only generated JSON; main consumer impact is documented semver bumps and the new optional Google Drive picker secret for productivity toolkits.
> 
> **Overview**
> Refreshes **generated toolkit metadata** under `toolkit-docs-generator/data/toolkits/` after a successful deploy (scheduled docs pipeline). This is documentation/catalog data, not runtime app code.
> 
> **Version bumps** bump every tool’s `fullyQualifiedName` and the toolkit `version` for **GitHub** (`3.2.0` → `4.0.0`), **Google Docs** (`6.0.0` → `7.0.0`), **Google Drive** (`5.3.0` → `6.0.0`), **Google Sheets** (`5.2.0` → `6.0.0`), and **Google Slides** (`1.4.2` → `2.0.0`). `index.json` records the same versions plus catalog entries for **Jira**, **Microsoft SharePoint**, **Microsoft Teams**, and **Slack** without corresponding JSON changes in this diff.
> 
> **Google productivity toolkits** now document **`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL`** on most Drive-scoped tools (replacing “no secrets” on many entries). **`GenerateGoogleFilePickerUrl`** copy is rewritten to describe per-file Drive picker access (not sign-in). Toolkit **`summary`** fields are expanded; several tools gain or refresh **`codeExample`** blocks. **Google Docs** `EditDocument` drops **`OPENAI_API_KEY`** from `secretsInfo` in favor of the picker secret.
> 
> **GitHub** changes are limited to version strings and `generatedAt` timestamps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 871550349e0378cd5834085d41780bbc6878399b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->