### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/app/en/resources/integrations/productivity/_meta.tsx
+++ b/app/en/resources/integrations/productivity/_meta.tsx
@@ -25,6 +25,10 @@ const meta: MetaRecord = {
     title: "Figma",
     href: "/en/resources/integrations/productivity/figma",
   },
+  forkable: {
+    title: "Forkable",
+    href: "/en/resources/integrations/productivity/forkable",
+  },
   gmail: {
     title: "Gmail",
     href: "/en/resources/integrations/productivity/gmail",

--- a/toolkit-docs-generator/data/toolkits/forkable.json
+++ b/toolkit-docs-generator/data/toolkits/forkable.json
@@ -1,0 +1,474 @@
+{
+  "id": "Forkable",
+  "label": "Forkable",
+  "version": "1.0.1",
+  "description": "Arcade tools for Forkable — list this week's meals, browse menus, and pick what you want delivered",
+  "metadata": {
+    "category": "productivity",
+    "iconUrl": "https://design-system.arcade.dev/icons/forkable.svg",
+    "isBYOC": false,
+    "isPro": false,
+    "type": "arcade",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/productivity/forkable",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": null,
+  "tools": [
+    {
+      "name": "CheckMealRestrictions",
+      "qualifiedName": "Forkable.CheckMealRestrictions",
+      "fullyQualifiedName": "Forkable.CheckMealRestrictions@1.0.1",
+      "description": "Check whether picking this item (with the given modifier selections) would\nconflict with the signed-in user's dietary restrictions.\n\nReturns the list of conflict tags (e.g. `[\"dairy_free\"]`) — empty if the\nitem is safe. Call this before `pick_meal` to warn the user, or to let the\nagent pick a different item.",
+      "parameters": [
+        {
+          "name": "menu_id",
+          "type": "string",
+          "required": true,
+          "description": "The menu the item belongs to — the `menu_id` from a `list_menu_items` entry.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "item_id",
+          "type": "string",
+          "required": true,
+          "description": "The menu item to check — the `item_id` from a `list_menu_items` entry.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "selections",
+          "type": "json",
+          "required": false,
+          "description": "Modifier picks as { modifier_id: [option_id, ...] }. Omit if the item has no modifiers.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FORKABLE_EMAIL",
+        "FORKABLE_PASSWORD"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FORKABLE_EMAIL",
+          "type": "unknown"
+        },
+        {
+          "name": "FORKABLE_PASSWORD",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Forkable.CheckMealRestrictions",
+        "parameters": {
+          "menu_id": {
+            "value": "menu_8a3f21c0-4d7e-4b9a-bc12-e5f6a7d8e901",
+            "type": "string",
+            "required": true
+          },
+          "item_id": {
+            "value": "item_3c7b9e2d-1a4f-4c8e-9d25-f0a1b2c3d4e5",
+            "type": "string",
+            "required": true
+          },
+          "selections": {
+            "value": "{\"mod_toppings\": [\"opt_extra_cheese\", \"opt_bacon\"], \"mod_sauce\": [\"opt_ranch\"]}",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListMenuItems",
+      "qualifiedName": "Forkable.ListMenuItems",
+      "fullyQualifiedName": "Forkable.ListMenuItems@1.0.1",
+      "description": "Fetch the full menu (sections, items, prices, modifiers) for one or more menu IDs.\n\nEach item ships with the `item_id` and `menu_id` you'll need to pass to `pick_meal`.",
+      "parameters": [
+        {
+          "name": "menu_ids",
+          "type": "array",
+          "innerType": "string",
+          "required": true,
+          "description": "The Forkable menu IDs to fetch. Use the `available_menu_ids` from a `list_my_meals_this_week` entry. At least one ID is required.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "club_id",
+          "type": "string",
+          "required": true,
+          "description": "The meal club ID for the delivery — the `meal_club_id` from a `list_my_meals_this_week` entry.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FORKABLE_EMAIL",
+        "FORKABLE_PASSWORD"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FORKABLE_EMAIL",
+          "type": "unknown"
+        },
+        {
+          "name": "FORKABLE_PASSWORD",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Forkable.ListMenuItems",
+        "parameters": {
+          "menu_ids": {
+            "value": [
+              "menu_78432",
+              "menu_91205",
+              "menu_66748"
+            ],
+            "type": "array",
+            "required": true
+          },
+          "club_id": {
+            "value": "club_30471",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListMyMealsThisWeek",
+      "qualifiedName": "Forkable.ListMyMealsThisWeek",
+      "fullyQualifiedName": "Forkable.ListMyMealsThisWeek@1.0.1",
+      "description": "List your upcoming Forkable delivery days and what's currently picked for each.\n\nEach entry shows the delivery date, current state (open / locked / delivered),\nthe meal currently assigned to you (`my_pick`), and the menu IDs you can swap to\nvia `list_menu_items` + `pick_meal`. Results are sorted by delivery date.\n\nAn entry whose `my_pick.piece_id` is empty has no meal allocated to you yet —\n`pick_meal` cannot operate on it (it only swaps existing picks).",
+      "parameters": [
+        {
+          "name": "from_date",
+          "type": "string",
+          "required": false,
+          "description": "First day of the window in YYYY-MM-DD format. Leave empty to start at Monday of the current week.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "days",
+          "type": "integer",
+          "required": false,
+          "description": "How many days from `from_date` to include in the window (1-31). Defaults to 7.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FORKABLE_EMAIL",
+        "FORKABLE_PASSWORD"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FORKABLE_EMAIL",
+          "type": "unknown"
+        },
+        {
+          "name": "FORKABLE_PASSWORD",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Forkable.ListMyMealsThisWeek",
+        "parameters": {
+          "from_date": {
+            "value": "2025-01-27",
+            "type": "string",
+            "required": false
+          },
+          "days": {
+            "value": 7,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "PickMeal",
+      "qualifiedName": "Forkable.PickMeal",
+      "fullyQualifiedName": "Forkable.PickMeal@1.0.1",
+      "description": "Replace your assigned meal on one delivery with a different menu item.\n\nOnly works on deliveries that already have a meal allocated to you (a\nnon-empty `my_pick.piece_id`). Forkable's `replacePiece` mutation swaps an\nexisting pick; it can't create one from nothing — initial allocation\nhappens on the Forkable side.\n\nThe mutation returns the refreshed delivery; this tool surfaces the new pick\nand the updated amount due.",
+      "parameters": [
+        {
+          "name": "delivery_id",
+          "type": "string",
+          "required": true,
+          "description": "The Forkable delivery ID — the `delivery_id` from a `list_my_meals_this_week` entry.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "piece_id",
+          "type": "string",
+          "required": true,
+          "description": "Your current piece ID for that delivery — the `my_pick.piece_id` from a `list_my_meals_this_week` entry. This is what gets replaced. If `my_pick.piece_id` is empty, this delivery has no meal allocated to you yet and there is nothing to replace.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "item_id",
+          "type": "string",
+          "required": true,
+          "description": "The menu item you want — the `item_id` from a `list_menu_items` entry.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "menu_id",
+          "type": "string",
+          "required": true,
+          "description": "The menu the chosen item belongs to — the `menu_id` from a `list_menu_items` entry.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "instructions",
+          "type": "string",
+          "required": false,
+          "description": "Free-text note to the venue (e.g. 'no onions'). Leave empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "selections",
+          "type": "json",
+          "required": false,
+          "description": "Modifier picks as { modifier_id: [option_id, ...] }. Omit if the item has no modifiers.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FORKABLE_EMAIL",
+        "FORKABLE_PASSWORD"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FORKABLE_EMAIL",
+          "type": "unknown"
+        },
+        {
+          "name": "FORKABLE_PASSWORD",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Forkable.PickMeal",
+        "parameters": {
+          "delivery_id": {
+            "value": "dlv_8f3k2p9q",
+            "type": "string",
+            "required": true
+          },
+          "piece_id": {
+            "value": "pce_4m7n1r6t",
+            "type": "string",
+            "required": true
+          },
+          "item_id": {
+            "value": "itm_9x2b5w8y",
+            "type": "string",
+            "required": true
+          },
+          "menu_id": {
+            "value": "mnu_3c6d0e4f",
+            "type": "string",
+            "required": true
+          },
+          "instructions": {
+            "value": "no onions, extra sauce on the side",
+            "type": "string",
+            "required": false
+          },
+          "selections": {
+            "value": "{\"mod_protein\": [\"opt_chicken\"], \"mod_size\": [\"opt_large\"], \"mod_extras\": [\"opt_avocado\", \"opt_jalapenos\"]}",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SkipMeal",
+      "qualifiedName": "Forkable.SkipMeal",
+      "fullyQualifiedName": "Forkable.SkipMeal@1.0.1",
+      "description": "Skip a day — removes your assigned meal from a Forkable order.\n\nUse only when the delivery is still open for changes (`locked: false`\nand not `past_late_order_deadline`).",
+      "parameters": [
+        {
+          "name": "order_id",
+          "type": "string",
+          "required": true,
+          "description": "The order ID for the delivery you want to skip — the `order_id` from a `list_my_meals_this_week` entry.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "piece_id",
+          "type": "string",
+          "required": true,
+          "description": "Your current piece ID for that order — the `my_pick.piece_id` from a `list_my_meals_this_week` entry.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FORKABLE_EMAIL",
+        "FORKABLE_PASSWORD"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FORKABLE_EMAIL",
+          "type": "unknown"
+        },
+        {
+          "name": "FORKABLE_PASSWORD",
+          "type": "password"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Forkable.SkipMeal",
+        "parameters": {
+          "order_id": {
+            "value": "ord_7f3a92bc1d4e5f08",
+            "type": "string",
+            "required": true
+          },
+          "piece_id": {
+            "value": "pce_2d8c41fa9b673e15",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-06-04T12:06:50.592Z",
+  "summary": "**Forkable** is a workplace meal delivery service; this toolkit lets agents and users browse weekly menus, inspect dietary restrictions, and manage picks (swap or skip) entirely through code.\n\n## Capabilities\n\n- **Weekly schedule visibility** — retrieve upcoming delivery days, current pick state (open / locked / delivered), and linked menu IDs in one call.\n- **Menu browsing** — fetch full menu details (sections, items, prices, modifiers, IDs) for one or more menus at once.\n- **Meal selection & modification** — swap an existing allocated meal with any available menu item, receiving the refreshed pick and updated amount due.\n- **Skip management** — remove an assigned meal from an open (unlocked) delivery day.\n- **Dietary safety checks** — validate a prospective item + modifier combination against the signed-in user's dietary restrictions before committing a pick.\n\n## Secrets\n\nThis toolkit requires credentials for a Forkable account. No OAuth flow is used — authentication is performed with a registered email and password.\n\n- **`FORKABLE_EMAIL`** — The email address associated with your Forkable account. This is the same address used to log in at [forkable.com](https://www.forkable.com). No special account tier is required.\n\n- **`FORKABLE_PASSWORD`** — The password for that Forkable account. Retrieve or reset it via the Forkable login/account page. Store it as a secret rather than hardcoding it — never expose it in prompts or logs.\n\nStore both secrets in the Arcade secrets manager. See the [Arcade secrets docs](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for setup instructions, or manage them directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
+}

--- a/toolkit-docs-generator/data/toolkits/github.json
+++ b/toolkit-docs-generator/data/toolkits/github.json
@@ -1,7 +1,7 @@
 {
   "id": "Github",
   "label": "GitHub",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Arcade.dev LLM tools for Github",
   "metadata": {
     "category": "development",
@@ -22,7 +22,7 @@
     {
       "name": "AssignPullRequestUser",
       "qualifiedName": "Github.AssignPullRequestUser",
-      "fullyQualifiedName": "Github.AssignPullRequestUser@4.0.0",
+      "fullyQualifiedName": "Github.AssignPullRequestUser@4.1.0",
       "description": "Assign a user to a pull request with intelligent search and fuzzy matching.",
       "parameters": [
         {
@@ -157,7 +157,7 @@
     {
       "name": "CheckPullRequestMergeStatus",
       "qualifiedName": "Github.CheckPullRequestMergeStatus",
-      "fullyQualifiedName": "Github.CheckPullRequestMergeStatus@4.0.0",
+      "fullyQualifiedName": "Github.CheckPullRequestMergeStatus@4.1.0",
       "description": "Check if a pull request is ready to merge without attempting the merge.",
       "parameters": [
         {
@@ -261,7 +261,7 @@
     {
       "name": "CountStargazers",
       "qualifiedName": "Github.CountStargazers",
-      "fullyQualifiedName": "Github.CountStargazers@4.0.0",
+      "fullyQualifiedName": "Github.CountStargazers@4.1.0",
       "description": "Count the number of stargazers (stars) for a GitHub repository.",
       "parameters": [
         {
@@ -339,7 +339,7 @@
     {
       "name": "CreateBranch",
       "qualifiedName": "Github.CreateBranch",
-      "fullyQualifiedName": "Github.CreateBranch@4.0.0",
+      "fullyQualifiedName": "Github.CreateBranch@4.1.0",
       "description": "Create a new branch in a repository.",
       "parameters": [
         {
@@ -443,7 +443,7 @@
     {
       "name": "CreateFile",
       "qualifiedName": "Github.CreateFile",
-      "fullyQualifiedName": "Github.CreateFile@4.0.0",
+      "fullyQualifiedName": "Github.CreateFile@4.1.0",
       "description": "Create a new file or overwrite an existing file in a repository.\n\nThe explicit mode parameter reduces accidental data loss: the default CREATE mode refuses to\ntouch existing files, while OVERWRITE must be chosen intentionally.",
       "parameters": [
         {
@@ -589,7 +589,7 @@
     {
       "name": "CreateIssue",
       "qualifiedName": "Github.CreateIssue",
-      "fullyQualifiedName": "Github.CreateIssue@4.0.0",
+      "fullyQualifiedName": "Github.CreateIssue@4.1.0",
       "description": "Create an issue in a GitHub repository.\n\nOptionally add the created issue to a project by specifying add_to_project_number\nand add_to_project_scope.",
       "parameters": [
         {
@@ -784,7 +784,7 @@
     {
       "name": "CreateIssueComment",
       "qualifiedName": "Github.CreateIssueComment",
-      "fullyQualifiedName": "Github.CreateIssueComment@4.0.0",
+      "fullyQualifiedName": "Github.CreateIssueComment@4.1.0",
       "description": "Create a comment on an issue in a GitHub repository.",
       "parameters": [
         {
@@ -888,7 +888,7 @@
     {
       "name": "CreatePullRequest",
       "qualifiedName": "Github.CreatePullRequest",
-      "fullyQualifiedName": "Github.CreatePullRequest@4.0.0",
+      "fullyQualifiedName": "Github.CreatePullRequest@4.1.0",
       "description": "Create a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -1090,7 +1090,7 @@
     {
       "name": "CreateReplyForReviewComment",
       "qualifiedName": "Github.CreateReplyForReviewComment",
-      "fullyQualifiedName": "Github.CreateReplyForReviewComment@4.0.0",
+      "fullyQualifiedName": "Github.CreateReplyForReviewComment@4.1.0",
       "description": "Create a reply to a review comment for a pull request.\n\nOptionally resolve the conversation thread after replying by setting resolve_thread=True\nand providing the thread_id (GraphQL Node ID).",
       "parameters": [
         {
@@ -1233,7 +1233,7 @@
     {
       "name": "CreateReviewComment",
       "qualifiedName": "Github.CreateReviewComment",
-      "fullyQualifiedName": "Github.CreateReviewComment@4.0.0",
+      "fullyQualifiedName": "Github.CreateReviewComment@4.1.0",
       "description": "Create a review comment for a pull request in a GitHub repository.\n\nIMPORTANT: Line numbers must be part of the diff (changed lines only).\nGitHub's API requires line numbers that exist in the pull request diff, not just any line\nin the file. If the line wasn't changed in the PR, the comment will fail with 422 error.\n\nIf the subject_type is not 'file', then the start_line and end_line parameters are required.\nIf the subject_type is 'file', then the start_line and end_line parameters are ignored.\nIf the commit_id is not provided, the latest commit SHA from the PR will be used.\n\nTIP: Use subject_type='file' to comment on the entire file if unsure about line positions.",
       "parameters": [
         {
@@ -1434,7 +1434,7 @@
     {
       "name": "GetFileContents",
       "qualifiedName": "Github.GetFileContents",
-      "fullyQualifiedName": "Github.GetFileContents@4.0.0",
+      "fullyQualifiedName": "Github.GetFileContents@4.1.0",
       "description": "Get the contents of a file in a repository.\n\nReturns the decoded content (if text) along with metadata like SHA, size, and line count.\nFor large files, use start_line and end_line to retrieve specific line ranges.",
       "parameters": [
         {
@@ -1564,7 +1564,7 @@
     {
       "name": "GetIssue",
       "qualifiedName": "Github.GetIssue",
-      "fullyQualifiedName": "Github.GetIssue@4.0.0",
+      "fullyQualifiedName": "Github.GetIssue@4.1.0",
       "description": "Get a specific issue from a GitHub repository.",
       "parameters": [
         {
@@ -1655,7 +1655,7 @@
     {
       "name": "GetPullRequest",
       "qualifiedName": "Github.GetPullRequest",
-      "fullyQualifiedName": "Github.GetPullRequest@4.0.0",
+      "fullyQualifiedName": "Github.GetPullRequest@4.1.0",
       "description": "Get details of a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -1759,7 +1759,7 @@
     {
       "name": "GetRepository",
       "qualifiedName": "Github.GetRepository",
-      "fullyQualifiedName": "Github.GetRepository@4.0.0",
+      "fullyQualifiedName": "Github.GetRepository@4.1.0",
       "description": "Get a repository.\n\nRetrieves detailed information about a repository using the GitHub API.",
       "parameters": [
         {
@@ -1837,7 +1837,7 @@
     {
       "name": "GetReviewWorkload",
       "qualifiedName": "Github.GetReviewWorkload",
-      "fullyQualifiedName": "Github.GetReviewWorkload@4.0.0",
+      "fullyQualifiedName": "Github.GetReviewWorkload@4.1.0",
       "description": "Get pull requests awaiting review by the authenticated user.\n\nReturns PRs where user is requested as reviewer and PRs user has recently reviewed.",
       "parameters": [],
       "auth": {
@@ -1887,7 +1887,7 @@
     {
       "name": "GetUserOpenItems",
       "qualifiedName": "Github.GetUserOpenItems",
-      "fullyQualifiedName": "Github.GetUserOpenItems@4.0.0",
+      "fullyQualifiedName": "Github.GetUserOpenItems@4.1.0",
       "description": "Get user's currently open pull requests and issues across all repositories.\n\nReturns open PRs and issues authored by the authenticated user.",
       "parameters": [
         {
@@ -1952,7 +1952,7 @@
     {
       "name": "GetUserRecentActivity",
       "qualifiedName": "Github.GetUserRecentActivity",
-      "fullyQualifiedName": "Github.GetUserRecentActivity@4.0.0",
+      "fullyQualifiedName": "Github.GetUserRecentActivity@4.1.0",
       "description": "Get the authenticated user's recent pull requests, reviews, issues, and commits.\n\nReturns PRs they authored, merged PRs, PRs they reviewed, issues they opened, and commits pushed",
       "parameters": [
         {
@@ -2030,7 +2030,7 @@
     {
       "name": "ListIssues",
       "qualifiedName": "Github.ListIssues",
-      "fullyQualifiedName": "Github.ListIssues@4.0.0",
+      "fullyQualifiedName": "Github.ListIssues@4.1.0",
       "description": "List issues in a GitHub repository.",
       "parameters": [
         {
@@ -2223,7 +2223,7 @@
     {
       "name": "ListOrgRepositories",
       "qualifiedName": "Github.ListOrgRepositories",
-      "fullyQualifiedName": "Github.ListOrgRepositories@4.0.0",
+      "fullyQualifiedName": "Github.ListOrgRepositories@4.1.0",
       "description": "List repositories for the specified organization.",
       "parameters": [
         {
@@ -2368,7 +2368,7 @@
     {
       "name": "ListProjectFields",
       "qualifiedName": "Github.ListProjectFields",
-      "fullyQualifiedName": "Github.ListProjectFields@4.0.0",
+      "fullyQualifiedName": "Github.ListProjectFields@4.1.0",
       "description": "List fields for a Projects V2 project.\n\nReturns all custom fields configured for the project, including field types\nand available options for select/iteration fields.",
       "parameters": [
         {
@@ -2492,7 +2492,7 @@
     {
       "name": "ListProjectItems",
       "qualifiedName": "Github.ListProjectItems",
-      "fullyQualifiedName": "Github.ListProjectItems@4.0.0",
+      "fullyQualifiedName": "Github.ListProjectItems@4.1.0",
       "description": "List items for a Projects V2 project with optional filtering.",
       "parameters": [
         {
@@ -2711,7 +2711,7 @@
     {
       "name": "ListProjects",
       "qualifiedName": "Github.ListProjects",
-      "fullyQualifiedName": "Github.ListProjects@4.0.0",
+      "fullyQualifiedName": "Github.ListProjects@4.1.0",
       "description": "List Projects V2 across organization or user scopes.",
       "parameters": [
         {
@@ -2891,7 +2891,7 @@
     {
       "name": "ListPullRequestCommits",
       "qualifiedName": "Github.ListPullRequestCommits",
-      "fullyQualifiedName": "Github.ListPullRequestCommits@4.0.0",
+      "fullyQualifiedName": "Github.ListPullRequestCommits@4.1.0",
       "description": "List commits (from oldest to newest) on a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -3008,7 +3008,7 @@
     {
       "name": "ListPullRequests",
       "qualifiedName": "Github.ListPullRequests",
-      "fullyQualifiedName": "Github.ListPullRequests@4.0.0",
+      "fullyQualifiedName": "Github.ListPullRequests@4.1.0",
       "description": "List pull requests in a GitHub repository.\n\nBy default returns newest pull requests first (direction=DESC).",
       "parameters": [
         {
@@ -3202,7 +3202,7 @@
     {
       "name": "ListRepositoryActivities",
       "qualifiedName": "Github.ListRepositoryActivities",
-      "fullyQualifiedName": "Github.ListRepositoryActivities@4.0.0",
+      "fullyQualifiedName": "Github.ListRepositoryActivities@4.1.0",
       "description": "List repository activities.\n\nRetrieves a detailed history of changes to a repository, such as pushes, merges,\nforce pushes, and branch changes, and associates these changes with commits and users.",
       "parameters": [
         {
@@ -3400,7 +3400,7 @@
     {
       "name": "ListRepositoryCollaborators",
       "qualifiedName": "Github.ListRepositoryCollaborators",
-      "fullyQualifiedName": "Github.ListRepositoryCollaborators@4.0.0",
+      "fullyQualifiedName": "Github.ListRepositoryCollaborators@4.1.0",
       "description": "List collaborators for a repository.\n\nReturns users who have access to the repository and can be requested as reviewers\nfor pull requests. Useful for discovering who can review your PR.\n\nDetail levels:\n- basic: Only explicit collaborators (fast, minimal API calls)\n- include_org_members: Add all org members (default, moderate API calls)\n- full_profiles: Add org members + enrich with names/emails (slow, many API calls)",
       "parameters": [
         {
@@ -3570,7 +3570,7 @@
     {
       "name": "ListRepositoryLabels",
       "qualifiedName": "Github.ListRepositoryLabels",
-      "fullyQualifiedName": "Github.ListRepositoryLabels@4.0.0",
+      "fullyQualifiedName": "Github.ListRepositoryLabels@4.1.0",
       "description": "List all labels defined in a repository.",
       "parameters": [
         {
@@ -3674,7 +3674,7 @@
     {
       "name": "ListReviewCommentsInARepository",
       "qualifiedName": "Github.ListReviewCommentsInARepository",
-      "fullyQualifiedName": "Github.ListReviewCommentsInARepository@4.0.0",
+      "fullyQualifiedName": "Github.ListReviewCommentsInARepository@4.1.0",
       "description": "List review comments in a GitHub repository.",
       "parameters": [
         {
@@ -3823,7 +3823,7 @@
     {
       "name": "ListReviewCommentsOnPullRequest",
       "qualifiedName": "Github.ListReviewCommentsOnPullRequest",
-      "fullyQualifiedName": "Github.ListReviewCommentsOnPullRequest@4.0.0",
+      "fullyQualifiedName": "Github.ListReviewCommentsOnPullRequest@4.1.0",
       "description": "List review comments on a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -3998,7 +3998,7 @@
     {
       "name": "ListStargazers",
       "qualifiedName": "Github.ListStargazers",
-      "fullyQualifiedName": "Github.ListStargazers@4.0.0",
+      "fullyQualifiedName": "Github.ListStargazers@4.1.0",
       "description": "List the stargazers for a GitHub repository.\n\nReturns stargazers in chronological order (oldest first).",
       "parameters": [
         {
@@ -4102,7 +4102,7 @@
     {
       "name": "ManageLabels",
       "qualifiedName": "Github.ManageLabels",
-      "fullyQualifiedName": "Github.ManageLabels@4.0.0",
+      "fullyQualifiedName": "Github.ManageLabels@4.1.0",
       "description": "Add or remove labels from an issue or pull request.\n\nSupports fuzzy matching for typo tolerance. Both issues and pull requests\nsupport labels through the same API. You can add and remove labels in a\nsingle operation.",
       "parameters": [
         {
@@ -4259,7 +4259,7 @@
     {
       "name": "ManagePullRequestReviewers",
       "qualifiedName": "Github.ManagePullRequestReviewers",
-      "fullyQualifiedName": "Github.ManagePullRequestReviewers@4.0.0",
+      "fullyQualifiedName": "Github.ManagePullRequestReviewers@4.1.0",
       "description": "Manage reviewers for a pull request.",
       "parameters": [
         {
@@ -4416,7 +4416,7 @@
     {
       "name": "MergePullRequest",
       "qualifiedName": "Github.MergePullRequest",
-      "fullyQualifiedName": "Github.MergePullRequest@4.0.0",
+      "fullyQualifiedName": "Github.MergePullRequest@4.1.0",
       "description": "Merge a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -4576,7 +4576,7 @@
     {
       "name": "ResolveReviewThread",
       "qualifiedName": "Github.ResolveReviewThread",
-      "fullyQualifiedName": "Github.ResolveReviewThread@4.0.0",
+      "fullyQualifiedName": "Github.ResolveReviewThread@4.1.0",
       "description": "Resolve or unresolve a pull request review conversation thread.",
       "parameters": [
         {
@@ -4678,9 +4678,100 @@
       }
     },
     {
+      "name": "SearchCode",
+      "qualifiedName": "Github.SearchCode",
+      "fullyQualifiedName": "Github.SearchCode@4.1.0",
+      "description": "Search code across the authorized GitHub scope.\n\nReturns matching files with the matched fragments inlined so the caller\ncan read each match in context without a follow-up file fetch.",
+      "parameters": [
+        {
+          "name": "query",
+          "type": "string",
+          "required": true,
+          "description": "GitHub code-search query string (raw GitHub search syntax).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-100). Defaults to 30.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position of the first result to return (0-999). GitHub's code search exposes at most 1000 results per query, so any offset at or beyond 1000 is rejected. Defaults to 0 (first result).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "github",
+        "providerType": "oauth2",
+        "scopes": []
+      },
+      "secrets": [
+        "GITHUB_SERVER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "GITHUB_SERVER_URL",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Matched files from cross-org code search."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Github.SearchCode",
+        "parameters": {
+          "query": {
+            "value": "useState repo:facebook/react language:TypeScript",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "github",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "source_code"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "SearchMyRepos",
       "qualifiedName": "Github.SearchMyRepos",
-      "fullyQualifiedName": "Github.SearchMyRepos@4.0.0",
+      "fullyQualifiedName": "Github.SearchMyRepos@4.1.0",
       "description": "Search repositories accessible to the authenticated user with fuzzy matching.",
       "parameters": [
         {
@@ -4801,7 +4892,7 @@
     {
       "name": "SearchProjectItem",
       "qualifiedName": "Github.SearchProjectItem",
-      "fullyQualifiedName": "Github.SearchProjectItem@4.0.0",
+      "fullyQualifiedName": "Github.SearchProjectItem@4.1.0",
       "description": "Search for a specific item in a Projects V2 project.",
       "parameters": [
         {
@@ -4954,7 +5045,7 @@
     {
       "name": "SetStarred",
       "qualifiedName": "Github.SetStarred",
-      "fullyQualifiedName": "Github.SetStarred@4.0.0",
+      "fullyQualifiedName": "Github.SetStarred@4.1.0",
       "description": "Star or un-star a GitHub repository.",
       "parameters": [
         {
@@ -5045,7 +5136,7 @@
     {
       "name": "SubmitPullRequestReview",
       "qualifiedName": "Github.SubmitPullRequestReview",
-      "fullyQualifiedName": "Github.SubmitPullRequestReview@4.0.0",
+      "fullyQualifiedName": "Github.SubmitPullRequestReview@4.1.0",
       "description": "Submit a review for a pull request.",
       "parameters": [
         {
@@ -5166,7 +5257,7 @@
     {
       "name": "UpdateFileLines",
       "qualifiedName": "Github.UpdateFileLines",
-      "fullyQualifiedName": "Github.UpdateFileLines@4.0.0",
+      "fullyQualifiedName": "Github.UpdateFileLines@4.1.0",
       "description": "Replace a block of lines within a file (1-indexed, inclusive). Set mode=FileUpdateMode.APPEND\nto add new content to the end of the file.",
       "parameters": [
         {
@@ -5338,7 +5429,7 @@
     {
       "name": "UpdateIssue",
       "qualifiedName": "Github.UpdateIssue",
-      "fullyQualifiedName": "Github.UpdateIssue@4.0.0",
+      "fullyQualifiedName": "Github.UpdateIssue@4.1.0",
       "description": "Update an issue in a GitHub repository.\n\nParameters that are not provided (None) will not be updated or cleared.\nUpdates apply to the issue in the repository. If the issue is in a project,\nthe project item will automatically reflect these changes.",
       "parameters": [
         {
@@ -5519,7 +5610,7 @@
     {
       "name": "UpdatePullRequest",
       "qualifiedName": "Github.UpdatePullRequest",
-      "fullyQualifiedName": "Github.UpdatePullRequest@4.0.0",
+      "fullyQualifiedName": "Github.UpdatePullRequest@4.1.0",
       "description": "Update a pull request in a GitHub repository.",
       "parameters": [
         {
@@ -5679,7 +5770,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Github.WhoAmI",
-      "fullyQualifiedName": "Github.WhoAmI@4.0.0",
+      "fullyQualifiedName": "Github.WhoAmI@4.1.0",
       "description": "Get information about the authenticated GitHub user.\n\nReturns profile, organizations, and teams.",
       "parameters": [],
       "auth": {
@@ -5766,6 +5857,6 @@
     "import { Callout, Tabs } from \"nextra/components\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-05-28T12:15:52.149Z",
-  "summary": "Arcade's GitHub toolkit provides authenticated access to GitHub resources, enabling automated repository, issue, pull request, review, and Projects V2 workflows. It exposes high-level actions that handle fuzzy matching, diff-aware edits, and user-centric queries without forcing agents to juggle raw REST calls.\n\n**Capabilities**\n- Manage repository and file operations: create branches, read files with line ranges, create or overwrite files, and replace line blocks safely.\n- Drive the pull request lifecycle: create, update, list, merge, check merge readiness, manage reviewers, submit reviews, and reply to or resolve review threads.\n- Administer issues and labels with fuzzy-matched add/remove, comments, assignment, and issue-to-project linking.\n- Query Projects V2 fields and items, list stargazers, collaborators, labels, activities, and authenticated-user views (open items, recent activity, review workload).\n\n**OAuth**\nRequires GitHub OAuth. See the [Arcade GitHub auth provider docs](https://docs.arcade.dev/en/references/auth-providers/github) for configuration.\n\n**Secrets**\n- `GITHUB_SERVER_URL` — override for GitHub Enterprise endpoints. Configure in the [Arcade Dashboard](https://api.arcade.dev/dashboard/auth/secrets) per the [Arcade secret setup guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets)."
+  "generatedAt": "2026-06-04T12:06:47.066Z",
+  "summary": "# GitHub Toolkit\n\nThe GitHub toolkit integrates Arcade with the GitHub API, enabling LLM-powered automation of repositories, pull requests, issues, code review, and project management across personal and organization scopes.\n\n## Capabilities\n\n- **Repository & file operations:** Create branches, read/write/update files (with safe create-vs-overwrite modes), list org and user repositories, retrieve repository metadata, and track activity history.\n- **Pull requests & code review:** Create, update, merge, and inspect PRs; manage reviewers and labels; post and reply to review comments (with diff-aware line targeting); resolve/unresolve conversation threads; check merge readiness; and retrieve review workload and recent activity.\n- **Issues:** Create, update, list, and comment on issues; add issues directly to Projects V2 at creation time; manage labels with fuzzy-matching support.\n- **Projects V2:** List projects across org and user scopes, enumerate project fields and items, search for specific items, and link issues to projects.\n- **Search & discovery:** Full-text code search with inline match context, fuzzy repository search, collaborator discovery with configurable detail levels, and stargazer listing/counting.\n- **Identity & starring:** Retrieve the authenticated user's profile, organizations, and teams; star or unstar repositories.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via the **GitHub** provider. See the [GitHub auth provider docs](https://docs.arcade.dev/en/references/auth-providers/github) for setup details.\n\n## Secrets\n\n- **`GITHUB_SERVER_URL`** — The base URL of the GitHub API server. By default this points to `https://api.github.com`. Override this secret when targeting a **GitHub Enterprise Server** instance (e.g., `https://github.your-company.com/api/v3`). Obtain the correct URL from your GitHub Enterprise Server administrator or from your enterprise's GitHub settings. No special permissions are required to determine the URL; it is a configuration value, not a credential.\n\nFor guidance on configuring secrets in Arcade, see [Tool Secrets](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets). You can also manage secrets directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-29T12:08:54.966Z",
+  "generatedAt": "2026-06-04T12:07:03.994Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -228,6 +228,15 @@
       "authType": "none"
     },
     {
+      "id": "Forkable",
+      "label": "Forkable",
+      "version": "1.0.1",
+      "category": "productivity",
+      "type": "arcade",
+      "toolCount": 5,
+      "authType": "none"
+    },
+    {
       "id": "FreshserviceApi",
       "label": "Freshservice API",
       "version": "0.3.0",
@@ -239,10 +248,10 @@
     {
       "id": "Github",
       "label": "GitHub",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "category": "development",
       "type": "arcade",
-      "toolCount": 42,
+      "toolCount": 43,
       "authType": "oauth2"
     },
     {
@@ -581,16 +590,16 @@
     {
       "id": "MicrosoftOutlookMail",
       "label": "Microsoft Outlook Mail",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "category": "productivity",
       "type": "arcade",
-      "toolCount": 26,
+      "toolCount": 28,
       "authType": "oauth2"
     },
     {
       "id": "MicrosoftPowerpoint",
       "label": "Microsoft PowerPoint",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 8,
@@ -599,7 +608,7 @@
     {
       "id": "MicrosoftSharepoint",
       "label": "Microsoft SharePoint",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 36,

--- a/toolkit-docs-generator/data/toolkits/microsoftoutlookmail.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftoutlookmail.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftOutlookMail",
   "label": "Microsoft Outlook Mail",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Arcade.dev LLM tools for Outlook Mail",
   "metadata": {
     "category": "productivity",
@@ -31,7 +31,7 @@
     {
       "name": "CreateAndSendEmail",
       "qualifiedName": "MicrosoftOutlookMail.CreateAndSendEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.CreateAndSendEmail@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.CreateAndSendEmail@0.4.0",
       "description": "Create and immediately send a new email in Outlook to the specified recipients.\n\nReturns the sent message's ``message_id`` and ``conversation_id`` so callers\ncan immediately chain follow-ups (e.g. reply to what they just sent) without\nhaving to search Sent Items.",
       "parameters": [
         {
@@ -170,7 +170,7 @@
     {
       "name": "CreateDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.CreateDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.CreateDraftEmail@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.CreateDraftEmail@0.4.0",
       "description": "Compose a new draft email in Outlook",
       "parameters": [
         {
@@ -309,7 +309,7 @@
     {
       "name": "GetEmail",
       "qualifiedName": "MicrosoftOutlookMail.GetEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.GetEmail@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.GetEmail@0.4.0",
       "description": "Retrieve a single email message by its ID.\n\nReturns email metadata and body content. By default, the body is returned\nas plain text (HTML tags stripped) and capped at 5000 characters. Set\nbody_format to HTML to get the original markup. Use body_offset to\ncontinue reading long emails, or set max_body_characters to None for the\nfull body.\n\nUse this tool to read the full content of an email after finding it via\nsearch_emails or any listing tool.",
       "parameters": [
         {
@@ -412,7 +412,7 @@
     {
       "name": "ListEmailAttachments",
       "qualifiedName": "MicrosoftOutlookMail.ListEmailAttachments",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailAttachments@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailAttachments@0.4.0",
       "description": "List attachment metadata for an email message.\n\nReturns metadata only (name, size, type, etc.). Attachment content is not included.\nUse this tool when the user wants to know what files are attached to an email.",
       "parameters": [
         {
@@ -499,7 +499,7 @@
     {
       "name": "ListEmails",
       "qualifiedName": "MicrosoftOutlookMail.ListEmails",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmails@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmails@0.4.0",
       "description": "List emails in the user's mailbox across all folders.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).\n\nSince this tool lists email across all folders, it may return sent items,\ndrafts, and other items that are not in the inbox.",
       "parameters": [
         {
@@ -607,7 +607,7 @@
     {
       "name": "ListEmailsByProperty",
       "qualifiedName": "MicrosoftOutlookMail.ListEmailsByProperty",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsByProperty@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsByProperty@0.4.0",
       "description": "List emails in the user's mailbox across all folders filtering by a property.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).\n\nSorting by RECEIVED_DATE_TIME works with any filter property. Sorting by\na different property (SUBJECT, SENDER, IMPORTANCE) while filtering by an\nunrelated property may fail due to a Microsoft Graph API restriction. If\nthis happens, either sort by RECEIVED_DATE_TIME, or use list_emails (no\nfilter) with the desired sort_by.",
       "parameters": [
         {
@@ -773,7 +773,7 @@
     {
       "name": "ListEmailsInFolder",
       "qualifiedName": "MicrosoftOutlookMail.ListEmailsInFolder",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsInFolder@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsInFolder@0.4.0",
       "description": "List the user's emails in the specified folder.\n\nExactly one of `well_known_folder_name` or `folder_id` MUST be provided.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
       "parameters": [
         {
@@ -915,7 +915,7 @@
     {
       "name": "ListMailFolders",
       "qualifiedName": "MicrosoftOutlookMail.ListMailFolders",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListMailFolders@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListMailFolders@0.4.0",
       "description": "List mail folders in the user's mailbox.\n\nReturns folder names, IDs, unread counts, and total item counts.\nUse the folder ID in follow-up calls to list_emails_in_folder.\nOmit parent_folder_id to list top-level folders, or provide a folder ID\nto list its child folders.",
       "parameters": [
         {
@@ -1012,9 +1012,104 @@
       }
     },
     {
+      "name": "MoveEmailToFolder",
+      "qualifiedName": "MicrosoftOutlookMail.MoveEmailToFolder",
+      "fullyQualifiedName": "MicrosoftOutlookMail.MoveEmailToFolder@0.4.0",
+      "description": "Move an email message to a different folder in Outlook.\n\nExactly one of `destination_well_known_folder_name` or\n`destination_folder_id` MUST be provided. Use `list_mail_folders` to\ndiscover custom folder IDs.",
+      "parameters": [
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the email message to move.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "destination_well_known_folder_name",
+          "type": "string",
+          "required": false,
+          "description": "The well-known destination folder. Provide this when moving to inbox, drafts, sent items, deleted items, or another built-in folder; otherwise omit and set destination_folder_id.",
+          "enum": [
+            "deleteditems",
+            "drafts",
+            "inbox",
+            "junkemail",
+            "sentitems",
+            "starred",
+            "tasks"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "destination_folder_id",
+          "type": "string",
+          "required": false,
+          "description": "The destination folder ID for a custom folder. Provide this when the destination is not a well-known folder; otherwise omit and set destination_well_known_folder_name.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "MailboxSettings.Read",
+          "Mail.ReadWrite"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.MoveEmailToFolder",
+        "parameters": {
+          "message_id": {
+            "value": "AAMkAGI2TG93AAA=",
+            "type": "string",
+            "required": true
+          },
+          "destination_well_known_folder_name": {
+            "value": "inbox",
+            "type": "string",
+            "required": false
+          },
+          "destination_folder_id": {
+            "value": "",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "ReplyToEmail",
       "qualifiedName": "MicrosoftOutlookMail.ReplyToEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ReplyToEmail@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ReplyToEmail@0.4.0",
       "description": "Reply to an existing email in Outlook.\n\nUse this tool to reply to the sender or all recipients of the email.\nSpecify the reply_type to determine the scope of the reply.",
       "parameters": [
         {
@@ -1104,7 +1199,7 @@
     {
       "name": "SearchEmails",
       "qualifiedName": "MicrosoftOutlookMail.SearchEmails",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SearchEmails@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SearchEmails@0.4.0",
       "description": "Search emails across the user's entire mailbox.\n\nCombines full-text keyword search with structured filters for sender,\nread status, attachments, importance, and more. All provided parameters\nare combined with AND. Results are ordered by date sent (most recent first).\n\nEmail bodies are truncated to 255 characters for efficient skimming.\nUse get_email with the message_id to retrieve the full email content.\n\nUse this tool when the user wants to find emails by content, topic, sender,\nor a combination of criteria. For exact property filtering (e.g., by\nconversationId or flag status), use list_emails_by_property instead.\n\n.. note::\n   Microsoft Graph's ``$search`` on messages is backed by the Microsoft\n   Search index, which returns message IDs in the legacy REST-ID format\n   even when the client opts into Immutable IDs (which other tools in\n   this toolkit do by default). Do not directly compare a ``message_id``\n   from ``search_emails`` against one from ``list_emails`` /\n   ``get_email`` — the ID shapes differ. To chain from a search hit,\n   pass the returned ID straight back into ``get_email`` (which accepts\n   either format), and use ``conversation_id`` as the deduplication\n   key across result sets.",
       "parameters": [
         {
@@ -1328,7 +1423,7 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.SendDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SendDraftEmail@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SendDraftEmail@0.4.0",
       "description": "Send an existing draft email in Outlook.\n\nSends any un-sent message — draft, reply-draft, reply-all draft, or\nforward draft — and returns the message's ``message_id`` and\n``conversation_id`` so callers can chain follow-ups (e.g. reply to\nthe message they just sent) without searching Sent Items.",
       "parameters": [
         {
@@ -1389,7 +1484,7 @@
     {
       "name": "SharedMailboxCheckCapabilities",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxCheckCapabilities",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCheckCapabilities@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCheckCapabilities@0.4.0",
       "description": "Check which provided mailboxes are reachable via shared mailbox APIs.\n\nThis is a capability checker, not an Exchange permission inventory. It\nverifies whether each provided mailbox can be reached through a cheap,\nread-only Graph call. When checking multiple mailboxes, pass them together\nin one ``owner_emails`` list so results can be deduplicated and rate-limited\nconsistently. Microsoft Graph does not expose exact ``Send As`` vs ``Send\non behalf`` permissions, so the response names that limitation explicitly\ninstead of guessing.",
       "parameters": [
         {
@@ -1454,7 +1549,7 @@
     {
       "name": "SharedMailboxCreateAndSendEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateAndSendEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateAndSendEmail@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateAndSendEmail@0.4.0",
       "description": "Create and immediately send an email from a shared or delegated mailbox.\n\nUse this when the user wants the email to be sent from a team inbox (like\nsales@ or support@) or from an executive's mailbox they have been\ndelegated access to, rather than from their own address.",
       "parameters": [
         {
@@ -1606,7 +1701,7 @@
     {
       "name": "SharedMailboxCreateDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateDraftEmail@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateDraftEmail@0.4.0",
       "description": "Compose a new draft email in a shared or delegated mailbox.",
       "parameters": [
         {
@@ -1758,7 +1853,7 @@
     {
       "name": "SharedMailboxGetEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxGetEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxGetEmail@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxGetEmail@0.4.0",
       "description": "Retrieve a single email from a shared or delegated mailbox by message ID.\n\nReturns email metadata and body content. By default, the body is returned\nas plain text (HTML tags stripped) and capped at 5000 characters. Use\nbody_offset to continue reading long emails, or set max_body_characters\nto None for the full body.",
       "parameters": [
         {
@@ -1874,7 +1969,7 @@
     {
       "name": "SharedMailboxListEmailAttachments",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailAttachments",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailAttachments@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailAttachments@0.4.0",
       "description": "List attachment metadata for an email in a shared or delegated mailbox.",
       "parameters": [
         {
@@ -1974,7 +2069,7 @@
     {
       "name": "SharedMailboxListEmails",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmails",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmails@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmails@0.4.0",
       "description": "List emails in a shared or delegated mailbox, across all folders.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
       "parameters": [
         {
@@ -2095,7 +2190,7 @@
     {
       "name": "SharedMailboxListEmailsByProperty",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsByProperty",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsByProperty@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsByProperty@0.4.0",
       "description": "List emails in a shared or delegated mailbox filtered by a property.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
       "parameters": [
         {
@@ -2274,7 +2369,7 @@
     {
       "name": "SharedMailboxListEmailsInFolder",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsInFolder",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsInFolder@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsInFolder@0.4.0",
       "description": "List emails in a specific folder of a shared or delegated mailbox.\n\nExactly one of `well_known_folder_name` or `folder_id` MUST be provided.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
       "parameters": [
         {
@@ -2429,7 +2524,7 @@
     {
       "name": "SharedMailboxListMailFolders",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListMailFolders",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListMailFolders@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListMailFolders@0.4.0",
       "description": "List mail folders in a shared or delegated mailbox.\n\nReturns folder names, IDs, unread counts, and total item counts.\nUse the folder ID when listing emails in a specific folder.",
       "parameters": [
         {
@@ -2539,9 +2634,117 @@
       }
     },
     {
+      "name": "SharedMailboxMoveEmailToFolder",
+      "qualifiedName": "MicrosoftOutlookMail.SharedMailboxMoveEmailToFolder",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxMoveEmailToFolder@0.4.0",
+      "description": "Move an email message to a different folder in a shared or delegated mailbox.\n\nExactly one of `destination_well_known_folder_name` or\n`destination_folder_id` MUST be provided. Use\n`shared_mailbox_list_mail_folders` (with the same `owner_email`) to\ndiscover custom folder IDs; folder IDs are specific to the target\nmailbox.",
+      "parameters": [
+        {
+          "name": "owner_email",
+          "type": "string",
+          "required": true,
+          "description": "The mailbox address that contains the message. Can be a team or shared mailbox, or a specific person's mailbox you have delegate access to. Provide the exact mailbox email address.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the email message to move.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "destination_well_known_folder_name",
+          "type": "string",
+          "required": false,
+          "description": "The well-known destination folder. Provide this when moving to inbox, drafts, sent items, deleted items, or another built-in folder; otherwise omit and set destination_folder_id.",
+          "enum": [
+            "deleteditems",
+            "drafts",
+            "inbox",
+            "junkemail",
+            "sentitems",
+            "starred",
+            "tasks"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "destination_folder_id",
+          "type": "string",
+          "required": false,
+          "description": "The destination folder ID for a custom folder. Provide this when the destination is not a well-known folder; otherwise omit and set destination_well_known_folder_name.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "MailboxSettings.Read",
+          "Mail.ReadWrite.Shared"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SharedMailboxMoveEmailToFolder",
+        "parameters": {
+          "owner_email": {
+            "value": "support-team@contoso.com",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": "AAMkAGU2ZjBhNTEtZDQ3MC00YWE5LWJkYjAtNmFhZDg4MzQ1NzExBGAAAAAAA",
+            "type": "string",
+            "required": true
+          },
+          "destination_well_known_folder_name": {
+            "value": "deleteditems",
+            "type": "string",
+            "required": false
+          },
+          "destination_folder_id": {
+            "value": "",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "SharedMailboxReplyToEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxReplyToEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxReplyToEmail@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxReplyToEmail@0.4.0",
       "description": "Reply to an email in a shared or delegated mailbox.\n\nThe reply is sent from the shared mailbox address, not the signed-in\nuser's personal address. Specify reply_type to reply only to the sender\nor to all recipients.",
       "parameters": [
         {
@@ -2644,7 +2847,7 @@
     {
       "name": "SharedMailboxSearchEmails",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxSearchEmails",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxSearchEmails@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxSearchEmails@0.4.0",
       "description": "Search emails in a shared or delegated mailbox.\n\nCombines full-text keyword search with structured filters for sender,\nread status, attachments, importance, and more. All provided parameters\nare combined with AND. Results are ordered by date sent (most recent first).\n\nEmail bodies are truncated to 255 characters. Retrieve a message by its\nmessage ID when the full content is needed.\n\n.. note::\n   Search results may use a different Graph ID shape than list/get\n   results. Use returned message IDs directly for message retrieval and\n   ``conversation_id`` for deduplication across result sets.",
       "parameters": [
         {
@@ -2880,7 +3083,7 @@
     {
       "name": "SharedMailboxSendDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxSendDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxSendDraftEmail@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxSendDraftEmail@0.4.0",
       "description": "Send an existing draft email from a shared or delegated mailbox.\n\nThis tool can send any un-sent email in the shared mailbox:\n    - draft\n    - reply-draft\n    - reply-all draft\n    - forward draft\n\nReturns the message's ``message_id`` and ``conversation_id`` so callers\ncan chain follow-ups (e.g. reply to the message they just sent) without\nsearching Sent Items.",
       "parameters": [
         {
@@ -2954,7 +3157,7 @@
     {
       "name": "SharedMailboxUpdateDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxUpdateDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxUpdateDraftEmail@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxUpdateDraftEmail@0.4.0",
       "description": "Update an existing draft email in a shared or delegated mailbox.\n\nOverwrites the subject and body of a draft (if provided) and modifies its\nrecipient lists by selectively adding or removing email addresses.",
       "parameters": [
         {
@@ -3151,7 +3354,7 @@
     {
       "name": "UpdateDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.UpdateDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.UpdateDraftEmail@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.UpdateDraftEmail@0.4.0",
       "description": "Update an existing draft email in Outlook.\n\nThis tool overwrites the subject and body of a draft email (if provided),\nand modifies its recipient lists by selectively adding or removing email addresses.\n\nThis tool can update any un-sent email:\n    - draft\n    - reply-draft\n    - reply-all draft\n    - forward draft",
       "parameters": [
         {
@@ -3335,7 +3538,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftOutlookMail.WhoAmI",
-      "fullyQualifiedName": "MicrosoftOutlookMail.WhoAmI@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookMail.WhoAmI@0.4.0",
       "description": "Get comprehensive user profile and Outlook Mail environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, mailbox settings, automatic replies configuration, and other\nimportant profile details from Outlook Mail services.",
       "parameters": [],
       "auth": {
@@ -3382,6 +3585,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-05-13T11:50:30.471Z",
-  "summary": "The **Microsoft Outlook Mail** toolkit provides Arcade LLM tools for reading, composing, sending, searching, and managing email in Outlook via the Microsoft Graph API. It covers both personal mailboxes and shared/delegated mailboxes (e.g., team inboxes like `support@`).\n\n## Capabilities\n\n- **Compose & Send:** Create and immediately send emails, compose drafts, update drafts (subject, body, recipients), and send existing drafts — including reply-drafts, reply-all drafts, and forward drafts. Returns `message_id` and `conversation_id` for chaining follow-ups.\n- **Read & Retrieve:** Fetch full email content by ID with configurable body format (plain text or HTML), character limits, and pagination offset for long messages.\n- **Search & Filter:** Full-text keyword search across the entire mailbox with structured filters (sender, read status, attachments, importance); list emails globally or within a specific folder; filter by exact property (conversation ID, flag status, etc.); sort by date, subject, sender, or importance.\n- **Folder & Attachment Metadata:** List all mail folders (with unread/total counts) at any level of the hierarchy; list attachment metadata (name, size, type) for any message.\n- **Shared & Delegated Mailboxes:** Full parity set of tools for shared/delegated mailboxes — compose, send, read, search, list, reply, update drafts, and check mailbox reachability — with replies sent from the shared address, not the signed-in user.\n- **Identity & Mailbox Settings:** Retrieve the authenticated user's profile, mailbox settings, and auto-reply configuration via `WhoAmI`.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 with **Microsoft** as the identity provider. Arcade handles the authorization flow automatically.\n\nSee the [Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration details."
+  "generatedAt": "2026-06-04T12:06:49.152Z",
+  "summary": "The Microsoft Outlook Mail toolkit connects Arcade to the Microsoft Graph Mail API, enabling LLMs to read, compose, send, search, organize, and manage email in both personal and shared/delegated Outlook mailboxes.\n\n## Capabilities\n\n- **Read & search mail** — retrieve individual messages (with pagination and HTML/plain-text control), list emails across all folders or within a specific folder, filter by structured properties (sender, flag, importance, conversation, etc.), and run full-text keyword searches with combined AND filters across an entire mailbox.\n- **Compose & send** — create and immediately send emails, compose drafts, update draft recipients/subject/body, send existing drafts (including reply, reply-all, and forward drafts), and reply to messages (sender-only or reply-all).\n- **Folder & organization management** — list top-level and nested mail folders with unread/total counts, discover custom folder IDs, and move messages between folders using well-known folder names or folder IDs.\n- **Attachments** — list attachment metadata (name, size, type) for any message without downloading content.\n- **Shared & delegated mailboxes** — a full parallel set of tools (prefixed `SharedMailbox`) covers all read, compose, send, search, folder, and attachment operations against team inboxes (e.g., `sales@`, `support@`) or executive mailboxes the user has delegate access to; includes a capability checker to verify mailbox reachability before acting.\n- **Identity & mailbox settings** — retrieve the authenticated user's profile, mailbox settings, and automatic-replies configuration via `WhoAmI`.\n\n## OAuth\n\nThis toolkit authenticates via **Microsoft** OAuth 2.0. Arcade manages token acquisition and refresh automatically.\n\nSee the [Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration details."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftpowerpoint.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftpowerpoint.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftPowerpoint",
   "label": "Microsoft PowerPoint",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Arcade.dev LLM tools for Microsoft PowerPoint",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "CreatePresentation",
       "qualifiedName": "MicrosoftPowerpoint.CreatePresentation",
-      "fullyQualifiedName": "MicrosoftPowerpoint.CreatePresentation@0.2.1",
+      "fullyQualifiedName": "MicrosoftPowerpoint.CreatePresentation@0.3.0",
       "description": "Create a new PowerPoint presentation in OneDrive.\n\nThe presentation will be created with a title slide containing the specified title.",
       "parameters": [
         {
@@ -99,7 +99,7 @@
     {
       "name": "CreateSlide",
       "qualifiedName": "MicrosoftPowerpoint.CreateSlide",
-      "fullyQualifiedName": "MicrosoftPowerpoint.CreateSlide@0.2.1",
+      "fullyQualifiedName": "MicrosoftPowerpoint.CreateSlide@0.3.0",
       "description": "Append a new slide to the end of an existing PowerPoint presentation in OneDrive.\n\nThe slide will be added at the end of the presentation. Both title and body\nare optional to support layouts like BLANK or TITLE_ONLY.\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -114,7 +114,7 @@
           "name": "slide_title",
           "type": "string",
           "required": false,
-          "description": "The title for the new slide. Optional for layouts like BLANK.",
+          "description": "The title for the new slide. Supports markdown: **bold**, *italic*, and __underline__. Optional for layouts like BLANK.",
           "enum": null,
           "inferrable": true
         },
@@ -122,7 +122,7 @@
           "name": "slide_body",
           "type": "string",
           "required": false,
-          "description": "The body content for the new slide. Supports markdown: **bold**, *italic*, __underline__, and bullet points (- item, use spaces for nesting). Optional for layouts like TITLE_ONLY or BLANK.",
+          "description": "The body content for the new slide. Supports markdown: **bold**, *italic*, __underline__, [links](url), `inline code`, # headers, ``` code fences, and bullet points (- item, use spaces for nesting). Optional for layouts like TITLE_ONLY or BLANK.",
           "enum": null,
           "inferrable": true
         },
@@ -208,7 +208,7 @@
     {
       "name": "CreateTwoContentSlide",
       "qualifiedName": "MicrosoftPowerpoint.CreateTwoContentSlide",
-      "fullyQualifiedName": "MicrosoftPowerpoint.CreateTwoContentSlide@0.2.1",
+      "fullyQualifiedName": "MicrosoftPowerpoint.CreateTwoContentSlide@0.3.0",
       "description": "Append a TWO_CONTENT slide with side-by-side content areas to a PowerPoint presentation.\n\nThis layout is useful for comparisons, pros/cons lists, or any content that\nbenefits from a two-column layout.\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -223,7 +223,7 @@
           "name": "slide_title",
           "type": "string",
           "required": false,
-          "description": "The title for the new slide.",
+          "description": "The title for the new slide. Supports markdown: **bold**, *italic*, and __underline__.",
           "enum": null,
           "inferrable": true
         },
@@ -231,7 +231,7 @@
           "name": "left_body",
           "type": "string",
           "required": false,
-          "description": "Content for the left side of the slide. Supports markdown: **bold**, *italic*, __underline__, and bullet points (- item, use spaces for nesting).",
+          "description": "Content for the left side of the slide. Supports markdown: **bold**, *italic*, __underline__, [links](url), `inline code`, # headers, ``` code fences, and bullet points (- item, use spaces for nesting).",
           "enum": null,
           "inferrable": true
         },
@@ -239,7 +239,7 @@
           "name": "right_body",
           "type": "string",
           "required": false,
-          "description": "Content for the right side of the slide. Supports markdown: **bold**, *italic*, __underline__, and bullet points (- item, use spaces for nesting).",
+          "description": "Content for the right side of the slide. Supports markdown: **bold**, *italic*, __underline__, [links](url), `inline code`, # headers, ``` code fences, and bullet points (- item, use spaces for nesting).",
           "enum": null,
           "inferrable": true
         }
@@ -307,7 +307,7 @@
     {
       "name": "GetAllSlideNotes",
       "qualifiedName": "MicrosoftPowerpoint.GetAllSlideNotes",
-      "fullyQualifiedName": "MicrosoftPowerpoint.GetAllSlideNotes@0.2.1",
+      "fullyQualifiedName": "MicrosoftPowerpoint.GetAllSlideNotes@0.3.0",
       "description": "Get all speaker notes from every slide in a PowerPoint presentation.\n\nReturns notes for all slides in one call, which is more efficient than\ncalling get_slide_notes for each slide individually. Notes are returned\nin markdown format.",
       "parameters": [
         {
@@ -367,7 +367,7 @@
     {
       "name": "GetPresentationAsMarkdown",
       "qualifiedName": "MicrosoftPowerpoint.GetPresentationAsMarkdown",
-      "fullyQualifiedName": "MicrosoftPowerpoint.GetPresentationAsMarkdown@0.2.1",
+      "fullyQualifiedName": "MicrosoftPowerpoint.GetPresentationAsMarkdown@0.3.0",
       "description": "Get the content of a PowerPoint presentation as markdown.\n\nThis tool downloads the presentation and converts it to a markdown representation,\npreserving text content, tables, and chart data. Images and other media are\nrepresented as placeholders.",
       "parameters": [
         {
@@ -427,7 +427,7 @@
     {
       "name": "GetSlideNotes",
       "qualifiedName": "MicrosoftPowerpoint.GetSlideNotes",
-      "fullyQualifiedName": "MicrosoftPowerpoint.GetSlideNotes@0.2.1",
+      "fullyQualifiedName": "MicrosoftPowerpoint.GetSlideNotes@0.3.0",
       "description": "Get the speaker notes from a specific slide in a PowerPoint presentation.\n\nSpeaker notes are returned in markdown format, preserving basic formatting\nlike bold, italic, and bullet points.",
       "parameters": [
         {
@@ -500,7 +500,7 @@
     {
       "name": "SetSlideNotes",
       "qualifiedName": "MicrosoftPowerpoint.SetSlideNotes",
-      "fullyQualifiedName": "MicrosoftPowerpoint.SetSlideNotes@0.2.1",
+      "fullyQualifiedName": "MicrosoftPowerpoint.SetSlideNotes@0.3.0",
       "description": "Set or update the speaker notes on a specific slide in a PowerPoint presentation.\n\nNotes can be formatted using markdown:\n- **bold** for bold text\n- *italic* for italic text\n- __underline__ for underlined text\n- Lines starting with - or * become bullet points\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.\n- Indent with spaces for nested bullets",
       "parameters": [
         {
@@ -586,7 +586,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftPowerpoint.WhoAmI",
-      "fullyQualifiedName": "MicrosoftPowerpoint.WhoAmI@0.2.1",
+      "fullyQualifiedName": "MicrosoftPowerpoint.WhoAmI@0.3.0",
       "description": "Get information about the current user and their PowerPoint environment.",
       "parameters": [],
       "auth": {
@@ -632,6 +632,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-04-27T11:41:15.672Z",
-  "summary": "Arcade's Microsoft PowerPoint toolkit lets developers create, modify, and extract PowerPoint presentations stored in OneDrive through Microsoft Graph.\n\n**Capabilities**\n- Create presentations and append slides, including title, blank, and two-content layouts.\n- Add slide body content with Markdown-style formatting for bold, italic, underline, and bullet lists.\n- Read, set, and export speaker notes across one slide or all slides.\n- Convert presentations to Markdown with text, tables, chart data, and media placeholders.\n- Use resumable uploads for large presentations and fetch authenticated user information.\n\n**OAuth**\n- **Provider**: Microsoft\n- **Scopes**: Files.Read, Files.ReadWrite, User.Read\n\n**Secrets**\n- No secret types required for toolkit operation."
+  "generatedAt": "2026-06-04T12:06:45.030Z",
+  "summary": "## Microsoft PowerPoint Toolkit\n\nThe Microsoft PowerPoint toolkit provides Arcade LLM tools for creating and managing PowerPoint presentations stored in OneDrive via the Microsoft Graph API.\n\n## Capabilities\n\n- **Presentation creation**: Create new presentations in OneDrive with a title slide; supports both small and large files (>4 MB via resumable upload sessions).\n- **Slide authoring**: Append slides with standard or two-column (`TWO_CONTENT`) layouts; titles and body content are optional to support blank or title-only layouts.\n- **Speaker notes management**: Read notes from a single slide or all slides at once; write/update notes with Markdown formatting (bold, italic, underline, bullets with nesting support).\n- **Content reading**: Export a full presentation to Markdown, preserving text, tables, and chart data; images and media are represented as placeholders.\n- **User context**: Retrieve information about the authenticated user and their PowerPoint environment.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via the **Microsoft** provider. See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration details."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftsharepoint.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftsharepoint.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftSharepoint",
   "label": "Microsoft SharePoint",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Arcade.dev LLM tools for Microsoft SharePoint",
   "metadata": {
     "category": "productivity",
@@ -27,7 +27,7 @@
     {
       "name": "AddWorksheet",
       "qualifiedName": "MicrosoftSharepoint.AddWorksheet",
-      "fullyQualifiedName": "MicrosoftSharepoint.AddWorksheet@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.AddWorksheet@0.2.0",
       "description": "Add a new worksheet to a SharePoint Excel workbook.\n\nNote: The new worksheet name may not be immediately visible to other\ntools due to a brief Graph API propagation delay (up to ~10 s). Pass\nthe returned ``session_id`` to subsequent calls that reference the new\nworksheet to mitigate this.",
       "parameters": [
         {
@@ -128,7 +128,7 @@
     {
       "name": "CopyItem",
       "qualifiedName": "MicrosoftSharepoint.CopyItem",
-      "fullyQualifiedName": "MicrosoftSharepoint.CopyItem@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.CopyItem@0.2.0",
       "description": "Copy a file or folder. Returns a completed item or an operation id.",
       "parameters": [
         {
@@ -228,7 +228,7 @@
     {
       "name": "CreateFolder",
       "qualifiedName": "MicrosoftSharepoint.CreateFolder",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateFolder@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateFolder@0.2.0",
       "description": "Create a new folder in a SharePoint drive.",
       "parameters": [
         {
@@ -315,7 +315,7 @@
     {
       "name": "CreatePresentation",
       "qualifiedName": "MicrosoftSharepoint.CreatePresentation",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreatePresentation@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreatePresentation@0.2.0",
       "description": "Create a new PowerPoint presentation in a SharePoint drive.\n\nThe presentation will be created with a title slide containing the specified title.",
       "parameters": [
         {
@@ -402,7 +402,7 @@
     {
       "name": "CreateShareLink",
       "qualifiedName": "MicrosoftSharepoint.CreateShareLink",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateShareLink@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateShareLink@0.2.0",
       "description": "Create a share link for a SharePoint drive item.",
       "parameters": [
         {
@@ -476,7 +476,7 @@
     {
       "name": "CreateSlide",
       "qualifiedName": "MicrosoftSharepoint.CreateSlide",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateSlide@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateSlide@0.2.0",
       "description": "Append a new slide to the end of an existing PowerPoint presentation in a SharePoint drive.\n\nThe slide will be added at the end of the presentation. Both title and body\nare optional to support layouts like BLANK or TITLE_ONLY.\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -499,7 +499,7 @@
           "name": "slide_title",
           "type": "string",
           "required": false,
-          "description": "The title for the new slide. Optional for layouts like BLANK.",
+          "description": "The title for the new slide. Supports markdown: **bold**, *italic*, and __underline__. Optional for layouts like BLANK.",
           "enum": null,
           "inferrable": true
         },
@@ -507,7 +507,7 @@
           "name": "slide_body",
           "type": "string",
           "required": false,
-          "description": "The body content for the new slide. Supports markdown: **bold**, *italic*, __underline__, and bullet points (- item, use spaces for nesting). Optional for layouts like TITLE_ONLY or BLANK.",
+          "description": "The body content for the new slide. Supports markdown: **bold**, *italic*, __underline__, [links](url), `inline code`, # headers, ``` code fences, and bullet points (- item, use spaces for nesting). Optional for layouts like TITLE_ONLY or BLANK.",
           "enum": null,
           "inferrable": true
         },
@@ -599,7 +599,7 @@
     {
       "name": "CreateTwoContentSlide",
       "qualifiedName": "MicrosoftSharepoint.CreateTwoContentSlide",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateTwoContentSlide@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateTwoContentSlide@0.2.0",
       "description": "Append a TWO_CONTENT slide with side-by-side content areas to a SharePoint PowerPoint.\n\nThis layout is useful for comparisons, pros/cons lists, or any content that\nbenefits from a two-column layout.\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -622,7 +622,7 @@
           "name": "slide_title",
           "type": "string",
           "required": false,
-          "description": "The title for the new slide.",
+          "description": "The title for the new slide. Supports markdown: **bold**, *italic*, and __underline__.",
           "enum": null,
           "inferrable": true
         },
@@ -630,7 +630,7 @@
           "name": "left_body",
           "type": "string",
           "required": false,
-          "description": "Content for the left side of the slide. Supports markdown: **bold**, *italic*, __underline__, and bullet points (- item, use spaces for nesting).",
+          "description": "Content for the left side of the slide. Supports markdown: **bold**, *italic*, __underline__, [links](url), `inline code`, # headers, ``` code fences, and bullet points (- item, use spaces for nesting).",
           "enum": null,
           "inferrable": true
         },
@@ -638,7 +638,7 @@
           "name": "right_body",
           "type": "string",
           "required": false,
-          "description": "Content for the right side of the slide. Supports markdown: **bold**, *italic*, __underline__, and bullet points (- item, use spaces for nesting).",
+          "description": "Content for the right side of the slide. Supports markdown: **bold**, *italic*, __underline__, [links](url), `inline code`, # headers, ``` code fences, and bullet points (- item, use spaces for nesting).",
           "enum": null,
           "inferrable": true
         }
@@ -712,7 +712,7 @@
     {
       "name": "CreateWordDocument",
       "qualifiedName": "MicrosoftSharepoint.CreateWordDocument",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateWordDocument@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateWordDocument@0.2.0",
       "description": "Create a new Word document in a SharePoint drive.\n\n4MB upload limit. Optionally include text content.",
       "parameters": [
         {
@@ -825,7 +825,7 @@
     {
       "name": "CreateWorkbook",
       "qualifiedName": "MicrosoftSharepoint.CreateWorkbook",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateWorkbook@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateWorkbook@0.2.0",
       "description": "Create a new Excel workbook (.xlsx) in a SharePoint drive.\n\nOnly .xlsx files are supported.",
       "parameters": [
         {
@@ -926,7 +926,7 @@
     {
       "name": "DeleteItem",
       "qualifiedName": "MicrosoftSharepoint.DeleteItem",
-      "fullyQualifiedName": "MicrosoftSharepoint.DeleteItem@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.DeleteItem@0.2.0",
       "description": "Delete a file or folder from a SharePoint drive.",
       "parameters": [
         {
@@ -1000,7 +1000,7 @@
     {
       "name": "DeleteWorksheet",
       "qualifiedName": "MicrosoftSharepoint.DeleteWorksheet",
-      "fullyQualifiedName": "MicrosoftSharepoint.DeleteWorksheet@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.DeleteWorksheet@0.2.0",
       "description": "Delete a worksheet from a SharePoint Excel workbook.\n\nCannot delete the last worksheet in a workbook.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -1101,7 +1101,7 @@
     {
       "name": "GetAllSlideNotes",
       "qualifiedName": "MicrosoftSharepoint.GetAllSlideNotes",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetAllSlideNotes@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetAllSlideNotes@0.2.0",
       "description": "Get all speaker notes from every slide in a SharePoint PowerPoint presentation.\n\nReturns notes for all slides in one call, which is more efficient than\ncalling get_slide_notes for each slide individually. Notes are returned\nin markdown format.",
       "parameters": [
         {
@@ -1175,7 +1175,7 @@
     {
       "name": "GetCopyStatus",
       "qualifiedName": "MicrosoftSharepoint.GetCopyStatus",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetCopyStatus@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetCopyStatus@0.2.0",
       "description": "Check status of an async copy operation using the token returned by copy_item.",
       "parameters": [
         {
@@ -1249,7 +1249,7 @@
     {
       "name": "GetDrivesFromSite",
       "qualifiedName": "MicrosoftSharepoint.GetDrivesFromSite",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetDrivesFromSite@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetDrivesFromSite@0.2.0",
       "description": "Retrieve drives / document libraries from a SharePoint site.\n\nIf you have a site name, it is not necessary to call Sharepoint.SearchSites first.\nYou can simply call this tool with the site name / keywords.",
       "parameters": [
         {
@@ -1310,7 +1310,7 @@
     {
       "name": "GetItemsFromList",
       "qualifiedName": "MicrosoftSharepoint.GetItemsFromList",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetItemsFromList@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetItemsFromList@0.2.0",
       "description": "Retrieve items from a list in a SharePoint site.\n\nNote: The Microsoft Graph API does not offer endpoints to retrieve list item attachments.\nBecause of that, the only information we can get is whether the item has attachments or not.",
       "parameters": [
         {
@@ -1384,7 +1384,7 @@
     {
       "name": "GetListsFromSite",
       "qualifiedName": "MicrosoftSharepoint.GetListsFromSite",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetListsFromSite@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetListsFromSite@0.2.0",
       "description": "Retrieve lists from a SharePoint site.",
       "parameters": [
         {
@@ -1445,7 +1445,7 @@
     {
       "name": "GetPage",
       "qualifiedName": "MicrosoftSharepoint.GetPage",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetPage@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetPage@0.2.0",
       "description": "Retrieve metadata and the contents of a page in a SharePoint site.\n\nPage content is a list of Microsoft Sharepoint web part objects, such as text, images, banners,\nbuttons, etc.\n\nIf `include_page_content` is set to False, the tool will return only the page metadata.",
       "parameters": [
         {
@@ -1532,7 +1532,7 @@
     {
       "name": "GetPresentationAsMarkdown",
       "qualifiedName": "MicrosoftSharepoint.GetPresentationAsMarkdown",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetPresentationAsMarkdown@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetPresentationAsMarkdown@0.2.0",
       "description": "Get the content of a PowerPoint presentation stored in a SharePoint drive as markdown.\n\nThis tool downloads the presentation and converts it to a markdown representation,\npreserving text content, tables, and chart data. Images and other media are\nrepresented as placeholders.",
       "parameters": [
         {
@@ -1606,7 +1606,7 @@
     {
       "name": "GetSite",
       "qualifiedName": "MicrosoftSharepoint.GetSite",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetSite@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetSite@0.2.0",
       "description": "Retrieve information about a specific SharePoint site by its ID, URL, or name.",
       "parameters": [
         {
@@ -1667,7 +1667,7 @@
     {
       "name": "GetSlideNotes",
       "qualifiedName": "MicrosoftSharepoint.GetSlideNotes",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetSlideNotes@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetSlideNotes@0.2.0",
       "description": "Get the speaker notes from a specific slide in a SharePoint PowerPoint presentation.\n\nSpeaker notes are returned in markdown format, preserving basic formatting\nlike bold, italic, and bullet points.",
       "parameters": [
         {
@@ -1754,7 +1754,7 @@
     {
       "name": "GetWordDocument",
       "qualifiedName": "MicrosoftSharepoint.GetWordDocument",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetWordDocument@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetWordDocument@0.2.0",
       "description": "Get a Word document's metadata and content from a SharePoint drive. Supports only `.docx`.\n\nReturns the document content as Markdown by default.\nReturns only metadata when metadata_only is True.",
       "parameters": [
         {
@@ -1841,7 +1841,7 @@
     {
       "name": "GetWorkbookMetadata",
       "qualifiedName": "MicrosoftSharepoint.GetWorkbookMetadata",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetWorkbookMetadata@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetWorkbookMetadata@0.2.0",
       "description": "Get metadata about an Excel workbook in a SharePoint drive, including worksheet list.",
       "parameters": [
         {
@@ -1929,7 +1929,7 @@
     {
       "name": "GetWorksheetData",
       "qualifiedName": "MicrosoftSharepoint.GetWorksheetData",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetWorksheetData@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetWorksheetData@0.2.0",
       "description": "Read cell values from a worksheet in a SharePoint Excel workbook.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -2082,7 +2082,7 @@
     {
       "name": "InsertTextAtEndOfWordDocument",
       "qualifiedName": "MicrosoftSharepoint.InsertTextAtEndOfWordDocument",
-      "fullyQualifiedName": "MicrosoftSharepoint.InsertTextAtEndOfWordDocument@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.InsertTextAtEndOfWordDocument@0.2.0",
       "description": "Append text to the end of an existing Word document.\n\nThis tool only supports files with the `.docx` extension and enforces the 4MB limit.",
       "parameters": [
         {
@@ -2169,7 +2169,7 @@
     {
       "name": "ListItemsInFolder",
       "qualifiedName": "MicrosoftSharepoint.ListItemsInFolder",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListItemsInFolder@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListItemsInFolder@0.2.0",
       "description": "Retrieve items from a folder in a drive in a SharePoint site.\n\nNote: The Microsoft Graph API requires retrieving all items,\nincluding those skipped by offset.\nExecution time increases with higher offset values.",
       "parameters": [
         {
@@ -2269,7 +2269,7 @@
     {
       "name": "ListPages",
       "qualifiedName": "MicrosoftSharepoint.ListPages",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListPages@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListPages@0.2.0",
       "description": "Retrieve pages from a SharePoint site.\n\nThe Microsoft Graph API does not support pagination on this endpoint.",
       "parameters": [
         {
@@ -2343,7 +2343,7 @@
     {
       "name": "ListRootItemsInDrive",
       "qualifiedName": "MicrosoftSharepoint.ListRootItemsInDrive",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListRootItemsInDrive@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListRootItemsInDrive@0.2.0",
       "description": "Retrieve items from the root of a drive in a SharePoint site.\n\nNote: The Microsoft Graph API requires retrieving all items,\nincluding those skipped by offset.\nExecution time increases with higher offset values.",
       "parameters": [
         {
@@ -2430,7 +2430,7 @@
     {
       "name": "ListSites",
       "qualifiedName": "MicrosoftSharepoint.ListSites",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListSites@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListSites@0.2.0",
       "description": "List all SharePoint sites accessible to the current user.",
       "parameters": [
         {
@@ -2504,7 +2504,7 @@
     {
       "name": "MoveItem",
       "qualifiedName": "MicrosoftSharepoint.MoveItem",
-      "fullyQualifiedName": "MicrosoftSharepoint.MoveItem@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.MoveItem@0.2.0",
       "description": "Move a file or folder to a new location in a SharePoint drive.",
       "parameters": [
         {
@@ -2591,7 +2591,7 @@
     {
       "name": "RenameWorksheet",
       "qualifiedName": "MicrosoftSharepoint.RenameWorksheet",
-      "fullyQualifiedName": "MicrosoftSharepoint.RenameWorksheet@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.RenameWorksheet@0.2.0",
       "description": "Rename an existing worksheet in a SharePoint Excel workbook.\n\nNote: The new name may not be immediately visible to other tools due\nto a brief Graph API propagation delay (up to ~10 s). Pass the returned\n``session_id`` to subsequent calls that reference the renamed worksheet\nto mitigate this. If referencing a recently added worksheet as the source,\nthe same delay applies; retry with the ``session_id`` if a\nWorksheetNotFoundError occurs.",
       "parameters": [
         {
@@ -2705,7 +2705,7 @@
     {
       "name": "SearchDriveItems",
       "qualifiedName": "MicrosoftSharepoint.SearchDriveItems",
-      "fullyQualifiedName": "MicrosoftSharepoint.SearchDriveItems@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.SearchDriveItems@0.2.0",
       "description": "Search for items in one or more Sharepoint drives.\n\nNote: When searching a single Drive and/or Folder,\nthe API must retrieve all items including those skipped by offset.\nExecution time increases with higher offset values.",
       "parameters": [
         {
@@ -2818,7 +2818,7 @@
     {
       "name": "SearchSites",
       "qualifiedName": "MicrosoftSharepoint.SearchSites",
-      "fullyQualifiedName": "MicrosoftSharepoint.SearchSites@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.SearchSites@0.2.0",
       "description": "Search for SharePoint sites by name or description.\n\nIn case you need to retrieve a specific site by its name, ID or SharePoint URL, use the\n`Sharepoint.GetSite` tool instead, passing the ID, name or SharePoint URL to it.",
       "parameters": [
         {
@@ -2905,7 +2905,7 @@
     {
       "name": "SetSlideNotes",
       "qualifiedName": "MicrosoftSharepoint.SetSlideNotes",
-      "fullyQualifiedName": "MicrosoftSharepoint.SetSlideNotes@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.SetSlideNotes@0.2.0",
       "description": "Set or update the speaker notes on a specific slide in a SharePoint PowerPoint.\n\nNotes can be formatted using markdown:\n- **bold** for bold text\n- *italic* for italic text\n- __underline__ for underlined text\n- Lines starting with - or * become bullet points\n- Indent with spaces for nested bullets\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -3005,7 +3005,7 @@
     {
       "name": "UpdateCell",
       "qualifiedName": "MicrosoftSharepoint.UpdateCell",
-      "fullyQualifiedName": "MicrosoftSharepoint.UpdateCell@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.UpdateCell@0.2.0",
       "description": "Update a single cell value in a SharePoint Excel workbook.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -3145,7 +3145,7 @@
     {
       "name": "UpdateRange",
       "qualifiedName": "MicrosoftSharepoint.UpdateRange",
-      "fullyQualifiedName": "MicrosoftSharepoint.UpdateRange@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.UpdateRange@0.2.0",
       "description": "Update multiple cells in a SharePoint Excel worksheet using sparse dict format.\n\nOnly specified cells are updated; unspecified cells remain unchanged.\n\nInternally, a single PATCH request is sent covering the bounding box\nof all specified cells.  Cells within the box that are not in the\ninput are sent as ``null``, which the Graph API treats as \"skip\".\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -3259,7 +3259,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftSharepoint.WhoAmI",
-      "fullyQualifiedName": "MicrosoftSharepoint.WhoAmI@0.1.3",
+      "fullyQualifiedName": "MicrosoftSharepoint.WhoAmI@0.2.0",
       "description": "Get information about the current user and their SharePoint environment.",
       "parameters": [],
       "auth": {
@@ -3306,6 +3306,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-05-28T12:15:52.149Z",
-  "summary": "The Microsoft SharePoint toolkit connects Arcade to Microsoft SharePoint via the Microsoft Graph API, enabling LLMs to read, write, and manage SharePoint sites, drives, lists, pages, and Office documents programmatically.\n\n## Capabilities\n\n- **Site & drive navigation** — list, search, and inspect SharePoint sites, document libraries, drives, folders, pages, and lists; retrieve the current user's context.\n- **File operations** — copy, move, delete, rename, and create share links for files and folders; check async copy status; search across drives.\n- **Excel workbook management** — create workbooks, add/rename/delete worksheets, read cell ranges, update individual cells or sparse multi-cell ranges, and retrieve workbook metadata. Session IDs mitigate Graph API propagation delays after structural changes.\n- **PowerPoint authoring** — create presentations, append single-content or two-column slides, set or retrieve per-slide speaker notes, get full presentation content as Markdown.\n- **Word document handling** — create `.docx` files, read content as Markdown, append text to existing documents (4 MB limit enforced).\n- **Lists and pages** — retrieve SharePoint list items (attachment presence noted but not downloadable via Graph), list and read site pages including web part content.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 delegated auth via the **Microsoft** provider. Arcade manages the token flow; see the [Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for setup details."
+  "generatedAt": "2026-06-04T12:06:45.042Z",
+  "summary": "The Microsoft SharePoint toolkit integrates Arcade with Microsoft SharePoint via the Microsoft Graph API, enabling LLMs to read, write, and manage SharePoint content programmatically.\n\n## Capabilities\n\n- **Site & drive navigation** — list, search, and retrieve sites, drives/document libraries, lists, list items, folders, and root drive contents; look up the current user's SharePoint environment.\n- **File & folder management** — create folders, copy, move, rename, and delete files or folders; check async copy operation status; generate share links for drive items.\n- **Excel workbook editing** — create workbooks, add/rename/delete worksheets, read cell ranges, update individual cells or sparse multi-cell ranges, and retrieve workbook metadata. Propagation-delay mitigations via `session_id` are built in.\n- **PowerPoint authoring** — create presentations with a title slide, append standard or two-column-layout slides, get/set/update speaker notes per slide or across all slides, and export presentations to Markdown (preserving text, tables, and chart data).\n- **Word document handling** — create `.docx` files with optional initial content, retrieve document content as Markdown or metadata-only, and append text to existing documents (4 MB limit).\n- **SharePoint pages & lists** — list and retrieve site pages (with full web-part content or metadata-only), and read items from SharePoint lists.\n\n## OAuth\n\nThis toolkit authenticates via **Microsoft** OAuth 2.0. See the [Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration details, required permissions, and setup steps."
 }


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/26950477626

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and generated metadata only; no application runtime code. Forkable docs reference password secrets—standard for integration docs, not a code-path change.
> 
> **Overview**
> Scheduled **MCP / toolkit docs** refresh: generated JSON under `toolkit-docs-generator/data/toolkits/` and a nav entry for the new integration.
> 
> **New Forkable productivity toolkit (v1.0.1)** — Adds `forkable.json` with five secret-based tools (weekly meals, menus, dietary checks, pick/skip) and registers **Forkable** in the productivity integrations `_meta.tsx`.
> 
> **GitHub toolkit 4.0.0 → 4.1.0** — Bumps all tool FQNs and adds **`Github.SearchCode`** (cross-repo code search with inline match context). Refreshes the toolkit `summary` and `generatedAt`.
> 
> **Microsoft Outlook Mail 0.3.1 → 0.4.0** — Adds **`MoveEmailToFolder`** and **`SharedMailboxMoveEmailToFolder`**; index tool count 26 → 28. Summary text updated for folder moves.
> 
> **Microsoft PowerPoint 0.2.1 → 0.3.0** and **SharePoint 0.1.3 → 0.2.0** — Version-only bumps on existing tools; slide title/body parameter docs now mention extra markdown (links, headers, code fences).
> 
> **`index.json`** — Regenerated catalog timestamp; registers Forkable; reflects GitHub and Outlook Mail version/count changes (and other Microsoft version bumps listed in the index).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62aa803f2c77db157333290ec1a70a91d6b531a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->