### PR TITLE
chore: update @arcadeai/design-system to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://arcade.dev/",
   "dependencies": {
-    "@arcadeai/design-system": "3.42.4",
+    "@arcadeai/design-system": "3.44.1",
     "@mdx-js/mdx": "3.1.1",
     "@mdx-js/react": "3.1.1",
     "@next/third-parties": "16.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
   .:
     dependencies:
       '@arcadeai/design-system':
-        specifier: 3.42.4
-        version: 3.42.4(@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.73.1(react@19.2.5))(react@19.2.5)(recharts@3.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1))(tailwindcss@4.2.4)
+        specifier: 3.44.1
+        version: 3.44.1(@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.73.1(react@19.2.5))(react@19.2.5)(recharts@3.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1))(tailwindcss@4.2.4)
       '@mdx-js/mdx':
         specifier: 3.1.1
         version: 3.1.1
@@ -282,8 +282,8 @@ packages:
       zod:
         optional: true
 
-  '@arcadeai/design-system@3.42.4':
-    resolution: {integrity: sha512-Qcg0Eah36DzAQEqdxP1/5DFMynM0YxJW0I6mRzbGOKK1OOrji/d6PLdopPZG806Ux9zZVVW3MyrYghsUMm7xTw==}
+  '@arcadeai/design-system@3.44.1':
+    resolution: {integrity: sha512-APIE9Hq9FKnvVPScOVx5ZHAZAPceo7olvQ5A1jU/81Tpg5emibnmJpAuRwv6y3LuJzVS1/WoFSAewZqGVKlZ5w==}
     engines: {bun: '>=1.3.5'}
     peerDependencies:
       '@hookform/resolvers': '>=5.2.1'
@@ -4728,7 +4728,7 @@ snapshots:
     optionalDependencies:
       zod: 4.3.6
 
-  '@arcadeai/design-system@3.42.4(@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.73.1(react@19.2.5))(react@19.2.5)(recharts@3.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1))(tailwindcss@4.2.4)':
+  '@arcadeai/design-system@3.44.1(@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.73.1(react@19.2.5))(react@19.2.5)(recharts@3.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1))(tailwindcss@4.2.4)':
     dependencies:
       '@base-ui/react': 1.3.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@base-ui/utils': 0.2.6(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
This PR updates `@arcadeai/design-system` to the latest published version.

It runs a design-system compatibility test gate before opening this PR.
If that gate fails, the workflow stops and no PR is created.

- Trigger: `workflow_dispatch`
- Run: https://github.com/ArcadeAI/docs/actions/runs/27158928335

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine design-system version bump with no local code changes; workflow runs a compatibility test gate before opening the PR.
> 
> **Overview**
> Bumps **`@arcadeai/design-system`** from **3.42.4** to **3.44.1** in `package.json` and refreshes **`pnpm-lock.yaml`** so the docs site resolves the new package version.
> 
> This is a dependency-only change with no edits to app source; UI that imports the design system will pick up whatever changed in that release (components, styles, utilities).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 976907414a286a35533dbbbeb6ab05a28558b580. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->