### PR TITLE
chore: update @arcadeai/design-system to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://arcade.dev/",
   "dependencies": {
-    "@arcadeai/design-system": "3.41.1",
+    "@arcadeai/design-system": "3.42.4",
     "@mdx-js/mdx": "3.1.1",
     "@mdx-js/react": "3.1.1",
     "@next/third-parties": "16.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
   .:
     dependencies:
       '@arcadeai/design-system':
-        specifier: 3.41.1
-        version: 3.41.1(@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.73.1(react@19.2.5))(react@19.2.5)(recharts@3.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1))(tailwindcss@4.2.4)
+        specifier: 3.42.4
+        version: 3.42.4(@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.73.1(react@19.2.5))(react@19.2.5)(recharts@3.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1))(tailwindcss@4.2.4)
       '@mdx-js/mdx':
         specifier: 3.1.1
         version: 3.1.1
@@ -282,8 +282,8 @@ packages:
       zod:
         optional: true
 
-  '@arcadeai/design-system@3.41.1':
-    resolution: {integrity: sha512-JqdYdAuzPsQa83K4WaoQ4xnAU5FJmUTH5LSFoOi6iGtdUCQ1IWe0y7TfIUA3IGDlgHXJ3qfMkvPxlBpAfqBsJA==}
+  '@arcadeai/design-system@3.42.4':
+    resolution: {integrity: sha512-Qcg0Eah36DzAQEqdxP1/5DFMynM0YxJW0I6mRzbGOKK1OOrji/d6PLdopPZG806Ux9zZVVW3MyrYghsUMm7xTw==}
     engines: {bun: '>=1.3.5'}
     peerDependencies:
       '@hookform/resolvers': '>=5.2.1'
@@ -4728,7 +4728,7 @@ snapshots:
     optionalDependencies:
       zod: 4.3.6
 
-  '@arcadeai/design-system@3.41.1(@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.73.1(react@19.2.5))(react@19.2.5)(recharts@3.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1))(tailwindcss@4.2.4)':
+  '@arcadeai/design-system@3.42.4(@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.73.1(react@19.2.5))(react@19.2.5)(recharts@3.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1))(tailwindcss@4.2.4)':
     dependencies:
       '@base-ui/react': 1.3.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@base-ui/utils': 0.2.6(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
This PR updates `@arcadeai/design-system` to the latest published version.

It runs a design-system compatibility test gate before opening this PR.
If that gate fails, the workflow stops and no PR is created.

- Trigger: `workflow_dispatch`
- Run: https://github.com/ArcadeAI/docs/actions/runs/26919625372

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency upgrade with no local code edits; compatibility is gated by CI before merge.
> 
> **Overview**
> Bumps **`@arcadeai/design-system`** from **3.41.1** to **3.42.4** in `package.json` and refreshes **`pnpm-lock.yaml`** so the docs app resolves the new package version. There are **no application source changes** in this diff—only dependency metadata.
> 
> This aligns with the automated update workflow that runs a design-system compatibility gate before opening the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a34312912fce4de929af3b588908f9a65bc75a0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->