### PR TITLE
updated the changelog (and hopefully fixed the agent's routine)

### DIFF
--- a/app/en/references/changelog/page.mdx
+++ b/app/en/references/changelog/page.mdx
@@ -9,6 +9,72 @@ import { Callout } from "nextra/components";
 
 _Here's what's new at Arcade.dev!_
 
+## 2026-06-05
+
+**Arcade MCP Servers**
+
+- `[feature - 🚀]` Add Github_SearchCode for cross-organizational code search functionality.
+- `[feature - 🚀]` Rebuilds the arcade_google_flights toolkit to support full trip-planning lifecycle.
+- `[feature - 🚀]` Add support for recurring events in Google Calendar API integration.
+- `[feature - 🚀]` Add ChatGPT as a supported MCP client in the mcp-gateway-connect feature.
+- `[feature - 🚀]` Add move email to folder tools in the Microsoft Outlook Mail toolkit for better email organization.
+- `[feature - 🚀]` Add Resend transactional email toolkit with API-key authentication for email operations.
+- `[feature - 🚀]` Add create_or_edit_spreadsheet tool for batch operations on Google Sheets.
+- `[documentation - 📝]` Updating documentation for MCP Servers.
+- `[documentation - 📝]` Removed outdated PAT and notification references from GitHub MCP server documentation.
+
+**Platform and Engine**
+
+- `[feature - 🚀]` Swap primary and tertiary colors in the design system to improve UI clarity.
+- `[feature - 🚀]` Add User Source CRUD audit logging and emission framework in the coordinator.
+- `[feature - 🚀]` Make OIDC scopes configurable per User Source, enhancing integration with Microsoft Entra ID.
+- `[bugfix - 🐛]` Fix dark mode visibility for 'forkable' and 'squareup' icons.
+- `[bugfix - 🐛]` Tone down primary lime usage in dashboard accents for improved UI coherence.
+- `[bugfix - 🐛]` Bump Next.js versions for improved security.
+- `[bugfix - 🐛]` Fix OIDC sign-in form action generation to use BASE_URL instead of request URL.
+- `[bugfix - 🐛]` Fix slugification of gateway names in the Claude Code mcp add command to handle spaces correctly.
+- `[bugfix - 🐛]` Fix dashboard text visibility in light mode by introducing a new brand text token.
+- `[bugfix - 🐛]` Fix OAuth verifier selection in Playground to enhance security. (monorepo PR #1532)
+- `[maintenance - 🔧]` Patched 30 high-severity Dependabot CVEs across 15 packages.
+- `[documentation - 📝]` Updated User Sources for configurable scopes and added Advanced section in the Dashboard.
+
+**Misc**
+
+- `[documentation - 📝]` Add Microsoft Entra ID setup guide for Arcade User Sources.
+- `[documentation - 📝]` Adds Okta setup guide to user sources documentation.
+- `[documentation - 📝]` Adds Stytch setup guide for user sources.
+- `[documentation - 📝]` Adds a Clerk setup guide for OAuth applications in user sources.
+- `[documentation - 📝]` Adds an Auth0 setup guide for configuring user sources in Arcade.
+
+## 2026-05-29
+
+**Frameworks**
+
+- `[feature - 🚀]` Replace Reddit demo suggestion with Google Calendar in ui-kit. (monorepo PR #1390)
+
+**Arcade MCP Servers**
+
+- `[feature - 🚀]` Reshape PR objects to nested structure for improved GitHub MCP server integration.
+- `[feature - 🚀]` Reintroduce optional file picker URL suggestion in Google Workspace toolkits to enhance user experience.
+- `[feature - 🚀]` Add Forkable meal-picker toolkit for managing weekly meal selections.
+- `[bugfix - 🐛]` Improve tool descriptions to prevent confusion with prompt injections.
+- `[bugfix - 🐛]` Fix deprecated Confluence version pin to restore backward compatibility.
+- `[bugfix - 🐛]` Fix markdown rendering in PowerPoint slide bodies and titles.
+- `[documentation - 📝]` Update of MCP Servers documentation for Math toolkit version bump.
+
+**Platform and Engine**
+
+- `[feature - 🚀]` Implement static-user-source gateway login.
+- `[bugfix - 🐛]` Refactor to remove unused /v1/tokens/exchange endpoint to enhance security.
+- `[bugfix - 🐛]` Restore tool errors handling in MCP tools to improve error reporting.
+- `[feature - 🚀]` Add CIMD-specific guidance for unknown_client error in OAuth2 error page.
+- `[bugfix - 🐛]` Fix self-hosted `arcade login` process to resolve double '/oauth2' URL issue and path mismatches.
+
+**Misc**
+
+- `[documentation - 📝]` Clarifies the separation of /admin/catalog/* and /tool_metadata* routes in engine documentation.
+- `[documentation - 📝]` Add User Sources overview and integrate User Source into MCP Gateway authentication options.
+
 ## 2026-05-22
 
 **Arcade MCP Servers**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only MDX changelog updates with no runtime or application code changes.
> 
> **Overview**
> Inserts two new weekly sections at the top of `app/en/references/changelog/page.mdx`, ahead of the existing **2026-05-22** entry.
> 
> **2026-06-05** covers MCP server additions (GitHub code search, Google Flights rebuild, Google Calendar recurring events, ChatGPT MCP client, Outlook mail folders, Resend toolkit, Google Sheets batch tool), platform work (design tokens, User Source audit logging, configurable OIDC scopes), assorted UI/OAuth/Playground fixes, Dependabot CVE patches, and new User Source setup guides (Entra, Okta, Stytch, Clerk, Auth0).
> 
> **2026-05-29** documents ui-kit demo change, GitHub PR shape and Google Workspace picker updates, Forkable meal-picker toolkit, static User Source gateway login, removal of `/v1/tokens/exchange`, MCP tool error handling restore, and User Sources / MCP Gateway auth documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c910dc5838d83f732af0ffffddf0fa8c7bca4773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->