### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/app/en/resources/integrations/productivity/_meta.tsx
+++ b/app/en/resources/integrations/productivity/_meta.tsx
@@ -97,6 +97,10 @@ const meta: MetaRecord = {
     title: "Microsoft Word",
     href: "/en/resources/integrations/productivity/microsoft-word",
   },
+  resend: {
+    title: "Resend",
+    href: "/en/resources/integrations/productivity/resend",
+  },
   "-- Starter": {
     type: "separator",
     title: "Starter",

--- a/toolkit-docs-generator/data/toolkits/gmail.json
+++ b/toolkit-docs-generator/data/toolkits/gmail.json
@@ -1,7 +1,7 @@
 {
   "id": "Gmail",
   "label": "Gmail",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Arcade.dev LLM tools for Gmail",
   "metadata": {
     "category": "productivity",
@@ -30,7 +30,7 @@
     {
       "name": "ChangeEmailLabels",
       "qualifiedName": "Gmail.ChangeEmailLabels",
-      "fullyQualifiedName": "Gmail.ChangeEmailLabels@7.0.0",
+      "fullyQualifiedName": "Gmail.ChangeEmailLabels@7.0.1",
       "description": "Add and remove labels from an email using the Gmail API.",
       "parameters": [
         {
@@ -124,7 +124,7 @@
     {
       "name": "CreateLabel",
       "qualifiedName": "Gmail.CreateLabel",
-      "fullyQualifiedName": "Gmail.CreateLabel@7.0.0",
+      "fullyQualifiedName": "Gmail.CreateLabel@7.0.1",
       "description": "Create a new label in the user's mailbox.",
       "parameters": [
         {
@@ -184,7 +184,7 @@
     {
       "name": "DeleteDraftEmail",
       "qualifiedName": "Gmail.DeleteDraftEmail",
-      "fullyQualifiedName": "Gmail.DeleteDraftEmail@7.0.0",
+      "fullyQualifiedName": "Gmail.DeleteDraftEmail@7.0.1",
       "description": "Delete a draft email using the Gmail API.",
       "parameters": [
         {
@@ -244,7 +244,7 @@
     {
       "name": "GetThread",
       "qualifiedName": "Gmail.GetThread",
-      "fullyQualifiedName": "Gmail.GetThread@7.0.0",
+      "fullyQualifiedName": "Gmail.GetThread@7.0.1",
       "description": "Get the specified thread by ID.",
       "parameters": [
         {
@@ -304,7 +304,7 @@
     {
       "name": "ListDraftEmails",
       "qualifiedName": "Gmail.ListDraftEmails",
-      "fullyQualifiedName": "Gmail.ListDraftEmails@7.0.0",
+      "fullyQualifiedName": "Gmail.ListDraftEmails@7.0.1",
       "description": "Lists draft emails in the user's draft mailbox using the Gmail API.",
       "parameters": [
         {
@@ -364,7 +364,7 @@
     {
       "name": "ListEmails",
       "qualifiedName": "Gmail.ListEmails",
-      "fullyQualifiedName": "Gmail.ListEmails@7.0.0",
+      "fullyQualifiedName": "Gmail.ListEmails@7.0.1",
       "description": "Read emails from a Gmail account and extract plain text content.\n\nBy default, obvious automated emails are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all emails regardless of source.",
       "parameters": [
         {
@@ -437,7 +437,7 @@
     {
       "name": "ListEmailsByHeader",
       "qualifiedName": "Gmail.ListEmailsByHeader",
-      "fullyQualifiedName": "Gmail.ListEmailsByHeader@7.0.0",
+      "fullyQualifiedName": "Gmail.ListEmailsByHeader@7.0.1",
       "description": "Search for emails by header using the Gmail API.\n\nBy default, obvious automated emails are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all emails regardless of source.",
       "parameters": [
         {
@@ -596,7 +596,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Gmail.ListLabels",
-      "fullyQualifiedName": "Gmail.ListLabels@7.0.0",
+      "fullyQualifiedName": "Gmail.ListLabels@7.0.1",
       "description": "List all the labels in the user's mailbox.",
       "parameters": [],
       "auth": {
@@ -641,7 +641,7 @@
     {
       "name": "ListThreads",
       "qualifiedName": "Gmail.ListThreads",
-      "fullyQualifiedName": "Gmail.ListThreads@7.0.0",
+      "fullyQualifiedName": "Gmail.ListThreads@7.0.1",
       "description": "List threads in the user's mailbox.\n\nBy default, obvious automated threads are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all threads regardless of source.",
       "parameters": [
         {
@@ -740,7 +740,7 @@
     {
       "name": "ReplyToEmail",
       "qualifiedName": "Gmail.ReplyToEmail",
-      "fullyQualifiedName": "Gmail.ReplyToEmail@7.0.0",
+      "fullyQualifiedName": "Gmail.ReplyToEmail@7.0.1",
       "description": "Send a reply to an email message.",
       "parameters": [
         {
@@ -880,7 +880,7 @@
     {
       "name": "SearchThreads",
       "qualifiedName": "Gmail.SearchThreads",
-      "fullyQualifiedName": "Gmail.SearchThreads@7.0.0",
+      "fullyQualifiedName": "Gmail.SearchThreads@7.0.1",
       "description": "Search for threads in the user's mailbox.\n\nBy default, obvious automated threads are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all threads regardless of source.",
       "parameters": [
         {
@@ -1069,7 +1069,7 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "Gmail.SendDraftEmail",
-      "fullyQualifiedName": "Gmail.SendDraftEmail@7.0.0",
+      "fullyQualifiedName": "Gmail.SendDraftEmail@7.0.1",
       "description": "Send a draft email using the Gmail API.",
       "parameters": [
         {
@@ -1129,7 +1129,7 @@
     {
       "name": "SendEmail",
       "qualifiedName": "Gmail.SendEmail",
-      "fullyQualifiedName": "Gmail.SendEmail@7.0.0",
+      "fullyQualifiedName": "Gmail.SendEmail@7.0.1",
       "description": "Send an email using the Gmail API.",
       "parameters": [
         {
@@ -1265,7 +1265,7 @@
     {
       "name": "TrashEmail",
       "qualifiedName": "Gmail.TrashEmail",
-      "fullyQualifiedName": "Gmail.TrashEmail@7.0.0",
+      "fullyQualifiedName": "Gmail.TrashEmail@7.0.1",
       "description": "Move an email to the trash folder using the Gmail API.",
       "parameters": [
         {
@@ -1325,7 +1325,7 @@
     {
       "name": "UpdateDraftEmail",
       "qualifiedName": "Gmail.UpdateDraftEmail",
-      "fullyQualifiedName": "Gmail.UpdateDraftEmail@7.0.0",
+      "fullyQualifiedName": "Gmail.UpdateDraftEmail@7.0.1",
       "description": "Update an existing email draft using the Gmail API.\n\nSingle-part ``text/plain`` and single-part ``text/html`` drafts both support full\nbody replacement; the rebuild follows the existing draft's content type, so a\nplain draft stays plain and an HTML draft stays HTML. Plain-text input supplied\nagainst an HTML draft is auto-converted to HTML, and HTML input supplied against\na plain draft is stored verbatim as ``text/plain``. Reply drafts preserve their\nreply-quote tail (``> `` lines for plain, ``<blockquote>`` for HTML) when the\nbody is supplied as a top-only update.\n\nMultipart drafts and drafts with attachments still fail when the body changes;\nin those cases the tool succeeds only when the effective body is unchanged\n(metadata-only update preserving the existing MIME tree). Edit those drafts in\nGmail directly.\n\nFor each of subject, body, recipient, cc, and bcc, omitting the parameter or passing\n``None`` leaves that part of the draft unchanged (for cc/bcc, existing headers are kept;\npass an empty list to clear).",
       "parameters": [
         {
@@ -1457,7 +1457,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Gmail.WhoAmI",
-      "fullyQualifiedName": "Gmail.WhoAmI@7.0.0",
+      "fullyQualifiedName": "Gmail.WhoAmI@7.0.1",
       "description": "Get comprehensive user profile and Gmail account information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Gmail account statistics, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1504,7 +1504,7 @@
     {
       "name": "WriteDraftEmail",
       "qualifiedName": "Gmail.WriteDraftEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftEmail@7.0.0",
+      "fullyQualifiedName": "Gmail.WriteDraftEmail@7.0.1",
       "description": "Compose a new email draft using the Gmail API.",
       "parameters": [
         {
@@ -1640,7 +1640,7 @@
     {
       "name": "WriteDraftReplyEmail",
       "qualifiedName": "Gmail.WriteDraftReplyEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@7.0.0",
+      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@7.0.1",
       "description": "Compose a draft reply to an email message.",
       "parameters": [
         {
@@ -1791,6 +1791,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-05-16T11:29:50.553Z",
+  "generatedAt": "2026-06-05T12:07:56.912Z",
   "summary": "The Gmail toolkit provides Arcade LLM tools for interacting with Gmail via the Gmail API. It enables agents and applications to read, compose, send, organize, and manage email on behalf of authenticated Google users.\n\n## Capabilities\n\n- **Reading & searching**: List emails, threads, and drafts with built-in filtering that excludes automated/promotional mail by default (`exclude_automated=False` to override); search threads by query or by header value; retrieve full threads by ID.\n- **Composing & sending**: Write new draft emails or draft replies, send emails directly, reply to existing messages, and send or delete existing drafts.\n- **Draft management**: Update existing drafts (supports plain-text and HTML single-part bodies with smart content-type handling and reply-quote preservation; metadata-only updates for multipart/attachment drafts); delete drafts.\n- **Labels & organization**: List, create, and apply/remove labels on emails; move emails to trash.\n- **Account info**: Retrieve the authenticated user's profile, email address, profile picture, and Gmail account statistics via `WhoAmI`.\n\n## OAuth\n\nAuthentication uses OAuth 2.0 via the **Google** provider. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for configuration details."
 }

--- a/toolkit-docs-generator/data/toolkits/googlecalendar.json
+++ b/toolkit-docs-generator/data/toolkits/googlecalendar.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleCalendar",
   "label": "Google Calendar",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "description": "Arcade.dev LLM tools for Google Calendar",
   "metadata": {
     "category": "productivity",
@@ -27,8 +27,8 @@
     {
       "name": "CreateEvent",
       "qualifiedName": "GoogleCalendar.CreateEvent",
-      "fullyQualifiedName": "GoogleCalendar.CreateEvent@3.3.2",
-      "description": "Create a new event/meeting/sync/meetup in the specified calendar.",
+      "fullyQualifiedName": "GoogleCalendar.CreateEvent@3.4.0",
+      "description": "Create a new event/meeting/sync/meetup in the specified calendar.\n\nPass `recurrence` to create a repeating event.",
       "parameters": [
         {
           "name": "summary",
@@ -119,6 +119,15 @@
           "description": "Whether to add a Google Meet link to the event. Defaults to False.",
           "enum": null,
           "inferrable": true
+        },
+        {
+          "name": "recurrence",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Recurrence rules for a repeating event, in RFC 5545 format. Each entry is an RRULE/RDATE/EXDATE line; a bare rule is automatically prefixed with 'RRULE:'. Examples: ['RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR;COUNT=10'] for every Mon/Wed/Fri for 10 occurrences, or ['RRULE:FREQ=DAILY;UNTIL=20241231T000000Z'] for daily until 2024-12-31. Omit for a one-time event.",
+          "enum": null,
+          "inferrable": true
         }
       ],
       "auth": {
@@ -140,17 +149,17 @@
         "toolName": "GoogleCalendar.CreateEvent",
         "parameters": {
           "summary": {
-            "value": "Project Kickoff Meeting",
+            "value": "Team Sprint Planning Meeting",
             "type": "string",
             "required": true
           },
           "start_datetime": {
-            "value": "2026-03-10T09:00:00-04:00",
+            "value": "2025-03-15T10:00:00",
             "type": "string",
             "required": true
           },
           "end_datetime": {
-            "value": "2026-03-10T10:00:00-04:00",
+            "value": "2025-03-15T11:30:00",
             "type": "string",
             "required": true
           },
@@ -160,12 +169,12 @@
             "required": false
           },
           "description": {
-            "value": "Initial project kickoff to align on scope, timeline, and next steps.",
+            "value": "Weekly sprint planning session to review backlog, assign tasks, and set goals for the upcoming sprint.",
             "type": "string",
             "required": false
           },
           "location": {
-            "value": "Conference Room B / Zoom",
+            "value": "Conference Room B, 123 Main St, San Francisco, CA 94105",
             "type": "string",
             "required": false
           },
@@ -176,8 +185,9 @@
           },
           "attendee_emails": {
             "value": [
-              "alice@example.com",
-              "bob@example.org"
+              "alice.johnson@example.com",
+              "bob.smith@example.com",
+              "carol.white@example.com"
             ],
             "type": "array",
             "required": false
@@ -190,6 +200,13 @@
           "add_google_meet": {
             "value": true,
             "type": "boolean",
+            "required": false
+          },
+          "recurrence": {
+            "value": [
+              "RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=8"
+            ],
+            "type": "array",
             "required": false
           }
         },
@@ -218,7 +235,7 @@
     {
       "name": "DeleteEvent",
       "qualifiedName": "GoogleCalendar.DeleteEvent",
-      "fullyQualifiedName": "GoogleCalendar.DeleteEvent@3.3.2",
+      "fullyQualifiedName": "GoogleCalendar.DeleteEvent@3.4.0",
       "description": "Delete an event from Google Calendar.",
       "parameters": [
         {
@@ -308,7 +325,7 @@
     {
       "name": "FindTimeSlotsWhenEveryoneIsFree",
       "qualifiedName": "GoogleCalendar.FindTimeSlotsWhenEveryoneIsFree",
-      "fullyQualifiedName": "GoogleCalendar.FindTimeSlotsWhenEveryoneIsFree@3.3.2",
+      "fullyQualifiedName": "GoogleCalendar.FindTimeSlotsWhenEveryoneIsFree@3.4.0",
       "description": "Provides time slots when everyone is free within a given date range and time boundaries.",
       "parameters": [
         {
@@ -424,7 +441,7 @@
     {
       "name": "ListCalendars",
       "qualifiedName": "GoogleCalendar.ListCalendars",
-      "fullyQualifiedName": "GoogleCalendar.ListCalendars@3.3.2",
+      "fullyQualifiedName": "GoogleCalendar.ListCalendars@3.4.0",
       "description": "List all calendars accessible by the user.",
       "parameters": [
         {
@@ -524,7 +541,7 @@
     {
       "name": "ListEvents",
       "qualifiedName": "GoogleCalendar.ListEvents",
-      "fullyQualifiedName": "GoogleCalendar.ListEvents@3.3.2",
+      "fullyQualifiedName": "GoogleCalendar.ListEvents@3.4.0",
       "description": "List events from the specified calendar within the given datetime range.\n\nmin_end_datetime serves as the lower bound (exclusive) for an event's end time.\nmax_start_datetime serves as the upper bound (exclusive) for an event's start time.\n\nFor example:\nIf min_end_datetime is set to 2024-09-15T09:00:00 and max_start_datetime\nis set to 2024-09-16T17:00:00, the function will return events that:\n1. End after 09:00 on September 15, 2024 (exclusive)\n2. Start before 17:00 on September 16, 2024 (exclusive)\nThis means an event starting at 08:00 on September 15 and\nending at 10:00 on September 15 would be included, but an\nevent starting at 17:00 on September 16 would not be included.",
       "parameters": [
         {
@@ -624,7 +641,7 @@
     {
       "name": "UpdateEvent",
       "qualifiedName": "GoogleCalendar.UpdateEvent",
-      "fullyQualifiedName": "GoogleCalendar.UpdateEvent@3.3.2",
+      "fullyQualifiedName": "GoogleCalendar.UpdateEvent@3.4.0",
       "description": "Update an existing event in the specified calendar with the provided details.\nOnly the provided fields will be updated; others will remain unchanged.\n\n`updated_start_datetime` and `updated_end_datetime` are\nindependent and can be provided separately.",
       "parameters": [
         {
@@ -697,6 +714,15 @@
           "inferrable": true
         },
         {
+          "name": "updated_recurrence",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Updated recurrence rules for a repeating event, in RFC 5545 format. Each entry is an RRULE/RDATE/EXDATE line; a bare rule is automatically prefixed with 'RRULE:'. Provide the full set of rules to replace the event's existing recurrence, e.g. ['RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR;COUNT=10'] for every Mon/Wed/Fri for 10 occurrences. Pass an empty list ([]) to REMOVE recurrence and make the event a one-time event. Omit (leave unset) to leave recurrence unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
           "name": "attendee_emails_to_add",
           "type": "array",
           "innerType": "string",
@@ -757,17 +783,17 @@
         "toolName": "GoogleCalendar.UpdateEvent",
         "parameters": {
           "event_id": {
-            "value": "evt_9a8b7c6d",
+            "value": "abc123xyz789eventid",
             "type": "string",
             "required": true
           },
           "updated_start_datetime": {
-            "value": "2026-03-10T09:00:00",
+            "value": "2024-12-31T15:30:00",
             "type": "string",
             "required": false
           },
           "updated_end_datetime": {
-            "value": "2026-03-10T10:30:00",
+            "value": "2024-12-31T17:30:00",
             "type": "string",
             "required": false
           },
@@ -777,17 +803,17 @@
             "required": false
           },
           "updated_summary": {
-            "value": "Quarterly Planning Meeting",
+            "value": "Team Year-End Review Meeting",
             "type": "string",
             "required": false
           },
           "updated_description": {
-            "value": "Discuss Q2 objectives, budget allocation, and hiring needs.",
+            "value": "Annual review of team goals, achievements, and plans for the upcoming year.",
             "type": "string",
             "required": false
           },
           "updated_location": {
-            "value": "Conference Room B / Zoom",
+            "value": "Conference Room B, 123 Main St, San Francisco, CA 94105",
             "type": "string",
             "required": false
           },
@@ -796,17 +822,24 @@
             "type": "string",
             "required": false
           },
+          "updated_recurrence": {
+            "value": [
+              "RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR;COUNT=10"
+            ],
+            "type": "array",
+            "required": false
+          },
           "attendee_emails_to_add": {
             "value": [
               "alice@example.com",
-              "bob@company.com"
+              "bob@company.org"
             ],
             "type": "array",
             "required": false
           },
           "attendee_emails_to_remove": {
             "value": [
-              "carol@example.com"
+              "charlie@oldcompany.com"
             ],
             "type": "array",
             "required": false
@@ -847,7 +880,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleCalendar.WhoAmI",
-      "fullyQualifiedName": "GoogleCalendar.WhoAmI@3.3.2",
+      "fullyQualifiedName": "GoogleCalendar.WhoAmI@3.4.0",
       "description": "Get comprehensive user profile and Google Calendar environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Calendar access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -912,6 +945,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-02-26T20:45:10.392Z",
-  "summary": "Arcade.dev offers a toolkit for Google Calendar that streamlines event management and calendar interaction through powerful APIs. This toolkit enables developers to effectively create, update, and manage calendar events while accessing user calendars.\n\n**Capabilities:**\n- Create and delete events seamlessly.\n- Fetch user calendars and events within specified date ranges.\n- Identify time slots when all participants are available.\n- Retrieve user profile information from Google services.\n\n**OAuth:**\n- Provider: Google\n- Scopes: `https://www.googleapis.com/auth/calendar.events`, `https://www.googleapis.com/auth/calendar.readonly`, `https://www.googleapis.com/auth/userinfo.email`, `https://www.googleapis.com/auth/userinfo.profile`."
+  "generatedAt": "2026-06-05T12:08:01.475Z",
+  "summary": "The Google Calendar toolkit for Arcade integrates with Google Calendar via OAuth, enabling LLMs to read, create, update, and delete calendar data on behalf of authenticated users.\n\n## Capabilities\n\n- **Calendar discovery & user context:** List all calendars accessible to the user and retrieve the authenticated user's profile, email, and Calendar access permissions.\n- **Event querying:** List events within a datetime range using precise exclusive bounds on both start and end times, supporting complex filtering across one or more days.\n- **Event management:** Create single or recurring events (via recurrence rules), update individual fields of existing events without overwriting unchanged fields, and delete events.\n- **Scheduling assistance:** Find available time slots when all specified participants are free within a given date range and time boundaries.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via the **Google** provider. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details, required API enablement, and scope coverage."
 }

--- a/toolkit-docs-generator/data/toolkits/googlecontacts.json
+++ b/toolkit-docs-generator/data/toolkits/googlecontacts.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleContacts",
   "label": "Google Contacts",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "description": "Arcade.dev LLM tools for Google Contacts",
   "metadata": {
     "category": "productivity",
@@ -27,7 +27,7 @@
     {
       "name": "CreateContact",
       "qualifiedName": "GoogleContacts.CreateContact",
-      "fullyQualifiedName": "GoogleContacts.CreateContact@3.5.2",
+      "fullyQualifiedName": "GoogleContacts.CreateContact@3.5.3",
       "description": "Create a new contact record in Google Contacts.\n\nExamples:\n```\ncreate_contact(given_name=\"Alice\")\ncreate_contact(given_name=\"Alice\", family_name=\"Smith\")\ncreate_contact(given_name=\"Alice\", email=\"alice@example.com\")\ncreate_contact(given_name=\"Alice\", phone_number=\"+1234567890\")\ncreate_contact(\n    given_name=\"Alice\",\n    family_name=\"Smith\",\n    email=\"alice@example.com\",\n    phone_number=\"+1234567890\",\n)\n```",
       "parameters": [
         {
@@ -124,7 +124,7 @@
     {
       "name": "SearchContactsByEmail",
       "qualifiedName": "GoogleContacts.SearchContactsByEmail",
-      "fullyQualifiedName": "GoogleContacts.SearchContactsByEmail@3.5.2",
+      "fullyQualifiedName": "GoogleContacts.SearchContactsByEmail@3.5.3",
       "description": "Search the user's contacts in Google Contacts by email address.",
       "parameters": [
         {
@@ -195,7 +195,7 @@
     {
       "name": "SearchContactsByName",
       "qualifiedName": "GoogleContacts.SearchContactsByName",
-      "fullyQualifiedName": "GoogleContacts.SearchContactsByName@3.5.2",
+      "fullyQualifiedName": "GoogleContacts.SearchContactsByName@3.5.3",
       "description": "Search the user's contacts in Google Contacts by name.",
       "parameters": [
         {
@@ -266,7 +266,7 @@
     {
       "name": "SearchContactsByPhoneNumber",
       "qualifiedName": "GoogleContacts.SearchContactsByPhoneNumber",
-      "fullyQualifiedName": "GoogleContacts.SearchContactsByPhoneNumber@3.5.2",
+      "fullyQualifiedName": "GoogleContacts.SearchContactsByPhoneNumber@3.5.3",
       "description": "Search the user's contacts in Google Contacts by phone number.",
       "parameters": [
         {
@@ -337,7 +337,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleContacts.WhoAmI",
-      "fullyQualifiedName": "GoogleContacts.WhoAmI@3.5.2",
+      "fullyQualifiedName": "GoogleContacts.WhoAmI@3.5.3",
       "description": "Get comprehensive user profile and Google Contacts environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Contacts access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -392,6 +392,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-02-26T20:45:10.393Z",
+  "generatedAt": "2026-06-05T12:07:56.906Z",
   "summary": "Google Contacts (Arcade.dev) toolkit enables LLM-driven apps to read, create, and manage a user's Google Contacts and profile data with OAuth-backed access. It provides consolidated contact operations and user environment insights for chatbots, CRMs, and automation.\n\n**Capabilities**\n- Create and update structured contact records (names, emails, phones) and return normalized contact payloads.\n- Search and retrieve contacts by name, email, or phone with consistent result formatting and paging support.\n- Access authenticated user profile and Contacts environment metadata (permissions, profile picture, email).\n- Field validation, normalization, and merge/deduplication-ready metadata to aid downstream workflows.\n\n**OAuth**\nProvider: google\nScopes:\n- https://www.googleapis.com/auth/contacts\n- https://www.googleapis.com/auth/contacts.readonly\n- https://www.googleapis.com/auth/userinfo.email\n- https://www.googleapis.com/auth/userinfo.profile"
 }

--- a/toolkit-docs-generator/data/toolkits/googledocs.json
+++ b/toolkit-docs-generator/data/toolkits/googledocs.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleDocs",
   "label": "Google Docs",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Arcade.dev LLM tools for Google Docs",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "CommentOnDocument",
       "qualifiedName": "GoogleDocs.CommentOnDocument",
-      "fullyQualifiedName": "GoogleDocs.CommentOnDocument@7.0.0",
+      "fullyQualifiedName": "GoogleDocs.CommentOnDocument@7.0.1",
       "description": "Comment on a specific document by its ID.",
       "parameters": [
         {
@@ -106,7 +106,7 @@
     {
       "name": "CreateBlankDocument",
       "qualifiedName": "GoogleDocs.CreateBlankDocument",
-      "fullyQualifiedName": "GoogleDocs.CreateBlankDocument@7.0.0",
+      "fullyQualifiedName": "GoogleDocs.CreateBlankDocument@7.0.1",
       "description": "Create a blank Google Docs document with the specified title.",
       "parameters": [
         {
@@ -166,7 +166,7 @@
     {
       "name": "CreateDocumentFromText",
       "qualifiedName": "GoogleDocs.CreateDocumentFromText",
-      "fullyQualifiedName": "GoogleDocs.CreateDocumentFromText@7.0.0",
+      "fullyQualifiedName": "GoogleDocs.CreateDocumentFromText@7.0.1",
       "description": "Create a Google Docs document with the specified title and text content.\n\nWhen input_format is MARKDOWN, the text_content is parsed as Markdown and the resulting\ndocument is formatted with headings, bold, italic, bullet lists, and numbered lists.",
       "parameters": [
         {
@@ -255,7 +255,7 @@
     {
       "name": "EditDocument",
       "qualifiedName": "GoogleDocs.EditDocument",
-      "fullyQualifiedName": "GoogleDocs.EditDocument@7.0.0",
+      "fullyQualifiedName": "GoogleDocs.EditDocument@7.0.1",
       "description": "Read or edit a Google Docs document using structured batchUpdate requests.\n\nWhen called without requests, returns the document content in DocMD format (block IDs,\ncharacter indices, and text styles). When called with requests, applies the edits and\nreturns the updated DocMD. Use the DocMD indices from the response to construct\nrequests for subsequent calls.",
       "parameters": [
         {
@@ -442,7 +442,7 @@
     {
       "name": "GenerateGoogleFilePickerUrl",
       "qualifiedName": "GoogleDocs.GenerateGoogleFilePickerUrl",
-      "fullyQualifiedName": "GoogleDocs.GenerateGoogleFilePickerUrl@7.0.0",
+      "fullyQualifiedName": "GoogleDocs.GenerateGoogleFilePickerUrl@7.0.1",
       "description": "Generate a URL where the user can grant this app access to specific Drive files.\n\nOpens Google's first-party Drive picker. The user selects which files to share\nwith this application — it is not a sign-in or credential prompt.\n\nUse this when a prior tool reported that a file was not found or access was denied,\nand the user expects the file to exist. After the user completes the picker flow,\nretry the prior tool.",
       "parameters": [],
       "auth": {
@@ -485,7 +485,7 @@
     {
       "name": "GetDocumentAsDocmd",
       "qualifiedName": "GoogleDocs.GetDocumentAsDocmd",
-      "fullyQualifiedName": "GoogleDocs.GetDocumentAsDocmd@7.0.0",
+      "fullyQualifiedName": "GoogleDocs.GetDocumentAsDocmd@7.0.1",
       "description": "Get the latest version of the specified Google Docs document as DocMD.\nThe DocMD output will include tags that can be used to annotate the document with location\ninformation, the type of block, block IDs, and other metadata. If the document has tabs,\nall tabs are included in sequential order unless a specific tab_id is provided.",
       "parameters": [
         {
@@ -565,7 +565,7 @@
     {
       "name": "GetDocumentById",
       "qualifiedName": "GoogleDocs.GetDocumentById",
-      "fullyQualifiedName": "GoogleDocs.GetDocumentById@7.0.0",
+      "fullyQualifiedName": "GoogleDocs.GetDocumentById@7.0.1",
       "description": "DEPRECATED DO NOT USE THIS TOOL\nGet the latest version of the specified Google Docs document.",
       "parameters": [
         {
@@ -632,7 +632,7 @@
     {
       "name": "GetDocumentMetadata",
       "qualifiedName": "GoogleDocs.GetDocumentMetadata",
-      "fullyQualifiedName": "GoogleDocs.GetDocumentMetadata@7.0.0",
+      "fullyQualifiedName": "GoogleDocs.GetDocumentMetadata@7.0.1",
       "description": "Get metadata for a Google Docs document including hierarchical tab structure.\nReturns document title, ID, URL, total character count, and nested tab information\nwith character counts for each tab.",
       "parameters": [
         {
@@ -699,7 +699,7 @@
     {
       "name": "InsertTextAtEndOfDocument",
       "qualifiedName": "GoogleDocs.InsertTextAtEndOfDocument",
-      "fullyQualifiedName": "GoogleDocs.InsertTextAtEndOfDocument@7.0.0",
+      "fullyQualifiedName": "GoogleDocs.InsertTextAtEndOfDocument@7.0.1",
       "description": "Updates an existing Google Docs document using the batchUpdate API endpoint.",
       "parameters": [
         {
@@ -779,7 +779,7 @@
     {
       "name": "ListDocumentComments",
       "qualifiedName": "GoogleDocs.ListDocumentComments",
-      "fullyQualifiedName": "GoogleDocs.ListDocumentComments@7.0.0",
+      "fullyQualifiedName": "GoogleDocs.ListDocumentComments@7.0.1",
       "description": "List all comments on the specified Google Docs document.",
       "parameters": [
         {
@@ -859,7 +859,7 @@
     {
       "name": "SearchAndRetrieveDocuments",
       "qualifiedName": "GoogleDocs.SearchAndRetrieveDocuments",
-      "fullyQualifiedName": "GoogleDocs.SearchAndRetrieveDocuments@7.0.0",
+      "fullyQualifiedName": "GoogleDocs.SearchAndRetrieveDocuments@7.0.1",
       "description": "Searches for documents in the user's Google Drive and returns documents with their main body\ncontent and tab metadata. Excludes documents that are in the trash.\n\nReturns main body content only with metadata about tabs. Use get_document_as_docmd() to retrieve\nfull tab content for specific documents. Use search_documents() for metadata-only searches.",
       "parameters": [
         {
@@ -1070,7 +1070,7 @@
     {
       "name": "SearchDocuments",
       "qualifiedName": "GoogleDocs.SearchDocuments",
-      "fullyQualifiedName": "GoogleDocs.SearchDocuments@7.0.0",
+      "fullyQualifiedName": "GoogleDocs.SearchDocuments@7.0.1",
       "description": "Searches for documents in the user's Google Drive. Excludes documents in trash.\nReturns metadata only. Use get_document_metadata or get_document_as_docmd for content.",
       "parameters": [
         {
@@ -1263,7 +1263,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleDocs.WhoAmI",
-      "fullyQualifiedName": "GoogleDocs.WhoAmI@7.0.0",
+      "fullyQualifiedName": "GoogleDocs.WhoAmI@7.0.1",
       "description": "Get comprehensive user profile and Google Docs environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Docs access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1334,6 +1334,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-05-28T12:16:03.702Z",
+  "generatedAt": "2026-06-05T12:07:56.906Z",
   "summary": "## Google Docs Toolkit\n\nThe Google Docs toolkit lets LLM agents create, read, edit, search, and annotate Google Docs documents through the Google Docs and Drive APIs via Arcade.\n\n## Capabilities\n\n- **Document creation:** Create blank documents or populate them from plain text or Markdown (with automatic heading, bold, italic, and list formatting).\n- **Document reading & metadata:** Retrieve full document content in DocMD format (block IDs, character indices, text styles, tab structure) or fetch metadata-only (title, ID, URL, character counts, tab hierarchy).\n- **Structured editing:** Apply batchUpdate requests using DocMD indices for precise in-document edits; append text to document ends.\n- **Search & discovery:** Search Drive for documents by query, with options to return metadata only or include full body content; trash is automatically excluded.\n- **Comments:** Add new comments to a document or list all existing comments.\n- **User & access management:** Retrieve authenticated user profile and permissions; generate a Google Drive inline file picker URL to grant per-file access when a document is not found or access is denied.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 with **Google** as the provider. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details.\n\n## Secrets\n\n- **`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL`** — A flag/URL secret that activates the `GenerateGoogleFilePickerUrl` tool, which opens Google's first-party Drive file picker so users can grant the app access to specific files without a full re-authentication flow. To obtain or configure this value, you set it in your Arcade environment to enable the picker endpoint. Refer to the [Arcade secrets documentation](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to define secrets, and manage them at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/googledrive.json
+++ b/toolkit-docs-generator/data/toolkits/googledrive.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleDrive",
   "label": "Google Drive",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Arcade.dev LLM tools for Google Drive",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "CreateFolder",
       "qualifiedName": "GoogleDrive.CreateFolder",
-      "fullyQualifiedName": "GoogleDrive.CreateFolder@6.0.0",
+      "fullyQualifiedName": "GoogleDrive.CreateFolder@6.0.1",
       "description": "Create a new folder in Google Drive.\n\nBy default, parent folder paths are resolved in My Drive. For shared drives, use folder IDs\nor provide shared_drive_id.",
       "parameters": [
         {
@@ -119,7 +119,7 @@
     {
       "name": "DownloadFile",
       "qualifiedName": "GoogleDrive.DownloadFile",
-      "fullyQualifiedName": "GoogleDrive.DownloadFile@6.0.0",
+      "fullyQualifiedName": "GoogleDrive.DownloadFile@6.0.1",
       "description": "Download a blob file (non-workspace file) from Google Drive as base64 encoded content.\n\nFor small files (under ~5MB raw), returns the file content directly in the response as base64.\nFor large files, returns metadata with requires_chunked_download=True - use download_file_chunk\nto retrieve the file in parts.\n\nBy default, paths are resolved in My Drive. For shared drives, use file IDs or provide\nshared_drive_id.",
       "parameters": [
         {
@@ -199,7 +199,7 @@
     {
       "name": "DownloadFileChunk",
       "qualifiedName": "GoogleDrive.DownloadFileChunk",
-      "fullyQualifiedName": "GoogleDrive.DownloadFileChunk@6.0.0",
+      "fullyQualifiedName": "GoogleDrive.DownloadFileChunk@6.0.1",
       "description": "Download a specific byte range of a file from Google Drive.\n\nUse this for large files that require chunked download (when download_file returns\nrequires_chunked_download=True). Call repeatedly with increasing start_byte values\nto retrieve the complete file.\n\nReturns the chunk content as base64, along with progress information including\nwhether this is the final chunk.",
       "parameters": [
         {
@@ -305,7 +305,7 @@
     {
       "name": "GenerateGoogleFilePickerUrl",
       "qualifiedName": "GoogleDrive.GenerateGoogleFilePickerUrl",
-      "fullyQualifiedName": "GoogleDrive.GenerateGoogleFilePickerUrl@6.0.0",
+      "fullyQualifiedName": "GoogleDrive.GenerateGoogleFilePickerUrl@6.0.1",
       "description": "Generate a URL where the user can grant this app access to specific Drive files.\n\nOpens Google's first-party Drive picker. The user selects which files to share\nwith this application — it is not a sign-in or credential prompt.\n\nUse this when a prior tool reported that a file was not found or access was denied,\nand the user expects the file to exist. After the user completes the picker flow,\nretry the prior tool.",
       "parameters": [],
       "auth": {
@@ -348,7 +348,7 @@
     {
       "name": "GetFileTreeStructure",
       "qualifiedName": "GoogleDrive.GetFileTreeStructure",
-      "fullyQualifiedName": "GoogleDrive.GetFileTreeStructure@6.0.0",
+      "fullyQualifiedName": "GoogleDrive.GetFileTreeStructure@6.0.1",
       "description": "Get the file/folder tree structure of the user's entire Google Drive.\nVery inefficient for large drives. Use with caution.",
       "parameters": [
         {
@@ -494,7 +494,7 @@
     {
       "name": "ListFilePermissions",
       "qualifiedName": "GoogleDrive.ListFilePermissions",
-      "fullyQualifiedName": "GoogleDrive.ListFilePermissions@6.0.0",
+      "fullyQualifiedName": "GoogleDrive.ListFilePermissions@6.0.1",
       "description": "List permissions on a Google Drive file or folder.\n\nReturns the individual people (and groups) with access and the current General access\n(link sharing) state. `general_access` is computed across the ENTIRE file regardless of\nfiltering -- so \"is this doc public?\" is always answered authoritatively.\n\nWhen `roles` is provided, `people` and `total_people` reflect only collaborators whose\nrole matches the filter. Truncated collaborators beyond `limit` are not returned;\n`has_more` indicates whether truncation occurred.",
       "parameters": [
         {
@@ -609,7 +609,7 @@
     {
       "name": "MoveFile",
       "qualifiedName": "GoogleDrive.MoveFile",
-      "fullyQualifiedName": "GoogleDrive.MoveFile@6.0.0",
+      "fullyQualifiedName": "GoogleDrive.MoveFile@6.0.1",
       "description": "Move a file or folder to a different folder within the same Google Drive.\n\nCan move to a folder (keeping name), or move and rename in one operation. By default, paths\nare resolved in My Drive. For shared drives, use file IDs or provide shared_drive_id.",
       "parameters": [
         {
@@ -715,7 +715,7 @@
     {
       "name": "RemoveAllCollaborators",
       "qualifiedName": "GoogleDrive.RemoveAllCollaborators",
-      "fullyQualifiedName": "GoogleDrive.RemoveAllCollaborators@6.0.0",
+      "fullyQualifiedName": "GoogleDrive.RemoveAllCollaborators@6.0.1",
       "description": "Remove all user collaborators (and optionally groups) from a Google Drive file.\n\nThe file owner and the calling user are always preserved. Groups are preserved by default\nbecause the Drive API cannot verify group membership -- pass include_groups=True to opt in.\nInherited shared-drive permissions are never removable from the file level and are skipped.\n\nUse except_people to preserve additional people or groups by email or name. Ambiguous or\nunmatched except_people entries raise an error to avoid accidentally removing someone the\ncaller meant to keep.",
       "parameters": [
         {
@@ -825,7 +825,7 @@
     {
       "name": "RenameFile",
       "qualifiedName": "GoogleDrive.RenameFile",
-      "fullyQualifiedName": "GoogleDrive.RenameFile@6.0.0",
+      "fullyQualifiedName": "GoogleDrive.RenameFile@6.0.1",
       "description": "Rename a file or folder in Google Drive.\n\nBy default, paths are resolved in My Drive. For files in shared drives, either use the file ID\ndirectly or provide the shared_drive_id parameter.",
       "parameters": [
         {
@@ -918,7 +918,7 @@
     {
       "name": "RevokeFileAccess",
       "qualifiedName": "GoogleDrive.RevokeFileAccess",
-      "fullyQualifiedName": "GoogleDrive.RevokeFileAccess@6.0.0",
+      "fullyQualifiedName": "GoogleDrive.RevokeFileAccess@6.0.1",
       "description": "Revoke access for specific people or groups on a Google Drive file.\n\nIdentifies matches by email (exact, case-insensitive) or display name. When an input\nmatches multiple people, the clear matches are still revoked and the ambiguous input is\nsurfaced in the `ambiguous` response field with candidate details so the agent can\nre-prompt the user for just the uncertain ones. Inputs that don't match any collaborator\nare returned in `not_found`. Pending-owner matches (mid-ownership-transfer) are skipped\nand surfaced in `skipped_pending_owner` so the clean revokes in the batch still land.\nOwner permissions cannot be revoked -- transfer ownership first.\n\nWhen a grantee has both a direct and an inherited permission (e.g., shared-drive member\nalso granted directly on the file), revoking the direct row leaves the inherited access\nintact. The inherited row is surfaced in `skipped_inherited` so callers don't assume the\ngrantee is fully removed -- inherited access must be adjusted at the shared drive level.",
       "parameters": [
         {
@@ -1016,7 +1016,7 @@
     {
       "name": "SearchFiles",
       "qualifiedName": "GoogleDrive.SearchFiles",
-      "fullyQualifiedName": "GoogleDrive.SearchFiles@6.0.0",
+      "fullyQualifiedName": "GoogleDrive.SearchFiles@6.0.1",
       "description": "Search for files in Google Drive.\n\nThe provided 'query' should only contain the search terms.\nThe tool will construct the full search query for you.",
       "parameters": [
         {
@@ -1219,7 +1219,7 @@
     {
       "name": "SetGeneralAccess",
       "qualifiedName": "GoogleDrive.SetGeneralAccess",
-      "fullyQualifiedName": "GoogleDrive.SetGeneralAccess@6.0.0",
+      "fullyQualifiedName": "GoogleDrive.SetGeneralAccess@6.0.1",
       "description": "Change the 'General access' (link sharing) setting on a Google Drive file.\n\nIdempotent: calling with the same state as the current configuration is a no-op. When access\nis 'domain', the link is scoped to the caller's email domain -- NOT the file owner's domain.\nFor cross-org collaboration (e.g., editing a file owned by another organization), confirm\nwith the user which domain they intend before calling. Google will reject domain sharing\nfor personal accounts (gmail.com, outlook.com, etc.) -- the tool translates that rejection\ninto a friendly error.\n\nThe response's `access` and `role` fields report the EFFECTIVE state after the transition,\nnot the requested state. For files on shared drives, inherited link permissions cannot be\nchanged from the file level -- if the request would have required removing an inherited\npermission, the effective state will reflect the inherited permission that remained. When\n`skipped_inherited` is non-empty, inspect it to understand why effective state may differ\nfrom what was requested.",
       "parameters": [
         {
@@ -1346,7 +1346,7 @@
     {
       "name": "ShareFile",
       "qualifiedName": "GoogleDrive.ShareFile",
-      "fullyQualifiedName": "GoogleDrive.ShareFile@6.0.0",
+      "fullyQualifiedName": "GoogleDrive.ShareFile@6.0.1",
       "description": "Share a file or folder in Google Drive with specific people by granting them permissions.\n\nIf a user already has permission on the file, their role will be updated to the new role.\nBy default, paths are resolved in My Drive. For shared drives, use file IDs or provide\nshared_drive_id.",
       "parameters": [
         {
@@ -1487,7 +1487,7 @@
     {
       "name": "UploadFile",
       "qualifiedName": "GoogleDrive.UploadFile",
-      "fullyQualifiedName": "GoogleDrive.UploadFile@6.0.0",
+      "fullyQualifiedName": "GoogleDrive.UploadFile@6.0.1",
       "description": "Upload a file to Google Drive from a URL.\n\nFetches the file content from the provided URL and uploads it to Google Drive.\nSupports files of any size - uses resumable upload internally for large files.\n\nCANNOT upload Google Workspace files (Google Docs, Sheets, Slides)\nCANNOT upload files larger than 25MB",
       "parameters": [
         {
@@ -1618,7 +1618,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleDrive.WhoAmI",
-      "fullyQualifiedName": "GoogleDrive.WhoAmI@6.0.0",
+      "fullyQualifiedName": "GoogleDrive.WhoAmI@6.0.1",
       "description": "Get comprehensive user profile and Google Drive environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Drive storage information, the shared\ndrives (and their IDs) the user has access to, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1668,6 +1668,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-05-28T12:15:56.126Z",
+  "generatedAt": "2026-06-05T12:07:56.906Z",
   "summary": "# Google Drive Toolkit\n\nThe Google Drive toolkit connects Arcade to Google Drive via OAuth, enabling LLMs to manage files, folders, sharing, and permissions on behalf of authenticated users.\n\n## Capabilities\n\n- **File & folder management:** Create folders, move, rename, and search files across My Drive and shared drives (by path or ID).\n- **Upload & download:** Upload files to Drive from a URL (up to 25 MB, non-Workspace formats); download blob files directly or in byte-range chunks for large files.\n- **Permissions & sharing:** Share files with specific people, revoke or bulk-remove collaborators, set general/link-sharing access (including domain scoping), and list all permissions with role filtering.\n- **Drive introspection:** Retrieve the full file/folder tree, look up authenticated user profile and storage info, and enumerate accessible shared drives and their IDs.\n- **File picker integration:** Generate a Google-hosted Drive Picker URL so users can grant the app access to specific files when a prior tool reports not-found or access-denied.\n\n## OAuth\n\nAuthentication uses OAuth 2.0 via the **Google** provider. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details.\n\n## Secrets\n\n- **`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL`** — Controls whether the `GoogleDrive.GenerateGoogleFilePickerUrl` tool surfaces an inline Google Drive Picker URL. This is an Arcade-side feature flag, not a credential issued by Google. Set its value in the Arcade secrets manager to enable the picker flow. There is no external provider dashboard for this secret; it is configured entirely within Arcade.\n\nSee the [Arcade secrets documentation](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to store and reference secrets, or manage them directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/googleflights.json
+++ b/toolkit-docs-generator/data/toolkits/googleflights.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleFlights",
   "label": "Google Flights",
-  "version": "3.2.2",
+  "version": "4.0.4",
   "description": "Arcade.dev LLM tools for getting flights via Google Flights",
   "metadata": {
     "category": "search",
@@ -16,32 +16,16 @@
   "auth": null,
   "tools": [
     {
-      "name": "SearchOneWayFlights",
-      "qualifiedName": "GoogleFlights.SearchOneWayFlights",
-      "fullyQualifiedName": "GoogleFlights.SearchOneWayFlights@3.2.2",
-      "description": "Retrieve flight search results for a one-way flight using Google Flights",
+      "name": "GetFlightBookingOptions",
+      "qualifiedName": "GoogleFlights.GetFlightBookingOptions",
+      "fullyQualifiedName": "GoogleFlights.GetFlightBookingOptions@4.0.4",
+      "description": "Resolve a ``booking_token`` to the airlines and OTAs selling that itinerary.\n\nPass a ``booking_token`` returned by ``search_flights`` or\n``search_multi_city_flights`` to get the vendors selling that\nspecific flight. The token encodes the route, dates, cabin class,\nand passenger counts (every segment for multi-city), so there are\nno ``travel_class``, ``num_adults``, or ``num_children`` parameters;\nsupplying a cabin or party size would silently disagree with the\nitinerary the token was issued for.\n\nLeave ``include_booking_post_data`` off (the default) when an LLM\nis comparing prices; turn it on only when a backend needs to\nrebuild the vendor hand-off, since the POST body is multiple\nkilobytes per option.",
       "parameters": [
         {
-          "name": "departure_airport_code",
+          "name": "booking_token",
           "type": "string",
           "required": true,
-          "description": "The departure airport code. An uppercase 3-letter code",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "arrival_airport_code",
-          "type": "string",
-          "required": true,
-          "description": "The arrival airport code. An uppercase 3-letter code",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "outbound_date",
-          "type": "string",
-          "required": true,
-          "description": "Flight departure date in YYYY-MM-DD format",
+          "description": "An opaque booking_token from a previously-returned itinerary. The token already encodes the originating route, dates, cabin class, passenger counts, and (for multi-city) every segment, so no other search inputs are needed to identify or price the itinerary.",
           "enum": null,
           "inferrable": true
         },
@@ -49,65 +33,32 @@
           "name": "currency_code",
           "type": "string",
           "required": false,
-          "description": "Currency of the returned prices. Defaults to 'USD'",
+          "description": "ISO 4217 currency code for prices in the response. Defaults to 'USD'.",
           "enum": null,
           "inferrable": true
         },
         {
-          "name": "travel_class",
-          "type": "string",
+          "name": "include_booking_post_data",
+          "type": "boolean",
           "required": false,
-          "description": "Travel class of the flight. Defaults to 'ECONOMY'",
-          "enum": [
-            "ECONOMY",
-            "PREMIUM_ECONOMY",
-            "BUSINESS",
-            "FIRST"
-          ],
+          "description": "Surface the raw per-vendor POST hand-off (booking_request_post_url and booking_request_post_data) on POST-method options. The POST body Google would send to the vendor is multiple kilobytes per option, and an LLM comparing vendors does not need it. Backends that need to replay the vendor hand-off can opt in. The clickable booking_request_url and booking_request_method are always surfaced regardless. Defaults to false.",
+          "enum": null,
           "inferrable": true
         },
         {
-          "name": "num_adults",
+          "name": "limit",
           "type": "integer",
           "required": false,
-          "description": "Number of adult passengers. Defaults to 1",
+          "description": "Maximum vendor offers to return in this response (1-30). Defaults to 10. A popular round-trip can easily return 30+ vendors; the default keeps the response compact, and the caller can page through for the long tail.",
           "enum": null,
           "inferrable": true
         },
         {
-          "name": "num_children",
+          "name": "page",
           "type": "integer",
           "required": false,
-          "description": "Number of child passengers. Defaults to 0",
+          "description": "Page number for pagination. Increment to fetch the next slice when has_more is true. Defaults to 1 (first page).",
           "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "max_stops",
-          "type": "string",
-          "required": false,
-          "description": "Maximum number of stops (layovers) for the flight. Defaults to any number of stops",
-          "enum": [
-            "ANY",
-            "NONSTOP",
-            "ONE",
-            "TWO"
-          ],
-          "inferrable": true
-        },
-        {
-          "name": "sort_by",
-          "type": "string",
-          "required": false,
-          "description": "The sorting order of the results. Defaults to TOP_FLIGHTS.",
-          "enum": [
-            "TOP_FLIGHTS",
-            "PRICE",
-            "DEPARTURE_TIME",
-            "ARRIVAL_TIME",
-            "DURATION",
-            "EMISSIONS"
-          ],
           "inferrable": true
         }
       ],
@@ -123,11 +74,381 @@
       ],
       "output": {
         "type": "json",
-        "description": "Flight search results from the Google Flights API"
+        "description": "Vendors selling the chosen itinerary."
       },
       "documentationChunks": [],
       "codeExample": {
-        "toolName": "GoogleFlights.SearchOneWayFlights",
+        "toolName": "GoogleFlights.GetFlightBookingOptions",
+        "parameters": {
+          "booking_token": {
+            "value": "Alb2V3RhYmxlX2ZsaWdodF90b2tlbl9leGFtcGxlX0xBWC1KRkstMjAyNS0wOC0xNS1lY29ub215LTFhZHVsdA==",
+            "type": "string",
+            "required": true
+          },
+          "currency_code": {
+            "value": "EUR",
+            "type": "string",
+            "required": false
+          },
+          "include_booking_post_data": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "limit": {
+            "value": 15,
+            "type": "integer",
+            "required": false
+          },
+          "page": {
+            "value": 1,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "travel"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "LookupAirports",
+      "qualifiedName": "GoogleFlights.LookupAirports",
+      "fullyQualifiedName": "GoogleFlights.LookupAirports@4.0.4",
+      "description": "Find IATA airport codes for a city, country, or airport name.\n\nMetropolitan codes (NYC, LON, TYO, PAR, ...) are accepted as a\n``departure_airport_code`` or ``arrival_airport_code`` in flight\nsearches and mean \"any airport in this city\".",
+      "parameters": [
+        {
+          "name": "query",
+          "type": "string",
+          "required": true,
+          "description": "A city name, country name, airport name, or IATA code to search for. Case-insensitive substring match (e.g. 'paris', 'london', 'JFK', 'tokyo').",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of airports and cities to return in each list (1-25). Defaults to 10.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number for pagination. Increment to fetch the next slice when has_more is true. Defaults to 1 (first page).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Matching airports and metropolitan city codes."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "GoogleFlights.LookupAirports",
+        "parameters": {
+          "query": {
+            "value": "paris",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 5,
+            "type": "integer",
+            "required": false
+          },
+          "page": {
+            "value": 1,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "travel"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchFlights",
+      "qualifiedName": "GoogleFlights.SearchFlights",
+      "fullyQualifiedName": "GoogleFlights.SearchFlights@4.0.4",
+      "description": "Search Google Flights for one-way or round-trip itineraries.\n\nFor a trip where the traveler returns to their origin, issue a\nsingle call with both ``outbound_date`` and ``return_date`` set.\nDo NOT issue two separate one-way searches in opposite directions\nand sum the prices: airlines price round-trip fares independently\nfrom one-way fares, so the sum of two cheapest one-ways is rarely\nequal to the cheapest round-trip and is typically more expensive.",
+      "parameters": [
+        {
+          "name": "departure_airport_code",
+          "type": "string",
+          "required": true,
+          "description": "IATA code of the origin airport or metro city (e.g. SFO, JFK, LHR, NYC, PAR). Three uppercase letters. Metro codes are expanded to all their member airports before search.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "arrival_airport_code",
+          "type": "string",
+          "required": true,
+          "description": "IATA code of the destination airport or metro city. Three uppercase letters. Metro codes are expanded to all their member airports before search.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "outbound_date",
+          "type": "string",
+          "required": true,
+          "description": "Outbound departure date in YYYY-MM-DD format. Past dates return an empty flights list with a structured `past_date` warning rather than an error.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "return_date",
+          "type": "string",
+          "required": false,
+          "description": "Return date in YYYY-MM-DD format for a round-trip search. Leave empty for a one-way search. When set and earlier than outbound_date, the response returns an empty flights list with a structured `return_before_outbound` warning rather than raising.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "currency_code",
+          "type": "string",
+          "required": false,
+          "description": "ISO 4217 currency code for prices in the response. Defaults to 'USD'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "travel_class",
+          "type": "string",
+          "required": false,
+          "description": "Cabin class to search. Defaults to ECONOMY.",
+          "enum": [
+            "ECONOMY",
+            "PREMIUM_ECONOMY",
+            "BUSINESS",
+            "FIRST"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "num_adults",
+          "type": "integer",
+          "required": false,
+          "description": "Number of adult passengers (12+). Must be >= 1 when num_children > 0. Defaults to 1.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "num_children",
+          "type": "integer",
+          "required": false,
+          "description": "Number of child passengers (under 12). Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_stops",
+          "type": "string",
+          "required": false,
+          "description": "Maximum allowed number of layovers. Defaults to ANY.",
+          "enum": [
+            "ANY",
+            "NONSTOP",
+            "ONE",
+            "TWO"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "sort_by",
+          "type": "string",
+          "required": false,
+          "description": "Sort order for the results. Defaults to TOP_FLIGHTS (Google's blended rank).",
+          "enum": [
+            "TOP_FLIGHTS",
+            "PRICE",
+            "DEPARTURE_TIME",
+            "ARRIVAL_TIME",
+            "DURATION",
+            "EMISSIONS"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "include_airlines",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Restrict results to these 2-letter IATA airline codes (e.g. ['DL', 'AA']). Leave empty for no filter. Cannot be combined with exclude_airlines.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "exclude_airlines",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Exclude these 2-letter IATA airline codes from results. Leave empty for no filter. Cannot be combined with include_airlines.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "outbound_departure_window",
+          "type": "string",
+          "required": false,
+          "description": "Time-of-day window for the outbound departure. Defaults to ANY.",
+          "enum": [
+            "ANY",
+            "EARLY_MORNING",
+            "MORNING",
+            "AFTERNOON",
+            "EVENING"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "outbound_arrival_window",
+          "type": "string",
+          "required": false,
+          "description": "Time-of-day window for the outbound arrival. Defaults to ANY.",
+          "enum": [
+            "ANY",
+            "EARLY_MORNING",
+            "MORNING",
+            "AFTERNOON",
+            "EVENING"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "return_departure_window",
+          "type": "string",
+          "required": false,
+          "description": "Time-of-day window for the return-leg departure. Only takes effect when return_date is set; otherwise a `return_param_ignored_one_way` warning is emitted and the value is dropped. Defaults to ANY.",
+          "enum": [
+            "ANY",
+            "EARLY_MORNING",
+            "MORNING",
+            "AFTERNOON",
+            "EVENING"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "return_arrival_window",
+          "type": "string",
+          "required": false,
+          "description": "Time-of-day window for the return-leg arrival. Only takes effect when return_date is set; otherwise a `return_param_ignored_one_way` warning is emitted and the value is dropped. Defaults to ANY.",
+          "enum": [
+            "ANY",
+            "EARLY_MORNING",
+            "MORNING",
+            "AFTERNOON",
+            "EVENING"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "max_total_duration_minutes",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum end-to-end itinerary duration in minutes (each direction). Leave empty for no limit.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "connection_airport_code",
+          "type": "string",
+          "required": false,
+          "description": "Require itineraries to connect through this 3-letter IATA airport. Filters results client-side after the search, so nonstop itineraries are dropped and the response may shrink. Leave empty for no constraint.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "avoid_overnight_layovers",
+          "type": "boolean",
+          "required": false,
+          "description": "Drop itineraries with any layover that requires sleeping at the connecting airport. The decision is exposed on each layover as layovers[].requires_airport_sleep, derived from upstream's overnight flag OR a six-hour duration threshold (catches airport-sleep cases Google does not always tag). Filtered client-side, so the response may shrink. Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "include_price_history",
+          "type": "boolean",
+          "required": false,
+          "description": "Include the ~60-row daily price_history series under price_insights. Off by default because the rolling history dwarfs the rest of the response for an LLM that only needs typical_lowest_for_route, price_level, and typical_price_range. Set true when the caller is specifically visualising the price trend over time.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum itineraries to return in this response (1-50). Defaults to 20. A popular route can easily return 50+ itineraries; trim down to keep the response compact, or page through to see more.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number for pagination. Increment to fetch the next slice when has_more is true. Defaults to 1 (first page).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "SERP_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "SERP_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Itineraries from Google Flights."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "GoogleFlights.SearchFlights",
         "parameters": {
           "departure_airport_code": {
             "value": "JFK",
@@ -140,9 +461,14 @@
             "required": true
           },
           "outbound_date": {
-            "value": "2026-03-15",
+            "value": "2025-09-15",
             "type": "string",
             "required": true
+          },
+          "return_date": {
+            "value": "2025-09-25",
+            "type": "string",
+            "required": false
           },
           "currency_code": {
             "value": "USD",
@@ -170,8 +496,282 @@
             "required": false
           },
           "sort_by": {
-            "value": "PRICE",
+            "value": "TOP_FLIGHTS",
             "type": "string",
+            "required": false
+          },
+          "include_airlines": {
+            "value": [
+              "BA",
+              "AA"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "exclude_airlines": {
+            "value": [],
+            "type": "array",
+            "required": false
+          },
+          "outbound_departure_window": {
+            "value": "MORNING",
+            "type": "string",
+            "required": false
+          },
+          "outbound_arrival_window": {
+            "value": "AFTERNOON",
+            "type": "string",
+            "required": false
+          },
+          "return_departure_window": {
+            "value": "EVENING",
+            "type": "string",
+            "required": false
+          },
+          "return_arrival_window": {
+            "value": "MORNING",
+            "type": "string",
+            "required": false
+          },
+          "max_total_duration_minutes": {
+            "value": 600,
+            "type": "integer",
+            "required": false
+          },
+          "connection_airport_code": {
+            "value": "ORD",
+            "type": "string",
+            "required": false
+          },
+          "avoid_overnight_layovers": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "include_price_history": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "limit": {
+            "value": 10,
+            "type": "integer",
+            "required": false
+          },
+          "page": {
+            "value": 1,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "travel"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchMultiCityFlights",
+      "qualifiedName": "GoogleFlights.SearchMultiCityFlights",
+      "fullyQualifiedName": "GoogleFlights.SearchMultiCityFlights@4.0.4",
+      "description": "Search Google Flights for a multi-city (open-jaw) itinerary.\n\nUse this for trips that are neither a simple one-way nor a round-trip\n(e.g. an open-jaw three-leg trip that ends back at the origin).\nThe open-jaw bundle is typically cheaper than the equivalent set\nof one-way searches summed; never substitute multiple\n``search_flights`` calls for a single multi-city query.",
+      "parameters": [
+        {
+          "name": "segments",
+          "type": "array",
+          "innerType": "json",
+          "required": true,
+          "description": "Ordered list of itinerary segments. Each segment has departure_airport_code (IATA), arrival_airport_code (IATA), and outbound_date (YYYY-MM-DD). Between 2 and 6 segments. Dates must be non-decreasing and all today or later. Metro codes are expanded to their member airports before search.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "currency_code",
+          "type": "string",
+          "required": false,
+          "description": "ISO 4217 currency code for prices in the response. Defaults to 'USD'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "travel_class",
+          "type": "string",
+          "required": false,
+          "description": "Cabin class to search across every segment. Defaults to ECONOMY.",
+          "enum": [
+            "ECONOMY",
+            "PREMIUM_ECONOMY",
+            "BUSINESS",
+            "FIRST"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "num_adults",
+          "type": "integer",
+          "required": false,
+          "description": "Number of adult passengers. Must be >= 1 when num_children > 0. Defaults to 1.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "num_children",
+          "type": "integer",
+          "required": false,
+          "description": "Number of child passengers. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_stops",
+          "type": "string",
+          "required": false,
+          "description": "Maximum allowed number of layovers per segment. Defaults to ANY.",
+          "enum": [
+            "ANY",
+            "NONSTOP",
+            "ONE",
+            "TWO"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "sort_by",
+          "type": "string",
+          "required": false,
+          "description": "Sort order for the results. Defaults to TOP_FLIGHTS.",
+          "enum": [
+            "TOP_FLIGHTS",
+            "PRICE",
+            "DEPARTURE_TIME",
+            "ARRIVAL_TIME",
+            "DURATION",
+            "EMISSIONS"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "avoid_overnight_layovers",
+          "type": "boolean",
+          "required": false,
+          "description": "Drop itineraries with any layover that requires sleeping at the connecting airport, on any segment. The decision is exposed on each layover as layovers[].requires_airport_sleep, derived from upstream's overnight flag OR a six-hour duration threshold (catches multi-leg airport-sleep cases Google does not always tag). Filtered client-side, so the response may shrink. Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum itineraries to return in this response (1-50). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "page",
+          "type": "integer",
+          "required": false,
+          "description": "Page number for pagination. Increment to fetch the next slice when has_more is true. Defaults to 1 (first page).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "SERP_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "SERP_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Multi-city itineraries from Google Flights."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "GoogleFlights.SearchMultiCityFlights",
+        "parameters": {
+          "segments": {
+            "value": [
+              {
+                "departure_airport_code": "JFK",
+                "arrival_airport_code": "LHR",
+                "outbound_date": "2025-09-10"
+              },
+              {
+                "departure_airport_code": "LHR",
+                "arrival_airport_code": "CDG",
+                "outbound_date": "2025-09-15"
+              },
+              {
+                "departure_airport_code": "CDG",
+                "arrival_airport_code": "JFK",
+                "outbound_date": "2025-09-20"
+              }
+            ],
+            "type": "array",
+            "required": true
+          },
+          "currency_code": {
+            "value": "EUR",
+            "type": "string",
+            "required": false
+          },
+          "travel_class": {
+            "value": "BUSINESS",
+            "type": "string",
+            "required": false
+          },
+          "num_adults": {
+            "value": 2,
+            "type": "integer",
+            "required": false
+          },
+          "num_children": {
+            "value": 1,
+            "type": "integer",
+            "required": false
+          },
+          "max_stops": {
+            "value": "1",
+            "type": "string",
+            "required": false
+          },
+          "sort_by": {
+            "value": "TOP_FLIGHTS",
+            "type": "string",
+            "required": false
+          },
+          "avoid_overnight_layovers": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "limit": {
+            "value": 15,
+            "type": "integer",
+            "required": false
+          },
+          "page": {
+            "value": 1,
+            "type": "integer",
             "required": false
           }
         },
@@ -229,6 +829,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-26T20:45:10.403Z",
-  "summary": "The Arcade toolkit for Google Flights empowers developers to seamlessly integrate flight search capabilities into their applications, allowing for efficient retrieval of flight information.  \n\n**Capabilities**  \n- Access comprehensive one-way flight search results from Google Flights.  \n- Easily integrate with existing applications for enhanced user experience.  \n- Streamlined queries for fast and relevant flight data.  \n\n**OAuth**  \n- No OAuth requirements; utilize API key for access.  \n\n**Secrets**  \n- Secret type: API key.  \n- Example: SERP_API_KEY is necessary for utilizing the flight search tool.  "
+  "generatedAt": "2026-06-05T12:08:01.562Z",
+  "summary": "The Google Flights toolkit lets LLMs search and resolve flight itineraries via the SerpApi Google Flights endpoint. It covers airport lookup, one-way/round-trip search, multi-city search, and booking option resolution.\n\n## Capabilities\n\n- **Airport discovery** — resolve city names, country names, or airport names to IATA codes (including metropolitan codes like NYC or LON) for use in flight searches.\n- **One-way & round-trip search** — query Google Flights for itineraries with flexible cabin class, passenger counts, and date options; round-trips are fetched in a single call to reflect true bundled pricing.\n- **Multi-city / open-jaw search** — book complex multi-leg itineraries in one query, which typically prices cheaper than summing equivalent one-way fares.\n- **Booking option resolution** — convert a `booking_token` from a search result into the full list of airlines and OTAs selling that specific itinerary, with optional POST data for backend vendor hand-offs.\n\n## Secrets\n\n- **`SERP_API_KEY`** — An API key issued by [SerpApi](https://serpapi.com), the service that powers the underlying Google Flights data. To obtain one: create an account at [https://serpapi.com/users/sign_up](https://serpapi.com/users/sign_up), then retrieve your private API key from the [SerpApi dashboard](https://serpapi.com/manage-api-key). The key must have access to the Google Flights engine; free-tier accounts include a limited monthly search quota, while paid plans unlock higher volume. Pass this key as the `SERP_API_KEY` secret in your Arcade configuration.\n\nSee the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to store secrets, or manage them directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/googlesheets.json
+++ b/toolkit-docs-generator/data/toolkits/googlesheets.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleSheets",
   "label": "Google Sheets",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Arcade.dev LLM tools for Google Sheets.",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "AddNoteToCell",
       "qualifiedName": "GoogleSheets.AddNoteToCell",
-      "fullyQualifiedName": "GoogleSheets.AddNoteToCell@6.0.0",
+      "fullyQualifiedName": "GoogleSheets.AddNoteToCell@6.0.1",
       "description": "Add a note to a specific cell in a spreadsheet. A note is a small\npiece of text attached to a cell (shown with a black triangle) that\nappears when you hover over the cell.\n\nsheet_id_or_name takes precedence over sheet_position. If a sheet is not mentioned,\nthen always assume the default sheet_position is sufficient.",
       "parameters": [
         {
@@ -158,7 +158,7 @@
     {
       "name": "CreateSpreadsheet",
       "qualifiedName": "GoogleSheets.CreateSpreadsheet",
-      "fullyQualifiedName": "GoogleSheets.CreateSpreadsheet@6.0.0",
+      "fullyQualifiedName": "GoogleSheets.CreateSpreadsheet@6.0.1",
       "description": "Create a new spreadsheet with the provided title and data in its first sheet\n\nReturns the newly created spreadsheet's id and title",
       "parameters": [
         {
@@ -231,7 +231,7 @@
     {
       "name": "GenerateGoogleFilePickerUrl",
       "qualifiedName": "GoogleSheets.GenerateGoogleFilePickerUrl",
-      "fullyQualifiedName": "GoogleSheets.GenerateGoogleFilePickerUrl@6.0.0",
+      "fullyQualifiedName": "GoogleSheets.GenerateGoogleFilePickerUrl@6.0.1",
       "description": "Generate a URL where the user can grant this app access to specific Drive files.\n\nOpens Google's first-party Drive picker. The user selects which files to share\nwith this application — it is not a sign-in or credential prompt.\n\nUse this when a prior tool reported that a file was not found or access was denied,\nand the user expects the file to exist. After the user completes the picker flow,\nretry the prior tool.",
       "parameters": [],
       "auth": {
@@ -274,7 +274,7 @@
     {
       "name": "GetSpreadsheet",
       "qualifiedName": "GoogleSheets.GetSpreadsheet",
-      "fullyQualifiedName": "GoogleSheets.GetSpreadsheet@6.0.0",
+      "fullyQualifiedName": "GoogleSheets.GetSpreadsheet@6.0.1",
       "description": "Gets the specified range of cells from a single sheet in the spreadsheet.\n\nsheet_id_or_name takes precedence over sheet_position. If a sheet is not mentioned,\nthen always assume the default sheet_position is sufficient.",
       "parameters": [
         {
@@ -419,7 +419,7 @@
     {
       "name": "GetSpreadsheetMetadata",
       "qualifiedName": "GoogleSheets.GetSpreadsheetMetadata",
-      "fullyQualifiedName": "GoogleSheets.GetSpreadsheetMetadata@6.0.0",
+      "fullyQualifiedName": "GoogleSheets.GetSpreadsheetMetadata@6.0.1",
       "description": "Gets the metadata for a spreadsheet including the metadata for the sheets in the spreadsheet.\n\nUse this tool to get the name, position, ID, and URL of all sheets in a spreadsheet as well as\nthe number of rows and columns in each sheet.\n\nDoes not return the content/data of the sheets in the spreadsheet - only the metadata.\nExcludes spreadsheets that are in the trash.",
       "parameters": [
         {
@@ -486,7 +486,7 @@
     {
       "name": "SearchSpreadsheets",
       "qualifiedName": "GoogleSheets.SearchSpreadsheets",
-      "fullyQualifiedName": "GoogleSheets.SearchSpreadsheets@6.0.0",
+      "fullyQualifiedName": "GoogleSheets.SearchSpreadsheets@6.0.1",
       "description": "Searches for spreadsheets in the user's Google Drive based on the titles and content and\nreturns the title, ID, and URL for each matching spreadsheet.\n\nDoes not return the content/data of the sheets in the spreadsheets - only the metadata.\nExcludes spreadsheets that are in the trash.",
       "parameters": [
         {
@@ -679,7 +679,7 @@
     {
       "name": "UpdateCells",
       "qualifiedName": "GoogleSheets.UpdateCells",
-      "fullyQualifiedName": "GoogleSheets.UpdateCells@6.0.0",
+      "fullyQualifiedName": "GoogleSheets.UpdateCells@6.0.1",
       "description": "Write values to a Google Sheet using a flexible data format.\n\nsheet_id_or_name takes precedence over sheet_position. If a sheet is not mentioned,\nthen always assume the default sheet_position is sufficient.",
       "parameters": [
         {
@@ -785,7 +785,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleSheets.WhoAmI",
-      "fullyQualifiedName": "GoogleSheets.WhoAmI@6.0.0",
+      "fullyQualifiedName": "GoogleSheets.WhoAmI@6.0.1",
       "description": "Get comprehensive user profile and Google Sheets environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Sheets access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -832,7 +832,7 @@
     {
       "name": "WriteToCell",
       "qualifiedName": "GoogleSheets.WriteToCell",
-      "fullyQualifiedName": "GoogleSheets.WriteToCell@6.0.0",
+      "fullyQualifiedName": "GoogleSheets.WriteToCell@6.0.1",
       "description": "Write a value to a single cell in a spreadsheet.",
       "parameters": [
         {
@@ -954,6 +954,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-05-28T12:15:57.058Z",
+  "generatedAt": "2026-06-05T12:07:56.906Z",
   "summary": "The Google Sheets toolkit lets LLM agents create, read, search, and edit Google Sheets spreadsheets through Arcade, using Google OAuth for delegated user access.\n\n## Capabilities\n\n- **Spreadsheet discovery & metadata** — search across a user's Drive for spreadsheets by title/content, retrieve full sheet metadata (names, positions, IDs, URLs, dimensions) without loading cell data.\n- **Reading data** — fetch cell ranges from any sheet within a spreadsheet, with flexible sheet targeting by name, ID, or position.\n- **Writing & editing** — create new spreadsheets with initial data, write a single cell value, bulk-update cell ranges with flexible data formats, and attach hover notes to individual cells.\n- **File access recovery** — generate a Google Drive inline file-picker URL so users can grant the app access to specific files when a prior operation fails due to missing permissions, then retry the original tool.\n- **Identity & permissions inspection** — retrieve the authenticated user's profile, email, and Google Sheets access permissions via `WhoAmI`.\n\n## OAuth\n\nThis toolkit uses **Google OAuth 2.0** to act on behalf of the authenticated user. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for scopes, setup, and configuration details.\n\n## Secrets\n\n- **`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL`** — An API key that enables the `GoogleSheets.GenerateGoogleFilePickerUrl` tool to render Google's first-party Drive file picker. To obtain it, go to the [Google Cloud Console APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials) page for your project, click **Create credentials → API key**, and ensure the Google Picker API is enabled for your project under **APIs & Services → Library**. Restrict the key to the Picker API and to allowed HTTP referrers/origins as appropriate for your deployment. See [Google Picker API documentation](https://developers.google.com/drive/picker/guides/overview) for full setup details.\n\nStore secrets in Arcade via the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) or directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/googleslides.json
+++ b/toolkit-docs-generator/data/toolkits/googleslides.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleSlides",
   "label": "Google Slides",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Arcade.dev LLM tools for Google Slides",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "CommentOnPresentation",
       "qualifiedName": "GoogleSlides.CommentOnPresentation",
-      "fullyQualifiedName": "GoogleSlides.CommentOnPresentation@2.0.0",
+      "fullyQualifiedName": "GoogleSlides.CommentOnPresentation@2.0.1",
       "description": "Comment on a specific slide by its index in a Google Slides presentation.",
       "parameters": [
         {
@@ -106,7 +106,7 @@
     {
       "name": "CreatePresentation",
       "qualifiedName": "GoogleSlides.CreatePresentation",
-      "fullyQualifiedName": "GoogleSlides.CreatePresentation@2.0.0",
+      "fullyQualifiedName": "GoogleSlides.CreatePresentation@2.0.1",
       "description": "Create a new Google Slides presentation\nThe first slide will be populated with the specified title and subtitle.",
       "parameters": [
         {
@@ -179,7 +179,7 @@
     {
       "name": "CreateSlide",
       "qualifiedName": "GoogleSlides.CreateSlide",
-      "fullyQualifiedName": "GoogleSlides.CreateSlide@2.0.0",
+      "fullyQualifiedName": "GoogleSlides.CreateSlide@2.0.1",
       "description": "Create a new slide at the end of the specified presentation",
       "parameters": [
         {
@@ -272,7 +272,7 @@
     {
       "name": "GenerateGoogleFilePickerUrl",
       "qualifiedName": "GoogleSlides.GenerateGoogleFilePickerUrl",
-      "fullyQualifiedName": "GoogleSlides.GenerateGoogleFilePickerUrl@2.0.0",
+      "fullyQualifiedName": "GoogleSlides.GenerateGoogleFilePickerUrl@2.0.1",
       "description": "Generate a URL where the user can grant this app access to specific Drive files.\n\nOpens Google's first-party Drive picker. The user selects which files to share\nwith this application — it is not a sign-in or credential prompt.\n\nUse this when a prior tool reported that a file was not found or access was denied,\nand the user expects the file to exist. After the user completes the picker flow,\nretry the prior tool.",
       "parameters": [],
       "auth": {
@@ -315,7 +315,7 @@
     {
       "name": "GetPresentationAsMarkdown",
       "qualifiedName": "GoogleSlides.GetPresentationAsMarkdown",
-      "fullyQualifiedName": "GoogleSlides.GetPresentationAsMarkdown@2.0.0",
+      "fullyQualifiedName": "GoogleSlides.GetPresentationAsMarkdown@2.0.1",
       "description": "Get the specified Google Slides presentation and convert it to markdown.\n\nOnly retrieves the text content of the presentation and formats it as markdown.",
       "parameters": [
         {
@@ -382,7 +382,7 @@
     {
       "name": "ListPresentationComments",
       "qualifiedName": "GoogleSlides.ListPresentationComments",
-      "fullyQualifiedName": "GoogleSlides.ListPresentationComments@2.0.0",
+      "fullyQualifiedName": "GoogleSlides.ListPresentationComments@2.0.1",
       "description": "List all comments on the specified Google Slides presentation.",
       "parameters": [
         {
@@ -462,7 +462,7 @@
     {
       "name": "SearchPresentations",
       "qualifiedName": "GoogleSlides.SearchPresentations",
-      "fullyQualifiedName": "GoogleSlides.SearchPresentations@2.0.0",
+      "fullyQualifiedName": "GoogleSlides.SearchPresentations@2.0.1",
       "description": "Searches for presentations in the user's Google Drive.\nExcludes presentations that are in the trash.",
       "parameters": [
         {
@@ -655,7 +655,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleSlides.WhoAmI",
-      "fullyQualifiedName": "GoogleSlides.WhoAmI@2.0.0",
+      "fullyQualifiedName": "GoogleSlides.WhoAmI@2.0.1",
       "description": "Get comprehensive user profile and Google Slides environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Slides access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -713,6 +713,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-05-28T12:15:56.863Z",
+  "generatedAt": "2026-06-05T12:07:56.906Z",
   "summary": "The Google Slides toolkit lets Arcade-powered LLMs create, read, search, and annotate Google Slides presentations on behalf of authenticated users.\n\n## Capabilities\n\n- **Presentation management**: Create new presentations with a title and subtitle, or retrieve the full text content of any accessible presentation as Markdown.\n- **Slide & comment authoring**: Add slides to an existing presentation and post comments on specific slides by index; list all comments on a presentation.\n- **Search & discovery**: Search the authenticated user's Google Drive for presentations (trash excluded) and resolve access issues via the Google Drive inline file picker.\n- **Identity & environment inspection**: Retrieve the authenticated user's profile, email, permissions, and Google Slides environment details.\n\n## OAuth\n\nUses OAuth 2.0 via Google. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details.\n\n## Secrets\n\n- **`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL`**: Controls whether the `GoogleSlides.GenerateGoogleFilePickerUrl` tool is available. This secret is expected to be a URL (or a flag value) that enables the Google Drive inline picker flow — the mechanism that lets a user grant the app access to specific Drive files without a full re-authentication. This is not a standard Google API credential; it is an application-level configuration value specific to your Arcade deployment. Set this in your Arcade secrets store. Consult the [Arcade secrets documentation](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to configure it, and manage your values at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-04T12:07:03.994Z",
+  "generatedAt": "2026-06-05T12:08:12.529Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -266,7 +266,7 @@
     {
       "id": "Gmail",
       "label": "Gmail",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 18,
@@ -275,7 +275,7 @@
     {
       "id": "GoogleCalendar",
       "label": "Google Calendar",
-      "version": "3.3.2",
+      "version": "3.4.0",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 7,
@@ -284,7 +284,7 @@
     {
       "id": "GoogleContacts",
       "label": "Google Contacts",
-      "version": "3.5.2",
+      "version": "3.5.3",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 5,
@@ -293,7 +293,7 @@
     {
       "id": "GoogleDocs",
       "label": "Google Docs",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 13,
@@ -302,7 +302,7 @@
     {
       "id": "GoogleDrive",
       "label": "Google Drive",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 15,
@@ -320,10 +320,10 @@
     {
       "id": "GoogleFlights",
       "label": "Google Flights",
-      "version": "3.2.2",
+      "version": "4.0.4",
       "category": "search",
       "type": "arcade",
-      "toolCount": 1,
+      "toolCount": 4,
       "authType": "none"
     },
     {
@@ -374,7 +374,7 @@
     {
       "id": "GoogleSheets",
       "label": "Google Sheets",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 9,
@@ -392,7 +392,7 @@
     {
       "id": "GoogleSlides",
       "label": "Google Slides",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 8,
@@ -730,6 +730,15 @@
       "type": "arcade",
       "toolCount": 11,
       "authType": "oauth2"
+    },
+    {
+      "id": "Resend",
+      "label": "Resend",
+      "version": "0.1.0",
+      "category": "productivity",
+      "type": "arcade",
+      "toolCount": 4,
+      "authType": "none"
     },
     {
       "id": "Salesforce",

--- a/toolkit-docs-generator/data/toolkits/resend.json
+++ b/toolkit-docs-generator/data/toolkits/resend.json
@@ -1,0 +1,453 @@
+{
+  "id": "Resend",
+  "label": "Resend",
+  "version": "0.1.0",
+  "description": "Arcade.dev LLM tools for sending and managing transactional email via Resend",
+  "metadata": {
+    "category": "productivity",
+    "iconUrl": "https://design-system.arcade.dev/icons/resend.svg",
+    "isBYOC": false,
+    "isPro": false,
+    "type": "arcade",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/productivity/resend",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": null,
+  "tools": [
+    {
+      "name": "CancelEmail",
+      "qualifiedName": "Resend.CancelEmail",
+      "fullyQualifiedName": "Resend.CancelEmail@0.1.0",
+      "description": "Cancel a scheduled, not-yet-sent email.",
+      "parameters": [
+        {
+          "name": "email_id",
+          "type": "string",
+          "required": true,
+          "description": "Identifier of the scheduled email to cancel.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "RESEND_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "RESEND_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Confirmation that the scheduled email was cancelled."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Resend.CancelEmail",
+        "parameters": {
+          "email_id": {
+            "value": "549df11b-7685-4e61-b8e5-3f1234567890",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetEmail",
+      "qualifiedName": "Resend.GetEmail",
+      "fullyQualifiedName": "Resend.GetEmail@0.1.0",
+      "description": "Retrieve a single email by its Resend ID, including current delivery status.",
+      "parameters": [
+        {
+          "name": "email_id",
+          "type": "string",
+          "required": true,
+          "description": "The Resend-assigned identifier of the email to retrieve.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "RESEND_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "RESEND_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Current state and metadata of the email."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Resend.GetEmail",
+        "parameters": {
+          "email_id": {
+            "value": "54321abc-1234-5678-abcd-ef0123456789",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "RescheduleEmail",
+      "qualifiedName": "Resend.RescheduleEmail",
+      "fullyQualifiedName": "Resend.RescheduleEmail@0.1.0",
+      "description": "Reschedule a not-yet-sent email by updating its scheduled_at timestamp.",
+      "parameters": [
+        {
+          "name": "email_id",
+          "type": "string",
+          "required": true,
+          "description": "Identifier of the scheduled email to reschedule.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "scheduled_at",
+          "type": "string",
+          "required": true,
+          "description": "New send time as ISO 8601 (YYYY-MM-DDTHH:MM:SSZ) or natural language ('in 1 hour'). Only emails that have not yet been sent can be rescheduled.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "RESEND_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "RESEND_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Confirmation of the rescheduled email."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Resend.RescheduleEmail",
+        "parameters": {
+          "email_id": {
+            "value": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
+            "type": "string",
+            "required": true
+          },
+          "scheduled_at": {
+            "value": "2024-06-15T14:30:00Z",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SendEmail",
+      "qualifiedName": "Resend.SendEmail",
+      "fullyQualifiedName": "Resend.SendEmail@0.1.0",
+      "description": "Send a transactional email through Resend.\n\nReturns the Resend-assigned email_id. When scheduled_at is provided, the email is\nqueued for later delivery instead of sent immediately.",
+      "parameters": [
+        {
+          "name": "from_address",
+          "type": "string",
+          "required": true,
+          "description": "Sender address as a bare email or formatted display name plus email, e.g. 'Acme <onboarding@example.com>'. The sender domain must be verified in Resend.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "to",
+          "type": "array",
+          "innerType": "string",
+          "required": true,
+          "description": "Recipient email addresses. At least 1 and at most 50 entries.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "subject",
+          "type": "string",
+          "required": true,
+          "description": "Subject line of the email.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "html",
+          "type": "string",
+          "required": false,
+          "description": "HTML body of the email. Provide at least one of 'html' or 'text'. Leave empty for no HTML body.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "text",
+          "type": "string",
+          "required": false,
+          "description": "Plain-text body of the email. Provide at least one of 'html' or 'text'. Leave empty for no plain-text body.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cc",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "CC recipients. Omit for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "bcc",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "BCC recipients. Omit for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "reply_to",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Reply-To addresses. Replies from recipients are directed here instead of the sender. Omit to use the sender as the reply target.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "scheduled_at",
+          "type": "string",
+          "required": false,
+          "description": "When to deliver the message, as ISO 8601 (YYYY-MM-DDTHH:MM:SSZ) or natural language understood by Resend ('in 1 hour'). Leave empty to send immediately.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "attachments",
+          "type": "array",
+          "innerType": "json",
+          "required": false,
+          "description": "Files to attach, each fetched by Resend from a remote URL. Every attachment needs a 'filename' and a 'url' pointing to a publicly accessible file (not a local path). Optional 'content_type' overrides MIME detection. Omit for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "tags",
+          "type": "array",
+          "innerType": "json",
+          "required": false,
+          "description": "Custom tags for analytics or filtering. Each entry has a 'name' and a 'value'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "headers",
+          "type": "json",
+          "required": false,
+          "description": "Additional RFC 822 headers as a flat key/value mapping (e.g. {'X-Entity-Ref-ID': '...'}). Omit for none.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "RESEND_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "RESEND_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Identifier of the newly queued or sent email."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Resend.SendEmail",
+        "parameters": {
+          "from_address": {
+            "value": "Acme <onboarding@acme.com>",
+            "type": "string",
+            "required": true
+          },
+          "to": {
+            "value": [
+              "alice@example.com",
+              "bob@example.com"
+            ],
+            "type": "array",
+            "required": true
+          },
+          "subject": {
+            "value": "Welcome to Acme – Get Started Today!",
+            "type": "string",
+            "required": true
+          },
+          "html": {
+            "value": "<h1>Welcome!</h1><p>Thanks for signing up. <a href=\"https://acme.com/start\">Click here</a> to get started.</p>",
+            "type": "string",
+            "required": false
+          },
+          "text": {
+            "value": "Welcome! Thanks for signing up. Visit https://acme.com/start to get started.",
+            "type": "string",
+            "required": false
+          },
+          "cc": {
+            "value": [
+              "manager@acme.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "bcc": {
+            "value": [
+              "archive@acme.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "reply_to": {
+            "value": [
+              "support@acme.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "scheduled_at": {
+            "value": "2025-09-01T09:00:00Z",
+            "type": "string",
+            "required": false
+          },
+          "attachments": {
+            "value": [
+              {
+                "filename": "welcome-guide.pdf",
+                "url": "https://acme.com/assets/welcome-guide.pdf",
+                "content_type": "application/pdf"
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
+          "tags": {
+            "value": [
+              {
+                "name": "campaign",
+                "value": "onboarding-2025"
+              },
+              {
+                "name": "tier",
+                "value": "free"
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
+          "headers": {
+            "value": {
+              "X-Entity-Ref-ID": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+              "X-Mailer": "AcmeMailer/1.0"
+            },
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-06-05T12:08:02.909Z",
+  "summary": "The Resend toolkit integrates Resend's transactional email API with Arcade, enabling LLMs to send, schedule, inspect, and manage emails programmatically.\n\n## Capabilities\n\n- **Send & schedule email**: Send transactional email immediately or queue it for future delivery by supplying a `scheduled_at` timestamp; returns the Resend-assigned `email_id`.\n- **Inspect delivery status**: Retrieve a single email by its Resend ID to check current delivery state and metadata.\n- **Manage scheduled email**: Cancel or reschedule queued (not-yet-sent) emails by updating or voiding their scheduled delivery time.\n\n## Secrets\n\n`RESEND_API_KEY` — A Resend API key that authenticates all requests to the Resend API. To obtain one, log in to the [Resend dashboard](https://resend.com/api-keys) and create a new API key under **API Keys**. Assign at minimum the **Sending access** permission; if your use case requires retrieving or cancelling emails, ensure the key has the appropriate read/write permissions. API keys are scoped per team and tied to a verified sending domain — confirm at least one domain is verified in your Resend account before use.\n\nStore this secret in Arcade via the [secrets dashboard](https://api.arcade.dev/dashboard/auth/secrets) or follow the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets)."
+}


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/27013756186

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are generated documentation and toolkit metadata only, with no application runtime code in the diff.
> 
> **Overview**
> Scheduled **MCP server / integration docs** refresh: regenerated toolkit JSON under `toolkit-docs-generator/data/toolkits/` and wired **Resend** into the productivity integrations nav in `_meta.tsx`.
> 
> **New: Resend** (`0.1.0`) — docs for four tools: send transactional email (optional schedule), get status, reschedule, and cancel queued sends; uses `RESEND_API_KEY`.
> 
> **Google Calendar** (`3.3.2` → `3.4.0`) — documents **recurring events**: `recurrence` on create and `updated_recurrence` on update (RFC 5545 rules, including clearing recurrence with `[]`).
> 
> **Google Flights** (`3.2.2` → `4.0.4`) — replaces the single one-way search with **`SearchFlights`** (one-way and round-trip in one call), plus **`LookupAirports`**, **`SearchMultiCityFlights`**, and **`GetFlightBookingOptions`**; index tool count updates from 1 to 4.
> 
> **Patch-only bumps** (e.g. Gmail, Google Contacts, Docs, Drive, Sheets, Slides) — version and `fullyQualifiedName` strings and `generatedAt` timestamps; no new parameters in those diffs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcf86c22873720ed94558a3dc9d32db9820e077d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->