### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/app/en/resources/integrations/customer-support/_meta.tsx
+++ b/app/en/resources/integrations/customer-support/_meta.tsx
@@ -5,6 +5,14 @@ const meta: MetaRecord = {
     type: "separator",
     title: "Optimized",
   },
+  customerio: {
+    title: "Customer.io",
+    href: "/en/resources/integrations/customer-support/customerio",
+  },
+  freshdesk: {
+    title: "Freshdesk",
+    href: "/en/resources/integrations/customer-support/freshdesk",
+  },
   pylon: {
     title: "Pylon",
     href: "/en/resources/integrations/customer-support/pylon",

--- a/app/en/resources/integrations/development/_meta.tsx
+++ b/app/en/resources/integrations/development/_meta.tsx
@@ -9,6 +9,10 @@ const meta: MetaRecord = {
     title: "Bright Data",
     href: "/en/resources/integrations/development/brightdata",
   },
+  datadog: {
+    title: "Datadog",
+    href: "/en/resources/integrations/development/datadog",
+  },
   daytona: {
     title: "Daytona",
     href: "/en/resources/integrations/development/daytona",
@@ -36,6 +40,10 @@ const meta: MetaRecord = {
   posthog: {
     title: "PostHog",
     href: "/en/resources/integrations/development/posthog",
+  },
+  vercel: {
+    title: "Vercel",
+    href: "/en/resources/integrations/development/vercel",
   },
   "-- Starter": {
     type: "separator",

--- a/app/en/resources/integrations/productivity/_meta.tsx
+++ b/app/en/resources/integrations/productivity/_meta.tsx
@@ -9,6 +9,10 @@ const meta: MetaRecord = {
     title: "Asana",
     href: "/en/resources/integrations/productivity/asana",
   },
+  ashby: {
+    title: "Ashby",
+    href: "/en/resources/integrations/productivity/ashby",
+  },
   clickup: {
     title: "ClickUp",
     href: "/en/resources/integrations/productivity/clickup",

--- a/app/en/resources/integrations/sales/_meta.tsx
+++ b/app/en/resources/integrations/sales/_meta.tsx
@@ -5,6 +5,10 @@ const meta: MetaRecord = {
     type: "separator",
     title: "Optimized",
   },
+  apollo: {
+    title: "Apollo",
+    href: "/en/resources/integrations/sales/apollo",
+  },
   attio: {
     title: "Attio",
     href: "/en/resources/integrations/sales/attio",

--- a/app/en/resources/integrations/social/_meta.tsx
+++ b/app/en/resources/integrations/social/_meta.tsx
@@ -5,6 +5,10 @@ const meta: MetaRecord = {
     type: "separator",
     title: "Optimized",
   },
+  "discord-bot": {
+    title: "Discord Bot",
+    href: "/en/resources/integrations/social/discord-bot",
+  },
   linkedin: {
     title: "LinkedIn",
     href: "/en/resources/integrations/social/linkedin",

--- a/toolkit-docs-generator/data/toolkits/apollo.json
+++ b/toolkit-docs-generator/data/toolkits/apollo.json
@@ -1,0 +1,692 @@
+{
+  "id": "Apollo",
+  "label": "Apollo",
+  "version": "0.1.0",
+  "description": "Arcade tools designed for LLMs to interact with Apollo.io sales intelligence",
+  "metadata": {
+    "category": "sales",
+    "iconUrl": "https://design-system.arcade.dev/icons/apollo.svg",
+    "isBYOC": false,
+    "isPro": false,
+    "type": "arcade",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/sales/apollo",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": null,
+  "tools": [
+    {
+      "name": "EnrichOrganization",
+      "qualifiedName": "Apollo.EnrichOrganization",
+      "fullyQualifiedName": "Apollo.EnrichOrganization@0.1.0",
+      "description": "Turn a company domain into firmographics (industry, size, revenue, funding,\nlocation) so a rep can qualify and size an account. Consumes one enrichment\ncredit on a match; when the plan is out of credits the result reports\nstatus=insufficient_credits rather than failing.",
+      "parameters": [
+        {
+          "name": "domain",
+          "type": "string",
+          "required": true,
+          "description": "Company domain to look up, such as apollo.io. A full URL or www prefix is accepted and normalized.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "APOLLO_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "APOLLO_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The matched company, or found=False when no match."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Apollo.EnrichOrganization",
+        "parameters": {
+          "domain": {
+            "value": "stripe.com",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "EnrichPerson",
+      "qualifiedName": "Apollo.EnrichPerson",
+      "fullyQualifiedName": "Apollo.EnrichPerson@0.1.0",
+      "description": "Turn a known person into a verified profile with their current role and,\non request, contact details. Provide at least one identifier: an Apollo person\nID, a name (or first and last name), an email, or a LinkedIn URL; an employer\nname or domain alone is not enough to identify someone. Consumes one enrichment\ncredit on a match; when the plan is out of credits the result reports\nstatus=insufficient_credits rather than failing.",
+      "parameters": [
+        {
+          "name": "person_id",
+          "type": "string",
+          "required": false,
+          "description": "Apollo person ID, such as the id from a people search result. The most reliable identifier when available. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Full name of the person. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "first_name",
+          "type": "string",
+          "required": false,
+          "description": "First name, paired with last_name. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "last_name",
+          "type": "string",
+          "required": false,
+          "description": "Last name, paired with first_name. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "required": false,
+          "description": "Known email address of the person. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "organization_name",
+          "type": "string",
+          "required": false,
+          "description": "Employer name to disambiguate a name match. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "required": false,
+          "description": "Employer domain to disambiguate a name match. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "linkedin_url",
+          "type": "string",
+          "required": false,
+          "description": "LinkedIn profile URL of the person. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "reveal_work_email",
+          "type": "boolean",
+          "required": false,
+          "description": "When True, include the matched person's work email in the result. A successful match consumes an enrichment credit whether or not this is set, so the flag controls only whether the email value is surfaced. Default is False.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "APOLLO_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "APOLLO_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The matched person, or found=False when no match."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Apollo.EnrichPerson",
+        "parameters": {
+          "person_id": {
+            "value": "583f6b2e7b6b8a1d4e9c0f23",
+            "type": "string",
+            "required": false
+          },
+          "name": {
+            "value": "Jane Doe",
+            "type": "string",
+            "required": false
+          },
+          "first_name": {
+            "value": "Jane",
+            "type": "string",
+            "required": false
+          },
+          "last_name": {
+            "value": "Doe",
+            "type": "string",
+            "required": false
+          },
+          "email": {
+            "value": "jane.doe@techcorp.com",
+            "type": "string",
+            "required": false
+          },
+          "organization_name": {
+            "value": "TechCorp Inc.",
+            "type": "string",
+            "required": false
+          },
+          "domain": {
+            "value": "techcorp.com",
+            "type": "string",
+            "required": false
+          },
+          "linkedin_url": {
+            "value": "https://www.linkedin.com/in/janedoe",
+            "type": "string",
+            "required": false
+          },
+          "reveal_work_email": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetApiUsage",
+      "qualifiedName": "Apollo.GetApiUsage",
+      "fullyQualifiedName": "Apollo.GetApiUsage@0.1.0",
+      "description": "Report per-endpoint rate limits and how many requests remain, so the agent\ncan pace a batch of lookups and avoid being throttled. Requires an Apollo\nmaster API key.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "APOLLO_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "APOLLO_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Per-endpoint rate limits and remaining request counts."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Apollo.GetApiUsage",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchOrganizations",
+      "qualifiedName": "Apollo.SearchOrganizations",
+      "fullyQualifiedName": "Apollo.SearchOrganizations@0.1.0",
+      "description": "Find companies in Apollo's database that match a firmographic profile so a\nrep can prioritize the accounts worth working. Results include firmographics\ninline unless include_firmographics is disabled. Company search consumes plan\ncredits; when the plan is out of credits the result reports\nstatus=insufficient_credits with an empty list rather than failing.",
+      "parameters": [
+        {
+          "name": "keyword_tags",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Industry or keyword tags to match, such as fintech or cybersecurity. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "locations",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Headquarters locations, such as a city, state, or country. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "num_employees_ranges",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Headcount ranges, each formatted as min,max (for example 51,200). Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "revenue_min",
+          "type": "integer",
+          "required": false,
+          "description": "Minimum annual revenue in whole dollars. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "revenue_max",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum annual revenue in whole dollars. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "technology_uids",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Apollo technology UIDs the company must use. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "include_firmographics",
+          "type": "boolean",
+          "required": false,
+          "description": "When True, backfill each result with firmographics (industry, headcount, location, revenue, founded year) via enrichment so accounts can be ranked without a separate lookup; set False for a faster, lighter name/domain-only list. Default is True.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum companies to return, 1 to 100. Default is 25.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position into the matches. Default is 0 (first result).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "APOLLO_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "APOLLO_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Matching companies with pagination metadata."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Apollo.SearchOrganizations",
+        "parameters": {
+          "keyword_tags": {
+            "value": [
+              "fintech",
+              "cybersecurity",
+              "cloud computing"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "locations": {
+            "value": [
+              "San Francisco, CA",
+              "New York, NY",
+              "United States"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "num_employees_ranges": {
+            "value": [
+              "51,200",
+              "201,500"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "revenue_min": {
+            "value": 1000000,
+            "type": "integer",
+            "required": false
+          },
+          "revenue_max": {
+            "value": 50000000,
+            "type": "integer",
+            "required": false
+          },
+          "technology_uids": {
+            "value": [
+              "salesforce",
+              "aws",
+              "hubspot"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "include_firmographics": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchPeople",
+      "qualifiedName": "Apollo.SearchPeople",
+      "fullyQualifiedName": "Apollo.SearchPeople@0.1.0",
+      "description": "Find people in Apollo's database by role and the firmographics of their\nemployer. Returns lightweight records without email or phone; use person\nenrichment to reveal verified contact details.",
+      "parameters": [
+        {
+          "name": "person_titles",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Job titles to match, such as VP of Sales. Matched loosely unless include_similar_titles is disabled. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "person_seniorities",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Seniority levels of the person's current role. Default is None.",
+          "enum": [
+            "owner",
+            "founder",
+            "c_suite",
+            "partner",
+            "vp",
+            "head",
+            "director",
+            "manager",
+            "senior",
+            "entry",
+            "intern"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "person_locations",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Locations of the person, such as a city, state, or country. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "organization_locations",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Locations of the person's employer headquarters. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "organization_num_employees_ranges",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Employer headcount ranges, each formatted as min,max (for example 51,200). Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "employer_domains",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Company domains the person must work at. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "keywords",
+          "type": "string",
+          "required": false,
+          "description": "Free-text keywords matched across the person's profile. Default is None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "include_similar_titles",
+          "type": "boolean",
+          "required": false,
+          "description": "When True, titles match loosely (similar titles included). Set False to keep only people whose title exactly matches one of person_titles. Default is True.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum people to return, 1 to 100. Default is 25.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position into the matches. Default is 0 (first result).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "APOLLO_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "APOLLO_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Matching people with pagination metadata."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Apollo.SearchPeople",
+        "parameters": {
+          "person_titles": {
+            "value": [
+              "VP of Sales",
+              "Director of Marketing",
+              "Chief Revenue Officer"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "person_seniorities": {
+            "value": [
+              "vp",
+              "director",
+              "c_suite"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "person_locations": {
+            "value": [
+              "San Francisco, California",
+              "New York, NY",
+              "United States"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "organization_locations": {
+            "value": [
+              "Austin, Texas",
+              "London, United Kingdom"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "organization_num_employees_ranges": {
+            "value": [
+              "51,200",
+              "201,500"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "employer_domains": {
+            "value": [
+              "salesforce.com",
+              "hubspot.com"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "keywords": {
+            "value": "SaaS B2B growth strategy revenue",
+            "type": "string",
+            "required": false
+          },
+          "include_similar_titles": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-06-10T12:11:44.647Z",
+  "summary": "# Apollo Toolkit\n\nThe Apollo toolkit lets LLMs interact with [Apollo.io](https://www.apollo.io/) sales intelligence, enabling account research, lead discovery, and contact enrichment workflows via the Apollo API.\n\n## Capabilities\n\n- **Company intelligence**: Search Apollo's database by firmographic filters and enrich a company domain into detailed account data (industry, size, revenue, funding, location).\n- **People discovery & enrichment**: Search for people by role and employer profile, then enrich individual records with verified contact details using any available identifier (Apollo ID, name, email, or LinkedIn URL).\n- **Credit-aware results**: Enrichment and search operations report `status=insufficient_credits` with graceful degradation rather than hard failures when plan credits are exhausted.\n- **Rate-limit introspection**: Retrieve per-endpoint rate limits and remaining request counts to let agents pace batch workloads and avoid throttling.\n\n## Secrets\n\n`APOLLO_API_KEY` — A master API key issued by Apollo.io, required for all toolkit calls. The `Apollo.GetApiUsage` tool specifically requires the **master** API key (not a scoped or restricted key). Obtain it from the [Apollo.io API Keys settings page](https://app.apollo.io/#/settings/integrations/api) (Settings → Integrations → API Keys → Create new key). Ensure the key has the permissions your plan supports; enrichment and search calls consume plan credits tied to the key's account.\n\nSee the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to configure secrets in Arcade, or manage them directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
+}

--- a/toolkit-docs-generator/data/toolkits/ashby.json
+++ b/toolkit-docs-generator/data/toolkits/ashby.json
@@ -1,0 +1,729 @@
+{
+  "id": "Ashby",
+  "label": "Ashby",
+  "version": "0.1.0",
+  "description": "Arcade.dev tools for interacting with Ashby",
+  "metadata": {
+    "category": "productivity",
+    "iconUrl": "https://design-system.arcade.dev/icons/ashby.svg",
+    "isBYOC": true,
+    "isPro": false,
+    "type": "arcade",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/productivity/ashby",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": null,
+  "tools": [
+    {
+      "name": "AddCandidateNote",
+      "qualifiedName": "Ashby.AddCandidateNote",
+      "fullyQualifiedName": "Ashby.AddCandidateNote@0.1.0",
+      "description": "Add a plain-text note to a candidate (e.g. an agent handoff or summary).\n\nCreates a new note each time it runs. Requires the Candidates write permission\non the API key.",
+      "parameters": [
+        {
+          "name": "candidate_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the candidate to add the note to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "required": true,
+          "description": "The note text to add. Sent as plain text; do not pass HTML markup.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "send_notifications",
+          "type": "boolean",
+          "required": false,
+          "description": "Whether users subscribed to the candidate are notified of the note. Default is false.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "ASHBY_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ASHBY_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The created note."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Ashby.AddCandidateNote",
+        "parameters": {
+          "candidate_id": {
+            "value": "cand_01HABCDE1234FGHIJ5678KLMN",
+            "type": "string",
+            "required": true
+          },
+          "note": {
+            "value": "Candidate spoke with recruiter on initial screening call. Strong background in backend engineering with 5+ years of experience. Recommended to move forward to technical interview stage.",
+            "type": "string",
+            "required": true
+          },
+          "send_notifications": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ChangeApplicationStage",
+      "qualifiedName": "Ashby.ChangeApplicationStage",
+      "fullyQualifiedName": "Ashby.ChangeApplicationStage@0.1.0",
+      "description": "Move an application to a named interview stage, in either direction.\n\nResolves the stage name to its id inside the application's own interview plan,\nthen moves the application — you do not look up stage ids yourself. Works to\nadvance or to move a candidate back; if the name does not match, the error lists\nthe plan's available stage names, and an ambiguous name (two stages share it)\nerrors rather than guessing. Records a transition each time it runs. It cannot\nmove an application into an archived/rejected stage (Ashby requires an archive\nreason this tool does not collect). Requires the Candidates write and Interviews\nread permissions on the API key.",
+      "parameters": [
+        {
+          "name": "application_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the application to move.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "to_stage",
+          "type": "string",
+          "required": true,
+          "description": "The NAME of the destination interview stage, e.g. 'Onsite'. Resolved to the stage id for you within the application's interview plan.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "ASHBY_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ASHBY_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The application after the stage change."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Ashby.ChangeApplicationStage",
+        "parameters": {
+          "application_id": {
+            "value": "app_3f8a92c1-4b7e-4d21-9e6f-bc012345abcd",
+            "type": "string",
+            "required": true
+          },
+          "to_stage": {
+            "value": "Onsite Interview",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetCandidate",
+      "qualifiedName": "Ashby.GetCandidate",
+      "fullyQualifiedName": "Ashby.GetCandidate@0.1.0",
+      "description": "Get a candidate's profile and the ids of their applications.\n\nUse the returned application ids with feedback or application tools; the Ashby\nAPI does not list a candidate's applications directly. Requires the Candidates\nread permission on the API key.",
+      "parameters": [
+        {
+          "name": "candidate_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the candidate to fetch.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "ASHBY_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ASHBY_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The candidate's profile and the ids of their applications."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Ashby.GetCandidate",
+        "parameters": {
+          "candidate_id": {
+            "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetCandidateDebrief",
+      "qualifiedName": "Ashby.GetCandidateDebrief",
+      "fullyQualifiedName": "Ashby.GetCandidateDebrief@0.1.0",
+      "description": "Gather everything about a candidate for a debrief in one call.\n\nPulls the candidate's profile, the notes on file, and the interview feedback and\nscorecards across each of their applications, then returns them together — you do\nnot chain the candidate, note, and feedback reads yourself. Feedback covers up to\nthe candidate's first applications when there are many; an application whose\nfeedback can't be read is counted in `feedback_failed` rather than failing the\nwhole call. Requires the Candidates read permission on the API key.",
+      "parameters": [
+        {
+          "name": "candidate_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the candidate to gather a debrief for.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "ASHBY_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ASHBY_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The candidate's profile, notes, and interview feedback across their applications."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Ashby.GetCandidateDebrief",
+        "parameters": {
+          "candidate_id": {
+            "value": "cand_3f8a92b1-4d7e-4c21-ae56-9f0b123d4567",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListApplicationFeedback",
+      "qualifiedName": "Ashby.ListApplicationFeedback",
+      "fullyQualifiedName": "Ashby.ListApplicationFeedback@0.1.0",
+      "description": "Read the feedback and interview scorecards submitted on an application.\n\nUseful for synthesizing what reviewers said about a candidate before a debrief.\nRequires the Candidates read permission on the API key.",
+      "parameters": [
+        {
+          "name": "application_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the application whose feedback and interview scorecards to read.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from a previous call's next_cursor. Omit for the first page.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of feedback items to return on this page (1-100). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "ASHBY_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ASHBY_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Feedback / scorecards submitted on the application."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Ashby.ListApplicationFeedback",
+        "parameters": {
+          "application_id": {
+            "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": true
+          },
+          "cursor": {
+            "value": "eyJvZmZzZXQiOjUwfQ==",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListApplications",
+      "qualifiedName": "Ashby.ListApplications",
+      "fullyQualifiedName": "Ashby.ListApplications@0.1.0",
+      "description": "List the organization's applications, optionally filtered by job and/or status.\n\nThe Ashby API does not filter applications by candidate; to find a specific\ncandidate's applications, read the candidate first and use its application ids.\nRequires the Candidates read permission on the API key.",
+      "parameters": [
+        {
+          "name": "job_id",
+          "type": "string",
+          "required": false,
+          "description": "Return only applications to this job. Omit to return applications across all jobs.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "required": false,
+          "description": "Filter by application status. Omit for any status.",
+          "enum": [
+            "Active",
+            "Hired",
+            "Archived",
+            "Lead"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from a previous call's next_cursor. Omit for the first page.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of applications to return on this page (1-100). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "ASHBY_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ASHBY_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "A page of the organization's applications."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Ashby.ListApplications",
+        "parameters": {
+          "job_id": {
+            "value": "job_abc123xyz",
+            "type": "string",
+            "required": false
+          },
+          "status": {
+            "value": "active",
+            "type": "string",
+            "required": false
+          },
+          "cursor": {
+            "value": "eyJpZCI6IjEyMzQ1NiIsImRpcmVjdGlvbiI6Im5leHQifQ==",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListCandidateNotes",
+      "qualifiedName": "Ashby.ListCandidateNotes",
+      "fullyQualifiedName": "Ashby.ListCandidateNotes@0.1.0",
+      "description": "Read the notes recorded on a candidate, paginated via the cursor.\n\nRequires the Candidates read permission on the API key.",
+      "parameters": [
+        {
+          "name": "candidate_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the candidate whose notes to read.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from a previous call's next_cursor. Omit for the first page.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of notes to return on this page (1-100). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "ASHBY_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ASHBY_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "A page of the candidate's notes."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Ashby.ListCandidateNotes",
+        "parameters": {
+          "candidate_id": {
+            "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": true
+          },
+          "cursor": {
+            "value": "eyJsYXN0SWQiOiI0MmFiY2RlZi0xMjM0LTU2NzgtOTAxMi1hYmNkZWYxMjM0NTYifQ==",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListJobs",
+      "qualifiedName": "Ashby.ListJobs",
+      "fullyQualifiedName": "Ashby.ListJobs@0.1.0",
+      "description": "List the organization's jobs (roles), optionally filtered by status.\n\nA job is the role record; headcount slots (\"openings\") are a separate concept\nnot exposed here. Requires the Jobs read permission on the API key.",
+      "parameters": [
+        {
+          "name": "status",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Filter to jobs with these statuses. Omit to return jobs of every status.",
+          "enum": [
+            "Open",
+            "Closed",
+            "Archived",
+            "Draft"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from a previous call's next_cursor. Omit for the first page.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of jobs to return on this page (1-100). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "ASHBY_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ASHBY_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "A page of the organization's jobs."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Ashby.ListJobs",
+        "parameters": {
+          "status": {
+            "value": [
+              "open",
+              "closed"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "cursor": {
+            "value": "eyJpZCI6IjEyMzQ1NiIsInRpbWVzdGFtcCI6MTY5ODc2NTQzMn0=",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchCandidates",
+      "qualifiedName": "Ashby.SearchCandidates",
+      "fullyQualifiedName": "Ashby.SearchCandidates@0.1.0",
+      "description": "Search the organization's candidates by name and/or email.\n\nIntended for narrowing to a small set of known candidates (e.g. re-engaging a\npast applicant). Returns at most 100 matches; provide at least one of name or\nemail, each at least 3 characters. Requires the Candidates read permission on\nthe API key.",
+      "parameters": [
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Full or partial candidate name to match. Combined with email using AND when both are given. Omit to search by email only.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "required": false,
+          "description": "Candidate email address to match. Combined with name using AND when both are given. Omit to search by name only.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "ASHBY_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ASHBY_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Candidates across the organization matching the search (capped at 100 by the API)."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Ashby.SearchCandidates",
+        "parameters": {
+          "name": {
+            "value": "Jordan Lee",
+            "type": "string",
+            "required": false
+          },
+          "email": {
+            "value": "jordan.lee@example.com",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-06-10T12:11:44.524Z",
+  "summary": "Ashby is an all-in-one recruiting platform. This toolkit lets Arcade agents read and write recruiting data in Ashby — candidates, applications, jobs, notes, feedback, and interview stage progression.\n\n## Capabilities\n\n- **Candidate management**: Search candidates by name/email, retrieve full profiles (with application IDs), and add plain-text notes (e.g. agent handoffs or summaries).\n- **Application lifecycle**: List applications filtered by job or status, move applications forward or backward through named interview stages, and read submitted feedback/scorecards.\n- **Job listings**: Enumerate the organization's roles, optionally filtered by status.\n- **Debrief aggregation**: Pull a candidate's profile, all notes, and all interview feedback across applications in a single call — no manual chaining required.\n\n## Secrets\n\n- **`ASHBY_API_KEY`** — An Ashby API key scoped to the permissions required by the tools you use. Generate one in your Ashby account under **Settings → Integrations → API Keys**. Each key carries granular permissions; the tools in this toolkit require the following depending on usage:\n  - **Candidates read** — searching, reading profiles, listing notes, listing feedback, listing applications, debrief aggregation.\n  - **Candidates write** — adding notes, changing application stage.\n  - **Interviews read** — changing application stage (stage plan lookup).\n  - **Jobs read** — listing jobs.\n\n  Create and scope the key from the [Ashby API Keys settings page](https://app.ashbyhq.com/settings/api-keys). Note that Ashby API keys are organization-scoped; the key holder can read or write across all candidates and jobs in the org, so apply least-privilege scoping.\n\nSee the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to store secrets, or manage them directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
+}

--- a/toolkit-docs-generator/data/toolkits/brightdata.json
+++ b/toolkit-docs-generator/data/toolkits/brightdata.json
@@ -1,7 +1,7 @@
 {
   "id": "Brightdata",
   "label": "Bright Data",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Search, Crawl and Scrape any site, at scale, without getting blocked",
   "metadata": {
     "category": "development",
@@ -18,7 +18,7 @@
     {
       "name": "ScrapeAsMarkdown",
       "qualifiedName": "Brightdata.ScrapeAsMarkdown",
-      "fullyQualifiedName": "Brightdata.ScrapeAsMarkdown@0.5.0",
+      "fullyQualifiedName": "Brightdata.ScrapeAsMarkdown@0.5.1",
       "description": "    Scrape a webpage and return content in Markdown format using Bright Data.\n\n    Examples:\n        scrape_as_markdown(\"https://example.com\") -> \"# Example Page\n\nContent...\"\n        scrape_as_markdown(\"https://news.ycombinator.com\") -> \"# Hacker News\n...\"\n    ",
       "parameters": [
         {
@@ -83,7 +83,7 @@
     {
       "name": "SearchEngine",
       "qualifiedName": "Brightdata.SearchEngine",
-      "fullyQualifiedName": "Brightdata.SearchEngine@0.5.0",
+      "fullyQualifiedName": "Brightdata.SearchEngine@0.5.1",
       "description": "    Search using Google, Bing, or Yandex with advanced parameters using Bright Data.\n\n    Examples:\n        search_engine(\"climate change\") -> \"# Search Results\n\n## Climate Change - Wikipedia\n...\"\n        search_engine(\"Python tutorials\", engine=\"bing\", num_results=5) -> \"# Bing Results\n...\"\n        search_engine(\"cats\", search_type=\"images\", country_code=\"us\") -> \"# Image Results\n...\"\n    ",
       "parameters": [
         {
@@ -281,7 +281,7 @@
     {
       "name": "WebDataFeed",
       "qualifiedName": "Brightdata.WebDataFeed",
-      "fullyQualifiedName": "Brightdata.WebDataFeed@0.5.0",
+      "fullyQualifiedName": "Brightdata.WebDataFeed@0.5.1",
       "description": "Extract structured data from various websites like LinkedIn, Amazon, Instagram, etc.\nNEVER MADE UP LINKS - IF LINKS ARE NEEDED, EXECUTE search_engine FIRST.\nSupported source types:\n- amazon_product, amazon_product_reviews\n- linkedin_person_profile, linkedin_company_profile\n- zoominfo_company_profile\n- instagram_profiles, instagram_posts, instagram_reels, instagram_comments\n- facebook_posts, facebook_marketplace_listings, facebook_company_reviews\n- x_posts\n- zillow_properties_listing\n- booking_hotel_listings\n- youtube_videos\n\nExamples:\n    web_data_feed(\"amazon_product\", \"https://amazon.com/dp/B08N5WRWNW\")\n        -> \"{\"title\": \"Product Name\", ...}\"\n    web_data_feed(\"linkedin_person_profile\", \"https://linkedin.com/in/johndoe\")\n        -> \"{\"name\": \"John Doe\", ...}\"\n    web_data_feed(\n        \"facebook_company_reviews\", \"https://facebook.com/company\", num_of_reviews=50\n    ) -> \"[{\"review\": \"...\", ...}]\"",
       "parameters": [
         {
@@ -419,6 +419,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-03-01T11:12:08.063Z",
-  "summary": "Bright Data provides a developer toolkit for large-scale web search, crawling, and scraping, enabling reliable extraction of pages and structured data without getting blocked. It supports search queries, content-to-Markdown conversion, and configurable data feeds across many site types.\n\nDesigned for integration into data pipelines and analytics workflows with parameterized feeds and output formats.\n\n**Capabilities**\n- Scale-resistant crawling and scraping with anti-blocking behavior for sustained collection.\n- Flexible search engine queries with advanced parameters across major engines.\n- Transform pages into clean Markdown and emit structured JSON feeds for profiles, products, reviews, listings, and media.\n- Configurable extraction parameters for batching, pagination, and media handling.\n\n**Secrets**\n- API key (BRIGHTDATA_API_KEY) and zone token (BRIGHTDATA_ZONE). Example values: BRIGHTDATA_API_KEY=sk_..., BRIGHTDATA_ZONE=zone123."
+  "generatedAt": "2026-06-10T12:11:40.462Z",
+  "summary": "Bright Data provides a developer toolkit for large-scale web search, crawling, and scraping, enabling reliable extraction of pages and structured data without getting blocked. It supports search queries, content-to-Markdown conversion, and configurable data feeds across many site types.\n\nDesigned for integration into data pipelines and analytics workflows with parameterized feeds and output formats.\n\n**Capabilities**\n- Scale-resistant crawling and scraping with anti-blocking behavior for sustained collection.\n- Flexible search engine queries with advanced parameters across major engines.\n- Transform pages into clean Markdown and emit structured JSON feeds for profiles, products, reviews, listings, and media.\n- Configurable extraction parameters for batching, pagination, and media handling.\n\n**Secrets**\n\nSee the [Arcade secrets documentation](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to store and reference secrets in your Arcade configuration.\n\n- `BRIGHTDATA_API_KEY`: Your Bright Data API key. Obtain it from the [Bright Data dashboard](https://brightdata.com/cp/setting) under **Account Settings → API Tokens**. Generate a new token and copy the value; it will not be shown again. A paid or trial Bright Data account is required. Example: `BRIGHTDATA_API_KEY=sk_...`.\n- `BRIGHTDATA_ZONE`: The name of the Bright Data zone (proxy zone or dataset zone) the toolkit should target. Zones are created and managed in the Bright Data dashboard under **Proxies & Scraping Infrastructure**. Use the zone's string identifier as shown in the dashboard. Example: `BRIGHTDATA_ZONE=zone123`."
 }

--- a/toolkit-docs-generator/data/toolkits/clickhouse.json
+++ b/toolkit-docs-generator/data/toolkits/clickhouse.json
@@ -1,7 +1,7 @@
 {
   "id": "Clickhouse",
   "label": "Clickhouse",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Tools to query and explore a ClickHouse database",
   "metadata": {
     "category": "databases",
@@ -18,7 +18,7 @@
     {
       "name": "DiscoverDatabases",
       "qualifiedName": "Clickhouse.DiscoverDatabases",
-      "fullyQualifiedName": "Clickhouse.DiscoverDatabases@0.4.0",
+      "fullyQualifiedName": "Clickhouse.DiscoverDatabases@0.4.1",
       "description": "Discover all the databases in the ClickHouse database.",
       "parameters": [],
       "auth": null,
@@ -61,7 +61,7 @@
     {
       "name": "DiscoverSchemas",
       "qualifiedName": "Clickhouse.DiscoverSchemas",
-      "fullyQualifiedName": "Clickhouse.DiscoverSchemas@0.4.0",
+      "fullyQualifiedName": "Clickhouse.DiscoverSchemas@0.4.1",
       "description": "Discover all the schemas in the ClickHouse database.\n\nNote: ClickHouse doesn't have schemas like PostgreSQL, so this returns a default schema name.",
       "parameters": [],
       "auth": null,
@@ -104,7 +104,7 @@
     {
       "name": "DiscoverTables",
       "qualifiedName": "Clickhouse.DiscoverTables",
-      "fullyQualifiedName": "Clickhouse.DiscoverTables@0.4.0",
+      "fullyQualifiedName": "Clickhouse.DiscoverTables@0.4.1",
       "description": "Discover all the tables in the ClickHouse database when the list of tables is not known.\n\nALWAYS use this tool before any other tool that requires a table name.",
       "parameters": [],
       "auth": null,
@@ -147,14 +147,14 @@
     {
       "name": "ExecuteSelectQuery",
       "qualifiedName": "Clickhouse.ExecuteSelectQuery",
-      "fullyQualifiedName": "Clickhouse.ExecuteSelectQuery@0.4.0",
-      "description": "You have a connection to a ClickHouse database.\nExecute a SELECT query and return the results against the ClickHouse database.  No other queries (INSERT, UPDATE, DELETE, etc.) are allowed.\n\nONLY use this tool if you have already loaded the schema of the tables you need to query.  Use the <GetTableSchema> tool to load the schema if not already known.\n\nThe final query will be constructed as follows:\nSELECT {select_query_part} FROM {from_clause} JOIN {join_clause} WHERE {where_clause} HAVING {having_clause} ORDER BY {order_by_clause} LIMIT {limit} OFFSET {offset}\n\nWhen running queries, follow these rules which will help avoid errors:\n* Never \"select *\" from a table.  Always select the columns you need.\n* Always order your results by the most important columns first.  If you aren't sure, order by the primary key.\n* Always use case-insensitive queries to match strings in the query.\n* Always trim strings in the query.\n* Prefer LIKE queries over direct string matches or regex queries.\n* Only join on columns that are indexed or the primary key.  Do not join on arbitrary columns.\n* ClickHouse is case-sensitive, so be careful with table and column names.",
+      "fullyQualifiedName": "Clickhouse.ExecuteSelectQuery@0.4.1",
+      "description": "You have a connection to a ClickHouse database.\nExecute a SELECT query and return the results against the ClickHouse database.\nNo other queries (INSERT, UPDATE, DELETE, etc.) are allowed.\n\nONLY use this tool if you have already loaded the schema of the tables you need to query.\nUse the <GetTableSchema> tool to load the schema if not already known.\n\nThe final query will be constructed as follows:\nSELECT {select_query_part} FROM {from_clause} JOIN {join_clause}\nWHERE {where_clause} HAVING {having_clause}\nORDER BY {order_by_clause} LIMIT {limit} OFFSET {offset}\n\nWhen running queries, follow these rules which will help avoid errors:\n* Never \"select *\" from a table. Always select the columns you need.\n* Always order your results. Use the most important columns or the primary key if you're unsure.\n* Always use case-insensitive queries to match strings in the query.\n* Always trim strings in the query.\n* Prefer LIKE queries over direct string matches or regex queries.\n* Only join on columns that are indexed or the primary key. Do not join on arbitrary columns.\n* ClickHouse is case-sensitive, so be careful with table and column names.",
       "parameters": [
         {
           "name": "select_clause",
           "type": "string",
           "required": true,
-          "description": "This is the part of the SQL query that comes after the SELECT keyword wish a comma separated list of columns you wish to return.  Do not include the SELECT keyword.",
+          "description": "This is the part of the SQL query that comes after the SELECT keyword with a comma separated list of columns you wish to return. Do not include the SELECT keyword.",
           "enum": null,
           "inferrable": true
         },
@@ -162,7 +162,7 @@
           "name": "from_clause",
           "type": "string",
           "required": true,
-          "description": "This is the part of the SQL query that comes after the FROM keyword.  Do not include the FROM keyword.",
+          "description": "This is the part of the SQL query that comes after the FROM keyword. Do not include the FROM keyword.",
           "enum": null,
           "inferrable": true
         },
@@ -170,7 +170,7 @@
           "name": "limit",
           "type": "integer",
           "required": false,
-          "description": "The maximum number of rows to return.  This is the LIMIT clause of the query.  Default: 100.",
+          "description": "The maximum number of rows to return. This is the LIMIT clause of the query. Default: 100.",
           "enum": null,
           "inferrable": true
         },
@@ -186,7 +186,7 @@
           "name": "join_clause",
           "type": "string",
           "required": false,
-          "description": "This is the part of the SQL query that comes after the JOIN keyword.  Do not include the JOIN keyword.  If no join is needed, leave this blank.",
+          "description": "This is the part of the SQL query that comes after the JOIN keyword. Do not include the JOIN keyword. If no join is needed, leave this blank.",
           "enum": null,
           "inferrable": true
         },
@@ -194,7 +194,7 @@
           "name": "where_clause",
           "type": "string",
           "required": false,
-          "description": "This is the part of the SQL query that comes after the WHERE keyword.  Do not include the WHERE keyword.  If no where clause is needed, leave this blank.",
+          "description": "This is the part of the SQL query that comes after the WHERE keyword. Do not include the WHERE keyword. If no where clause is needed, leave this blank.",
           "enum": null,
           "inferrable": true
         },
@@ -202,7 +202,7 @@
           "name": "having_clause",
           "type": "string",
           "required": false,
-          "description": "This is the part of the SQL query that comes after the HAVING keyword.  Do not include the HAVING keyword.  If no having clause is needed, leave this blank.",
+          "description": "This is the part of the SQL query that comes after the HAVING keyword. Do not include the HAVING keyword. If no having clause is needed, leave this blank.",
           "enum": null,
           "inferrable": true
         },
@@ -210,7 +210,7 @@
           "name": "group_by_clause",
           "type": "string",
           "required": false,
-          "description": "This is the part of the SQL query that comes after the GROUP BY keyword.  Do not include the GROUP BY keyword.  If no group by clause is needed, leave this blank.",
+          "description": "This is the part of the SQL query that comes after the GROUP BY keyword. Do not include the GROUP BY keyword. If no group by clause is needed, leave this blank.",
           "enum": null,
           "inferrable": true
         },
@@ -218,7 +218,7 @@
           "name": "order_by_clause",
           "type": "string",
           "required": false,
-          "description": "This is the part of the SQL query that comes after the ORDER BY keyword.  Do not include the ORDER BY keyword.  If no order by clause is needed, leave this blank.",
+          "description": "This is the part of the SQL query that comes after the ORDER BY keyword. Do not include the ORDER BY keyword. If no order by clause is needed, leave this blank.",
           "enum": null,
           "inferrable": true
         },
@@ -226,7 +226,7 @@
           "name": "with_clause",
           "type": "string",
           "required": false,
-          "description": "This is the part of the SQL query that comes after the WITH keyword when basing the query on a virtual table.  If no WITH clause is needed, leave this blank.",
+          "description": "This is the part of the SQL query that comes after the WITH keyword when basing the query on a virtual table. If no WITH clause is needed, leave this blank.",
           "enum": null,
           "inferrable": true
         }
@@ -322,8 +322,8 @@
     {
       "name": "GetTableSchema",
       "qualifiedName": "Clickhouse.GetTableSchema",
-      "fullyQualifiedName": "Clickhouse.GetTableSchema@0.4.0",
-      "description": "Get the schema/structure of a ClickHouse table in the ClickHouse database when the schema is not known, and the name of the table is provided.\n\nThis tool should ALWAYS be used before executing any query.  All tables in the query must be discovered first using the <DiscoverTables> tool.",
+      "fullyQualifiedName": "Clickhouse.GetTableSchema@0.4.1",
+      "description": "Get the schema/structure of a ClickHouse table in the ClickHouse database\nwhen the schema is not known, and the name of the table is provided.\n\nThis tool should ALWAYS be used before executing any query.\nAll tables in the query must be discovered first\nusing the <DiscoverTables> tool.",
       "parameters": [
         {
           "name": "schema_name",
@@ -394,6 +394,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-03-01T11:12:22.108Z",
-  "summary": "Arcade ClickHouse toolkit provides programmatic access to ClickHouse databases, enabling discovery, schema inspection, and safe read-only querying. It helps explore databases and tables, load table schemas, and execute SELECT queries while enforcing rules that reduce errors and preserve performance.\n\n**Capabilities**\n- Discover databases and tables and load table schemas to support safe query construction.\n- Execute read-only, parameterized SELECT queries with guidance on joins, ordering, and string handling.\n- Enforce best practices (no SELECT *, careful case-sensitive identifiers, indexed joins, explicit column selection) to minimize errors and improve performance.\n\n**Secrets**\n- Accepts connection secrets (password, unknown) via CLICKHOUSE_DATABASE_CONNECTION_STRING — typically a DSN containing host, port, database, user, and password."
+  "generatedAt": "2026-06-10T12:11:40.463Z",
+  "summary": "## Arcade ClickHouse Toolkit\n\nProvides tools to connect to and explore a ClickHouse database, enabling agents to introspect structure and execute read-only queries.\n\n## Capabilities\n\n- **Schema discovery** — enumerate databases, retrieve a default schema representation, and list all tables in the connected instance.\n- **Table introspection** — fetch the full column structure of any named table before querying; required prior to any SELECT execution.\n- **Read-only query execution** — run parameterized SELECT queries with explicit support for joins, filtering, ordering, pagination (LIMIT/OFFSET), and HAVING clauses; INSERT/UPDATE/DELETE are blocked.\n\n## Secrets\n\n`CLICKHOUSE_DATABASE_CONNECTION_STRING` — A connection string that encodes the ClickHouse host, port, database name, username, and password needed to authenticate and connect to the instance. The format typically follows `clickhouse://[user]:[password]@[host]:[port]/[database]` (or the HTTP DSN variant your driver expects). Obtain this by noting your ClickHouse host and port (default native: `9000`, HTTP: `8123`), the target database, and a user account with at minimum `SELECT` privileges on the databases/tables you want to expose. You can create users and grant permissions via the ClickHouse `CREATE USER` / `GRANT` SQL commands or through your cloud provider's console (e.g., [ClickHouse Cloud console](https://clickhouse.com/docs/en/cloud/security/cloud-access-management)). For self-hosted instances, refer to the [ClickHouse access control documentation](https://clickhouse.com/docs/en/operations/access-rights).\n\nStore secrets in Arcade at https://api.arcade.dev/dashboard/auth/secrets and see the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for configuration details."
 }

--- a/toolkit-docs-generator/data/toolkits/customerio.json
+++ b/toolkit-docs-generator/data/toolkits/customerio.json
@@ -1,0 +1,1714 @@
+{
+  "id": "Customerio",
+  "label": "Customer.io",
+  "version": "0.1.0",
+  "description": "Arcade.dev LLM tools for Customer.io",
+  "metadata": {
+    "category": "customer-support",
+    "iconUrl": "https://design-system.arcade.dev/icons/customerio.svg",
+    "isBYOC": false,
+    "isPro": false,
+    "type": "arcade",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/customer-support/customerio",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": null,
+  "tools": [
+    {
+      "name": "DeletePerson",
+      "qualifiedName": "Customerio.DeletePerson",
+      "fullyQualifiedName": "Customerio.DeletePerson@0.1.0",
+      "description": "Delete a person record to honor a data-removal request.\n\nDeleting a person who does not exist is accepted as a no-op.",
+      "parameters": [
+        {
+          "name": "person_id",
+          "type": "string",
+          "required": true,
+          "description": "Id of the person to delete.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "identifier_type",
+          "type": "string",
+          "required": false,
+          "description": "Which kind of value person_id is, so the delete targets the right profile. Defaults to the external id you assigned the person; use the Customer.io internal id when person_id is a cio_id (people with no external id are returned that way), or email when it is an email address.",
+          "enum": [
+            "id",
+            "email",
+            "cio_id"
+          ],
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_SITE_ID",
+        "CUSTOMERIO_TRACKING_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_SITE_ID",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_TRACKING_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.DeletePerson",
+        "parameters": {
+          "person_id": {
+            "value": "user_7f3a92b1c4d8e056",
+            "type": "string",
+            "required": true
+          },
+          "identifier_type": {
+            "value": "email",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetCampaignMetrics",
+      "qualifiedName": "Customerio.GetCampaignMetrics",
+      "fullyQualifiedName": "Customerio.GetCampaignMetrics@0.1.0",
+      "description": "Read a campaign's aggregate delivery metrics over a period.",
+      "parameters": [
+        {
+          "name": "campaign_id",
+          "type": "string",
+          "required": true,
+          "description": "Id of the campaign whose metrics to read.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "period",
+          "type": "string",
+          "required": false,
+          "description": "Granularity of the metric series. Defaults to days.",
+          "enum": [
+            "hours",
+            "days",
+            "weeks",
+            "months"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "steps",
+          "type": "integer",
+          "required": false,
+          "description": "Number of periods to report, counting back from now. Defaults to 30.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_APP_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_APP_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.GetCampaignMetrics",
+        "parameters": {
+          "campaign_id": {
+            "value": "42",
+            "type": "string",
+            "required": true
+          },
+          "period": {
+            "value": "weeks",
+            "type": "string",
+            "required": false
+          },
+          "steps": {
+            "value": 12,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetNewsletterMetrics",
+      "qualifiedName": "Customerio.GetNewsletterMetrics",
+      "fullyQualifiedName": "Customerio.GetNewsletterMetrics@0.1.0",
+      "description": "Read a newsletter's aggregate delivery metrics over a period.",
+      "parameters": [
+        {
+          "name": "newsletter_id",
+          "type": "string",
+          "required": true,
+          "description": "Id of the newsletter whose metrics to read.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "period",
+          "type": "string",
+          "required": false,
+          "description": "Granularity of the metric series. Defaults to days.",
+          "enum": [
+            "hours",
+            "days",
+            "weeks",
+            "months"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "steps",
+          "type": "integer",
+          "required": false,
+          "description": "Number of periods to report, counting back from now. Defaults to 30.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_APP_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_APP_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.GetNewsletterMetrics",
+        "parameters": {
+          "newsletter_id": {
+            "value": "42",
+            "type": "string",
+            "required": true
+          },
+          "period": {
+            "value": "weeks",
+            "type": "string",
+            "required": false
+          },
+          "steps": {
+            "value": 12,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetPerson",
+      "qualifiedName": "Customerio.GetPerson",
+      "fullyQualifiedName": "Customerio.GetPerson@0.1.0",
+      "description": "Look up a person's profile by email or id.\n\nResolves the person by whichever identifier is supplied; an email shared by\nseveral people reports every match in the result.",
+      "parameters": [
+        {
+          "name": "email",
+          "type": "string",
+          "required": false,
+          "description": "Email address to look up the person by. Provide this or a person id.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "person_id",
+          "type": "string",
+          "required": false,
+          "description": "Customer.io person id to look up. Provide this or an email.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_APP_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_APP_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.GetPerson",
+        "parameters": {
+          "email": {
+            "value": "jane.doe@example.com",
+            "type": "string",
+            "required": false
+          },
+          "person_id": {
+            "value": "person_abc123",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "IdentifyPerson",
+      "qualifiedName": "Customerio.IdentifyPerson",
+      "fullyQualifiedName": "Customerio.IdentifyPerson@0.1.0",
+      "description": "Create or update a person and their attributes.\n\nExisting attributes not named in this call are preserved; named attributes\nare added or overwritten.",
+      "parameters": [
+        {
+          "name": "person_id",
+          "type": "string",
+          "required": true,
+          "description": "Stable id that identifies the person; creates the person if new.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "identifier_type",
+          "type": "string",
+          "required": false,
+          "description": "Which kind of value person_id is, so the write targets the right profile. Defaults to the external id you assigned the person; use the Customer.io internal id when person_id is a cio_id (people with no external id are returned that way), or email when it is an email address.",
+          "enum": [
+            "id",
+            "email",
+            "cio_id"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "required": false,
+          "description": "Email to set on the person. Provided values are stored as the email attribute; leave empty to leave the email unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "attributes",
+          "type": "json",
+          "required": false,
+          "description": "Attributes to set or update on the person, as a flat mapping of attribute name to value. Omitted attributes are left unchanged.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_SITE_ID",
+        "CUSTOMERIO_TRACKING_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_SITE_ID",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_TRACKING_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.IdentifyPerson",
+        "parameters": {
+          "person_id": {
+            "value": "user_7842abc123",
+            "type": "string",
+            "required": true
+          },
+          "identifier_type": {
+            "value": "email",
+            "type": "string",
+            "required": false
+          },
+          "email": {
+            "value": "jane.doe@example.com",
+            "type": "string",
+            "required": false
+          },
+          "attributes": {
+            "value": "{\"first_name\": \"Jane\", \"last_name\": \"Doe\", \"plan\": \"pro\", \"signed_up_at\": 1712000000, \"is_active\": true}",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListBroadcasts",
+      "qualifiedName": "Customerio.ListBroadcasts",
+      "fullyQualifiedName": "Customerio.ListBroadcasts@0.1.0",
+      "description": "List the workspace's broadcasts to discover ids that can be triggered.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_APP_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_APP_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.ListBroadcasts",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListCampaigns",
+      "qualifiedName": "Customerio.ListCampaigns",
+      "fullyQualifiedName": "Customerio.ListCampaigns@0.1.0",
+      "description": "List the campaigns in the workspace.",
+      "parameters": [
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum campaigns to return (1-1000). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0 (first result).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_APP_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_APP_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.ListCampaigns",
+        "parameters": {
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListNewsletters",
+      "qualifiedName": "Customerio.ListNewsletters",
+      "fullyQualifiedName": "Customerio.ListNewsletters@0.1.0",
+      "description": "List the newsletters in the workspace.",
+      "parameters": [
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum newsletters to return (1-1000). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0 (first result).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_APP_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_APP_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.ListNewsletters",
+        "parameters": {
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListPersonActivities",
+      "qualifiedName": "Customerio.ListPersonActivities",
+      "fullyQualifiedName": "Customerio.ListPersonActivities@0.1.0",
+      "description": "List a person's recent activities, most recent first, resolved by email\nor id. Optionally filter by activity type and/or name; filtering by name\nrequires an activity type. When an email matches several people, the first\nmatch's activities are returned.",
+      "parameters": [
+        {
+          "name": "person_id",
+          "type": "string",
+          "required": false,
+          "description": "Customer.io person id. Provide this or an email.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "required": false,
+          "description": "Email of the person. Provide this or a person id.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "activity_type",
+          "type": "string",
+          "required": false,
+          "description": "Restrict to one activity type. Leave empty for all types.",
+          "enum": [
+            "event",
+            "page",
+            "attribute_change",
+            "attribute_delete",
+            "secondary_id_change"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Restrict to activities with this exact name (e.g. an event name). Requires an activity type to also be set. Leave empty for any name.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum activities to return (1-1000). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from a prior page. Leave empty for the first page.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_APP_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_APP_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.ListPersonActivities",
+        "parameters": {
+          "person_id": {
+            "value": "P_7g3kd92mxq",
+            "type": "string",
+            "required": false
+          },
+          "email": {
+            "value": "jane.doe@example.com",
+            "type": "string",
+            "required": false
+          },
+          "activity_type": {
+            "value": "event",
+            "type": "string",
+            "required": false
+          },
+          "name": {
+            "value": "purchase_completed",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "cursor": {
+            "value": "eyJpZCI6IjEyMzQ1NiIsInRzIjoxNjk4NzY1NDMyf",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListPersonMessages",
+      "qualifiedName": "Customerio.ListPersonMessages",
+      "fullyQualifiedName": "Customerio.ListPersonMessages@0.1.0",
+      "description": "List a person's message and delivery history, most recent first,\nresolved by email or id. When an email matches several people, the first\nmatch's messages are returned.",
+      "parameters": [
+        {
+          "name": "person_id",
+          "type": "string",
+          "required": false,
+          "description": "Customer.io person id. Provide this or an email.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "required": false,
+          "description": "Email of the person. Provide this or a person id.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum messages to return (1-1000). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from a prior page. Leave empty for the first page.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_APP_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_APP_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.ListPersonMessages",
+        "parameters": {
+          "person_id": {
+            "value": "person_abc123",
+            "type": "string",
+            "required": false
+          },
+          "email": {
+            "value": "jane.doe@example.com",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "cursor": {
+            "value": "eyJpZCI6MTIzNDU2LCJkaXJlY3Rpb24iOiJuZXh0In0=",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListPersonSegments",
+      "qualifiedName": "Customerio.ListPersonSegments",
+      "fullyQualifiedName": "Customerio.ListPersonSegments@0.1.0",
+      "description": "List the segments a person belongs to, resolved by email or id. When an\nemail matches several people, the first match's segments are returned.",
+      "parameters": [
+        {
+          "name": "person_id",
+          "type": "string",
+          "required": false,
+          "description": "Customer.io person id. Provide this or an email.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "required": false,
+          "description": "Email of the person. Provide this or a person id.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_APP_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_APP_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.ListPersonSegments",
+        "parameters": {
+          "person_id": {
+            "value": "abc123xyz",
+            "type": "string",
+            "required": false
+          },
+          "email": {
+            "value": "jane.doe@example.com",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListSegmentMembers",
+      "qualifiedName": "Customerio.ListSegmentMembers",
+      "fullyQualifiedName": "Customerio.ListSegmentMembers@0.1.0",
+      "description": "List the ids of the people in a segment and the segment's total size.",
+      "parameters": [
+        {
+          "name": "segment_id",
+          "type": "string",
+          "required": true,
+          "description": "Id of the segment whose members to list.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum member ids to return (1-1000). Defaults to 100.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from a prior page. Leave empty for the first page.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_APP_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_APP_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.ListSegmentMembers",
+        "parameters": {
+          "segment_id": {
+            "value": "7",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 250,
+            "type": "integer",
+            "required": false
+          },
+          "cursor": {
+            "value": "WzE2MjM0NTY3ODksImFiYzEyMyJd",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListSegments",
+      "qualifiedName": "Customerio.ListSegments",
+      "fullyQualifiedName": "Customerio.ListSegments@0.1.0",
+      "description": "List the segments defined in the workspace.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_APP_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_APP_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.ListSegments",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListTransactionalMessages",
+      "qualifiedName": "Customerio.ListTransactionalMessages",
+      "fullyQualifiedName": "Customerio.ListTransactionalMessages@0.1.0",
+      "description": "List the transactional message templates in the workspace.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_APP_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_APP_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.ListTransactionalMessages",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "RecordEvent",
+      "qualifiedName": "Customerio.RecordEvent",
+      "fullyQualifiedName": "Customerio.RecordEvent@0.1.0",
+      "description": "Record a named custom event on a person's timeline to drive lifecycle\njourneys.",
+      "parameters": [
+        {
+          "name": "person_id",
+          "type": "string",
+          "required": true,
+          "description": "Id of the person the event is recorded against.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "Name of the custom event (e.g. purchased, signed_up).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "identifier_type",
+          "type": "string",
+          "required": false,
+          "description": "Which kind of value person_id is, so the event targets the right profile. Defaults to the external id you assigned the person; use the Customer.io internal id when person_id is a cio_id (people with no external id are returned that way), or email when it is an email address.",
+          "enum": [
+            "id",
+            "email",
+            "cio_id"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "data",
+          "type": "json",
+          "required": false,
+          "description": "Event data as a flat mapping of property name to value. Leave empty for an event with no data.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_SITE_ID",
+        "CUSTOMERIO_TRACKING_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_SITE_ID",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_TRACKING_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.RecordEvent",
+        "parameters": {
+          "person_id": {
+            "value": "user_7842930",
+            "type": "string",
+            "required": true
+          },
+          "name": {
+            "value": "purchased",
+            "type": "string",
+            "required": true
+          },
+          "identifier_type": {
+            "value": "id",
+            "type": "string",
+            "required": false
+          },
+          "data": {
+            "value": "{\"plan\": \"pro\", \"amount\": 49.99, \"currency\": \"USD\", \"item_count\": 3}",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchPeople",
+      "qualifiedName": "Customerio.SearchPeople",
+      "fullyQualifiedName": "Customerio.SearchPeople@0.1.0",
+      "description": "Find people by segment membership and/or an attribute, to build an\naudience without a known id. Supply at least one of a segment or an\nattribute name; both combine with AND.",
+      "parameters": [
+        {
+          "name": "segment_id",
+          "type": "string",
+          "required": false,
+          "description": "Restrict to members of this segment. Leave empty to not filter by segment.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "attribute_name",
+          "type": "string",
+          "required": false,
+          "description": "Restrict to people who have this attribute. Combine with an attribute value to match a specific value, or leave the value empty to match anyone the attribute is set on. Leave empty to not filter by attribute.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "attribute_value",
+          "type": "string",
+          "required": false,
+          "description": "Value the named attribute must equal. Ignored unless an attribute name is given; leave empty to match any value the attribute is set to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum people to return (1-1000). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from a prior page. Leave empty for the first page.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_APP_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_APP_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.SearchPeople",
+        "parameters": {
+          "segment_id": {
+            "value": "42",
+            "type": "string",
+            "required": false
+          },
+          "attribute_name": {
+            "value": "plan",
+            "type": "string",
+            "required": false
+          },
+          "attribute_value": {
+            "value": "premium",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 100,
+            "type": "integer",
+            "required": false
+          },
+          "cursor": {
+            "value": "eyJpZCI6Ijc4OTAiLCJkaXJlY3Rpb24iOiJuZXh0In0=",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SendTransactionalEmail",
+      "qualifiedName": "Customerio.SendTransactionalEmail",
+      "fullyQualifiedName": "Customerio.SendTransactionalEmail@0.1.0",
+      "description": "Send a transactional email to one recipient by its template id.",
+      "parameters": [
+        {
+          "name": "transactional_message_id",
+          "type": "string",
+          "required": true,
+          "description": "Id of the transactional message template to send.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "to",
+          "type": "string",
+          "required": true,
+          "description": "Recipient email address. The send is associated with the person who has this email; provide an email address, not a person id.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_data",
+          "type": "json",
+          "required": false,
+          "description": "Values for the template's variables, as a flat mapping of name to value. Leave empty when the template has no variables.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "subject",
+          "type": "string",
+          "required": false,
+          "description": "Subject line override. Leave empty to use the template's subject.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "from_address",
+          "type": "string",
+          "required": false,
+          "description": "From address override. Leave empty to use the template's sender.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "bcc",
+          "type": "string",
+          "required": false,
+          "description": "BCC address. Leave empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "reply_to",
+          "type": "string",
+          "required": false,
+          "description": "Reply-to address override. Leave empty to use the template's default.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_APP_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_APP_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.SendTransactionalEmail",
+        "parameters": {
+          "transactional_message_id": {
+            "value": "42",
+            "type": "string",
+            "required": true
+          },
+          "to": {
+            "value": "jane.doe@example.com",
+            "type": "string",
+            "required": true
+          },
+          "message_data": {
+            "value": "{\"first_name\": \"Jane\", \"order_id\": \"ORD-98765\", \"total\": \"$149.99\"}",
+            "type": "string",
+            "required": false
+          },
+          "subject": {
+            "value": "Your Order Confirmation #ORD-98765",
+            "type": "string",
+            "required": false
+          },
+          "from_address": {
+            "value": "noreply@mycompany.com",
+            "type": "string",
+            "required": false
+          },
+          "bcc": {
+            "value": "records@mycompany.com",
+            "type": "string",
+            "required": false
+          },
+          "reply_to": {
+            "value": "support@mycompany.com",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "TriggerBroadcast",
+      "qualifiedName": "Customerio.TriggerBroadcast",
+      "fullyQualifiedName": "Customerio.TriggerBroadcast@0.1.0",
+      "description": "Trigger an API broadcast to a segment or an explicit recipient list.",
+      "parameters": [
+        {
+          "name": "broadcast_id",
+          "type": "string",
+          "required": true,
+          "description": "Id of the API-triggered broadcast to launch.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "data",
+          "type": "json",
+          "required": false,
+          "description": "Trigger data referenced by the broadcast's content/liquid, as a flat mapping of name to value. Leave empty when the broadcast references no data.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "segment_id",
+          "type": "string",
+          "required": false,
+          "description": "Segment id to send to. Leave empty to use the broadcast's configured audience or an explicit recipient list.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "recipient_ids",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Explicit external customer ids to send to (the id you assigned the person, not a Customer.io cio_id). Leave empty to target a segment, recipient emails, or the configured audience.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "recipient_emails",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Explicit recipient email addresses to send to. Prefer this when you only have an email or a cio_id. Leave empty to target a segment or ids.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "CUSTOMERIO_APP_API_KEY",
+        "CUSTOMERIO_REGION"
+      ],
+      "secretsInfo": [
+        {
+          "name": "CUSTOMERIO_APP_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "CUSTOMERIO_REGION",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Customerio.TriggerBroadcast",
+        "parameters": {
+          "broadcast_id": {
+            "value": "broadcast_001",
+            "type": "string",
+            "required": true
+          },
+          "data": {
+            "value": {
+              "promo_code": "SUMMER20",
+              "discount_percent": 20,
+              "expiry_date": "2024-08-31"
+            },
+            "type": "string",
+            "required": false
+          },
+          "segment_id": {
+            "value": "seg_4892",
+            "type": "string",
+            "required": false
+          },
+          "recipient_ids": {
+            "value": [
+              "user_1023",
+              "user_4857",
+              "user_7391"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "recipient_emails": {
+            "value": [
+              "alice@example.com",
+              "bob@example.com",
+              "carol@example.com"
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-06-10T12:11:45.868Z",
+  "summary": "The Customer.io toolkit lets LLMs interact with a Customer.io workspace via the Tracking and App APIs. It covers the full lifecycle of contacts, messaging, and analytics — from identifying people and recording events through sending transactional emails and triggering broadcasts.\n\n## Capabilities\n\n- **Contact management**: Create, update, look up, search, and delete person profiles; resolve by email or ID; handle multi-match edge cases.\n- **Activity & message history**: Retrieve a person's timeline of activities (filterable by type/name) and full message/delivery history.\n- **Segments**: List workspace segments, check which segments a person belongs to, and enumerate segment members.\n- **Campaigns, newsletters & broadcasts**: List campaigns, newsletters, and broadcasts; read aggregate delivery metrics for campaigns and newsletters; trigger API broadcasts to segments or explicit recipient lists.\n- **Transactional messaging**: List transactional message templates and send transactional emails to a single recipient by template ID.\n- **Event tracking**: Record named custom events on a person's timeline to drive lifecycle journeys.\n\n## Secrets\n\nThis toolkit uses no OAuth flow. All credentials are supplied as secrets.\n\n- **`CUSTOMERIO_SITE_ID`** — The Site ID for your Customer.io workspace, used to authenticate Tracking API calls. Find it in the Customer.io dashboard under **Settings → API Credentials → Tracking API**. [Customer.io API Credentials docs](https://customer.io/docs/api/track/#section/Authentication)\n\n- **`CUSTOMERIO_TRACKING_API_KEY`** — The Tracking API Key paired with the Site ID above. Retrieved from the same **Settings → API Credentials → Tracking API** page. This key authenticates event, identify, and delete calls sent to the Tracking API endpoint.\n\n- **`CUSTOMERIO_APP_API_KEY`** — A Bearer token for the Customer.io App API (used for reading campaigns, newsletters, segments, sending transactional email, triggering broadcasts, etc.). Generate one in **Settings → API Credentials → App API Keys**. Scope the key to the minimum permissions your use case requires. [Customer.io App API auth docs](https://customer.io/docs/api/app/#section/Authentication)\n\n- **`CUSTOMERIO_REGION`** — Specifies the data region for your workspace (`US` or `EU`). This determines which API base URLs are used. You can confirm your region in **Settings → Workspace Settings**. Provide the appropriate string so requests are routed to the correct regional endpoint.\n\nSee the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to configure secrets, and manage them at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
+}

--- a/toolkit-docs-generator/data/toolkits/datadog.json
+++ b/toolkit-docs-generator/data/toolkits/datadog.json
@@ -1,0 +1,704 @@
+{
+  "id": "Datadog",
+  "label": "Datadog",
+  "version": "0.1.0",
+  "description": "Arcade.dev LLM tools for Datadog log and trace search",
+  "metadata": {
+    "category": "development",
+    "iconUrl": "https://design-system.arcade.dev/icons/datadog.svg",
+    "isBYOC": false,
+    "isPro": false,
+    "type": "arcade",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/development/datadog",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": null,
+  "tools": [
+    {
+      "name": "AggregateEvents",
+      "qualifiedName": "Datadog.AggregateEvents",
+      "fullyQualifiedName": "Datadog.AggregateEvents@0.1.0",
+      "description": "Aggregate log events or spans over a window, optionally grouped and bucketed by time.\n\nUse this single call for triage questions like which service errors most, whether an\nerror rate is rising, or whether a span's latency percentile is climbing (set\naggregation to a percentile with measure '@duration' and an interval), instead of\npaginating raw events. For spans, group_by facets, query filters, and the returned\nbucket labels all use the same field names span results expose ('resource',\n'operation'); the Datadog resource_name/operation_name facets are handled internally.",
+      "parameters": [
+        {
+          "name": "dataset",
+          "type": "string",
+          "required": true,
+          "description": "Whether to count log events or APM spans.",
+          "enum": [
+            "logs",
+            "spans"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "query",
+          "type": "string",
+          "required": false,
+          "description": "Datadog search query using facet syntax, e.g. 'status:error'. Empty counts everything in the window. Only indexed facets are filterable; a filter on a non-indexed field silently matches nothing rather than erroring.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "start_time",
+          "type": "string",
+          "required": false,
+          "description": "Start of the time window as Datadog date math (now-1h), ISO-8601 (YYYY-MM-DDTHH:MM:SSZ), or Unix epoch milliseconds. Defaults to now-1h.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "end_time",
+          "type": "string",
+          "required": false,
+          "description": "End of the time window, in the same formats as start_time. Defaults to now.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "group_by",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Facets to break the count down by, e.g. 'service' or 'status'. Multiple facets nest the grouping. Empty returns a single total for the window. Only configured facets are groupable; grouping by a non-facet field yields an empty bucket set (surfaced in warnings), not an error.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "interval",
+          "type": "string",
+          "required": false,
+          "description": "Bucket the counts into a time series with this rollup, e.g. '5m' or '1h'. Leave empty for a single total per group with no time buckets.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "group_limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of groups to return per facet (1-1000). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "aggregation",
+          "type": "string",
+          "required": false,
+          "description": "How to aggregate matching events. COUNT tallies events; the other values compute a statistic of the measure facet. Defaults to COUNT.",
+          "enum": [
+            "count",
+            "avg",
+            "min",
+            "max",
+            "sum",
+            "p50",
+            "p75",
+            "p90",
+            "p95",
+            "p99"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "measure",
+          "type": "string",
+          "required": false,
+          "description": "Numeric facet the statistic is computed over when aggregation is not COUNT, e.g. '@duration' for span latency (the value is then in nanoseconds). Defaults to '@duration'. Ignored when aggregation is COUNT.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DATADOG_API_KEY",
+        "DATADOG_APPLICATION_KEY",
+        "DATADOG_SITE"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DATADOG_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "DATADOG_APPLICATION_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "DATADOG_SITE",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Datadog.AggregateEvents",
+        "parameters": {
+          "dataset": {
+            "value": "spans",
+            "type": "string",
+            "required": true
+          },
+          "query": {
+            "value": "service:checkout-api status:error",
+            "type": "string",
+            "required": false
+          },
+          "start_time": {
+            "value": "now-3h",
+            "type": "string",
+            "required": false
+          },
+          "end_time": {
+            "value": "now",
+            "type": "string",
+            "required": false
+          },
+          "group_by": {
+            "value": [
+              "service",
+              "status"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "interval": {
+            "value": "15m",
+            "type": "string",
+            "required": false
+          },
+          "group_limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "aggregation": {
+            "value": "p95",
+            "type": "string",
+            "required": false
+          },
+          "measure": {
+            "value": "@duration",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DiscoverFacets",
+      "qualifiedName": "Datadog.DiscoverFacets",
+      "fullyQualifiedName": "Datadog.DiscoverFacets@0.1.0",
+      "description": "Probe which standard facets are groupable and filterable for a dataset in a window.\n\nCall this before grouping or filtering when the right facet name is uncertain,\ninstead of guessing a name and reading an empty bucket set back: it returns the\nfacets that actually have data to break down by right now, each with sample\nvalues. This resolves environment-specific naming (e.g. whether HTTP status is\nexposed as @http.status_code or @http.status) empirically rather than by guess.",
+      "parameters": [
+        {
+          "name": "dataset",
+          "type": "string",
+          "required": true,
+          "description": "Whether to probe log facets or APM span facets.",
+          "enum": [
+            "logs",
+            "spans"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "query",
+          "type": "string",
+          "required": false,
+          "description": "Datadog search query scoping the probe, e.g. 'status:error'. Empty probes against everything in the window (the widest, most reliable signal). For spans, filter on 'resource'/'operation' with the same names span results expose; they are mapped to Datadog's facets automatically.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "start_time",
+          "type": "string",
+          "required": false,
+          "description": "Start of the time window as Datadog date math (now-1h), ISO-8601 (YYYY-MM-DDTHH:MM:SSZ), or Unix epoch milliseconds. Defaults to now-1h.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "end_time",
+          "type": "string",
+          "required": false,
+          "description": "End of the time window, in the same formats as start_time. Defaults to now.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DATADOG_API_KEY",
+        "DATADOG_APPLICATION_KEY",
+        "DATADOG_SITE"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DATADOG_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "DATADOG_APPLICATION_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "DATADOG_SITE",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Datadog.DiscoverFacets",
+        "parameters": {
+          "dataset": {
+            "value": "logs",
+            "type": "string",
+            "required": true
+          },
+          "query": {
+            "value": "status:error service:checkout-api",
+            "type": "string",
+            "required": false
+          },
+          "start_time": {
+            "value": "now-3h",
+            "type": "string",
+            "required": false
+          },
+          "end_time": {
+            "value": "now",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetTrace",
+      "qualifiedName": "Datadog.GetTrace",
+      "fullyQualifiedName": "Datadog.GetTrace@0.1.0",
+      "description": "Retrieve a single trace assembled with a summary, bounding the span list.\n\nPages through the trace's spans internally; an unknown trace id returns an\nempty trace. Use this single call to inspect a trace end to end without\nrisking an oversized response on large traces.",
+      "parameters": [
+        {
+          "name": "trace_id",
+          "type": "string",
+          "required": true,
+          "description": "The Datadog trace id to inspect.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "start_time",
+          "type": "string",
+          "required": false,
+          "description": "Start of the window to search for the trace's spans, as Datadog date math (now-1h), ISO-8601 (YYYY-MM-DDTHH:MM:SSZ), or Unix epoch milliseconds. Defaults to now-1h.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "end_time",
+          "type": "string",
+          "required": false,
+          "description": "End of the window, in the same formats as start_time. Defaults to now.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_spans",
+          "type": "integer",
+          "required": false,
+          "description": "Upper bound on spans to include in the response (1-500). Defaults to 100. The returned set is further auto-fit to a token-safe size, so the default call is always safe; the summary covers every span the call assembled (summary_complete is false on the rare trace too large to assemble in full), and the kept spans are every error span plus the slowest, with the result marked truncated when any are dropped.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DATADOG_API_KEY",
+        "DATADOG_APPLICATION_KEY",
+        "DATADOG_SITE"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DATADOG_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "DATADOG_APPLICATION_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "DATADOG_SITE",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Datadog.GetTrace",
+        "parameters": {
+          "trace_id": {
+            "value": "7890123456789012345",
+            "type": "string",
+            "required": true
+          },
+          "start_time": {
+            "value": "now-3h",
+            "type": "string",
+            "required": false
+          },
+          "end_time": {
+            "value": "now",
+            "type": "string",
+            "required": false
+          },
+          "max_spans": {
+            "value": 250,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchLogs",
+      "qualifiedName": "Datadog.SearchLogs",
+      "fullyQualifiedName": "Datadog.SearchLogs@0.1.0",
+      "description": "Search Datadog log events matching a query over a time window.",
+      "parameters": [
+        {
+          "name": "query",
+          "type": "string",
+          "required": true,
+          "description": "Datadog logs search query using facet syntax, e.g. 'service:checkout status:error'. Empty matches all logs in the window. Only indexed facets are filterable: an attribute that merely appears in a result (e.g. an http status under a log's attributes) is not necessarily a queryable facet, and a filter on a non-indexed field silently matches nothing rather than erroring.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "start_time",
+          "type": "string",
+          "required": false,
+          "description": "Start of the time window as Datadog date math (now-1h), ISO-8601 (YYYY-MM-DDTHH:MM:SSZ), or Unix epoch milliseconds. Defaults to now-15m.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "end_time",
+          "type": "string",
+          "required": false,
+          "description": "End of the time window, in the same formats as start_time. Defaults to now.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_results",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of log events to return (1-1000). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "sort_order",
+          "type": "string",
+          "required": false,
+          "description": "Order results by event timestamp. Defaults to NEWEST.",
+          "enum": [
+            "newest",
+            "oldest"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from a previous result's next_cursor. Leave empty to fetch the first page.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DATADOG_API_KEY",
+        "DATADOG_APPLICATION_KEY",
+        "DATADOG_SITE"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DATADOG_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "DATADOG_APPLICATION_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "DATADOG_SITE",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Datadog.SearchLogs",
+        "parameters": {
+          "query": {
+            "value": "service:checkout status:error",
+            "type": "string",
+            "required": true
+          },
+          "start_time": {
+            "value": "now-1h",
+            "type": "string",
+            "required": false
+          },
+          "end_time": {
+            "value": "now",
+            "type": "string",
+            "required": false
+          },
+          "max_results": {
+            "value": 100,
+            "type": "integer",
+            "required": false
+          },
+          "sort_order": {
+            "value": "NEWEST",
+            "type": "string",
+            "required": false
+          },
+          "cursor": {
+            "value": "",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchSpans",
+      "qualifiedName": "Datadog.SearchSpans",
+      "fullyQualifiedName": "Datadog.SearchSpans@0.1.0",
+      "description": "Search Datadog APM spans matching a query over a time window.",
+      "parameters": [
+        {
+          "name": "query",
+          "type": "string",
+          "required": true,
+          "description": "Datadog spans search query using facet syntax, e.g. 'service:api-gateway status:error'. Filter on an endpoint or operation with the same field names that span results expose ('resource', 'operation'); they are mapped to Datadog's facets automatically. Quote values containing spaces or dots, e.g. resource:\"GET /v1/auth\". Bound span latency with @duration in nanoseconds (e.g. @duration:>500000000 for >500ms, or @duration:<60000000000 to exclude long-lived streaming spans when sorting by LONGEST). Empty matches all spans in the window. Only indexed facets are filterable: an attribute that merely appears in a span's meta is not necessarily a queryable facet, and a filter on a non-indexed field silently matches nothing rather than erroring.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "start_time",
+          "type": "string",
+          "required": false,
+          "description": "Start of the time window as Datadog date math (now-1h), ISO-8601 (YYYY-MM-DDTHH:MM:SSZ), or Unix epoch milliseconds. Defaults to now-15m.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "end_time",
+          "type": "string",
+          "required": false,
+          "description": "End of the time window, in the same formats as start_time. Defaults to now.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_results",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of spans to return (1-1000). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "sort_order",
+          "type": "string",
+          "required": false,
+          "description": "Order results by start time or duration. Use LONGEST to surface the slowest spans first. Defaults to NEWEST.",
+          "enum": [
+            "newest",
+            "oldest",
+            "longest"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from a previous result's next_cursor. Leave empty to fetch the first page.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DATADOG_API_KEY",
+        "DATADOG_APPLICATION_KEY",
+        "DATADOG_SITE"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DATADOG_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "DATADOG_APPLICATION_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "DATADOG_SITE",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Datadog.SearchSpans",
+        "parameters": {
+          "query": {
+            "value": "service:api-gateway status:error @duration:>500000000",
+            "type": "string",
+            "required": true
+          },
+          "start_time": {
+            "value": "now-1h",
+            "type": "string",
+            "required": false
+          },
+          "end_time": {
+            "value": "now",
+            "type": "string",
+            "required": false
+          },
+          "max_results": {
+            "value": 100,
+            "type": "integer",
+            "required": false
+          },
+          "sort_order": {
+            "value": "LONGEST",
+            "type": "string",
+            "required": false
+          },
+          "cursor": {
+            "value": "",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-06-10T12:11:45.864Z",
+  "summary": "Datadog toolkit for Arcade provides LLM tools to search, aggregate, and inspect Datadog logs, APM spans, and traces programmatically. It enables AI agents to perform observability triage — identifying error patterns, latency trends, and trace-level diagnostics — directly against a Datadog account.\n\n## Capabilities\n\n- **Log & span search**: Query log events and APM spans over configurable time windows using Datadog search syntax.\n- **Aggregation & bucketing**: Aggregate events or spans by count, percentile, or other measures, optionally grouped by facets and bucketed by time — suited for triage questions like rising error rates or latency trends without paginating raw results.\n- **Facet discovery**: Probe which facets have live data in a given window and dataset before filtering or grouping, resolving environment-specific naming empirically (e.g. `@http.status_code` vs `@http.status`).\n- **Trace inspection**: Retrieve a single assembled trace with span summary, handling internal pagination to avoid oversized responses on large traces.\n\n## Secrets\n\nThis toolkit requires three secrets configured in your Arcade environment.\n\n- **`DATADOG_API_KEY`** — A Datadog API key that authenticates requests to the Datadog API. Generate one in the Datadog dashboard under **Organization Settings → API Keys**. API keys are not scoped; any valid key for your org works. See [Datadog API Keys docs](https://docs.datadoghq.com/account_management/api-app-keys/#api-keys).\n\n- **`DATADOG_APPLICATION_KEY`** — A Datadog Application key, required alongside the API key to authorize read operations against logs, spans, and traces. Create one under **Organization Settings → Application Keys**. For least-privilege access, scope it to the specific permissions your agent needs (e.g. `logs_read_data`, `apm_read`). See [Datadog Application Keys docs](https://docs.datadoghq.com/account_management/api-app-keys/#application-keys).\n\n- **`DATADOG_SITE`** — The Datadog site URL for your account (e.g. `datadoghq.com`, `datadoghq.eu`, `us3.datadoghq.com`). This determines which regional API endpoint the toolkit calls. Find your site in the Datadog dashboard URL or under **Organization Settings**. See [Datadog site list](https://docs.datadoghq.com/getting_started/site/).\n\nConfigure secrets at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets). For details on how Arcade handles secrets in tools, see [https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets)."
+}

--- a/toolkit-docs-generator/data/toolkits/discordbot.json
+++ b/toolkit-docs-generator/data/toolkits/discordbot.json
@@ -1,0 +1,1689 @@
+{
+  "id": "DiscordBot",
+  "label": "Discord Bot",
+  "version": "0.1.0",
+  "description": "Arcade.dev LLM tools for Discord",
+  "metadata": {
+    "category": "social",
+    "iconUrl": "https://design-system.arcade.dev/icons/discord.svg",
+    "isBYOC": false,
+    "isPro": false,
+    "type": "arcade",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/social-communication/discord-bot",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": null,
+  "tools": [
+    {
+      "name": "AddReaction",
+      "qualifiedName": "DiscordBot.AddReaction",
+      "fullyQualifiedName": "DiscordBot.AddReaction@0.1.0",
+      "description": "Add an emoji reaction to a Discord message as the bot.",
+      "parameters": [
+        {
+          "name": "channel_id",
+          "type": "string",
+          "required": true,
+          "description": "The channel id the message is in.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the message to react to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "emoji",
+          "type": "string",
+          "required": true,
+          "description": "The emoji to add: a unicode emoji character, or a custom emoji as name:id.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The reaction outcome."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.AddReaction",
+        "parameters": {
+          "channel_id": {
+            "value": "1087654321098765432",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": "1123456789012345678",
+            "type": "string",
+            "required": true
+          },
+          "emoji": {
+            "value": "👍",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DeleteMessage",
+      "qualifiedName": "DiscordBot.DeleteMessage",
+      "fullyQualifiedName": "DiscordBot.DeleteMessage@0.1.0",
+      "description": "Delete a message from a Discord channel. This cannot be undone.",
+      "parameters": [
+        {
+          "name": "channel_id",
+          "type": "string",
+          "required": true,
+          "description": "The channel id the message is in.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the message to delete.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The delete outcome."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.DeleteMessage",
+        "parameters": {
+          "channel_id": {
+            "value": "1098765432109876543",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": "1123456789012345678",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "EditMessage",
+      "qualifiedName": "DiscordBot.EditMessage",
+      "fullyQualifiedName": "DiscordBot.EditMessage@0.1.0",
+      "description": "Edit a message the bot posted. The bot can only edit its own messages.\n\nEdits suppress @everyone, @here, and role mentions, so correcting an earlier post never\npings the whole server (Discord re-parses mentions in edited content by default).\n\nEditing a message authored by someone else is not an error: it returns a result whose\n``status`` is ``not_author`` so the caller can pivot (e.g. post a new message) without\nits tool chain aborting.",
+      "parameters": [
+        {
+          "name": "channel_id",
+          "type": "string",
+          "required": true,
+          "description": "The channel id the message is in.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the bot's message to edit.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "content",
+          "type": "string",
+          "required": true,
+          "description": "The new message text (1-2000 characters).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The message after editing."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.EditMessage",
+        "parameters": {
+          "channel_id": {
+            "value": "1098234567890123456",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": "1105678901234567890",
+            "type": "string",
+            "required": true
+          },
+          "content": {
+            "value": "Here is the updated announcement: the meeting has been rescheduled to Friday at 3:00 PM. Please update your calendars accordingly.",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetChannel",
+      "qualifiedName": "DiscordBot.GetChannel",
+      "fullyQualifiedName": "DiscordBot.GetChannel@0.1.0",
+      "description": "Get a single Discord channel's name, type, and topic.\n\nA missing channel (e.g. one that was deleted) is not an error: the result's ``status``\nis ``not_found`` so the caller can branch without a try/catch. A genuine permission\nproblem is still raised.",
+      "parameters": [
+        {
+          "name": "channel_id",
+          "type": "string",
+          "required": true,
+          "description": "The channel or thread id to fetch.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Full details for one channel."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.GetChannel",
+        "parameters": {
+          "channel_id": {
+            "value": "1103847562910478336",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetMessage",
+      "qualifiedName": "DiscordBot.GetMessage",
+      "fullyQualifiedName": "DiscordBot.GetMessage@0.1.0",
+      "description": "Fetch a single Discord message by id.\n\nA missing message (e.g. one that was deleted) is not an error: the result's ``status``\nis ``not_found`` so the caller can branch without a try/catch. A genuine permission\nproblem is still raised.",
+      "parameters": [
+        {
+          "name": "channel_id",
+          "type": "string",
+          "required": true,
+          "description": "The channel or thread id the message is in.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The message id to fetch.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The requested message."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.GetMessage",
+        "parameters": {
+          "channel_id": {
+            "value": "1098765432109876543",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": "1123456789012345678",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetServer",
+      "qualifiedName": "DiscordBot.GetServer",
+      "fullyQualifiedName": "DiscordBot.GetServer@0.1.0",
+      "description": "Get a single Discord server's name, owner, and member count.\n\nA server the bot cannot resolve (it is not a member, or the id is wrong) is not an\nerror: the result's ``status`` is ``not_found`` so the caller can branch without a\ntry/catch. A genuine permission problem is still raised.",
+      "parameters": [
+        {
+          "name": "server_id",
+          "type": "string",
+          "required": true,
+          "description": "The server (guild) id to fetch.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Full details for one server."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.GetServer",
+        "parameters": {
+          "server_id": {
+            "value": "817263940512847361",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetUser",
+      "qualifiedName": "DiscordBot.GetUser",
+      "fullyQualifiedName": "DiscordBot.GetUser@0.1.0",
+      "description": "Resolve a user id (such as a message author_id) into a human-readable name.\n\nPass server_id to fold in the user's nickname in that server. Use this to turn the opaque\nauthor_id on messages into a name without leaving the agent. A user id that resolves to no\naccount is not an error: the result's ``status`` is ``not_found`` so the caller can branch.",
+      "parameters": [
+        {
+          "name": "user_id",
+          "type": "string",
+          "required": true,
+          "description": "The user id to resolve, such as a message author_id.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "server_id",
+          "type": "string",
+          "required": false,
+          "description": "Resolve the user's nickname within this server (guild). Leave empty to return only the account-level profile.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The resolved user."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.GetUser",
+        "parameters": {
+          "user_id": {
+            "value": "298518199693426688",
+            "type": "string",
+            "required": true
+          },
+          "server_id": {
+            "value": "81384788765712384",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListActiveThreads",
+      "qualifiedName": "DiscordBot.ListActiveThreads",
+      "fullyQualifiedName": "DiscordBot.ListActiveThreads@0.1.0",
+      "description": "List a Discord server's currently active (non-archived) threads.",
+      "parameters": [
+        {
+          "name": "server_id",
+          "type": "string",
+          "required": true,
+          "description": "The server (guild) id whose active threads to list.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum threads to return (1-100). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position into the thread list. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The server's active threads."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.ListActiveThreads",
+        "parameters": {
+          "server_id": {
+            "value": "987654321098765432",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListChannels",
+      "qualifiedName": "DiscordBot.ListChannels",
+      "fullyQualifiedName": "DiscordBot.ListChannels@0.1.0",
+      "description": "List the channels in a Discord server, optionally filtered by type.",
+      "parameters": [
+        {
+          "name": "server_id",
+          "type": "string",
+          "required": true,
+          "description": "The server (guild) id whose channels to list.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "channel_type",
+          "type": "string",
+          "required": false,
+          "description": "Restrict results to one channel type. Defaults to ALL (no filter).",
+          "enum": [
+            "all",
+            "text",
+            "voice",
+            "category",
+            "announcement",
+            "forum"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum channels to return (1-100). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position into the filtered list. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The channels in the server."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.ListChannels",
+        "parameters": {
+          "server_id": {
+            "value": "819204756031488041",
+            "type": "string",
+            "required": true
+          },
+          "channel_type": {
+            "value": "TEXT",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListMessages",
+      "qualifiedName": "DiscordBot.ListMessages",
+      "fullyQualifiedName": "DiscordBot.ListMessages@0.1.0",
+      "description": "Read a channel's or thread's recent messages, newest first.",
+      "parameters": [
+        {
+          "name": "channel_id",
+          "type": "string",
+          "required": true,
+          "description": "The channel or thread id to read. A thread is a channel, so this reads threads too.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum messages to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "before",
+          "type": "string",
+          "required": false,
+          "description": "Return only messages older than this message id. Leave empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "after",
+          "type": "string",
+          "required": false,
+          "description": "Return only messages newer than this message id. Leave empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "around",
+          "type": "string",
+          "required": false,
+          "description": "Return messages centered on this message id. Leave empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "include_system",
+          "type": "boolean",
+          "required": false,
+          "description": "Include Discord's auto-generated system notices (thread-created, pin, join messages). Defaults to false, which keeps a catch-up read free of blank non-conversational rows.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Recent messages, newest first."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.ListMessages",
+        "parameters": {
+          "channel_id": {
+            "value": "1098234567890123456",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "before": {
+            "value": "1105678901234567890",
+            "type": "string",
+            "required": false
+          },
+          "after": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "around": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "include_system": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListPinnedMessages",
+      "qualifiedName": "DiscordBot.ListPinnedMessages",
+      "fullyQualifiedName": "DiscordBot.ListPinnedMessages@0.1.0",
+      "description": "List the pinned messages in a Discord channel.",
+      "parameters": [
+        {
+          "name": "channel_id",
+          "type": "string",
+          "required": true,
+          "description": "The channel id whose pinned messages to list.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The channel's pinned messages."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.ListPinnedMessages",
+        "parameters": {
+          "channel_id": {
+            "value": "987654321098765432",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListServers",
+      "qualifiedName": "DiscordBot.ListServers",
+      "fullyQualifiedName": "DiscordBot.ListServers@0.1.0",
+      "description": "List the Discord servers the bot is a member of and can act in.",
+      "parameters": [
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum servers to return (1-200). Defaults to 200.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "before",
+          "type": "string",
+          "required": false,
+          "description": "Return servers before this server id (for paging backward). Leave empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "after",
+          "type": "string",
+          "required": false,
+          "description": "Return servers after this server id; pass next_cursor to get the next page. Leave empty to start at the first page.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The servers the bot belongs to."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.ListServers",
+        "parameters": {
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "before": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "after": {
+            "value": "1102837465920512001",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "PinMessage",
+      "qualifiedName": "DiscordBot.PinMessage",
+      "fullyQualifiedName": "DiscordBot.PinMessage@0.1.0",
+      "description": "Pin a message in a Discord channel so the team can find it later.",
+      "parameters": [
+        {
+          "name": "channel_id",
+          "type": "string",
+          "required": true,
+          "description": "The channel id the message is in.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the message to pin.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The pin outcome."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.PinMessage",
+        "parameters": {
+          "channel_id": {
+            "value": "987654321098765432",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": "123456789012345678",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "RemoveReaction",
+      "qualifiedName": "DiscordBot.RemoveReaction",
+      "fullyQualifiedName": "DiscordBot.RemoveReaction@0.1.0",
+      "description": "Remove the bot's own emoji reaction from a Discord message.\n\nRemoves only the bot's reaction; other users' reactions with the same emoji are\nunaffected. Removing a reaction the bot never added is a no-op that returns\n``removed`` False, so the caller can tell that case apart from a real removal.",
+      "parameters": [
+        {
+          "name": "channel_id",
+          "type": "string",
+          "required": true,
+          "description": "The channel id the message is in.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the message to remove the reaction from.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "emoji",
+          "type": "string",
+          "required": true,
+          "description": "The emoji to remove: a unicode emoji character, or a custom emoji as name:id.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The reaction outcome."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.RemoveReaction",
+        "parameters": {
+          "channel_id": {
+            "value": "1098234567890123456",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": "1105987654321098765",
+            "type": "string",
+            "required": true
+          },
+          "emoji": {
+            "value": "👍",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ReplyToMessage",
+      "qualifiedName": "DiscordBot.ReplyToMessage",
+      "fullyQualifiedName": "DiscordBot.ReplyToMessage@0.1.0",
+      "description": "Reply to an existing Discord message so the answer stays tied to the question.\n\nTo reply inside a thread, pass the thread id as channel_id and a message id from\ninside the thread as message_id. A thread's own id is its starter message, which lives\nin the parent channel, not inside the thread.",
+      "parameters": [
+        {
+          "name": "channel_id",
+          "type": "string",
+          "required": true,
+          "description": "The channel id the original message is in.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the message to reply to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "content",
+          "type": "string",
+          "required": true,
+          "description": "The reply text (1-2000 characters).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "mention_author",
+          "type": "boolean",
+          "required": false,
+          "description": "Whether to ping the author of the message being replied to. Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The reply the bot posted."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.ReplyToMessage",
+        "parameters": {
+          "channel_id": {
+            "value": "1098234567890123456",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": "1105678901234567890",
+            "type": "string",
+            "required": true
+          },
+          "content": {
+            "value": "Great question! The answer is that Discord threads keep conversations organized by tying replies directly to the original message.",
+            "type": "string",
+            "required": true
+          },
+          "mention_author": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchMessages",
+      "qualifiedName": "DiscordBot.SearchMessages",
+      "fullyQualifiedName": "DiscordBot.SearchMessages@0.1.0",
+      "description": "Find messages by text and/or author in one channel or across a whole server.\n\nUse a single call with server_id to answer \"I remember a message but not where\" without\nlooping channels yourself; a server-wide search covers text and announcement channels plus\nactive threads and forum posts. Discord's bot API has no server-side message search, so\nthis scans recent messages locally and covers the most recent ``max_scan`` messages, not\nfull history. Matching reads ``content``, which is empty for messages the bot cannot see\nin full without the Message Content intent.",
+      "parameters": [
+        {
+          "name": "channel_id",
+          "type": "string",
+          "required": false,
+          "description": "The channel or thread id to search (a thread is a channel, so this searches threads too). Leave empty to search a whole server instead via server_id. Provide exactly one of channel_id or server_id.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "server_id",
+          "type": "string",
+          "required": false,
+          "description": "The server (guild) id to search across all of its text and announcement channels. Leave empty to search a single channel via channel_id. Provide exactly one of channel_id or server_id.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "query",
+          "type": "string",
+          "required": false,
+          "description": "Text to find in message content (case-insensitive). Leave empty to match any content, which is useful when filtering only by author_id.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "author_id",
+          "type": "string",
+          "required": false,
+          "description": "Only return messages posted by this author id. Leave empty to match any author. Combine with an empty query to list a user's recent messages.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum matching messages to return (1-50). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_scan",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum recent messages to scan while searching (50-1000). Defaults to 300. In a server-wide search this is the total budget shared across channels. Raise to look further back at the cost of more API calls.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Matching messages, newest first."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.SearchMessages",
+        "parameters": {
+          "channel_id": {
+            "value": null,
+            "type": "string",
+            "required": false
+          },
+          "server_id": {
+            "value": "987654321098765432",
+            "type": "string",
+            "required": false
+          },
+          "query": {
+            "value": "deployment update",
+            "type": "string",
+            "required": false
+          },
+          "author_id": {
+            "value": "123456789012345678",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 15,
+            "type": "integer",
+            "required": false
+          },
+          "max_scan": {
+            "value": 500,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SendMessage",
+      "qualifiedName": "DiscordBot.SendMessage",
+      "fullyQualifiedName": "DiscordBot.SendMessage@0.1.0",
+      "description": "Post a new message to a Discord channel as the bot.\n\nPosts with @everyone, @here, and role mentions suppressed so a routine update never\npings the whole server.",
+      "parameters": [
+        {
+          "name": "channel_id",
+          "type": "string",
+          "required": true,
+          "description": "The channel id to post to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "content",
+          "type": "string",
+          "required": true,
+          "description": "The message text to post (1-2000 characters).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The message the bot posted."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.SendMessage",
+        "parameters": {
+          "channel_id": {
+            "value": "1098765432109876543",
+            "type": "string",
+            "required": true
+          },
+          "content": {
+            "value": "🚀 Deployment to production completed successfully! Version 2.4.1 is now live. Check the changelog for details.",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "StartThread",
+      "qualifiedName": "DiscordBot.StartThread",
+      "fullyQualifiedName": "DiscordBot.StartThread@0.1.0",
+      "description": "Start a thread from a message, standalone in a text channel, or as a forum/media post.\n\nDiscord seeds forum and media posts from the create call but does not accept an opening\nbody for text-channel threads, so for those this posts ``content`` as a follow-up opening\nmessage in one call. Mentions in ``content`` are suppressed so seeding never pings the\nserver.",
+      "parameters": [
+        {
+          "name": "channel_id",
+          "type": "string",
+          "required": true,
+          "description": "The channel id to start the thread in.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "The thread name (1-100 characters).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": false,
+          "description": "Start the thread attached to this existing message. Leave empty to start a standalone thread in the channel.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "content",
+          "type": "string",
+          "required": false,
+          "description": "Body that seeds the thread (1-2000 characters). For a forum or media channel this opens the post and is required. For a standalone text-channel thread it is posted as the thread's opening message. Ignored when starting the thread from an existing message. Leave empty to open an unseeded text-channel thread.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "auto_archive_minutes",
+          "type": "string",
+          "required": false,
+          "description": "Inactivity period before Discord auto-archives the thread. Defaults to ONE_DAY.",
+          "enum": [
+            "60",
+            "1440",
+            "4320",
+            "10080"
+          ],
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The thread the bot created."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.StartThread",
+        "parameters": {
+          "channel_id": {
+            "value": "1098234567890123456",
+            "type": "string",
+            "required": true
+          },
+          "name": {
+            "value": "Weekly Discussion: Best Practices",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": "1102345678901234567",
+            "type": "string",
+            "required": false
+          },
+          "content": {
+            "value": "Welcome to this week's discussion thread! Feel free to share your thoughts and ideas on best practices for our community projects.",
+            "type": "string",
+            "required": false
+          },
+          "auto_archive_minutes": {
+            "value": "1440",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "UnpinMessage",
+      "qualifiedName": "DiscordBot.UnpinMessage",
+      "fullyQualifiedName": "DiscordBot.UnpinMessage@0.1.0",
+      "description": "Unpin a previously pinned message in a Discord channel.",
+      "parameters": [
+        {
+          "name": "channel_id",
+          "type": "string",
+          "required": true,
+          "description": "The channel id the message is in.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the message to unpin.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The unpin outcome."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.UnpinMessage",
+        "parameters": {
+          "channel_id": {
+            "value": "1094857263910473728",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": "1102938475610284032",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "WhoAmI",
+      "qualifiedName": "DiscordBot.WhoAmI",
+      "fullyQualifiedName": "DiscordBot.WhoAmI@0.1.0",
+      "description": "Return the authenticated Discord bot's own user identity.\n\nUse this to verify the configured bot token and confirm which bot account the tools\nact as. It is a verification helper, not a required preamble to the other tools.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "DISCORD_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "DISCORD_BOT_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The authenticated bot's identity."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "DiscordBot.WhoAmI",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-06-10T12:11:47.169Z",
+  "summary": "# Discord Bot Toolkit\n\nThe Discord Bot toolkit lets an Arcade-powered agent act as a Discord bot — reading and writing messages, managing threads, handling reactions, and inspecting server structure — all authenticated via a bot token rather than OAuth.\n\n## Capabilities\n\n- **Messaging**: Send, edit, delete, reply to, pin, and unpin messages across channels and threads; mention suppression (`@everyone`, `@here`, roles) is enforced on send, edit, and thread seed operations to prevent accidental server-wide pings.\n- **Search & retrieval**: Fetch individual messages, channels, servers, and users by ID; list recent messages (newest-first), pinned messages, and perform text/author search within a channel or across an entire server (local scan of recent history, not full Discord history).\n- **Thread & channel management**: List channels (filterable by type), list active (non-archived) threads, and start threads from a message, standalone in a text channel, or as forum/media posts.\n- **Reactions**: Add and remove the bot's own emoji reactions; removing a reaction never added is a safe no-op.\n- **Server & identity introspection**: List servers the bot belongs to, resolve user IDs to human-readable names (with optional per-server nickname lookup), and verify the active bot identity with `WhoAmI`.\n- **Graceful not-found handling**: Missing messages, channels, servers, and users return a structured `not_found` status rather than raising errors, letting agent chains branch without try/catch logic.\n\n## Secrets\n\n`DISCORD_BOT_TOKEN` — The bot token that authenticates every API call as your Discord bot. To obtain it:\n\n1. Open the [Discord Developer Portal](https://discord.com/developers/applications) and select (or create) your application.\n2. Go to **Bot** in the left sidebar.\n3. Under the **Token** section, click **Reset Token** (or **Copy** if already generated) to retrieve the token.\n4. Enable any [Privileged Gateway Intents](https://discord.com/developers/docs/topics/gateway#privileged-intents) your use case requires — notably **Message Content Intent** if you need full message body access via `SearchMessages` or `GetMessage`.\n5. Invite the bot to your server with appropriate permissions (e.g. `Read Messages`, `Send Messages`, `Manage Messages`) using the OAuth2 URL Generator in the portal.\n\nStore the token as an Arcade secret. See [Arcade tool secrets docs](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for configuration details, or manage secrets directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
+}

--- a/toolkit-docs-generator/data/toolkits/freshdesk.json
+++ b/toolkit-docs-generator/data/toolkits/freshdesk.json
@@ -1,0 +1,1926 @@
+{
+  "id": "Freshdesk",
+  "label": "Freshdesk",
+  "version": "0.1.1",
+  "description": "Arcade.dev LLM tools for Freshdesk customer support",
+  "metadata": {
+    "category": "customer-support",
+    "iconUrl": "https://design-system.arcade.dev/icons/freshdesk.svg",
+    "isBYOC": false,
+    "isPro": false,
+    "type": "arcade",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/customer-support/freshdesk",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": null,
+  "tools": [
+    {
+      "name": "AddPrivateNote",
+      "qualifiedName": "Freshdesk.AddPrivateNote",
+      "fullyQualifiedName": "Freshdesk.AddPrivateNote@0.1.1",
+      "description": "Add an internal private note to a ticket that the requester cannot see.",
+      "parameters": [
+        {
+          "name": "ticket_id",
+          "type": "integer",
+          "required": true,
+          "description": "The ticket to annotate.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "required": true,
+          "description": "The internal note text. Not visible to the requester.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "notify_agent_emails",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Agent emails to notify about the note. Defaults to notifying no one.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Confirmation referencing the created private note."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.AddPrivateNote",
+        "parameters": {
+          "ticket_id": {
+            "value": 48291,
+            "type": "integer",
+            "required": true
+          },
+          "body": {
+            "value": "Customer has a history of billing disputes. Escalate to Tier 2 support if unresolved within 24 hours.",
+            "type": "string",
+            "required": true
+          },
+          "notify_agent_emails": {
+            "value": [
+              "alice.johnson@support.example.com",
+              "bob.smith@support.example.com"
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CreateOrUpdateCompany",
+      "qualifiedName": "Freshdesk.CreateOrUpdateCompany",
+      "fullyQualifiedName": "Freshdesk.CreateOrUpdateCompany@0.1.1",
+      "description": "Create a new company account or update an existing one. To create, omit company_id and\nprovide a name; link a contact to the result by passing its id as a contact's company.",
+      "parameters": [
+        {
+          "name": "company_id",
+          "type": "integer",
+          "required": false,
+          "description": "Id of the company to update. Omit to create a new company instead.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Company name. When creating, this is required and must be unique. When updating, providing it renames the company and omitting it leaves the name unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "domains",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Email domains owned by the company, used to auto-associate new contacts. Providing this replaces the existing list; omitting it leaves the domains unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "required": false,
+          "description": "Free-text account note. Providing it sets the note; omitting it leaves it unchanged.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The created or updated company."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.CreateOrUpdateCompany",
+        "parameters": {
+          "company_id": {
+            "value": 10045,
+            "type": "integer",
+            "required": false
+          },
+          "name": {
+            "value": "Acme Corporation",
+            "type": "string",
+            "required": false
+          },
+          "domains": {
+            "value": [
+              "acme.com",
+              "acmecorp.net"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "note": {
+            "value": "Enterprise customer since 2021. Renewal due in Q3.",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CreateOrUpdateContact",
+      "qualifiedName": "Freshdesk.CreateOrUpdateContact",
+      "fullyQualifiedName": "Freshdesk.CreateOrUpdateContact@0.1.1",
+      "description": "Create a new contact or update an existing one. To create, omit contact_id and\nprovide a name plus at least one of email, phone, or mobile.",
+      "parameters": [
+        {
+          "name": "contact_id",
+          "type": "integer",
+          "required": false,
+          "description": "Id of the contact to update. Omit to create a new contact instead.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Contact name. When creating, this is required. When updating, providing it changes the name and omitting it leaves the name unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "required": false,
+          "description": "Contact email. Providing it sets the email; omitting it leaves it unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "phone",
+          "type": "string",
+          "required": false,
+          "description": "Contact phone. Providing it sets the phone; omitting it leaves it unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "mobile",
+          "type": "string",
+          "required": false,
+          "description": "Contact mobile. Providing it sets the mobile; omitting it leaves it unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "company_id",
+          "type": "integer",
+          "required": false,
+          "description": "Company to associate the contact with. Omitting it leaves it unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "job_title",
+          "type": "string",
+          "required": false,
+          "description": "Contact job title. Providing it sets the title; omitting it leaves it unchanged.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The created or updated contact."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.CreateOrUpdateContact",
+        "parameters": {
+          "contact_id": {
+            "value": 1042,
+            "type": "integer",
+            "required": false
+          },
+          "name": {
+            "value": "Jane Doe",
+            "type": "string",
+            "required": false
+          },
+          "email": {
+            "value": "jane.doe@example.com",
+            "type": "string",
+            "required": false
+          },
+          "phone": {
+            "value": "+1-555-123-4567",
+            "type": "string",
+            "required": false
+          },
+          "mobile": {
+            "value": "+1-555-987-6543",
+            "type": "string",
+            "required": false
+          },
+          "company_id": {
+            "value": 305,
+            "type": "integer",
+            "required": false
+          },
+          "job_title": {
+            "value": "Product Manager",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CreateTicket",
+      "qualifiedName": "Freshdesk.CreateTicket",
+      "fullyQualifiedName": "Freshdesk.CreateTicket@0.1.1",
+      "description": "Open a ticket on a customer's behalf. Requires a subject, a description, and a\nrequester identified by email or id.",
+      "parameters": [
+        {
+          "name": "subject",
+          "type": "string",
+          "required": true,
+          "description": "The ticket subject line.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "required": true,
+          "description": "The ticket's first-message body. Plain text or HTML.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "requester_email",
+          "type": "string",
+          "required": false,
+          "description": "Email of the contact the ticket is for. Provide this or requester_id. Leave empty when using requester_id.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "requester_id",
+          "type": "integer",
+          "required": false,
+          "description": "Id of an existing contact the ticket is for. Provide this or requester_email.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "required": false,
+          "description": "Initial status. Defaults to OPEN.",
+          "enum": [
+            "open",
+            "pending",
+            "resolved",
+            "closed"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "priority",
+          "type": "string",
+          "required": false,
+          "description": "Initial priority. Defaults to MEDIUM.",
+          "enum": [
+            "low",
+            "medium",
+            "high",
+            "urgent"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "group_id",
+          "type": "integer",
+          "required": false,
+          "description": "Group to assign the new ticket to. Defaults to unassigned.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "agent_id",
+          "type": "integer",
+          "required": false,
+          "description": "Agent to assign as owner. Defaults to unassigned.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The created ticket with its conversation."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.CreateTicket",
+        "parameters": {
+          "subject": {
+            "value": "Unable to reset my account password",
+            "type": "string",
+            "required": true
+          },
+          "description": {
+            "value": "<p>Hello Support,</p><p>I have been trying to reset my password for the past two days but I never receive the reset email. Could you please help me regain access to my account?</p><p>Thank you.</p>",
+            "type": "string",
+            "required": true
+          },
+          "requester_email": {
+            "value": "jane.doe@example.com",
+            "type": "string",
+            "required": false
+          },
+          "requester_id": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          },
+          "status": {
+            "value": "OPEN",
+            "type": "string",
+            "required": false
+          },
+          "priority": {
+            "value": "HIGH",
+            "type": "string",
+            "required": false
+          },
+          "group_id": {
+            "value": 48001234567,
+            "type": "integer",
+            "required": false
+          },
+          "agent_id": {
+            "value": 48009876543,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetArticle",
+      "qualifiedName": "Freshdesk.GetArticle",
+      "fullyQualifiedName": "Freshdesk.GetArticle@0.1.1",
+      "description": "Read a single knowledge base article's full content by id.\n\nA missing id returns a not-found envelope (``found`` false) rather than raising, so a\nstale or guessed id can be recovered from within the same turn.",
+      "parameters": [
+        {
+          "name": "article_id",
+          "type": "integer",
+          "required": true,
+          "description": "The article's unique identifier.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The article's full content, or a not-found envelope."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.GetArticle",
+        "parameters": {
+          "article_id": {
+            "value": 48291,
+            "type": "integer",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetCompany",
+      "qualifiedName": "Freshdesk.GetCompany",
+      "fullyQualifiedName": "Freshdesk.GetCompany@0.1.1",
+      "description": "Read a single company's details by id.\n\nA missing id returns a not-found envelope (``found`` false) rather than raising, so a\nstale or guessed id can be recovered from within the same turn.",
+      "parameters": [
+        {
+          "name": "company_id",
+          "type": "integer",
+          "required": true,
+          "description": "The company's unique identifier.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The company's full detail, or a not-found envelope."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.GetCompany",
+        "parameters": {
+          "company_id": {
+            "value": 48291,
+            "type": "integer",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetContact",
+      "qualifiedName": "Freshdesk.GetContact",
+      "fullyQualifiedName": "Freshdesk.GetContact@0.1.1",
+      "description": "Read a single contact's details by id.\n\nA missing id returns a not-found envelope (``found`` false) rather than raising, so a\nstale or guessed id can be recovered from within the same turn.",
+      "parameters": [
+        {
+          "name": "contact_id",
+          "type": "integer",
+          "required": true,
+          "description": "The contact's unique identifier.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The contact's full detail, or a not-found envelope."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.GetContact",
+        "parameters": {
+          "contact_id": {
+            "value": 1042,
+            "type": "integer",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetCustomerOverview",
+      "qualifiedName": "Freshdesk.GetCustomerOverview",
+      "fullyQualifiedName": "Freshdesk.GetCustomerOverview@0.1.1",
+      "description": "Assemble one requester's full context — their contact record, their company, and their\ntickets — in a single call instead of three separate lookups.\n\nIdentify the requester by contact_id or email; a missing requester returns a not-found\nenvelope rather than raising, so a stale id or wrong email can be recovered in the same turn.",
+      "parameters": [
+        {
+          "name": "contact_id",
+          "type": "integer",
+          "required": false,
+          "description": "Id of the requester to profile. Takes precedence over email. Omit to look up by email.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "required": false,
+          "description": "Exact email of the requester to profile. Used only when contact_id is omitted.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "include_closed",
+          "type": "boolean",
+          "required": false,
+          "description": "Include resolved and closed tickets too (true) or only open and pending ones (false). Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "ticket_limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum tickets to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The requester's contact, company, and tickets in one envelope."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.GetCustomerOverview",
+        "parameters": {
+          "contact_id": {
+            "value": 1023847,
+            "type": "integer",
+            "required": false
+          },
+          "email": {
+            "value": "jane.doe@example.com",
+            "type": "string",
+            "required": false
+          },
+          "include_closed": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "ticket_limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetTicket",
+      "qualifiedName": "Freshdesk.GetTicket",
+      "fullyQualifiedName": "Freshdesk.GetTicket@0.1.1",
+      "description": "Read a ticket together with its full public-reply and private-note history.\n\nA missing id returns a not-found envelope (``found`` false) rather than raising, so a\nstale or guessed id can be recovered from within the same turn.",
+      "parameters": [
+        {
+          "name": "ticket_id",
+          "type": "integer",
+          "required": true,
+          "description": "The ticket's unique identifier.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The ticket with its conversation, or a not-found envelope."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.GetTicket",
+        "parameters": {
+          "ticket_id": {
+            "value": 10842,
+            "type": "integer",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListAgents",
+      "qualifiedName": "Freshdesk.ListAgents",
+      "fullyQualifiedName": "Freshdesk.ListAgents@0.1.1",
+      "description": "List the helpdesk's agents, optionally filtered to one email, for routing tickets.",
+      "parameters": [
+        {
+          "name": "email",
+          "type": "string",
+          "required": false,
+          "description": "Exact email to find a single agent by. Leave empty to list all agents.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum agents to return (1-100). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Helpdesk agents with pagination metadata."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.ListAgents",
+        "parameters": {
+          "email": {
+            "value": "john.doe@example.com",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListGroups",
+      "qualifiedName": "Freshdesk.ListGroups",
+      "fullyQualifiedName": "Freshdesk.ListGroups@0.1.1",
+      "description": "List the helpdesk's groups for routing tickets to a team.",
+      "parameters": [
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum groups to return (1-100). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Helpdesk groups with pagination metadata."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.ListGroups",
+        "parameters": {
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "MergeTickets",
+      "qualifiedName": "Freshdesk.MergeTickets",
+      "fullyQualifiedName": "Freshdesk.MergeTickets@0.1.1",
+      "description": "Merge duplicate tickets into one. Use this to consolidate related tickets from the same\nrequester so the conversation lives in a single place; the secondary tickets are closed.",
+      "parameters": [
+        {
+          "name": "primary_ticket_id",
+          "type": "integer",
+          "required": true,
+          "description": "The ticket that survives the merge and absorbs the others.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "secondary_ticket_ids",
+          "type": "array",
+          "innerType": "integer",
+          "required": true,
+          "description": "Ids of the duplicate tickets to fold into the primary. Each is closed and its conversation linked into the primary ticket.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "note",
+          "type": "string",
+          "required": false,
+          "description": "Internal note added to the primary ticket recording the merge. Leave empty to add no note.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Confirmation of the merge."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.MergeTickets",
+        "parameters": {
+          "primary_ticket_id": {
+            "value": 10245,
+            "type": "integer",
+            "required": true
+          },
+          "secondary_ticket_ids": {
+            "value": [
+              10389,
+              10412,
+              10467
+            ],
+            "type": "array",
+            "required": true
+          },
+          "note": {
+            "value": "Merging duplicate tickets submitted by the same requester regarding the login issue reported on 2024-03-15. Tickets #10389, #10412, and #10467 have been consolidated here.",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ReplyToTicket",
+      "qualifiedName": "Freshdesk.ReplyToTicket",
+      "fullyQualifiedName": "Freshdesk.ReplyToTicket@0.1.1",
+      "description": "Post a public reply on a ticket that the requester can see.",
+      "parameters": [
+        {
+          "name": "ticket_id",
+          "type": "integer",
+          "required": true,
+          "description": "The ticket to reply to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "required": true,
+          "description": "The public reply text the requester will see. Plain text or HTML.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Confirmation referencing the created public reply."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.ReplyToTicket",
+        "parameters": {
+          "ticket_id": {
+            "value": 10482,
+            "type": "integer",
+            "required": true
+          },
+          "body": {
+            "value": "<p>Thank you for reaching out to our support team! We have reviewed your issue and are happy to let you know that a fix has been deployed. Please clear your browser cache and try again. If the problem persists, don't hesitate to reply to this ticket and we'll be happy to assist further.</p>",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchArticles",
+      "qualifiedName": "Freshdesk.SearchArticles",
+      "fullyQualifiedName": "Freshdesk.SearchArticles@0.1.1",
+      "description": "Search the knowledge base for published solution articles matching a term.",
+      "parameters": [
+        {
+          "name": "term",
+          "type": "string",
+          "required": true,
+          "description": "The keyword or phrase to search published articles for.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum articles to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Matching published articles with pagination metadata."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.SearchArticles",
+        "parameters": {
+          "term": {
+            "value": "reset password",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 10,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchCompanies",
+      "qualifiedName": "Freshdesk.SearchCompanies",
+      "fullyQualifiedName": "Freshdesk.SearchCompanies@0.1.1",
+      "description": "Find companies by name. Match is by name prefix; use the full name for an exact hit.\n\nReturns lightweight summaries without the company note; read a single company by id for\nits full detail.",
+      "parameters": [
+        {
+          "name": "query",
+          "type": "string",
+          "required": true,
+          "description": "Name or name prefix to match companies by. The name autocomplete requires at least 2 characters; a single-character query returns no matches rather than an error.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum companies to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Matching companies with pagination metadata."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.SearchCompanies",
+        "parameters": {
+          "query": {
+            "value": "Acme",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchContacts",
+      "qualifiedName": "Freshdesk.SearchContacts",
+      "fullyQualifiedName": "Freshdesk.SearchContacts@0.1.1",
+      "description": "Find contacts by name, exact email, or company. With no filters, returns recent\ncontacts.\n\nCombining a name with a company scans up to the company's first 1000 contacts and matches the\nname among them; at a company with more contacts than that, a name match recorded beyond the\nscan may not appear.",
+      "parameters": [
+        {
+          "name": "query",
+          "type": "string",
+          "required": false,
+          "description": "Name or name prefix to match contacts by. Leave empty to not filter by name. The name autocomplete requires at least 2 characters; a single-character query returns no matches rather than an error.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "required": false,
+          "description": "Exact email to look up a contact by. Leave empty to not filter by email.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "company_id",
+          "type": "integer",
+          "required": false,
+          "description": "Only include contacts at this company. Defaults to no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum contacts to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Matching contacts with pagination metadata."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.SearchContacts",
+        "parameters": {
+          "query": {
+            "value": "Jo",
+            "type": "string",
+            "required": false
+          },
+          "email": {
+            "value": "john.doe@example.com",
+            "type": "string",
+            "required": false
+          },
+          "company_id": {
+            "value": 452871,
+            "type": "integer",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchTickets",
+      "qualifiedName": "Freshdesk.SearchTickets",
+      "fullyQualifiedName": "Freshdesk.SearchTickets@0.1.1",
+      "description": "Find tickets in the queue by status, priority, requester, agent, group, tag,\ntype, or recency. With no filters, returns the most recently updated tickets.\n\nPass requester_id (or requester_email) to pull one customer's full ticket history;\nother filters then refine that requester's tickets. A just-created ticket may take a\nmoment to appear here while Freshdesk indexes it.",
+      "parameters": [
+        {
+          "name": "status",
+          "type": "string",
+          "required": false,
+          "description": "Only include tickets with this status. Defaults to no filter.",
+          "enum": [
+            "open",
+            "pending",
+            "resolved",
+            "closed"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "priority",
+          "type": "string",
+          "required": false,
+          "description": "Only include tickets with this priority. Defaults to no filter.",
+          "enum": [
+            "low",
+            "medium",
+            "high",
+            "urgent"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "requester_email",
+          "type": "string",
+          "required": false,
+          "description": "Only include tickets opened by the contact with this email. Leave empty for no filter. Ignored when requester_id is given.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "requester_id",
+          "type": "integer",
+          "required": false,
+          "description": "Only include tickets opened by the contact with this id. Takes precedence over requester_email. Defaults to no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "agent_id",
+          "type": "integer",
+          "required": false,
+          "description": "Only include tickets assigned to this agent. Defaults to no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "group_id",
+          "type": "integer",
+          "required": false,
+          "description": "Only include tickets in this group. Defaults to no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "tag",
+          "type": "string",
+          "required": false,
+          "description": "Only include tickets carrying this tag. Leave empty for no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "ticket_type",
+          "type": "string",
+          "required": false,
+          "description": "Only include tickets of this type. Leave empty for no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "updated_since",
+          "type": "string",
+          "required": false,
+          "description": "Only include tickets updated on or after this date (YYYY-MM-DD). Leave empty for no lower bound.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum tickets to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Matching tickets, newest first, with pagination metadata."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.SearchTickets",
+        "parameters": {
+          "status": {
+            "value": "open",
+            "type": "string",
+            "required": false
+          },
+          "priority": {
+            "value": "high",
+            "type": "string",
+            "required": false
+          },
+          "requester_email": {
+            "value": "jane.doe@example.com",
+            "type": "string",
+            "required": false
+          },
+          "requester_id": {
+            "value": 48291,
+            "type": "integer",
+            "required": false
+          },
+          "agent_id": {
+            "value": 7163,
+            "type": "integer",
+            "required": false
+          },
+          "group_id": {
+            "value": 3042,
+            "type": "integer",
+            "required": false
+          },
+          "tag": {
+            "value": "billing",
+            "type": "string",
+            "required": false
+          },
+          "ticket_type": {
+            "value": "Question",
+            "type": "string",
+            "required": false
+          },
+          "updated_since": {
+            "value": "2024-03-01",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "UpdateTicket",
+      "qualifiedName": "Freshdesk.UpdateTicket",
+      "fullyQualifiedName": "Freshdesk.UpdateTicket@0.1.1",
+      "description": "Change a ticket's status, priority, assignee, or group. Fields left unset are\nunchanged; at least one field must be provided.",
+      "parameters": [
+        {
+          "name": "ticket_id",
+          "type": "integer",
+          "required": true,
+          "description": "The ticket to update.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "required": false,
+          "description": "New status. Omit to leave the status unchanged.",
+          "enum": [
+            "open",
+            "pending",
+            "resolved",
+            "closed"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "priority",
+          "type": "string",
+          "required": false,
+          "description": "New priority. Omit to leave the priority unchanged.",
+          "enum": [
+            "low",
+            "medium",
+            "high",
+            "urgent"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "agent_id",
+          "type": "integer",
+          "required": false,
+          "description": "Agent to assign as owner. Omit to leave the assignee unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "group_id",
+          "type": "integer",
+          "required": false,
+          "description": "Group to move the ticket to. Omit to leave the group unchanged.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The updated ticket with its conversation."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.UpdateTicket",
+        "parameters": {
+          "ticket_id": {
+            "value": 48321,
+            "type": "integer",
+            "required": true
+          },
+          "status": {
+            "value": "pending",
+            "type": "string",
+            "required": false
+          },
+          "priority": {
+            "value": "high",
+            "type": "string",
+            "required": false
+          },
+          "agent_id": {
+            "value": 7654,
+            "type": "integer",
+            "required": false
+          },
+          "group_id": {
+            "value": 302,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "WhoAmI",
+      "qualifiedName": "Freshdesk.WhoAmI",
+      "fullyQualifiedName": "Freshdesk.WhoAmI@0.1.1",
+      "description": "Return the authenticated Freshdesk agent's profile.\n\nUse this to verify the configured API key and confirm which Freshdesk account\n(domain) the tools are connected to; it is not a required preamble to the other tools.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "FRESHDESK_API_KEY",
+        "FRESHDESK_DOMAIN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FRESHDESK_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "FRESHDESK_DOMAIN",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The authenticated agent's identity and connected account."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Freshdesk.WhoAmI",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "customer_support"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-06-10T12:11:46.919Z",
+  "summary": "**Freshdesk** is a customer support platform; this toolkit lets LLM agents read and write Freshdesk data — tickets, contacts, companies, agents, groups, and the knowledge base — without a human clicking through the UI.\n\n## Capabilities\n\n- **Ticket lifecycle** — create, read, update, merge, reply publicly, and add private internal notes to tickets; search the queue by status, priority, requester, agent, group, tag, type, or recency.\n- **Contact & company management** — create or update contacts and company accounts; search and retrieve individual records; handle stale or missing IDs gracefully via not-found envelopes rather than hard errors.\n- **Customer context assembly** — retrieve a requester's contact record, company, and full ticket history in a single call (`GetCustomerOverview`) instead of three separate lookups.\n- **Routing support** — list agents (filterable by email) and groups to assign or escalate tickets to the right team.\n- **Knowledge base** — search published solution articles by term and read full article content by ID.\n- **Account verification** — confirm the active API key and connected domain with `WhoAmI`.\n\n## Secrets\n\nThis toolkit requires two secrets configured in Arcade:\n\n- **`FRESHDESK_API_KEY`** — A per-agent or per-account API key that authenticates all requests. Obtain it from your Freshdesk portal: go to **Profile Settings → API Key** (top-right avatar menu). The key is scoped to the permissions of the agent account it belongs to; use an admin account's key if the toolkit needs to manage agents, groups, or perform bulk operations. See [Freshdesk API authentication docs](https://developers.freshdesk.com/api/#authentication) for details.\n\n- **`FRESHDESK_DOMAIN`** — Your Freshdesk subdomain (e.g., `yourcompany` if your helpdesk URL is `https://yourcompany.freshdesk.com`). This is not a credential but must be supplied so the toolkit knows which Freshdesk instance to target. Find it in the address bar when logged into your Freshdesk account.\n\nConfigure both secrets in the Arcade dashboard or via the Arcade secrets API. See the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) and manage secrets at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
+}

--- a/toolkit-docs-generator/data/toolkits/gmail.json
+++ b/toolkit-docs-generator/data/toolkits/gmail.json
@@ -1,7 +1,7 @@
 {
   "id": "Gmail",
   "label": "Gmail",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "description": "Arcade.dev LLM tools for Gmail",
   "metadata": {
     "category": "productivity",
@@ -30,7 +30,7 @@
     {
       "name": "ChangeEmailLabels",
       "qualifiedName": "Gmail.ChangeEmailLabels",
-      "fullyQualifiedName": "Gmail.ChangeEmailLabels@7.0.1",
+      "fullyQualifiedName": "Gmail.ChangeEmailLabels@7.1.0",
       "description": "Add and remove labels from an email using the Gmail API.",
       "parameters": [
         {
@@ -124,7 +124,7 @@
     {
       "name": "CreateLabel",
       "qualifiedName": "Gmail.CreateLabel",
-      "fullyQualifiedName": "Gmail.CreateLabel@7.0.1",
+      "fullyQualifiedName": "Gmail.CreateLabel@7.1.0",
       "description": "Create a new label in the user's mailbox.",
       "parameters": [
         {
@@ -184,7 +184,7 @@
     {
       "name": "DeleteDraftEmail",
       "qualifiedName": "Gmail.DeleteDraftEmail",
-      "fullyQualifiedName": "Gmail.DeleteDraftEmail@7.0.1",
+      "fullyQualifiedName": "Gmail.DeleteDraftEmail@7.1.0",
       "description": "Delete a draft email using the Gmail API.",
       "parameters": [
         {
@@ -244,7 +244,7 @@
     {
       "name": "GetThread",
       "qualifiedName": "Gmail.GetThread",
-      "fullyQualifiedName": "Gmail.GetThread@7.0.1",
+      "fullyQualifiedName": "Gmail.GetThread@7.1.0",
       "description": "Get the specified thread by ID.",
       "parameters": [
         {
@@ -304,7 +304,7 @@
     {
       "name": "ListDraftEmails",
       "qualifiedName": "Gmail.ListDraftEmails",
-      "fullyQualifiedName": "Gmail.ListDraftEmails@7.0.1",
+      "fullyQualifiedName": "Gmail.ListDraftEmails@7.1.0",
       "description": "Lists draft emails in the user's draft mailbox using the Gmail API.",
       "parameters": [
         {
@@ -364,7 +364,7 @@
     {
       "name": "ListEmails",
       "qualifiedName": "Gmail.ListEmails",
-      "fullyQualifiedName": "Gmail.ListEmails@7.0.1",
+      "fullyQualifiedName": "Gmail.ListEmails@7.1.0",
       "description": "Read emails from a Gmail account and extract plain text content.\n\nBy default, obvious automated emails are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all emails regardless of source.",
       "parameters": [
         {
@@ -437,7 +437,7 @@
     {
       "name": "ListEmailsByHeader",
       "qualifiedName": "Gmail.ListEmailsByHeader",
-      "fullyQualifiedName": "Gmail.ListEmailsByHeader@7.0.1",
+      "fullyQualifiedName": "Gmail.ListEmailsByHeader@7.1.0",
       "description": "Search for emails by header using the Gmail API.\n\nBy default, obvious automated emails are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all emails regardless of source.",
       "parameters": [
         {
@@ -596,7 +596,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Gmail.ListLabels",
-      "fullyQualifiedName": "Gmail.ListLabels@7.0.1",
+      "fullyQualifiedName": "Gmail.ListLabels@7.1.0",
       "description": "List all the labels in the user's mailbox.",
       "parameters": [],
       "auth": {
@@ -641,7 +641,7 @@
     {
       "name": "ListThreads",
       "qualifiedName": "Gmail.ListThreads",
-      "fullyQualifiedName": "Gmail.ListThreads@7.0.1",
+      "fullyQualifiedName": "Gmail.ListThreads@7.1.0",
       "description": "List threads in the user's mailbox.\n\nBy default, obvious automated threads are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all threads regardless of source.",
       "parameters": [
         {
@@ -740,8 +740,8 @@
     {
       "name": "ReplyToEmail",
       "qualifiedName": "Gmail.ReplyToEmail",
-      "fullyQualifiedName": "Gmail.ReplyToEmail@7.0.1",
-      "description": "Send a reply to an email message.",
+      "fullyQualifiedName": "Gmail.ReplyToEmail@7.1.0",
+      "description": "Send a reply to an email message, optionally with one or more file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
           "name": "body",
@@ -799,6 +799,15 @@
             "auto"
           ],
           "inferrable": true
+        },
+        {
+          "name": "attachments",
+          "type": "array",
+          "innerType": "json",
+          "required": false,
+          "description": "Files to attach. Give each file's local path as a URI in 'source' (formatted file:///absolute/path/to/file); the file's bytes are read and substituted on the client before the request is sent, so do not put base64 or file contents in 'source' yourself. 'filename' and 'mime_type' are optional and are taken from the file when omitted. Defaults to no attachments.",
+          "enum": null,
+          "inferrable": true
         }
       ],
       "auth": {
@@ -820,12 +829,12 @@
         "toolName": "Gmail.ReplyToEmail",
         "parameters": {
           "body": {
-            "value": "<p>Thank you for reaching out! I will get back to you with more details shortly.</p>",
+            "value": "<p>Thank you for your email! I have reviewed the details and will get back to you with a full response by end of day tomorrow. Please let me know if you need anything in the meantime.</p>",
             "type": "string",
             "required": true
           },
           "reply_to_message_id": {
-            "value": "18e4f2a3b7c91d05",
+            "value": "18e4f2a3b5c6d7e8",
             "type": "string",
             "required": true
           },
@@ -837,7 +846,7 @@
           "cc": {
             "value": [
               "manager@example.com",
-              "team-lead@example.com"
+              "teamlead@example.com"
             ],
             "type": "array",
             "required": false
@@ -852,6 +861,22 @@
           "content_type": {
             "value": "auto",
             "type": "string",
+            "required": false
+          },
+          "attachments": {
+            "value": [
+              {
+                "source": "file:///home/user/documents/project_summary.pdf",
+                "filename": "project_summary.pdf",
+                "mime_type": "application/pdf"
+              },
+              {
+                "source": "file:///home/user/images/diagram.png",
+                "filename": "diagram.png",
+                "mime_type": "image/png"
+              }
+            ],
+            "type": "array",
             "required": false
           }
         },
@@ -880,7 +905,7 @@
     {
       "name": "SearchThreads",
       "qualifiedName": "Gmail.SearchThreads",
-      "fullyQualifiedName": "Gmail.SearchThreads@7.0.1",
+      "fullyQualifiedName": "Gmail.SearchThreads@7.1.0",
       "description": "Search for threads in the user's mailbox.\n\nBy default, obvious automated threads are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all threads regardless of source.",
       "parameters": [
         {
@@ -1069,7 +1094,7 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "Gmail.SendDraftEmail",
-      "fullyQualifiedName": "Gmail.SendDraftEmail@7.0.1",
+      "fullyQualifiedName": "Gmail.SendDraftEmail@7.1.0",
       "description": "Send a draft email using the Gmail API.",
       "parameters": [
         {
@@ -1129,8 +1154,8 @@
     {
       "name": "SendEmail",
       "qualifiedName": "Gmail.SendEmail",
-      "fullyQualifiedName": "Gmail.SendEmail@7.0.1",
-      "description": "Send an email using the Gmail API.",
+      "fullyQualifiedName": "Gmail.SendEmail@7.1.0",
+      "description": "Send an email using the Gmail API, optionally with one or more file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
           "name": "subject",
@@ -1185,6 +1210,15 @@
             "auto"
           ],
           "inferrable": true
+        },
+        {
+          "name": "attachments",
+          "type": "array",
+          "innerType": "json",
+          "required": false,
+          "description": "Files to attach. Give each file's local path as a URI in 'source' (formatted file:///absolute/path/to/file); the file's bytes are read and substituted on the client before the request is sent, so do not put base64 or file contents in 'source' yourself. 'filename' and 'mime_type' are optional and are taken from the file when omitted. Defaults to no attachments.",
+          "enum": null,
+          "inferrable": true
         }
       ],
       "auth": {
@@ -1205,12 +1239,12 @@
         "toolName": "Gmail.SendEmail",
         "parameters": {
           "subject": {
-            "value": "Meeting Reminder: Project Kickoff Tomorrow at 10 AM",
+            "value": "Project Update: Q3 Milestone Review",
             "type": "string",
             "required": true
           },
           "body": {
-            "value": "<p>Hi Jane,</p><p>Just a friendly reminder that our project kickoff meeting is scheduled for <strong>tomorrow at 10:00 AM</strong> in Conference Room B.</p><p>Please bring your project outlines and any questions you may have.</p><p>Best regards,<br>John</p>",
+            "value": "<p>Hi Team,</p><p>Please find the latest project update attached. Let me know if you have any questions.</p><p>Best regards,<br>Alex</p>",
             "type": "string",
             "required": true
           },
@@ -1235,8 +1269,24 @@
             "required": false
           },
           "content_type": {
-            "value": "html",
+            "value": "auto",
             "type": "string",
+            "required": false
+          },
+          "attachments": {
+            "value": [
+              {
+                "source": "file:///home/alex/documents/q3_milestone_report.pdf",
+                "filename": "Q3_Milestone_Report.pdf",
+                "mime_type": "application/pdf"
+              },
+              {
+                "source": "file:///home/alex/documents/project_timeline.xlsx",
+                "filename": "Project_Timeline.xlsx",
+                "mime_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+              }
+            ],
+            "type": "array",
             "required": false
           }
         },
@@ -1265,7 +1315,7 @@
     {
       "name": "TrashEmail",
       "qualifiedName": "Gmail.TrashEmail",
-      "fullyQualifiedName": "Gmail.TrashEmail@7.0.1",
+      "fullyQualifiedName": "Gmail.TrashEmail@7.1.0",
       "description": "Move an email to the trash folder using the Gmail API.",
       "parameters": [
         {
@@ -1325,7 +1375,7 @@
     {
       "name": "UpdateDraftEmail",
       "qualifiedName": "Gmail.UpdateDraftEmail",
-      "fullyQualifiedName": "Gmail.UpdateDraftEmail@7.0.1",
+      "fullyQualifiedName": "Gmail.UpdateDraftEmail@7.1.0",
       "description": "Update an existing email draft using the Gmail API.\n\nSingle-part ``text/plain`` and single-part ``text/html`` drafts both support full\nbody replacement; the rebuild follows the existing draft's content type, so a\nplain draft stays plain and an HTML draft stays HTML. Plain-text input supplied\nagainst an HTML draft is auto-converted to HTML, and HTML input supplied against\na plain draft is stored verbatim as ``text/plain``. Reply drafts preserve their\nreply-quote tail (``> `` lines for plain, ``<blockquote>`` for HTML) when the\nbody is supplied as a top-only update.\n\nMultipart drafts and drafts with attachments still fail when the body changes;\nin those cases the tool succeeds only when the effective body is unchanged\n(metadata-only update preserving the existing MIME tree). Edit those drafts in\nGmail directly.\n\nFor each of subject, body, recipient, cc, and bcc, omitting the parameter or passing\n``None`` leaves that part of the draft unchanged (for cc/bcc, existing headers are kept;\npass an empty list to clear).",
       "parameters": [
         {
@@ -1457,7 +1507,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Gmail.WhoAmI",
-      "fullyQualifiedName": "Gmail.WhoAmI@7.0.1",
+      "fullyQualifiedName": "Gmail.WhoAmI@7.1.0",
       "description": "Get comprehensive user profile and Gmail account information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Gmail account statistics, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1504,8 +1554,8 @@
     {
       "name": "WriteDraftEmail",
       "qualifiedName": "Gmail.WriteDraftEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftEmail@7.0.1",
-      "description": "Compose a new email draft using the Gmail API.",
+      "fullyQualifiedName": "Gmail.WriteDraftEmail@7.1.0",
+      "description": "Compose a new email draft using the Gmail API, optionally with file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
           "name": "subject",
@@ -1560,6 +1610,15 @@
             "auto"
           ],
           "inferrable": true
+        },
+        {
+          "name": "attachments",
+          "type": "array",
+          "innerType": "json",
+          "required": false,
+          "description": "Files to attach. Give each file's local path as a URI in 'source' (formatted file:///absolute/path/to/file); the file's bytes are read and substituted on the client before the request is sent, so do not put base64 or file contents in 'source' yourself. 'filename' and 'mime_type' are optional and are taken from the file when omitted. Defaults to no attachments.",
+          "enum": null,
+          "inferrable": true
         }
       ],
       "auth": {
@@ -1580,12 +1639,12 @@
         "toolName": "Gmail.WriteDraftEmail",
         "parameters": {
           "subject": {
-            "value": "Project Update: Q3 Milestones Review",
+            "value": "Project Update: Q3 Milestone Review",
             "type": "string",
             "required": true
           },
           "body": {
-            "value": "<p>Hi Sarah,</p><p>I wanted to follow up on our discussion from last week regarding the Q3 milestones. Please find the summary below:</p><ul><li>Feature A: Completed</li><li>Feature B: In Progress</li><li>Feature C: Pending Review</li></ul><p>Let me know if you have any questions.</p><p>Best regards,<br>John</p>",
+            "value": "<p>Hi Sarah,</p><p>Just wanted to share the latest updates on our Q3 milestones. Please find the attached report for your review.</p><p>Let me know if you have any questions!</p><p>Best,<br>Alex</p>",
             "type": "string",
             "required": true
           },
@@ -1597,7 +1656,7 @@
           "cc": {
             "value": [
               "manager@example.com",
-              "teamlead@example.com"
+              "team-lead@example.com"
             ],
             "type": "array",
             "required": false
@@ -1610,8 +1669,24 @@
             "required": false
           },
           "content_type": {
-            "value": "html",
+            "value": "auto",
             "type": "string",
+            "required": false
+          },
+          "attachments": {
+            "value": [
+              {
+                "source": "file:///home/alex/documents/q3_milestone_report.pdf",
+                "filename": "Q3_Milestone_Report.pdf",
+                "mime_type": "application/pdf"
+              },
+              {
+                "source": "file:///home/alex/documents/budget_summary.xlsx",
+                "filename": "Budget_Summary.xlsx",
+                "mime_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+              }
+            ],
+            "type": "array",
             "required": false
           }
         },
@@ -1640,8 +1715,8 @@
     {
       "name": "WriteDraftReplyEmail",
       "qualifiedName": "Gmail.WriteDraftReplyEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@7.0.1",
-      "description": "Compose a draft reply to an email message.",
+      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@7.1.0",
+      "description": "Compose a draft reply to an email message, optionally with one or more file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
           "name": "body",
@@ -1699,6 +1774,15 @@
             "auto"
           ],
           "inferrable": true
+        },
+        {
+          "name": "attachments",
+          "type": "array",
+          "innerType": "json",
+          "required": false,
+          "description": "Files to attach. Give each file's local path as a URI in 'source' (formatted file:///absolute/path/to/file); the file's bytes are read and substituted on the client before the request is sent, so do not put base64 or file contents in 'source' yourself. 'filename' and 'mime_type' are optional and are taken from the file when omitted. Defaults to no attachments.",
+          "enum": null,
+          "inferrable": true
         }
       ],
       "auth": {
@@ -1720,12 +1804,12 @@
         "toolName": "Gmail.WriteDraftReplyEmail",
         "parameters": {
           "body": {
-            "value": "<p>Thank you for reaching out! I have reviewed your message and I am happy to confirm that we can proceed with the proposed timeline. Please let me know if you need any additional information.</p>",
+            "value": "<p>Thank you for your email. I have reviewed the details and will get back to you with a full response by end of day tomorrow. Please let me know if you have any urgent questions in the meantime.</p>",
             "type": "string",
             "required": true
           },
           "reply_to_message_id": {
-            "value": "18e4f2a3b1c9d705",
+            "value": "18f3a2c7d45e6b89",
             "type": "string",
             "required": true
           },
@@ -1752,6 +1836,22 @@
           "content_type": {
             "value": "auto",
             "type": "string",
+            "required": false
+          },
+          "attachments": {
+            "value": [
+              {
+                "source": "file:///home/user/documents/project_proposal.pdf",
+                "filename": "project_proposal.pdf",
+                "mime_type": "application/pdf"
+              },
+              {
+                "source": "file:///home/user/images/screenshot.png",
+                "filename": "screenshot.png",
+                "mime_type": "image/png"
+              }
+            ],
+            "type": "array",
             "required": false
           }
         },
@@ -1791,6 +1891,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-06-05T12:07:56.912Z",
-  "summary": "The Gmail toolkit provides Arcade LLM tools for interacting with Gmail via the Gmail API. It enables agents and applications to read, compose, send, organize, and manage email on behalf of authenticated Google users.\n\n## Capabilities\n\n- **Reading & searching**: List emails, threads, and drafts with built-in filtering that excludes automated/promotional mail by default (`exclude_automated=False` to override); search threads by query or by header value; retrieve full threads by ID.\n- **Composing & sending**: Write new draft emails or draft replies, send emails directly, reply to existing messages, and send or delete existing drafts.\n- **Draft management**: Update existing drafts (supports plain-text and HTML single-part bodies with smart content-type handling and reply-quote preservation; metadata-only updates for multipart/attachment drafts); delete drafts.\n- **Labels & organization**: List, create, and apply/remove labels on emails; move emails to trash.\n- **Account info**: Retrieve the authenticated user's profile, email address, profile picture, and Gmail account statistics via `WhoAmI`.\n\n## OAuth\n\nAuthentication uses OAuth 2.0 via the **Google** provider. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for configuration details."
+  "generatedAt": "2026-06-10T12:11:53.002Z",
+  "summary": "The Gmail toolkit provides Arcade LLM tools for interacting with a user's Gmail account via the Gmail API. It enables reading, composing, sending, organizing, and searching email — covering the full message and draft lifecycle.\n\n## Capabilities\n\n- **Reading & searching:** List emails, threads, and drafts with built-in automated-email filtering (no-reply senders, non-primary categories); search threads by query or header; retrieve full threads by ID; toggle automated filtering with `exclude_automated=False`.\n- **Composing & sending:** Send emails directly or via draft, reply to messages (including draft replies), with support for file attachments supplied as `file://` URIs — file bytes are read client-side and never pass through the conversation.\n- **Draft management:** Create, update, list, send, and delete drafts; update supports subject, body, recipients, cc, and bcc with partial updates (omit fields to preserve them); body replacement handles plain-text and single-part HTML drafts with auto-conversion; multipart/attachment drafts support metadata-only updates.\n- **Label management:** List, create, and apply/remove labels on messages.\n- **Account info:** Retrieve the authenticated user's profile, email address, Gmail statistics, and profile picture via `WhoAmI`.\n- **Trash:** Move messages to trash.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via Google. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details."
 }

--- a/toolkit-docs-generator/data/toolkits/googleflights.json
+++ b/toolkit-docs-generator/data/toolkits/googleflights.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleFlights",
   "label": "Google Flights",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "Arcade.dev LLM tools for getting flights via Google Flights",
   "metadata": {
     "category": "search",
@@ -18,7 +18,7 @@
     {
       "name": "GetFlightBookingOptions",
       "qualifiedName": "GoogleFlights.GetFlightBookingOptions",
-      "fullyQualifiedName": "GoogleFlights.GetFlightBookingOptions@4.0.4",
+      "fullyQualifiedName": "GoogleFlights.GetFlightBookingOptions@4.1.0",
       "description": "Resolve a ``booking_token`` to the airlines and OTAs selling that itinerary.\n\nPass a ``booking_token`` returned by ``search_flights`` or\n``search_multi_city_flights`` to get the vendors selling that\nspecific flight. The token encodes the route, dates, cabin class,\nand passenger counts (every segment for multi-city), so there are\nno ``travel_class``, ``num_adults``, or ``num_children`` parameters;\nsupplying a cabin or party size would silently disagree with the\nitinerary the token was issued for.\n\nLeave ``include_booking_post_data`` off (the default) when an LLM\nis comparing prices; turn it on only when a backend needs to\nrebuild the vendor hand-off, since the POST body is multiple\nkilobytes per option.",
       "parameters": [
         {
@@ -130,7 +130,7 @@
     {
       "name": "LookupAirports",
       "qualifiedName": "GoogleFlights.LookupAirports",
-      "fullyQualifiedName": "GoogleFlights.LookupAirports@4.0.4",
+      "fullyQualifiedName": "GoogleFlights.LookupAirports@4.1.0",
       "description": "Find IATA airport codes for a city, country, or airport name.\n\nMetropolitan codes (NYC, LON, TYO, PAR, ...) are accepted as a\n``departure_airport_code`` or ``arrival_airport_code`` in flight\nsearches and mean \"any airport in this city\".",
       "parameters": [
         {
@@ -209,8 +209,8 @@
     {
       "name": "SearchFlights",
       "qualifiedName": "GoogleFlights.SearchFlights",
-      "fullyQualifiedName": "GoogleFlights.SearchFlights@4.0.4",
-      "description": "Search Google Flights for one-way or round-trip itineraries.\n\nFor a trip where the traveler returns to their origin, issue a\nsingle call with both ``outbound_date`` and ``return_date`` set.\nDo NOT issue two separate one-way searches in opposite directions\nand sum the prices: airlines price round-trip fares independently\nfrom one-way fares, so the sum of two cheapest one-ways is rarely\nequal to the cheapest round-trip and is typically more expensive.",
+      "fullyQualifiedName": "GoogleFlights.SearchFlights@4.1.0",
+      "description": "Search Google Flights for one-way or round-trip itineraries.\n\nFor a trip where the traveler returns to their origin, issue a\nsingle call with both ``outbound_date`` and ``return_date`` set.\nDo NOT issue two separate one-way searches in opposite directions\nand sum the prices: airlines price round-trip fares independently\nfrom one-way fares, so the sum of two cheapest one-ways is rarely\nequal to the cheapest round-trip and is typically more expensive.\n\nEach returned itinerary carries a ``google_flights_url`` that opens\nthat specific pre-selected flight on Google Flights, so you can hand\nthe user a booking link straight from these results without a\nseparate booking-options lookup.",
       "parameters": [
         {
           "name": "departure_airport_code",
@@ -588,8 +588,8 @@
     {
       "name": "SearchMultiCityFlights",
       "qualifiedName": "GoogleFlights.SearchMultiCityFlights",
-      "fullyQualifiedName": "GoogleFlights.SearchMultiCityFlights@4.0.4",
-      "description": "Search Google Flights for a multi-city (open-jaw) itinerary.\n\nUse this for trips that are neither a simple one-way nor a round-trip\n(e.g. an open-jaw three-leg trip that ends back at the origin).\nThe open-jaw bundle is typically cheaper than the equivalent set\nof one-way searches summed; never substitute multiple\n``search_flights`` calls for a single multi-city query.",
+      "fullyQualifiedName": "GoogleFlights.SearchMultiCityFlights@4.1.0",
+      "description": "Search Google Flights for a multi-city (open-jaw) itinerary.\n\nUse this for trips that are neither a simple one-way nor a round-trip\n(e.g. an open-jaw three-leg trip that ends back at the origin).\nThe open-jaw bundle is typically cheaper than the equivalent set\nof one-way searches summed; never substitute multiple\n``search_flights`` calls for a single multi-city query.\n\nEach returned itinerary carries a ``google_flights_url`` that opens\nthat specific pre-selected itinerary on Google Flights, so you can\nhand the user a booking link straight from these results without a\nseparate booking-options lookup.",
       "parameters": [
         {
           "name": "segments",
@@ -829,6 +829,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-06-05T12:08:01.562Z",
-  "summary": "The Google Flights toolkit lets LLMs search and resolve flight itineraries via the SerpApi Google Flights endpoint. It covers airport lookup, one-way/round-trip search, multi-city search, and booking option resolution.\n\n## Capabilities\n\n- **Airport discovery** — resolve city names, country names, or airport names to IATA codes (including metropolitan codes like NYC or LON) for use in flight searches.\n- **One-way & round-trip search** — query Google Flights for itineraries with flexible cabin class, passenger counts, and date options; round-trips are fetched in a single call to reflect true bundled pricing.\n- **Multi-city / open-jaw search** — book complex multi-leg itineraries in one query, which typically prices cheaper than summing equivalent one-way fares.\n- **Booking option resolution** — convert a `booking_token` from a search result into the full list of airlines and OTAs selling that specific itinerary, with optional POST data for backend vendor hand-offs.\n\n## Secrets\n\n- **`SERP_API_KEY`** — An API key issued by [SerpApi](https://serpapi.com), the service that powers the underlying Google Flights data. To obtain one: create an account at [https://serpapi.com/users/sign_up](https://serpapi.com/users/sign_up), then retrieve your private API key from the [SerpApi dashboard](https://serpapi.com/manage-api-key). The key must have access to the Google Flights engine; free-tier accounts include a limited monthly search quota, while paid plans unlock higher volume. Pass this key as the `SERP_API_KEY` secret in your Arcade configuration.\n\nSee the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to store secrets, or manage them directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
+  "generatedAt": "2026-06-10T12:11:51.763Z",
+  "summary": "**Google Flights toolkit** integrates Google Flights data into LLM workflows via SerpApi, enabling agents to search flights, resolve booking options, and look up airport codes.\n\n## Capabilities\n\n- **Airport lookup** — Resolve city names, country names, or airport names to IATA codes (including metropolitan codes like NYC, LON) for use in flight searches.\n- **One-way & round-trip search** — Query Google Flights for one-way or round-trip itineraries in a single call; results include direct `google_flights_url` booking links per itinerary.\n- **Multi-city / open-jaw search** — Search bundled multi-leg itineraries that are priced independently (and typically cheaper) than equivalent summed one-ways.\n- **Booking option resolution** — Convert a `booking_token` from any search result into the full list of airlines and OTAs selling that specific itinerary, with optional POST data for backend vendor hand-off.\n\n## Secrets\n\n`SERP_API_KEY` — API key issued by [SerpApi](https://serpapi.com), the underlying service that fetches Google Flights data. To obtain it:\n1. Create or log in to an account at [serpapi.com](https://serpapi.com).\n2. Navigate to your [API Key page](https://serpapi.com/manage-api-key) in the SerpApi dashboard.\n3. Copy the key shown there. Free-tier accounts have a monthly search quota; paid plans unlock higher limits.\n\nStore the key as an Arcade secret. See the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for configuration details, or manage secrets directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/googlesheets.json
+++ b/toolkit-docs-generator/data/toolkits/googlesheets.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleSheets",
   "label": "Google Sheets",
-  "version": "6.0.1",
+  "version": "8.0.0",
   "description": "Arcade.dev LLM tools for Google Sheets.",
   "metadata": {
     "category": "productivity",
@@ -24,56 +24,33 @@
   },
   "tools": [
     {
-      "name": "AddNoteToCell",
-      "qualifiedName": "GoogleSheets.AddNoteToCell",
-      "fullyQualifiedName": "GoogleSheets.AddNoteToCell@6.0.1",
-      "description": "Add a note to a specific cell in a spreadsheet. A note is a small\npiece of text attached to a cell (shown with a black triangle) that\nappears when you hover over the cell.\n\nsheet_id_or_name takes precedence over sheet_position. If a sheet is not mentioned,\nthen always assume the default sheet_position is sufficient.",
+      "name": "CreateOrEditSpreadsheet",
+      "qualifiedName": "GoogleSheets.CreateOrEditSpreadsheet",
+      "fullyQualifiedName": "GoogleSheets.CreateOrEditSpreadsheet@8.0.0",
+      "description": "Create a new spreadsheet or batch-edit an existing one.\n\nOmit `spreadsheet_id` to create; provide it to edit. All writes flow through\n`requests[]` — typed operations like updateCells, addSheet, sortRange,\naddConditionalFormatRule, autoResizeDimensions, and more.\n\nFor updateCells use ExtendedValue with an explicit type field (stringValue,\nnumberValue, boolValue, formulaValue).\n\nBy default, build clean, professional-looking tables with restrained, consistent\nformatting and plain-text tab names/headers (no emojis); only use emojis or\ndecorative styling when the user explicitly asks for it.",
       "parameters": [
+        {
+          "name": "requests",
+          "type": "array",
+          "innerType": "json",
+          "required": false,
+          "description": "A list of Google Sheets `spreadsheets.batchUpdate` request objects. Each object must have exactly one key naming the operation. Examples:\n\nFIELDS MASK: updateCells, repeatCell, updateSheetProperties, and updateDimensionProperties take a `fields` mask listing which sub-fields to write — anything you set but don't name is silently ignored. You can OMIT `fields` and the tool auto-derives it from the data you provide (recommended). Pass an explicit `fields` only for surgical edits, or `fields: \"*\"` to overwrite every sub-field (clearing ones you didn't provide).\n\nupdateCells — write typed values and formatting to a range. Use `range` OR `start` to anchor the write. Values must be wrapped in `userEnteredValue` with an explicit type field (stringValue, numberValue, boolValue, formulaValue). `fields` is auto-derived when omitted:\n{\"updateCells\": {\"range\": {\"sheetId\": 0, \"startRowIndex\": 0, \"endRowIndex\": 1, \"startColumnIndex\": 0, \"endColumnIndex\": 3}, \"rows\": [{\"values\": [{\"userEnteredValue\": {\"stringValue\": \"Name\"}, \"userEnteredFormat\": {\"textFormat\": {\"bold\": true}}}, {\"userEnteredValue\": {\"numberValue\": 42}}, {\"userEnteredValue\": {\"formulaValue\": \"=SUM(B1:B10)\"}}]}], \"fields\": \"userEnteredValue,userEnteredFormat.textFormat.bold\"}}\n\nrepeatCell — apply one CellData to every cell in a range. Good for painting formatting, notes, or validation without enumerating rows:\n{\"repeatCell\": {\"range\": {\"sheetId\": 0, \"startRowIndex\": 1, \"endRowIndex\": 100}, \"cell\": {\"userEnteredFormat\": {\"backgroundColorStyle\": {\"rgbColor\": {\"red\": 0.95, \"green\": 0.95, \"blue\": 0.95}}}}, \"fields\": \"userEnteredFormat.backgroundColorStyle\"}}\n\nupdateBorders — set per-edge borders. Each side takes a Border with a style (SOLID, DASHED, DOTTED, NONE, SOLID_MEDIUM, SOLID_THICK, DOUBLE):\n{\"updateBorders\": {\"range\": {\"sheetId\": 0, \"startRowIndex\": 0, \"endRowIndex\": 3, \"startColumnIndex\": 0, \"endColumnIndex\": 3}, \"top\": {\"style\": \"SOLID_THICK\"}, \"bottom\": {\"style\": \"SOLID_THICK\"}, \"left\": {\"style\": \"SOLID\"}, \"right\": {\"style\": \"SOLID\"}, \"innerHorizontal\": {\"style\": \"DASHED\"}, \"innerVertical\": {\"style\": \"DASHED\"}}}\n\naddSheet — create a new tab. Omit sheetId to let Google assign one; read the new ID from created_resources in the reply:\n{\"addSheet\": {\"properties\": {\"title\": \"Q2\", \"index\": 1, \"gridProperties\": {\"rowCount\": 200, \"columnCount\": 26, \"frozenRowCount\": 1}}}}\n\ndeleteSheet — remove a tab permanently by sheetId:\n{\"deleteSheet\": {\"sheetId\": 1234567890}}\n\nduplicateSheet — clone a tab. newSheetId is auto-assigned when omitted:\n{\"duplicateSheet\": {\"sourceSheetId\": 0, \"insertSheetIndex\": 1, \"newSheetName\": \"Copy of Q1\"}}\n\nupdateSheetProperties — rename, reorder, freeze rows/columns, or recolor a tab. fields is rooted at properties:\n{\"updateSheetProperties\": {\"properties\": {\"sheetId\": 0, \"gridProperties\": {\"frozenRowCount\": 1}}, \"fields\": \"gridProperties.frozenRowCount\"}}\n\nupdateSpreadsheetProperties — rename the whole spreadsheet (file) or change workbook-level properties. Use this (not updateSheetProperties) to change the spreadsheet title:\n{\"updateSpreadsheetProperties\": {\"properties\": {\"title\": \"Q3 Report\"}, \"fields\": \"title\"}}\n\ninsertDimension — add rows or columns. Both startIndex and endIndex are REQUIRED:\n{\"insertDimension\": {\"range\": {\"sheetId\": 0, \"dimension\": \"ROWS\", \"startIndex\": 2, \"endIndex\": 4}, \"inheritFromBefore\": true}}\n\ndeleteDimension — remove rows or columns. Apply largest-index first within a batch to avoid index shift:\n{\"deleteDimension\": {\"range\": {\"sheetId\": 0, \"dimension\": \"COLUMNS\", \"startIndex\": 5, \"endIndex\": 8}}}\n\nmergeCells — mergeType is MERGE_ALL, MERGE_COLUMNS, or MERGE_ROWS:\n{\"mergeCells\": {\"range\": {\"sheetId\": 0, \"startRowIndex\": 0, \"endRowIndex\": 1, \"startColumnIndex\": 0, \"endColumnIndex\": 5}, \"mergeType\": \"MERGE_ALL\"}}\n\nunmergeCells — range must not partially span an existing merge:\n{\"unmergeCells\": {\"range\": {\"sheetId\": 0, \"startRowIndex\": 0, \"endRowIndex\": 1, \"startColumnIndex\": 0, \"endColumnIndex\": 5}}}\n\nfindReplace — scope with ONE of range, sheetId, or allSheets:\n{\"findReplace\": {\"find\": \"TBD\", \"replacement\": \"N/A\", \"matchCase\": false, \"matchEntireCell\": true, \"allSheets\": true}}\n\naddNamedRange — create a workbook-scoped named range. Server assigns namedRangeId:\n{\"addNamedRange\": {\"namedRange\": {\"name\": \"revenue\", \"range\": {\"sheetId\": 0, \"startRowIndex\": 1, \"endRowIndex\": 1000, \"startColumnIndex\": 1, \"endColumnIndex\": 2}}}}\n\naddProtectedRange — lock a range. warningOnly=true gives soft protection:\n{\"addProtectedRange\": {\"protectedRange\": {\"range\": {\"sheetId\": 0, \"startRowIndex\": 0, \"endRowIndex\": 1}, \"description\": \"Do not edit headers\", \"warningOnly\": true}}}\n\nsetDataValidation — attach a validation rule to a range. Omit rule to clear:\n{\"setDataValidation\": {\"range\": {\"sheetId\": 0, \"startRowIndex\": 1, \"endRowIndex\": 100, \"startColumnIndex\": 2, \"endColumnIndex\": 3}, \"rule\": {\"condition\": {\"type\": \"ONE_OF_LIST\", \"values\": [{\"userEnteredValue\": \"PENDING\"}, {\"userEnteredValue\": \"DONE\"}]}, \"strict\": true, \"showCustomUi\": true}}}\n\naddConditionalFormatRule — insert a conditional-format rule at given index. Use booleanRule for categorical formatting:\n{\"addConditionalFormatRule\": {\"index\": 0, \"rule\": {\"ranges\": [{\"sheetId\": 0, \"startRowIndex\": 1, \"endRowIndex\": 100}], \"booleanRule\": {\"condition\": {\"type\": \"NUMBER_LESS\", \"values\": [{\"userEnteredValue\": \"0\"}]}, \"format\": {\"backgroundColorStyle\": {\"rgbColor\": {\"red\": 1.0, \"green\": 0.9, \"blue\": 0.9}}}}}}}\n\naddChart — embed a chart. Server assigns chartId in the reply:\n{\"addChart\": {\"chart\": {\"spec\": {\"title\": \"Revenue by quarter\", \"basicChart\": {\"chartType\": \"COLUMN\", \"domains\": [{\"domain\": {\"sourceRange\": {\"sources\": [{\"sheetId\": 0, \"startRowIndex\": 0, \"endRowIndex\": 5, \"startColumnIndex\": 0, \"endColumnIndex\": 1}]}}}], \"series\": [{\"series\": {\"sourceRange\": {\"sources\": [{\"sheetId\": 0, \"startRowIndex\": 0, \"endRowIndex\": 5, \"startColumnIndex\": 1, \"endColumnIndex\": 2}]}}}]}}, \"position\": {\"newSheet\": true}}}}\n\nsortRange — sort rows in a range by one or more columns. sortSpecs is ordered by priority (first = primary sort key). sortOrder is ASCENDING or DESCENDING:\n{\"sortRange\": {\"range\": {\"sheetId\": 0, \"startRowIndex\": 1, \"endRowIndex\": 100, \"startColumnIndex\": 0, \"endColumnIndex\": 5}, \"sortSpecs\": [{\"dimensionIndex\": 0, \"sortOrder\": \"ASCENDING\"}, {\"dimensionIndex\": 2, \"sortOrder\": \"DESCENDING\"}]}}\n\nautoResizeDimensions — resize columns or rows to fit their content. dimension is COLUMNS or ROWS:\n{\"autoResizeDimensions\": {\"dimensions\": {\"sheetId\": 0, \"dimension\": \"COLUMNS\", \"startIndex\": 0, \"endIndex\": 3}}}\nNOTE: the tool automatically runs all autoResizeDimensions requests in a second batchUpdate call after all other requests have been applied. This ensures the resize measures post-write cell contents, including spilling formulas (ARRAYFORMULA, SEQUENCE, MAKEARRAY, QUERY) whose spill values only exist after the first call returns. If the resize call fails (e.g. transient error), writes are unaffected and a warning is returned instead of an error. updateDimensionProperties (pixelSize) sets an explicit pixel width and does not need this treatment — it can stay in the same batch as writes.\n\nupdateDimensionProperties — set explicit pixel size or hide a row/column. fields is a mask rooted at DimensionProperties:\n{\"updateDimensionProperties\": {\"range\": {\"sheetId\": 0, \"dimension\": \"COLUMNS\", \"startIndex\": 1, \"endIndex\": 2}, \"properties\": {\"pixelSize\": 200}, \"fields\": \"pixelSize\"}}\n",
+          "enum": null,
+          "inferrable": true
+        },
         {
           "name": "spreadsheet_id",
           "type": "string",
-          "required": true,
-          "description": "The id of the spreadsheet to add a comment to",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "column",
-          "type": "string",
-          "required": true,
-          "description": "The column string to add a note to. For example, 'A', 'F', or 'AZ'",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "row",
-          "type": "integer",
-          "required": true,
-          "description": "The row number to add a note to",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "note_text",
-          "type": "string",
-          "required": true,
-          "description": "The text for the note to add",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "sheet_position",
-          "type": "integer",
           "required": false,
-          "description": "The position/tab of the sheet in the spreadsheet to write to. A value of 1 represents the first (leftmost/Sheet1) sheet. Defaults to 1.",
+          "description": "ID of an existing spreadsheet to edit. Omit to create a new spreadsheet.",
           "enum": null,
           "inferrable": true
         },
         {
-          "name": "sheet_id_or_name",
+          "name": "title",
           "type": "string",
           "required": false,
-          "description": "The id or name of the sheet to write to. If provided, takes precedence over sheet_position.",
+          "description": "Title for a newly created spreadsheet. Ignored when spreadsheet_id is provided. Defaults to 'Untitled spreadsheet'.",
           "enum": null,
           "inferrable": true
         }
@@ -91,117 +68,384 @@
       "secretsInfo": [
         {
           "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
-          "type": "api_key"
+          "type": "token"
         }
       ],
       "output": {
         "type": "json",
-        "description": "The status of the operation"
+        "description": "Spreadsheet state after the operation."
       },
       "documentationChunks": [],
       "codeExample": {
-        "toolName": "GoogleSheets.AddNoteToCell",
+        "toolName": "GoogleSheets.CreateOrEditSpreadsheet",
         "parameters": {
+          "requests": {
+            "value": [
+              {
+                "updateSpreadsheetProperties": {
+                  "properties": {
+                    "title": "Q3 Sales Report 2024"
+                  },
+                  "fields": "title"
+                }
+              },
+              {
+                "addSheet": {
+                  "properties": {
+                    "title": "Summary",
+                    "index": 0,
+                    "gridProperties": {
+                      "rowCount": 500,
+                      "columnCount": 10,
+                      "frozenRowCount": 1
+                    }
+                  }
+                }
+              },
+              {
+                "updateCells": {
+                  "range": {
+                    "sheetId": 0,
+                    "startRowIndex": 0,
+                    "endRowIndex": 1,
+                    "startColumnIndex": 0,
+                    "endColumnIndex": 4
+                  },
+                  "rows": [
+                    {
+                      "values": [
+                        {
+                          "userEnteredValue": {
+                            "stringValue": "Product"
+                          },
+                          "userEnteredFormat": {
+                            "textFormat": {
+                              "bold": true
+                            }
+                          }
+                        },
+                        {
+                          "userEnteredValue": {
+                            "stringValue": "Units Sold"
+                          },
+                          "userEnteredFormat": {
+                            "textFormat": {
+                              "bold": true
+                            }
+                          }
+                        },
+                        {
+                          "userEnteredValue": {
+                            "stringValue": "Unit Price"
+                          },
+                          "userEnteredFormat": {
+                            "textFormat": {
+                              "bold": true
+                            }
+                          }
+                        },
+                        {
+                          "userEnteredValue": {
+                            "stringValue": "Total Revenue"
+                          },
+                          "userEnteredFormat": {
+                            "textFormat": {
+                              "bold": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "fields": "userEnteredValue,userEnteredFormat.textFormat.bold"
+                }
+              },
+              {
+                "updateCells": {
+                  "range": {
+                    "sheetId": 0,
+                    "startRowIndex": 1,
+                    "endRowIndex": 4,
+                    "startColumnIndex": 0,
+                    "endColumnIndex": 4
+                  },
+                  "rows": [
+                    {
+                      "values": [
+                        {
+                          "userEnteredValue": {
+                            "stringValue": "Widget A"
+                          }
+                        },
+                        {
+                          "userEnteredValue": {
+                            "numberValue": 320
+                          }
+                        },
+                        {
+                          "userEnteredValue": {
+                            "numberValue": 29.99
+                          }
+                        },
+                        {
+                          "userEnteredValue": {
+                            "formulaValue": "=B2*C2"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "values": [
+                        {
+                          "userEnteredValue": {
+                            "stringValue": "Widget B"
+                          }
+                        },
+                        {
+                          "userEnteredValue": {
+                            "numberValue": 145
+                          }
+                        },
+                        {
+                          "userEnteredValue": {
+                            "numberValue": 49.99
+                          }
+                        },
+                        {
+                          "userEnteredValue": {
+                            "formulaValue": "=B3*C3"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "values": [
+                        {
+                          "userEnteredValue": {
+                            "stringValue": "Widget C"
+                          }
+                        },
+                        {
+                          "userEnteredValue": {
+                            "numberValue": 210
+                          }
+                        },
+                        {
+                          "userEnteredValue": {
+                            "numberValue": 19.99
+                          }
+                        },
+                        {
+                          "userEnteredValue": {
+                            "formulaValue": "=B4*C4"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "repeatCell": {
+                  "range": {
+                    "sheetId": 0,
+                    "startRowIndex": 1,
+                    "endRowIndex": 100
+                  },
+                  "cell": {
+                    "userEnteredFormat": {
+                      "backgroundColorStyle": {
+                        "rgbColor": {
+                          "red": 0.95,
+                          "green": 0.95,
+                          "blue": 0.95
+                        }
+                      }
+                    }
+                  },
+                  "fields": "userEnteredFormat.backgroundColorStyle"
+                }
+              },
+              {
+                "updateBorders": {
+                  "range": {
+                    "sheetId": 0,
+                    "startRowIndex": 0,
+                    "endRowIndex": 4,
+                    "startColumnIndex": 0,
+                    "endColumnIndex": 4
+                  },
+                  "top": {
+                    "style": "SOLID_THICK"
+                  },
+                  "bottom": {
+                    "style": "SOLID_THICK"
+                  },
+                  "left": {
+                    "style": "SOLID"
+                  },
+                  "right": {
+                    "style": "SOLID"
+                  },
+                  "innerHorizontal": {
+                    "style": "DASHED"
+                  },
+                  "innerVertical": {
+                    "style": "DASHED"
+                  }
+                }
+              },
+              {
+                "setDataValidation": {
+                  "range": {
+                    "sheetId": 0,
+                    "startRowIndex": 1,
+                    "endRowIndex": 100,
+                    "startColumnIndex": 4,
+                    "endColumnIndex": 5
+                  },
+                  "rule": {
+                    "condition": {
+                      "type": "ONE_OF_LIST",
+                      "values": [
+                        {
+                          "userEnteredValue": "PENDING"
+                        },
+                        {
+                          "userEnteredValue": "SHIPPED"
+                        },
+                        {
+                          "userEnteredValue": "DELIVERED"
+                        }
+                      ]
+                    },
+                    "strict": true,
+                    "showCustomUi": true
+                  }
+                }
+              },
+              {
+                "addConditionalFormatRule": {
+                  "index": 0,
+                  "rule": {
+                    "ranges": [
+                      {
+                        "sheetId": 0,
+                        "startRowIndex": 1,
+                        "endRowIndex": 100,
+                        "startColumnIndex": 1,
+                        "endColumnIndex": 2
+                      }
+                    ],
+                    "booleanRule": {
+                      "condition": {
+                        "type": "NUMBER_LESS",
+                        "values": [
+                          {
+                            "userEnteredValue": "100"
+                          }
+                        ]
+                      },
+                      "format": {
+                        "backgroundColorStyle": {
+                          "rgbColor": {
+                            "red": 1,
+                            "green": 0.9,
+                            "blue": 0.9
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "sortRange": {
+                  "range": {
+                    "sheetId": 0,
+                    "startRowIndex": 1,
+                    "endRowIndex": 100,
+                    "startColumnIndex": 0,
+                    "endColumnIndex": 4
+                  },
+                  "sortSpecs": [
+                    {
+                      "dimensionIndex": 3,
+                      "sortOrder": "DESCENDING"
+                    }
+                  ]
+                }
+              },
+              {
+                "addChart": {
+                  "chart": {
+                    "spec": {
+                      "title": "Revenue by Product",
+                      "basicChart": {
+                        "chartType": "COLUMN",
+                        "domains": [
+                          {
+                            "domain": {
+                              "sourceRange": {
+                                "sources": [
+                                  {
+                                    "sheetId": 0,
+                                    "startRowIndex": 0,
+                                    "endRowIndex": 4,
+                                    "startColumnIndex": 0,
+                                    "endColumnIndex": 1
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ],
+                        "series": [
+                          {
+                            "series": {
+                              "sourceRange": {
+                                "sources": [
+                                  {
+                                    "sheetId": 0,
+                                    "startRowIndex": 0,
+                                    "endRowIndex": 4,
+                                    "startColumnIndex": 3,
+                                    "endColumnIndex": 4
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "position": {
+                      "newSheet": true
+                    }
+                  }
+                }
+              },
+              {
+                "autoResizeDimensions": {
+                  "dimensions": {
+                    "sheetId": 0,
+                    "dimension": "COLUMNS",
+                    "startIndex": 0,
+                    "endIndex": 4
+                  }
+                }
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
           "spreadsheet_id": {
             "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
-            "required": true
-          },
-          "column": {
-            "value": "C",
-            "type": "string",
-            "required": true
-          },
-          "row": {
-            "value": 5,
-            "type": "integer",
-            "required": true
-          },
-          "note_text": {
-            "value": "This value was updated on Q3 review — please verify before publishing.",
-            "type": "string",
-            "required": true
-          },
-          "sheet_position": {
-            "value": 2,
-            "type": "integer",
             "required": false
           },
-          "sheet_id_or_name": {
-            "value": "Sales Data",
-            "type": "string",
-            "required": false
-          }
-        },
-        "requiresAuth": true,
-        "authProvider": "google",
-        "tabLabel": "Call the Tool with User Authorization"
-      },
-      "metadata": {
-        "classification": {
-          "serviceDomains": [
-            "spreadsheets"
-          ]
-        },
-        "behavior": {
-          "operations": [
-            "update"
-          ],
-          "readOnly": false,
-          "destructive": false,
-          "idempotent": true,
-          "openWorld": true
-        },
-        "extras": null
-      }
-    },
-    {
-      "name": "CreateSpreadsheet",
-      "qualifiedName": "GoogleSheets.CreateSpreadsheet",
-      "fullyQualifiedName": "GoogleSheets.CreateSpreadsheet@6.0.1",
-      "description": "Create a new spreadsheet with the provided title and data in its first sheet\n\nReturns the newly created spreadsheet's id and title",
-      "parameters": [
-        {
-          "name": "title",
-          "type": "string",
-          "required": false,
-          "description": "The title of the new spreadsheet",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "data",
-          "type": "string",
-          "required": false,
-          "description": "The data to write to the spreadsheet. A JSON string (property names enclosed in double quotes) representing a dictionary that maps row numbers to dictionaries that map column letters to cell values. For example, data[23]['C'] would be the value of the cell in row 23, column C. Type hint: dict[int, dict[str, Union[int, float, str, bool]]]",
-          "enum": null,
-          "inferrable": true
-        }
-      ],
-      "auth": {
-        "providerId": "google",
-        "providerType": "oauth2",
-        "scopes": [
-          "https://www.googleapis.com/auth/drive.file"
-        ]
-      },
-      "secrets": [],
-      "secretsInfo": [],
-      "output": {
-        "type": "json",
-        "description": "The created spreadsheet's id and title"
-      },
-      "documentationChunks": [],
-      "codeExample": {
-        "toolName": "GoogleSheets.CreateSpreadsheet",
-        "parameters": {
           "title": {
-            "value": "Monthly Budget Report",
-            "type": "string",
-            "required": false
-          },
-          "data": {
-            "value": "{\"1\":{\"A\":\"Item\",\"B\":\"Amount\",\"C\":\"Category\"},\"2\":{\"A\":\"Rent\",\"B\":1200,\"C\":\"Housing\"},\"3\":{\"A\":\"Groceries\",\"B\":400,\"C\":\"Food\"},\"4\":{\"A\":\"Utilities\",\"B\":150,\"C\":\"Housing\"},\"5\":{\"A\":\"Internet\",\"B\":60,\"C\":\"Utilities\"}}",
+            "value": "Q3 Sales Report 2024",
             "type": "string",
             "required": false
           }
@@ -218,10 +462,12 @@
         },
         "behavior": {
           "operations": [
-            "create"
+            "create",
+            "update",
+            "delete"
           ],
           "readOnly": false,
-          "destructive": false,
+          "destructive": true,
           "idempotent": false,
           "openWorld": true
         },
@@ -231,7 +477,7 @@
     {
       "name": "GenerateGoogleFilePickerUrl",
       "qualifiedName": "GoogleSheets.GenerateGoogleFilePickerUrl",
-      "fullyQualifiedName": "GoogleSheets.GenerateGoogleFilePickerUrl@6.0.1",
+      "fullyQualifiedName": "GoogleSheets.GenerateGoogleFilePickerUrl@8.0.0",
       "description": "Generate a URL where the user can grant this app access to specific Drive files.\n\nOpens Google's first-party Drive picker. The user selects which files to share\nwith this application — it is not a sign-in or credential prompt.\n\nUse this when a prior tool reported that a file was not found or access was denied,\nand the user expects the file to exist. After the user completes the picker flow,\nretry the prior tool.",
       "parameters": [],
       "auth": {
@@ -272,64 +518,43 @@
       }
     },
     {
-      "name": "GetSpreadsheet",
-      "qualifiedName": "GoogleSheets.GetSpreadsheet",
-      "fullyQualifiedName": "GoogleSheets.GetSpreadsheet@6.0.1",
-      "description": "Gets the specified range of cells from a single sheet in the spreadsheet.\n\nsheet_id_or_name takes precedence over sheet_position. If a sheet is not mentioned,\nthen always assume the default sheet_position is sufficient.",
+      "name": "GetSpreadsheetEditHistory",
+      "qualifiedName": "GoogleSheets.GetSpreadsheetEditHistory",
+      "fullyQualifiedName": "GoogleSheets.GetSpreadsheetEditHistory@8.0.0",
+      "description": "Report who edited a spreadsheet and when, from Google Drive revisions.\n\nReports the \"who\" and \"when\" only — not which cells changed, and it can't revert.\n\n'summary' (default) answers \"who last edited this and when\" (read from the file's head,\nso always accurate), plus per-window aggregates (revisions read, contributors, first\nedit) and a preview of recent edits — computed over a bounded window of history per call.\nThese aggregates describe the whole history only when `is_incomplete` is false; it is\ntrue when the scan was resumed from a token and/or more history remains. To answer\n\"when was this first edited?\" or \"who contributed?\" reliably, call from the beginning\n(no `pagination_token`) and check `is_incomplete` is false. `pagination_token` is\nreturned when more pages remain so you can resume.\n\n'list' returns one page of individual revisions, oldest first. Drive can't sort\nnewest-first, so the most recent individual revisions are on the final page.",
       "parameters": [
         {
           "name": "spreadsheet_id",
           "type": "string",
           "required": true,
-          "description": "The id of the spreadsheet to get",
+          "description": "The id of the spreadsheet to get the edit history for.",
           "enum": null,
           "inferrable": true
         },
         {
-          "name": "sheet_position",
-          "type": "integer",
-          "required": false,
-          "description": "The position/tab of the sheet in the spreadsheet to get. A value of 1 represents the first (leftmost/Sheet1) sheet . Defaults to 1.",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "sheet_id_or_name",
+          "name": "mode",
           "type": "string",
           "required": false,
-          "description": "The id or name of the sheet to get. Defaults to None, which means sheet_position will be used instead.",
-          "enum": null,
+          "description": "'summary' (default): the latest edit, plus per-window aggregates (revisions read, contributors, first edit) that cover the whole history only when is_incomplete is false, and a preview of recent edits. 'list': one page of individual revisions.",
+          "enum": [
+            "summary",
+            "list"
+          ],
           "inferrable": true
         },
         {
-          "name": "start_row",
+          "name": "limit",
           "type": "integer",
           "required": false,
-          "description": "Starting row number (1-indexed, defaults to 1)",
+          "description": "Max revisions per page in 'list' mode. Between 1 and 50. Defaults to 20. Ignored in 'summary' mode.",
           "enum": null,
           "inferrable": true
         },
         {
-          "name": "start_col",
+          "name": "pagination_token",
           "type": "string",
           "required": false,
-          "description": "Starting column letter(s) or 1-based column number (defaults to 'A')",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "max_rows",
-          "type": "integer",
-          "required": false,
-          "description": "Maximum number of rows to fetch for each sheet in the spreadsheet. Must be between 1 and 1000. Defaults to 1000.",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "max_cols",
-          "type": "integer",
-          "required": false,
-          "description": "Maximum number of columns to fetch for each sheet in the spreadsheet. Must be between 1 and 100. Defaults to 100.",
+          "description": "Token from a previous response's pagination_token, to continue reading more history. Works in both modes.",
           "enum": null,
           "inferrable": true
         }
@@ -352,45 +577,30 @@
       ],
       "output": {
         "type": "json",
-        "description": "The spreadsheet properties and data for the specified sheet in the spreadsheet"
+        "description": "Edit history: who modified the spreadsheet and when. Always has spreadsheet_id and mode. 'summary' adds an accurate last_modified_time/last_modified_by, best-effort window_revision_count/contributors/first_modified_time, recent_edits, and is_incomplete. 'list' adds a page of revisions with revisions_count, limit, ordering, has_next_page. Both modes return a pagination_token when more history remains."
       },
       "documentationChunks": [],
       "codeExample": {
-        "toolName": "GoogleSheets.GetSpreadsheet",
+        "toolName": "GoogleSheets.GetSpreadsheetEditHistory",
         "parameters": {
           "spreadsheet_id": {
             "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
           },
-          "sheet_position": {
-            "value": 2,
-            "type": "integer",
-            "required": false
-          },
-          "sheet_id_or_name": {
-            "value": "Sales Data",
+          "mode": {
+            "value": "list",
             "type": "string",
             "required": false
           },
-          "start_row": {
-            "value": 3,
+          "limit": {
+            "value": 25,
             "type": "integer",
             "required": false
           },
-          "start_col": {
-            "value": "B",
+          "pagination_token": {
+            "value": "eyJwYWdlVG9rZW4iOiJBSHdlRVFBQUFBQVhZekp6TURBeE1EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREF3In0=",
             "type": "string",
-            "required": false
-          },
-          "max_rows": {
-            "value": 500,
-            "type": "integer",
-            "required": false
-          },
-          "max_cols": {
-            "value": 20,
-            "type": "integer",
             "required": false
           }
         },
@@ -417,16 +627,147 @@
       }
     },
     {
-      "name": "GetSpreadsheetMetadata",
-      "qualifiedName": "GoogleSheets.GetSpreadsheetMetadata",
-      "fullyQualifiedName": "GoogleSheets.GetSpreadsheetMetadata@6.0.1",
-      "description": "Gets the metadata for a spreadsheet including the metadata for the sheets in the spreadsheet.\n\nUse this tool to get the name, position, ID, and URL of all sheets in a spreadsheet as well as\nthe number of rows and columns in each sheet.\n\nDoes not return the content/data of the sheets in the spreadsheet - only the metadata.\nExcludes spreadsheets that are in the trash.",
+      "name": "InspectSpreadsheet",
+      "qualifiedName": "GoogleSheets.InspectSpreadsheet",
+      "fullyQualifiedName": "GoogleSheets.InspectSpreadsheet@8.0.0",
+      "description": "Inspect a Google Sheets spreadsheet's structure or read a range of cells.\n\nUse the default 'structure' mode to understand a workbook cheaply before reading.\nSwitch to 'read' mode to pull a range as a grid of rows, optionally with\nper-cell annotations and a rendered markdown/csv/tsv export.\n\nIn 'read' mode the response's per-tab 'sheets' block reports only tab identity and\nthe allocated grid; its scan-derived fields (used_range, populated_cell_count,\nformula_cell_count, first_row, table_regions) are placeholders (0/empty) because read\nmode does not scan the tab — they do NOT mean the tab is empty or that it has no\ntables. The data you read is in the top-level 'range' and 'rows'. Call 'structure'\nmode for those aggregates and for the workbook's charts, merges, protected ranges, and\nconditional formats.\n\nWorkflow for a tab that holds multiple tables, or a table that does not start at A1:\ncall 'structure' first and use that tab's estimated 'table_regions' to choose the\na1_range to read or filter, so you target one table instead of a glued multi-table\nrange.\n\nAlways check the response's top-level 'warnings' list: read mode reports there when a\nresult was capped or trimmed (cell budget, the per-cell annotation cap, or an empty\nfilter scan) and tells you how to recover (page 'next_range', narrow 'a1_range',\n'select_columns', or request fewer annotation kinds).",
       "parameters": [
         {
           "name": "spreadsheet_id",
           "type": "string",
           "required": true,
-          "description": "The id of the spreadsheet to get metadata for",
+          "description": "The id of the spreadsheet to inspect.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "mode",
+          "type": "string",
+          "required": false,
+          "description": "What to return. 'structure' (default) gives a cheap workbook overview: every tab's ids, allocated grid, frozen panes, merges, charts, protected ranges, conditional-format counts, real used range, first row, and ESTIMATED table_regions (A1 ranges of distinct data blocks per tab — a heuristic for spotting multiple tables in one tab; scope a1_range to one of these to read or filter a single table; empty for tabs too large to peek). 'read' pulls cell data from one tab.",
+          "enum": [
+            "structure",
+            "read"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "sheet_id",
+          "type": "integer",
+          "required": false,
+          "description": "Read mode only: select the tab by its numeric sheetId. Mutually exclusive with sheet_title. Defaults to the first tab when both are omitted.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "sheet_title",
+          "type": "string",
+          "required": false,
+          "description": "Read mode only: select the tab by name. Mutually exclusive with sheet_id. Defaults to the first tab when both are omitted.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "a1_range",
+          "type": "string",
+          "required": false,
+          "description": "Read mode only: the range of cells to pull, in A1 notation (e.g. 'A1:F100'), WITHIN the selected tab — the tab is chosen by sheet_id/sheet_title, and any sheet prefix here (e.g. 'Other!A1:B2') is ignored. Defaults to the tab's used range. This is also the paging knob — request the next range to page.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "annotations",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Read mode only: per-cell extras to include — pass only the kinds you need (e.g. ['formulas','notes']); each extra kind adds payload. Omit or leave empty to return values only (cheaper). Returned sparsely — one entry only per cell that carries a requested extra — and capped at the first 500 entries (row-major). Over that cap a warning is returned; rows may extend past the annotated slice, so a missing annotation beyond the cap is NOT authoritative — re-read a narrower a1_range, use select_columns, or request fewer kinds to confirm.",
+          "enum": [
+            "formulas",
+            "notes",
+            "number_formats",
+            "data_validation",
+            "conditional_formats",
+            "merges",
+            "types",
+            "hyperlinks",
+            "protected",
+            "spill"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "export_as",
+          "type": "string",
+          "required": false,
+          "description": "Read mode only: also render the returned values as text. Omit to return structured values only. csv/tsv are lossless; markdown is display-oriented (in-cell newlines become <br>, pipes are escaped).",
+          "enum": [
+            "markdown",
+            "csv",
+            "tsv"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "value_render",
+          "type": "string",
+          "required": false,
+          "description": "Read mode only: 'formatted' (default) returns display strings like '$1,234.50'; 'unformatted' returns raw values suitable for math.",
+          "enum": [
+            "formatted",
+            "unformatted"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "max_length",
+          "type": "integer",
+          "required": false,
+          "description": "Read mode only: cap each returned cell string at this many characters. A longer cell becomes '<first chars>…(+N chars)' (the suffix is not counted; N = hidden chars). Pass 0 for full, untruncated strings; a positive value below the floor (or negative) clamps up to the floor. Filtering still matches the full cell value. Defaults to a small cap (50).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_rows",
+          "type": "integer",
+          "required": false,
+          "description": "Read mode only: maximum rows to return. Sets truncated=True when the range has more rows; pass the returned next_range as a1_range to page. When filtering, this bounds the rows SCANNED per page (matches may be fewer, even 0 — page until next_range is empty). Also capped so rows x columns stays within 4000 cells: a wide range returns fewer rows than requested (with a warning) and pages the rest. Defaults to 200.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "filter_conditions",
+          "type": "array",
+          "innerType": "json",
+          "required": false,
+          "description": "Read mode only: keep only rows matching these conditions. Each is {column, op, value} where column is the spreadsheet column LETTER (e.g. 'C'), NOT the header name, and must be inside a1_range. Ops: eq/ne (exact string), contains/not_contains (case-insensitive substring), gt/gte/lt/lte (NUMERIC only — text columns match nothing), blank/not_blank (value is ignored — pass ''). Numeric ops parse currency like $1,234.50, but NOT percents (21%) or other formatted text — set value_render='unformatted' and compare against the underlying number (percents are stored as fractions, e.g. 0.21 for 21%). A warning is returned when a numeric filter matches nothing it scanned. Scans within a1_range only — page next_range for completeness, and scope a1_range to a single homogeneous table (use structure mode's table_regions to find each table's range; exclude header/title rows, which would otherwise be filtered as data).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "filter_combine",
+          "type": "string",
+          "required": false,
+          "description": "Read mode only: how to combine multiple filter_conditions — a single top-level 'and'/'or' applied to all conditions (no nested grouping or mixed and/or). Defaults to 'and'.",
+          "enum": [
+            "and",
+            "or"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "select_columns",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Read mode only: return only these columns, by spreadsheet column LETTER (not header name), in this order. Defaults to all columns in a1_range.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "include_headers",
+          "type": "boolean",
+          "required": false,
+          "description": "Structure mode only: include each tab's first row in the overview. Defaults to True.",
           "enum": null,
           "inferrable": true
         }
@@ -449,16 +790,100 @@
       ],
       "output": {
         "type": "json",
-        "description": "The spreadsheet metadata for the specified spreadsheet"
+        "description": "The requested structure overview or range data."
       },
       "documentationChunks": [],
       "codeExample": {
-        "toolName": "GoogleSheets.GetSpreadsheetMetadata",
+        "toolName": "GoogleSheets.InspectSpreadsheet",
         "parameters": {
           "spreadsheet_id": {
             "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
+          },
+          "mode": {
+            "value": "read",
+            "type": "string",
+            "required": false
+          },
+          "sheet_id": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          },
+          "sheet_title": {
+            "value": "Sales Data",
+            "type": "string",
+            "required": false
+          },
+          "a1_range": {
+            "value": "A1:H50",
+            "type": "string",
+            "required": false
+          },
+          "annotations": {
+            "value": [
+              "formulas",
+              "notes"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "export_as": {
+            "value": "csv",
+            "type": "string",
+            "required": false
+          },
+          "value_render": {
+            "value": "formatted",
+            "type": "string",
+            "required": false
+          },
+          "max_length": {
+            "value": 100,
+            "type": "integer",
+            "required": false
+          },
+          "max_rows": {
+            "value": 150,
+            "type": "integer",
+            "required": false
+          },
+          "filter_conditions": {
+            "value": [
+              {
+                "column": "C",
+                "op": "gte",
+                "value": "1000"
+              },
+              {
+                "column": "E",
+                "op": "contains",
+                "value": "active"
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
+          "filter_combine": {
+            "value": "and",
+            "type": "string",
+            "required": false
+          },
+          "select_columns": {
+            "value": [
+              "A",
+              "C",
+              "E",
+              "H"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "include_headers": {
+            "value": true,
+            "type": "boolean",
+            "required": false
           }
         },
         "requiresAuth": true,
@@ -486,7 +911,7 @@
     {
       "name": "SearchSpreadsheets",
       "qualifiedName": "GoogleSheets.SearchSpreadsheets",
-      "fullyQualifiedName": "GoogleSheets.SearchSpreadsheets@6.0.1",
+      "fullyQualifiedName": "GoogleSheets.SearchSpreadsheets@8.0.0",
       "description": "Searches for spreadsheets in the user's Google Drive based on the titles and content and\nreturns the title, ID, and URL for each matching spreadsheet.\n\nDoes not return the content/data of the sheets in the spreadsheets - only the metadata.\nExcludes spreadsheets that are in the trash.",
       "parameters": [
         {
@@ -677,115 +1102,9 @@
       }
     },
     {
-      "name": "UpdateCells",
-      "qualifiedName": "GoogleSheets.UpdateCells",
-      "fullyQualifiedName": "GoogleSheets.UpdateCells@6.0.1",
-      "description": "Write values to a Google Sheet using a flexible data format.\n\nsheet_id_or_name takes precedence over sheet_position. If a sheet is not mentioned,\nthen always assume the default sheet_position is sufficient.",
-      "parameters": [
-        {
-          "name": "spreadsheet_id",
-          "type": "string",
-          "required": true,
-          "description": "The id of the spreadsheet to write to",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "data",
-          "type": "string",
-          "required": true,
-          "description": "The data to write. A JSON string (property names enclosed in double quotes) representing a dictionary that maps row numbers to dictionaries that map column letters to cell values. For example, data[23]['C'] is the value for cell C23. This is the same format accepted by create_spreadsheet. Type hint: dict[int, dict[str, int | float | str | bool]]",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "sheet_position",
-          "type": "integer",
-          "required": false,
-          "description": "The position/tab of the sheet in the spreadsheet to write to. A value of 1 represents the first (leftmost/Sheet1) sheet. Defaults to 1.",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "sheet_id_or_name",
-          "type": "string",
-          "required": false,
-          "description": "The id or name of the sheet to write to. If provided, takes precedence over sheet_position.",
-          "enum": null,
-          "inferrable": true
-        }
-      ],
-      "auth": {
-        "providerId": "google",
-        "providerType": "oauth2",
-        "scopes": [
-          "https://www.googleapis.com/auth/drive.file"
-        ]
-      },
-      "secrets": [
-        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
-      ],
-      "secretsInfo": [
-        {
-          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
-          "type": "api_key"
-        }
-      ],
-      "output": {
-        "type": "json",
-        "description": "The status of the operation, including updated ranges and counts"
-      },
-      "documentationChunks": [],
-      "codeExample": {
-        "toolName": "GoogleSheets.UpdateCells",
-        "parameters": {
-          "spreadsheet_id": {
-            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
-            "type": "string",
-            "required": true
-          },
-          "data": {
-            "value": "{\"1\": {\"A\": \"Name\", \"B\": \"Age\", \"C\": \"Score\"}, \"2\": {\"A\": \"Alice\", \"B\": 30, \"C\": 95.5}, \"3\": {\"A\": \"Bob\", \"B\": 25, \"C\": 87.0}, \"4\": {\"A\": \"Charlie\", \"B\": 35, \"C\": true}}",
-            "type": "string",
-            "required": true
-          },
-          "sheet_position": {
-            "value": 1,
-            "type": "integer",
-            "required": false
-          },
-          "sheet_id_or_name": {
-            "value": "Sheet1",
-            "type": "string",
-            "required": false
-          }
-        },
-        "requiresAuth": true,
-        "authProvider": "google",
-        "tabLabel": "Call the Tool with User Authorization"
-      },
-      "metadata": {
-        "classification": {
-          "serviceDomains": [
-            "spreadsheets"
-          ]
-        },
-        "behavior": {
-          "operations": [
-            "update"
-          ],
-          "readOnly": false,
-          "destructive": false,
-          "idempotent": true,
-          "openWorld": true
-        },
-        "extras": null
-      }
-    },
-    {
       "name": "WhoAmI",
       "qualifiedName": "GoogleSheets.WhoAmI",
-      "fullyQualifiedName": "GoogleSheets.WhoAmI@6.0.1",
+      "fullyQualifiedName": "GoogleSheets.WhoAmI@8.0.0",
       "description": "Get comprehensive user profile and Google Sheets environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Sheets access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -828,125 +1147,6 @@
         },
         "extras": null
       }
-    },
-    {
-      "name": "WriteToCell",
-      "qualifiedName": "GoogleSheets.WriteToCell",
-      "fullyQualifiedName": "GoogleSheets.WriteToCell@6.0.1",
-      "description": "Write a value to a single cell in a spreadsheet.",
-      "parameters": [
-        {
-          "name": "spreadsheet_id",
-          "type": "string",
-          "required": true,
-          "description": "The id of the spreadsheet to write to",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "column",
-          "type": "string",
-          "required": true,
-          "description": "The column string to write to. For example, 'A', 'F', or 'AZ'",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "row",
-          "type": "integer",
-          "required": true,
-          "description": "The row number to write to",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "value",
-          "type": "string",
-          "required": true,
-          "description": "The value to write to the cell",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "sheet_name",
-          "type": "string",
-          "required": false,
-          "description": "The name of the sheet to write to. Defaults to 'Sheet1'",
-          "enum": null,
-          "inferrable": true
-        }
-      ],
-      "auth": {
-        "providerId": "google",
-        "providerType": "oauth2",
-        "scopes": [
-          "https://www.googleapis.com/auth/drive.file"
-        ]
-      },
-      "secrets": [
-        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
-      ],
-      "secretsInfo": [
-        {
-          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
-          "type": "api_key"
-        }
-      ],
-      "output": {
-        "type": "json",
-        "description": "The status of the operation"
-      },
-      "documentationChunks": [],
-      "codeExample": {
-        "toolName": "GoogleSheets.WriteToCell",
-        "parameters": {
-          "spreadsheet_id": {
-            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
-            "type": "string",
-            "required": true
-          },
-          "column": {
-            "value": "C",
-            "type": "string",
-            "required": true
-          },
-          "row": {
-            "value": 7,
-            "type": "integer",
-            "required": true
-          },
-          "value": {
-            "value": "Q3 Revenue",
-            "type": "string",
-            "required": true
-          },
-          "sheet_name": {
-            "value": "Summary",
-            "type": "string",
-            "required": false
-          }
-        },
-        "requiresAuth": true,
-        "authProvider": "google",
-        "tabLabel": "Call the Tool with User Authorization"
-      },
-      "metadata": {
-        "classification": {
-          "serviceDomains": [
-            "spreadsheets"
-          ]
-        },
-        "behavior": {
-          "operations": [
-            "update"
-          ],
-          "readOnly": false,
-          "destructive": false,
-          "idempotent": true,
-          "openWorld": true
-        },
-        "extras": null
-      }
     }
   ],
   "documentationChunks": [],
@@ -954,6 +1154,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-06-05T12:07:56.906Z",
-  "summary": "The Google Sheets toolkit lets LLM agents create, read, search, and edit Google Sheets spreadsheets through Arcade, using Google OAuth for delegated user access.\n\n## Capabilities\n\n- **Spreadsheet discovery & metadata** — search across a user's Drive for spreadsheets by title/content, retrieve full sheet metadata (names, positions, IDs, URLs, dimensions) without loading cell data.\n- **Reading data** — fetch cell ranges from any sheet within a spreadsheet, with flexible sheet targeting by name, ID, or position.\n- **Writing & editing** — create new spreadsheets with initial data, write a single cell value, bulk-update cell ranges with flexible data formats, and attach hover notes to individual cells.\n- **File access recovery** — generate a Google Drive inline file-picker URL so users can grant the app access to specific files when a prior operation fails due to missing permissions, then retry the original tool.\n- **Identity & permissions inspection** — retrieve the authenticated user's profile, email, and Google Sheets access permissions via `WhoAmI`.\n\n## OAuth\n\nThis toolkit uses **Google OAuth 2.0** to act on behalf of the authenticated user. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for scopes, setup, and configuration details.\n\n## Secrets\n\n- **`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL`** — An API key that enables the `GoogleSheets.GenerateGoogleFilePickerUrl` tool to render Google's first-party Drive file picker. To obtain it, go to the [Google Cloud Console APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials) page for your project, click **Create credentials → API key**, and ensure the Google Picker API is enabled for your project under **APIs & Services → Library**. Restrict the key to the Picker API and to allowed HTTP referrers/origins as appropriate for your deployment. See [Google Picker API documentation](https://developers.google.com/drive/picker/guides/overview) for full setup details.\n\nStore secrets in Arcade via the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) or directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
+  "generatedAt": "2026-06-10T12:12:15.675Z",
+  "summary": "**Google Sheets toolkit** connects Arcade to Google Sheets (and Drive), enabling LLMs to create, read, edit, search, and audit spreadsheets on behalf of authenticated users.\n\n## Capabilities\n\n- **Spreadsheet creation & editing** — Create new spreadsheets or batch-edit existing ones using typed cell operations (updateCells, addSheet, sortRange, addConditionalFormatRule, autoResizeDimensions, and more); supports formulas, formatting, and structured table layouts.\n- **Structure inspection & data reading** — Inspect workbook structure (tabs, charts, merges, conditional formats, table regions) cheaply before reading, then pull specific cell ranges as grids with optional annotations and markdown/CSV/TSV export.\n- **Search & discovery** — Search a user's Google Drive for spreadsheets by title or content, returning metadata (title, ID, URL); excludes trashed files.\n- **Edit history auditing** — Retrieve revision history (contributor identity and timestamps) from Drive; supports summary mode (aggregates, recent preview) and paginated list mode for full history traversal.\n- **Drive file picker integration** — Generate a first-party Google Drive Picker URL to let users grant file-level access when a file is not found or access is denied, enabling retry flows.\n- **User profile & permissions** — Retrieve the authenticated user's name, email, profile picture, and Google Sheets access permissions.\n\n## OAuth\n\nThis toolkit uses **OAuth 2.0** via Google. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details.\n\n## Secrets\n\n`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL`\n\nThis secret is a **URL override or feature flag value** that controls the behavior of the inline Google Drive Picker flow used by `GoogleSheets.GenerateGoogleFilePickerUrl`. It is not a credential issued by Google — it is a configuration value set by the developer (or Arcade platform operator) to enable or customize the picker URL endpoint used internally. Set this in your Arcade secrets configuration; no specific Google dashboard page issues it.\n\nSee the [Arcade secrets configuration docs](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to define and manage secrets, and the [Arcade secrets dashboard](https://api.arcade.dev/dashboard/auth/secrets) to set values."
 }

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-05T12:08:12.529Z",
+  "generatedAt": "2026-06-10T12:12:28.789Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -10,6 +10,15 @@
       "type": "arcade_starter",
       "toolCount": 96,
       "authType": "oauth2"
+    },
+    {
+      "id": "Apollo",
+      "label": "Apollo",
+      "version": "0.1.0",
+      "category": "sales",
+      "type": "arcade",
+      "toolCount": 5,
+      "authType": "none"
     },
     {
       "id": "ArcadeEngineApi",
@@ -37,6 +46,15 @@
       "type": "arcade_starter",
       "toolCount": 199,
       "authType": "oauth2"
+    },
+    {
+      "id": "Ashby",
+      "label": "Ashby",
+      "version": "0.1.0",
+      "category": "productivity",
+      "type": "arcade",
+      "toolCount": 9,
+      "authType": "none"
     },
     {
       "id": "AshbyApi",
@@ -68,7 +86,7 @@
     {
       "id": "Brightdata",
       "label": "Bright Data",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "category": "development",
       "type": "community",
       "toolCount": 3,
@@ -86,7 +104,7 @@
     {
       "id": "Clickhouse",
       "label": "Clickhouse",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "category": "databases",
       "type": "community",
       "toolCount": 5,
@@ -129,6 +147,15 @@
       "authType": "none"
     },
     {
+      "id": "Customerio",
+      "label": "Customer.io",
+      "version": "0.1.0",
+      "category": "customer-support",
+      "type": "arcade",
+      "toolCount": 18,
+      "authType": "none"
+    },
+    {
       "id": "CustomerioApi",
       "label": "Customer.io API",
       "version": "0.2.1",
@@ -156,6 +183,15 @@
       "authType": "none"
     },
     {
+      "id": "Datadog",
+      "label": "Datadog",
+      "version": "0.1.0",
+      "category": "development",
+      "type": "arcade",
+      "toolCount": 5,
+      "authType": "none"
+    },
+    {
       "id": "DatadogApi",
       "label": "Datadog API",
       "version": "0.2.1",
@@ -172,6 +208,15 @@
       "type": "arcade",
       "toolCount": 46,
       "authType": "oauth2"
+    },
+    {
+      "id": "DiscordBot",
+      "label": "Discord Bot",
+      "version": "0.1.0",
+      "category": "social",
+      "type": "arcade",
+      "toolCount": 20,
+      "authType": "none"
     },
     {
       "id": "Dropbox",
@@ -237,6 +282,15 @@
       "authType": "none"
     },
     {
+      "id": "Freshdesk",
+      "label": "Freshdesk",
+      "version": "0.1.1",
+      "category": "customer-support",
+      "type": "arcade",
+      "toolCount": 19,
+      "authType": "none"
+    },
+    {
       "id": "FreshserviceApi",
       "label": "Freshservice API",
       "version": "0.3.0",
@@ -266,7 +320,7 @@
     {
       "id": "Gmail",
       "label": "Gmail",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 18,
@@ -320,7 +374,7 @@
     {
       "id": "GoogleFlights",
       "label": "Google Flights",
-      "version": "4.0.4",
+      "version": "4.1.0",
       "category": "search",
       "type": "arcade",
       "toolCount": 4,
@@ -374,10 +428,10 @@
     {
       "id": "GoogleSheets",
       "label": "Google Sheets",
-      "version": "6.0.1",
+      "version": "8.0.0",
       "category": "productivity",
       "type": "arcade",
-      "toolCount": 9,
+      "toolCount": 6,
       "authType": "oauth2"
     },
     {
@@ -518,7 +572,7 @@
     {
       "id": "Linear",
       "label": "Linear",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 42,
@@ -644,7 +698,7 @@
     {
       "id": "Mongodb",
       "label": "MongoDB",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "category": "databases",
       "type": "community",
       "toolCount": 6,
@@ -828,6 +882,15 @@
       "category": "productivity",
       "type": "arcade_starter",
       "toolCount": 246,
+      "authType": "none"
+    },
+    {
+      "id": "Vercel",
+      "label": "Vercel",
+      "version": "0.1.0",
+      "category": "development",
+      "type": "arcade",
+      "toolCount": 23,
       "authType": "none"
     },
     {

--- a/toolkit-docs-generator/data/toolkits/linear.json
+++ b/toolkit-docs-generator/data/toolkits/linear.json
@@ -1,7 +1,7 @@
 {
   "id": "Linear",
   "label": "Linear",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Arcade tools designed for LLMs to interact with Linear",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "AddComment",
       "qualifiedName": "Linear.AddComment",
-      "fullyQualifiedName": "Linear.AddComment@3.4.0",
+      "fullyQualifiedName": "Linear.AddComment@3.5.0",
       "description": "Add a comment to an issue.",
       "parameters": [
         {
@@ -99,7 +99,7 @@
     {
       "name": "AddProjectComment",
       "qualifiedName": "Linear.AddProjectComment",
-      "fullyQualifiedName": "Linear.AddProjectComment@3.4.0",
+      "fullyQualifiedName": "Linear.AddProjectComment@3.5.0",
       "description": "Add a comment to a project's document content.\n\nIMPORTANT: Due to Linear API limitations, comments created via the API will NOT\nappear visually anchored inline in the document (no yellow highlight on text).\nThe comment will be stored and can be retrieved via list_project_comments, but\nit will appear in the comments panel rather than inline in the document.\n\nFor true inline comments that are visually anchored to text, users should create\nthem directly in the Linear UI by selecting text and adding a comment.\n\nThe quoted_text parameter stores metadata about what text the comment references,\nwhich is useful for context even though the comment won't be visually anchored.",
       "parameters": [
         {
@@ -198,7 +198,7 @@
     {
       "name": "AddProjectToInitiative",
       "qualifiedName": "Linear.AddProjectToInitiative",
-      "fullyQualifiedName": "Linear.AddProjectToInitiative@3.4.0",
+      "fullyQualifiedName": "Linear.AddProjectToInitiative@3.5.0",
       "description": "Link a project to an initiative.\n\nBoth initiative and project can be specified by ID or name.\nIf a name is provided, fuzzy matching is used to resolve it.",
       "parameters": [
         {
@@ -284,7 +284,7 @@
     {
       "name": "ArchiveInitiative",
       "qualifiedName": "Linear.ArchiveInitiative",
-      "fullyQualifiedName": "Linear.ArchiveInitiative@3.4.0",
+      "fullyQualifiedName": "Linear.ArchiveInitiative@3.5.0",
       "description": "Archive an initiative.\n\nArchived initiatives are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -357,7 +357,7 @@
     {
       "name": "ArchiveIssue",
       "qualifiedName": "Linear.ArchiveIssue",
-      "fullyQualifiedName": "Linear.ArchiveIssue@3.4.0",
+      "fullyQualifiedName": "Linear.ArchiveIssue@3.5.0",
       "description": "Archive an issue.\n\nArchived issues are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -417,7 +417,7 @@
     {
       "name": "ArchiveProject",
       "qualifiedName": "Linear.ArchiveProject",
-      "fullyQualifiedName": "Linear.ArchiveProject@3.4.0",
+      "fullyQualifiedName": "Linear.ArchiveProject@3.5.0",
       "description": "Archive a project.\n\nArchived projects are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -490,7 +490,7 @@
     {
       "name": "CreateInitiative",
       "qualifiedName": "Linear.CreateInitiative",
-      "fullyQualifiedName": "Linear.CreateInitiative@3.4.0",
+      "fullyQualifiedName": "Linear.CreateInitiative@3.5.0",
       "description": "Create a new Linear initiative.\n\nInitiatives are high-level strategic goals that group related projects.",
       "parameters": [
         {
@@ -596,7 +596,7 @@
     {
       "name": "CreateIssue",
       "qualifiedName": "Linear.CreateIssue",
-      "fullyQualifiedName": "Linear.CreateIssue@3.4.0",
+      "fullyQualifiedName": "Linear.CreateIssue@3.5.0",
       "description": "Create a new Linear issue with validation.\n\nWhen assignee is None or '@me', the issue is assigned to the authenticated user.\nAll entity references (team, assignee, labels, state, project, cycle, parent)\nare validated before creation. If an entity is not found, suggestions are\nreturned to help correct the input.",
       "parameters": [
         {
@@ -679,6 +679,14 @@
           "inferrable": true
         },
         {
+          "name": "milestone",
+          "type": "string",
+          "required": false,
+          "description": "Project milestone to assign, by milestone name or ID. The milestone must belong to this issue's project, so a project must also be set. Default is None (no milestone).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
           "name": "parent_issue",
           "type": "string",
           "required": false,
@@ -750,12 +758,12 @@
             "required": true
           },
           "title": {
-            "value": "Fix null pointer exception in user authentication flow",
+            "value": "Fix login page redirect bug",
             "type": "string",
             "required": true
           },
           "description": {
-            "value": "## Bug Report\n\nA null pointer exception occurs when a user attempts to log in with an expired token.\n\n**Steps to reproduce:**\n1. Let a session token expire\n2. Attempt to log in again\n3. Observe the error in logs\n\n**Expected:** Graceful re-authentication prompt\n**Actual:** Server returns 500 with NPE",
+            "value": "## Bug Report\n\nUsers are being redirected to a 404 page after successful login.\n\n**Steps to reproduce:**\n1. Navigate to `/login`\n2. Enter valid credentials\n3. Click 'Sign In'\n\n**Expected:** Redirect to dashboard\n**Actual:** Redirect to `/home` which returns 404",
             "type": "string",
             "required": false
           },
@@ -767,14 +775,13 @@
           "labels_to_add": {
             "value": [
               "bug",
-              "high-impact",
-              "backend"
+              "high-priority"
             ],
             "type": "array",
             "required": false
           },
           "priority": {
-            "value": "urgent",
+            "value": "high",
             "type": "string",
             "required": false
           },
@@ -784,17 +791,22 @@
             "required": false
           },
           "project": {
-            "value": "Q3 Platform Stability",
+            "value": "Q3 Platform Improvements",
             "type": "string",
             "required": false
           },
           "cycle": {
-            "value": "Cycle 12",
+            "value": "Sprint 42",
+            "type": "string",
+            "required": false
+          },
+          "milestone": {
+            "value": "Beta Release",
             "type": "string",
             "required": false
           },
           "parent_issue": {
-            "value": "ENG-204",
+            "value": "ENG-101",
             "type": "string",
             "required": false
           },
@@ -804,17 +816,17 @@
             "required": false
           },
           "due_date": {
-            "value": "2025-08-15",
+            "value": "2024-09-15",
             "type": "string",
             "required": false
           },
           "attachment_url": {
-            "value": "https://sentry.io/organizations/example/issues/123456789/",
+            "value": "https://github.com/example-org/repo/issues/88",
             "type": "string",
             "required": false
           },
           "attachment_title": {
-            "value": "Sentry Error Trace – NPE in AuthService",
+            "value": "GitHub Issue Reference #88",
             "type": "string",
             "required": false
           },
@@ -849,7 +861,7 @@
     {
       "name": "CreateIssueRelation",
       "qualifiedName": "Linear.CreateIssueRelation",
-      "fullyQualifiedName": "Linear.CreateIssueRelation@3.4.0",
+      "fullyQualifiedName": "Linear.CreateIssueRelation@3.5.0",
       "description": "Create a relation between two issues.\n\nRelation types define the relationship from the source issue's perspective:\n- blocks: Source issue blocks the related issue\n- blockedBy: Source issue is blocked by the related issue\n- duplicate: Source issue is a duplicate of the related issue\n- related: Issues are related (bidirectional)",
       "parameters": [
         {
@@ -940,7 +952,7 @@
     {
       "name": "CreateProject",
       "qualifiedName": "Linear.CreateProject",
-      "fullyQualifiedName": "Linear.CreateProject@3.4.0",
+      "fullyQualifiedName": "Linear.CreateProject@3.5.0",
       "description": "Create a new Linear project.\n\nTeam is validated before creation. If team is not found, suggestions are\nreturned to help correct the input. Lead is validated if provided.",
       "parameters": [
         {
@@ -1111,7 +1123,7 @@
     {
       "name": "CreateProjectUpdate",
       "qualifiedName": "Linear.CreateProjectUpdate",
-      "fullyQualifiedName": "Linear.CreateProjectUpdate@3.4.0",
+      "fullyQualifiedName": "Linear.CreateProjectUpdate@3.5.0",
       "description": "Create a project status update.\n\nProject updates are posts that communicate progress, blockers, or status\nchanges to stakeholders. They appear in the project's Updates tab and\ncan include a health status indicator.",
       "parameters": [
         {
@@ -1201,7 +1213,7 @@
     {
       "name": "GetCycle",
       "qualifiedName": "Linear.GetCycle",
-      "fullyQualifiedName": "Linear.GetCycle@3.4.0",
+      "fullyQualifiedName": "Linear.GetCycle@3.5.0",
       "description": "Get detailed information about a specific Linear cycle.",
       "parameters": [
         {
@@ -1261,7 +1273,7 @@
     {
       "name": "GetInitiative",
       "qualifiedName": "Linear.GetInitiative",
-      "fullyQualifiedName": "Linear.GetInitiative@3.4.0",
+      "fullyQualifiedName": "Linear.GetInitiative@3.5.0",
       "description": "Get detailed information about a specific Linear initiative.\n\nSupports lookup by ID or name (with fuzzy matching for name).",
       "parameters": [
         {
@@ -1363,7 +1375,7 @@
     {
       "name": "GetInitiativeDescription",
       "qualifiedName": "Linear.GetInitiativeDescription",
-      "fullyQualifiedName": "Linear.GetInitiativeDescription@3.4.0",
+      "fullyQualifiedName": "Linear.GetInitiativeDescription@3.5.0",
       "description": "Get an initiative's full description with pagination support.\n\nUse this tool when you need the complete description of an initiative that\nwas truncated in the get_initiative response. Supports chunked reading for\nvery large descriptions.",
       "parameters": [
         {
@@ -1449,7 +1461,7 @@
     {
       "name": "GetIssue",
       "qualifiedName": "Linear.GetIssue",
-      "fullyQualifiedName": "Linear.GetIssue@3.4.0",
+      "fullyQualifiedName": "Linear.GetIssue@3.5.0",
       "description": "Get detailed information about a specific Linear issue.\n\nAccepts either the issue UUID or the human-readable identifier (like TOO-123).",
       "parameters": [
         {
@@ -1561,7 +1573,7 @@
     {
       "name": "GetMilestone",
       "qualifiedName": "Linear.GetMilestone",
-      "fullyQualifiedName": "Linear.GetMilestone@3.4.0",
+      "fullyQualifiedName": "Linear.GetMilestone@3.5.0",
       "description": "Get a milestone by ID or name inside a project.",
       "parameters": [
         {
@@ -1647,7 +1659,7 @@
     {
       "name": "GetNotifications",
       "qualifiedName": "Linear.GetNotifications",
-      "fullyQualifiedName": "Linear.GetNotifications@3.4.0",
+      "fullyQualifiedName": "Linear.GetNotifications@3.5.0",
       "description": "Get the authenticated user's notifications.\n\nReturns notifications including issue mentions, comments, assignments,\nand state changes.",
       "parameters": [
         {
@@ -1733,7 +1745,7 @@
     {
       "name": "GetProject",
       "qualifiedName": "Linear.GetProject",
-      "fullyQualifiedName": "Linear.GetProject@3.4.0",
+      "fullyQualifiedName": "Linear.GetProject@3.5.0",
       "description": "Get detailed information about a specific Linear project.\n\nSupports lookup by ID, slug_id, or name (with fuzzy matching for name).",
       "parameters": [
         {
@@ -1849,7 +1861,7 @@
     {
       "name": "GetProjectDescription",
       "qualifiedName": "Linear.GetProjectDescription",
-      "fullyQualifiedName": "Linear.GetProjectDescription@3.4.0",
+      "fullyQualifiedName": "Linear.GetProjectDescription@3.5.0",
       "description": "Get a project's full description with pagination support.\n\nUse this tool when you need the complete description of a project that\nwas truncated in the get_project response. Supports chunked reading for\nvery large descriptions.",
       "parameters": [
         {
@@ -1935,7 +1947,7 @@
     {
       "name": "GetRecentActivity",
       "qualifiedName": "Linear.GetRecentActivity",
-      "fullyQualifiedName": "Linear.GetRecentActivity@3.4.0",
+      "fullyQualifiedName": "Linear.GetRecentActivity@3.5.0",
       "description": "Get the authenticated user's recent issue activity.\n\nReturns issues the user has recently created or been assigned to\nwithin the specified time period.",
       "parameters": [
         {
@@ -2008,7 +2020,7 @@
     {
       "name": "GetTeam",
       "qualifiedName": "Linear.GetTeam",
-      "fullyQualifiedName": "Linear.GetTeam@3.4.0",
+      "fullyQualifiedName": "Linear.GetTeam@3.5.0",
       "description": "Get detailed information about a specific Linear team.\n\nSupports lookup by ID, key (like TOO, ENG), or name (with fuzzy matching).",
       "parameters": [
         {
@@ -2098,7 +2110,7 @@
     {
       "name": "LinkGithubToIssue",
       "qualifiedName": "Linear.LinkGithubToIssue",
-      "fullyQualifiedName": "Linear.LinkGithubToIssue@3.4.0",
+      "fullyQualifiedName": "Linear.LinkGithubToIssue@3.5.0",
       "description": "Link a GitHub PR, commit, or issue to a Linear issue.\n\nAutomatically detects the artifact type from the URL and generates\nan appropriate title if not provided.",
       "parameters": [
         {
@@ -2184,7 +2196,7 @@
     {
       "name": "ListComments",
       "qualifiedName": "Linear.ListComments",
-      "fullyQualifiedName": "Linear.ListComments@3.4.0",
+      "fullyQualifiedName": "Linear.ListComments@3.5.0",
       "description": "List comments on an issue.\n\nReturns comments with user info, timestamps, and reply threading info.",
       "parameters": [
         {
@@ -2270,7 +2282,7 @@
     {
       "name": "ListCycles",
       "qualifiedName": "Linear.ListCycles",
-      "fullyQualifiedName": "Linear.ListCycles@3.4.0",
+      "fullyQualifiedName": "Linear.ListCycles@3.5.0",
       "description": "List Linear cycles, optionally filtered by team and status.\n\nCycles are time-boxed iterations (like sprints) for organizing work.",
       "parameters": [
         {
@@ -2382,7 +2394,7 @@
     {
       "name": "ListInitiatives",
       "qualifiedName": "Linear.ListInitiatives",
-      "fullyQualifiedName": "Linear.ListInitiatives@3.4.0",
+      "fullyQualifiedName": "Linear.ListInitiatives@3.5.0",
       "description": "List Linear initiatives, optionally filtered by keywords and other criteria.\n\nReturns all initiatives when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2488,7 +2500,7 @@
     {
       "name": "ListIssues",
       "qualifiedName": "Linear.ListIssues",
-      "fullyQualifiedName": "Linear.ListIssues@3.4.0",
+      "fullyQualifiedName": "Linear.ListIssues@3.5.0",
       "description": "List Linear issues, optionally filtered by keywords and other criteria.\n\nReturns all issues when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2671,7 +2683,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Linear.ListLabels",
-      "fullyQualifiedName": "Linear.ListLabels@3.4.0",
+      "fullyQualifiedName": "Linear.ListLabels@3.5.0",
       "description": "List available issue labels in the workspace.\n\nReturns labels that can be applied to issues. Use label IDs or names\nwhen creating or updating issues.",
       "parameters": [
         {
@@ -2731,7 +2743,7 @@
     {
       "name": "ListMilestones",
       "qualifiedName": "Linear.ListMilestones",
-      "fullyQualifiedName": "Linear.ListMilestones@3.4.0",
+      "fullyQualifiedName": "Linear.ListMilestones@3.5.0",
       "description": "List milestones in a Linear project.",
       "parameters": [
         {
@@ -2830,7 +2842,7 @@
     {
       "name": "ListProjectComments",
       "qualifiedName": "Linear.ListProjectComments",
-      "fullyQualifiedName": "Linear.ListProjectComments@3.4.0",
+      "fullyQualifiedName": "Linear.ListProjectComments@3.5.0",
       "description": "List comments on a project's document content.\n\nReturns comments with user info, timestamps, quoted text for inline comments,\nand reply threading info. Replies are nested under their parent comments.\n\nUse comment_filter to control which comments are returned:\n- only_quoted (default): Only comments attached to a quote in the text\n- only_unquoted: Only comments not attached to a particular quote\n- all: All comments regardless of being attached to a quote or not",
       "parameters": [
         {
@@ -2959,7 +2971,7 @@
     {
       "name": "ListProjects",
       "qualifiedName": "Linear.ListProjects",
-      "fullyQualifiedName": "Linear.ListProjects@3.4.0",
+      "fullyQualifiedName": "Linear.ListProjects@3.5.0",
       "description": "List Linear projects, optionally filtered by keywords and other criteria.\n\nReturns all projects when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -3084,7 +3096,7 @@
     {
       "name": "ListTeams",
       "qualifiedName": "Linear.ListTeams",
-      "fullyQualifiedName": "Linear.ListTeams@3.4.0",
+      "fullyQualifiedName": "Linear.ListTeams@3.5.0",
       "description": "List Linear teams, optionally filtered by keywords and other criteria.\n\nReturns all teams when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -3196,7 +3208,7 @@
     {
       "name": "ListWorkflowStates",
       "qualifiedName": "Linear.ListWorkflowStates",
-      "fullyQualifiedName": "Linear.ListWorkflowStates@3.4.0",
+      "fullyQualifiedName": "Linear.ListWorkflowStates@3.5.0",
       "description": "List available workflow states in the workspace.\n\nReturns workflow states that can be used for issue transitions.\nStates are team-specific and have different types.",
       "parameters": [
         {
@@ -3289,7 +3301,7 @@
     {
       "name": "ManageIssueSubscription",
       "qualifiedName": "Linear.ManageIssueSubscription",
-      "fullyQualifiedName": "Linear.ManageIssueSubscription@3.4.0",
+      "fullyQualifiedName": "Linear.ManageIssueSubscription@3.5.0",
       "description": "Subscribe to or unsubscribe from an issue's notifications.",
       "parameters": [
         {
@@ -3362,7 +3374,7 @@
     {
       "name": "ReplyToComment",
       "qualifiedName": "Linear.ReplyToComment",
-      "fullyQualifiedName": "Linear.ReplyToComment@3.4.0",
+      "fullyQualifiedName": "Linear.ReplyToComment@3.5.0",
       "description": "Reply to an existing comment on an issue.\n\nCreates a threaded reply to the specified parent comment.",
       "parameters": [
         {
@@ -3448,7 +3460,7 @@
     {
       "name": "ReplyToProjectComment",
       "qualifiedName": "Linear.ReplyToProjectComment",
-      "fullyQualifiedName": "Linear.ReplyToProjectComment@3.4.0",
+      "fullyQualifiedName": "Linear.ReplyToProjectComment@3.5.0",
       "description": "Reply to an existing comment on a project document.\n\nCreates a threaded reply to the specified parent comment.",
       "parameters": [
         {
@@ -3547,7 +3559,7 @@
     {
       "name": "TransitionIssueState",
       "qualifiedName": "Linear.TransitionIssueState",
-      "fullyQualifiedName": "Linear.TransitionIssueState@3.4.0",
+      "fullyQualifiedName": "Linear.TransitionIssueState@3.5.0",
       "description": "Transition a Linear issue to a new workflow state.\n\nThe target state is validated against the team's available states.",
       "parameters": [
         {
@@ -3633,7 +3645,7 @@
     {
       "name": "UpdateComment",
       "qualifiedName": "Linear.UpdateComment",
-      "fullyQualifiedName": "Linear.UpdateComment@3.4.0",
+      "fullyQualifiedName": "Linear.UpdateComment@3.5.0",
       "description": "Update an existing comment.",
       "parameters": [
         {
@@ -3706,7 +3718,7 @@
     {
       "name": "UpdateInitiative",
       "qualifiedName": "Linear.UpdateInitiative",
-      "fullyQualifiedName": "Linear.UpdateInitiative@3.4.0",
+      "fullyQualifiedName": "Linear.UpdateInitiative@3.5.0",
       "description": "Update a Linear initiative with partial updates.\n\nOnly fields that are explicitly provided will be updated.",
       "parameters": [
         {
@@ -3825,7 +3837,7 @@
     {
       "name": "UpdateIssue",
       "qualifiedName": "Linear.UpdateIssue",
-      "fullyQualifiedName": "Linear.UpdateIssue@3.4.0",
+      "fullyQualifiedName": "Linear.UpdateIssue@3.5.0",
       "description": "Update a Linear issue with partial updates.\n\nOnly fields that are explicitly provided will be updated. All entity\nreferences are validated before update.",
       "parameters": [
         {
@@ -3917,6 +3929,14 @@
           "inferrable": true
         },
         {
+          "name": "milestone",
+          "type": "string",
+          "required": false,
+          "description": "Project milestone to assign, by milestone name or ID. The milestone must belong to the issue's project (the project being set in this update, or the issue's current project). Omitting it leaves the existing milestone unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
           "name": "estimate",
           "type": "integer",
           "required": false,
@@ -3980,23 +4000,24 @@
             "required": true
           },
           "title": {
-            "value": "Improve onboarding flow and reduce drop-off",
+            "value": "Fix login button alignment on mobile",
             "type": "string",
             "required": false
           },
           "description": {
-            "value": "Update the onboarding flow to reduce user drop-off by simplifying steps and improving copy.\n\nAcceptance criteria:\n- Reduce first-week drop-off by 15%\n- Onboarding completion time under 3 minutes\n\nProposed changes:\n1. Merge steps 2 and 3\n2. Add contextual help tooltips\n3. Update microcopy for clarity",
+            "value": "## Bug Description\n\nThe login button is misaligned on screens smaller than 375px.\n\n**Steps to reproduce:**\n1. Open the app on a mobile device\n2. Navigate to the login page\n3. Observe the button position",
             "type": "string",
             "required": false
           },
           "assignee": {
-            "value": "alice@example.com",
+            "value": "jane.doe@example.com",
             "type": "string",
             "required": false
           },
           "labels_to_add": {
             "value": [
-              "onboarding",
+              "bug",
+              "mobile",
               "high-priority"
             ],
             "type": "array",
@@ -4010,7 +4031,7 @@
             "required": false
           },
           "priority": {
-            "value": "High",
+            "value": "high",
             "type": "string",
             "required": false
           },
@@ -4020,32 +4041,37 @@
             "required": false
           },
           "project": {
-            "value": "Website Redesign",
+            "value": "mobile-redesign",
             "type": "string",
             "required": false
           },
           "cycle": {
-            "value": "Sprint 12",
+            "value": "Sprint 14",
+            "type": "string",
+            "required": false
+          },
+          "milestone": {
+            "value": "Q2 Release",
             "type": "string",
             "required": false
           },
           "estimate": {
-            "value": 5,
+            "value": 3,
             "type": "integer",
             "required": false
           },
           "due_date": {
-            "value": "2026-03-31",
+            "value": "2025-08-15",
             "type": "string",
             "required": false
           },
           "attachment_url": {
-            "value": "https://example.com/designs/onboarding-v2",
+            "value": "https://www.figma.com/file/abc123/login-button-fix",
             "type": "string",
             "required": false
           },
           "attachment_title": {
-            "value": "Onboarding v2 Designs",
+            "value": "Figma Design Reference",
             "type": "string",
             "required": false
           },
@@ -4080,7 +4106,7 @@
     {
       "name": "UpdateProject",
       "qualifiedName": "Linear.UpdateProject",
-      "fullyQualifiedName": "Linear.UpdateProject@3.4.0",
+      "fullyQualifiedName": "Linear.UpdateProject@3.5.0",
       "description": "Update a Linear project with partial updates.\n\nOnly fields that are explicitly provided will be updated. All entity\nreferences are validated before update.\n\nIMPORTANT: Updating the 'content' field will break any existing inline\ncomment anchoring. The comments will still exist and be retrievable via\nlist_project_comments, but they will no longer appear visually anchored\nto text in the Linear UI. The 'description' field can be safely updated\nwithout affecting inline comments.",
       "parameters": [
         {
@@ -4284,7 +4310,7 @@
     {
       "name": "UpsertMilestone",
       "qualifiedName": "Linear.UpsertMilestone",
-      "fullyQualifiedName": "Linear.UpsertMilestone@3.4.0",
+      "fullyQualifiedName": "Linear.UpsertMilestone@3.5.0",
       "description": "Upsert a project's milestone.",
       "parameters": [
         {
@@ -4410,7 +4436,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Linear.WhoAmI",
-      "fullyQualifiedName": "Linear.WhoAmI@3.4.0",
+      "fullyQualifiedName": "Linear.WhoAmI@3.5.0",
       "description": "Get the authenticated user's profile and team memberships.\n\nReturns the current user's information including their name, email,\norganization, and the teams they belong to.",
       "parameters": [],
       "auth": {
@@ -4464,6 +4490,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-04-29T11:39:21.304Z",
-  "summary": "# Linear Toolkit\n\nProvides Arcade tools for LLMs to interact with [Linear](https://linear.app), enabling programmatic management of issues, projects, initiatives, cycles, and team workflows.\n\n## Capabilities\n\n- **Issue management:** Create, update, archive, transition workflow states, manage subscriptions, link GitHub PRs/commits, create issue relations (blocks, blocked-by, duplicate, related), and retrieve detailed issue data with fuzzy-matched entity validation.\n- **Comments & threading:** Add, update, list, and reply to threaded comments on both issues and project documents; project document comments are stored but rendered in the comments panel rather than visually anchored inline (Linear API limitation).\n- **Projects & milestones:** Create, update, archive, and query projects; manage milestones (upsert/get/list); post structured project status updates with health indicators; paginate large project descriptions.\n- **Initiatives & cycles:** Create, update, archive, and query high-level initiatives; link projects to initiatives; list and inspect time-boxed cycles (sprints) with team and status filters.\n- **Workspace & team metadata:** List teams, workflow states, labels, and notifications; retrieve recent user activity; look up team members and user profile via `WhoAmI`.\n- **Flexible lookups:** Most resources support lookup by UUID, human-readable identifier (e.g., `TOO-123`), slug, key, or name with fuzzy matching; suggestions are returned when an entity cannot be resolved.\n\n## OAuth\n\nThis toolkit authenticates via OAuth 2.0 with Linear. See the [Linear auth provider docs](https://docs.arcade.dev/en/references/auth-providers/linear) for setup details."
+  "generatedAt": "2026-06-10T12:12:02.745Z",
+  "summary": "# Linear Toolkit\n\nThe Linear toolkit connects LLMs to [Linear](https://linear.app) via the Arcade platform, enabling agents to fully manage issues, projects, initiatives, cycles, and team workflows programmatically.\n\n## Capabilities\n\n- **Issue lifecycle**: Create, update, archive, transition workflow states, manage relations (blocks/blocked-by/duplicate/related), subscribe to notifications, and link GitHub PRs/commits/issues.\n- **Projects & milestones**: Create, update, archive, and retrieve projects; add/list/upsert milestones; post and read project document comments with threading and quote metadata.\n- **Initiatives**: Create, update, archive, and list high-level strategic initiatives; link projects to initiatives; retrieve full paginated descriptions.\n- **Cycles & teams**: List time-boxed cycles filtered by team/status; inspect and list teams, workflow states, and issue labels across the workspace.\n- **Comments & threading**: Add, update, list, and reply to comments on both issues and project documents; retrieve threaded replies and quoted-text metadata (note: API-created project comments appear in the comments panel only, not visually anchored inline in the Linear UI).\n- **User context**: Retrieve the authenticated user's profile, team memberships, recent activity, and notifications.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via the **Linear** provider. See the [Arcade Linear auth provider docs](https://docs.arcade.dev/en/references/auth-providers/linear) for configuration details."
 }

--- a/toolkit-docs-generator/data/toolkits/mongodb.json
+++ b/toolkit-docs-generator/data/toolkits/mongodb.json
@@ -1,7 +1,7 @@
 {
   "id": "Mongodb",
   "label": "MongoDB",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Tools to query and explore a MongoDB database",
   "metadata": {
     "category": "databases",
@@ -18,8 +18,8 @@
     {
       "name": "AggregateDocuments",
       "qualifiedName": "Mongodb.AggregateDocuments",
-      "fullyQualifiedName": "Mongodb.AggregateDocuments@0.4.0",
-      "description": "Execute a MongoDB aggregation pipeline on a collection.\n\nONLY use this tool if you have already loaded the schema of the collection you need to query.\nUse the <get_collection_schema> tool to load the schema if not already known.\n\nReturns a list of JSON strings, where each string represents a result document from the aggregation (tools cannot return complex types).\n\nAggregation pipelines allow for complex data processing including:\n* $match - filter documents\n* $group - group documents and perform calculations\n* $project - reshape documents\n* $sort - sort documents\n* $limit - limit results\n* $lookup - join with other collections\n* And many more stages",
+      "fullyQualifiedName": "Mongodb.AggregateDocuments@0.4.1",
+      "description": "Execute a MongoDB aggregation pipeline on a collection.\n\nONLY use this tool if you have already loaded the schema of the collection you need to query.\nUse the <get_collection_schema> tool to load the schema if not already known.\n\nReturns a list of JSON strings, where each string represents a\nresult document from the aggregation\n(tools cannot return complex types).\n\nAggregation pipelines allow for complex data processing including:\n* $match - filter documents\n* $group - group documents and perform calculations\n* $project - reshape documents\n* $sort - sort documents\n* $limit - limit results\n* $lookup - join with other collections\n* And many more stages",
       "parameters": [
         {
           "name": "database_name",
@@ -122,7 +122,7 @@
     {
       "name": "CountDocuments",
       "qualifiedName": "Mongodb.CountDocuments",
-      "fullyQualifiedName": "Mongodb.CountDocuments@0.4.0",
+      "fullyQualifiedName": "Mongodb.CountDocuments@0.4.1",
       "description": "Count documents in a MongoDB collection matching the given filter.",
       "parameters": [
         {
@@ -206,8 +206,8 @@
     {
       "name": "DiscoverCollections",
       "qualifiedName": "Mongodb.DiscoverCollections",
-      "fullyQualifiedName": "Mongodb.DiscoverCollections@0.4.0",
-      "description": "Discover all the collections in the MongoDB database when the list of collections is not known.\n\nALWAYS use this tool before any other tool that requires a collection name.",
+      "fullyQualifiedName": "Mongodb.DiscoverCollections@0.4.1",
+      "description": "Discover all the collections in the MongoDB database.\n\nUse when the list of collections is not known.\nALWAYS use this tool before any other tool that requires a collection name.",
       "parameters": [
         {
           "name": "database_name",
@@ -264,7 +264,7 @@
     {
       "name": "DiscoverDatabases",
       "qualifiedName": "Mongodb.DiscoverDatabases",
-      "fullyQualifiedName": "Mongodb.DiscoverDatabases@0.4.0",
+      "fullyQualifiedName": "Mongodb.DiscoverDatabases@0.4.1",
       "description": "Discover all the databases in the MongoDB instance.",
       "parameters": [],
       "auth": null,
@@ -307,8 +307,8 @@
     {
       "name": "FindDocuments",
       "qualifiedName": "Mongodb.FindDocuments",
-      "fullyQualifiedName": "Mongodb.FindDocuments@0.4.0",
-      "description": "Find documents in a MongoDB collection.\n\nONLY use this tool if you have already loaded the schema of the collection you need to query.\nUse the <get_collection_schema> tool to load the schema if not already known.\n\nReturns a list of JSON strings, where each string represents a document from the collection (tools cannot return complex types).\n\nWhen running queries, follow these rules which will help avoid errors:\n* Always specify projection to limit fields returned if you don't need all data.\n* Always sort your results by the most important fields first. If you aren't sure, sort by '_id'.\n* Use appropriate MongoDB query operators for complex filtering ($gte, $lte, $in, $regex, etc.).\n* Be mindful of case sensitivity when querying string fields.\n* Use indexes when possible (typically on _id and commonly queried fields).",
+      "fullyQualifiedName": "Mongodb.FindDocuments@0.4.1",
+      "description": "Find documents in a MongoDB collection.\n\nONLY use this tool if you have already loaded the schema of the collection you need to query.\nUse the <get_collection_schema> tool to load the schema if not already known.\n\nReturns a list of JSON strings, where each string represents a\ndocument from the collection (tools cannot return complex types).\n\nWhen running queries, follow these rules which will help avoid errors:\n* Always specify projection to limit fields returned if you don't need all data.\n* Always sort your results by the most relevant fields first. Use '_id' if you're unsure.\n* Use appropriate MongoDB query operators for complex filtering ($gte, $lte, $in, $regex, etc.).\n* Be mindful of case sensitivity when querying string fields.\n* Use indexes when possible (typically on _id and commonly queried fields).",
       "parameters": [
         {
           "name": "database_name",
@@ -447,8 +447,8 @@
     {
       "name": "GetCollectionSchema",
       "qualifiedName": "Mongodb.GetCollectionSchema",
-      "fullyQualifiedName": "Mongodb.GetCollectionSchema@0.4.0",
-      "description": "Get the schema/structure of a MongoDB collection by sampling documents.\n\nSince MongoDB is schema-less, this tool samples a configurable number of documents\nto infer the schema structure and data types.\n\nThis tool should ALWAYS be used before executing any query. All collections in the query must be discovered first using the <discover_collections> tool.",
+      "fullyQualifiedName": "Mongodb.GetCollectionSchema@0.4.1",
+      "description": "Get the schema/structure of a MongoDB collection by sampling documents.\n\nSince MongoDB is schema-less, this tool samples a configurable number of documents\nto infer the schema structure and data types.\n\nThis tool should ALWAYS be used before executing any query.\nAll collections in the query must be discovered first using the <discover_collections> tool.",
       "parameters": [
         {
           "name": "database_name",
@@ -532,6 +532,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-03-01T11:12:23.245Z",
-  "summary": "Arcade's MongoDB toolkit provides tools to query and explore MongoDB instances. It enables schema sampling, collection discovery, filtered reads, counts, and aggregation pipelines for data exploration and analytics.\n\n**Capabilities**\n- Discover databases/collections and sample documents to infer schema structure before querying.\n- Perform efficient reads with projection, sorting and complex filtering to limit payloads and improve performance.\n- Execute aggregation pipelines for transformations, joins, grouping and analytics workflows.\n- Follow operational best practices: always discover collections first, fetch collection schema before queries, use indexes and limit returned fields.\n\n**Secrets**\n- password: MONGODB_CONNECTION_STRING — a connection string/credentials (e.g., mongodb+srv://user:password@cluster.example.com/db). Store securely and supply at runtime."
+  "generatedAt": "2026-06-10T12:11:59.596Z",
+  "summary": "The MongoDB toolkit connects Arcade to a MongoDB instance, enabling agents and tools to explore, query, and aggregate data across databases and collections.\n\n## Capabilities\n\n- **Discovery**: Enumerate all databases in a MongoDB instance and all collections within a database, establishing the context needed before any query runs.\n- **Schema inference**: Sample documents from a collection to infer field names and data types — essential since MongoDB is schema-less and must be introspected at runtime before querying.\n- **Document retrieval & counting**: Find documents with filtering, projection, sorting, and MongoDB query operators (`$gte`, `$lte`, `$in`, `$regex`, etc.); count matching documents without fetching them.\n- **Aggregation pipelines**: Execute multi-stage pipelines (`$match`, `$group`, `$project`, `$sort`, `$limit`, `$lookup`, and more) for complex data processing and cross-collection joins.\n\n## Secrets\n\n`MONGODB_CONNECTION_STRING` — The full connection URI used to authenticate and connect to your MongoDB instance (e.g., `mongodb+srv://user:password@cluster.mongodb.net/dbname`). It encodes the username, password, host(s), and any connection options. Obtain it from your MongoDB provider:\n\n- **MongoDB Atlas**: Navigate to your cluster → **Connect** → **Drivers** → copy the connection string, substituting your database user credentials. See the [Atlas connection string docs](https://www.mongodb.com/docs/atlas/driver-connection/).\n- **Self-hosted / MongoDB Community**: Construct the URI from your host, port, and credentials (e.g., `mongodb://username:password@host:27017/dbname`). See the [connection string URI format docs](https://www.mongodb.com/docs/manual/reference/connection-string/).\n\nStore this value as an Arcade secret. See [Arcade secret configuration](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) and manage secrets at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/vercel.json
+++ b/toolkit-docs-generator/data/toolkits/vercel.json
@@ -1,0 +1,2262 @@
+{
+  "id": "Vercel",
+  "label": "Vercel",
+  "version": "0.1.0",
+  "description": "Arcade.dev tools for interacting with Vercel",
+  "metadata": {
+    "category": "development",
+    "iconUrl": "https://design-system.arcade.dev/icons/vercel.svg",
+    "isBYOC": false,
+    "isPro": false,
+    "type": "arcade",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/development/vercel",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": null,
+  "tools": [
+    {
+      "name": "AddProjectDomain",
+      "qualifiedName": "Vercel.AddProjectDomain",
+      "fullyQualifiedName": "Vercel.AddProjectDomain@0.1.0",
+      "description": "Attach a custom domain to a project; the result reports its verification status.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project id (prj_...) or name to attach the domain to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "required": true,
+          "description": "Fully-qualified domain name to attach (e.g. app.example.com).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "redirect",
+          "type": "string",
+          "required": false,
+          "description": "Domain to redirect this domain to. Defaults to None (serve the project directly).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "git_branch",
+          "type": "string",
+          "required": false,
+          "description": "Git branch to bind the domain to. Defaults to None (the production branch).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.AddProjectDomain",
+        "parameters": {
+          "project": {
+            "value": "prj_4fBz9kLmXqR2wTyUvN8pJcDsEaHiOg",
+            "type": "string",
+            "required": true
+          },
+          "domain": {
+            "value": "app.example.com",
+            "type": "string",
+            "required": true
+          },
+          "redirect": {
+            "value": "www.example.com",
+            "type": "string",
+            "required": false
+          },
+          "git_branch": {
+            "value": "main",
+            "type": "string",
+            "required": false
+          },
+          "team": {
+            "value": "team_7kXqP3mLwRtUyNvBcDsEaHi",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CancelDeployment",
+      "qualifiedName": "Vercel.CancelDeployment",
+      "fullyQualifiedName": "Vercel.CancelDeployment@0.1.0",
+      "description": "Cancel an in-progress deployment.\n\nCanceling a deployment that has already finished is not an error: its current (terminal) state\nis returned unchanged rather than reporting a cancellation.",
+      "parameters": [
+        {
+          "name": "deployment",
+          "type": "string",
+          "required": true,
+          "description": "Deployment id (dpl_...) to cancel.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.CancelDeployment",
+        "parameters": {
+          "deployment": {
+            "value": "dpl_4MuNfvKgNxTbFuTpw9mYf3bHXQkL",
+            "type": "string",
+            "required": true
+          },
+          "team": {
+            "value": "team_7aB3cD9eF2gHiJkLmNoPqRsT",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CreateDeployment",
+      "qualifiedName": "Vercel.CreateDeployment",
+      "fullyQualifiedName": "Vercel.CreateDeployment@0.1.0",
+      "description": "Trigger a new deployment from inline source files, a git repository, or a prior deployment.\n\nThe target project must already exist (create it first); an unknown project name or id is\nrejected rather than silently auto-created. Exactly one source is required: pass files to\nupload source inline (no Git connection needed, the way to ship a first deployment on an\naccount without a connected repository), git_repo together with git_ref to deploy from a\nconnected repository, or redeploy_of to rebuild a prior deployment's source. Deploying from a\nrepository requires the Vercel account to have a connected Git integration for that provider.",
+      "parameters": [
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "Project name the deployment belongs to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "project",
+          "type": "string",
+          "required": false,
+          "description": "Project id (prj_...) or name to deploy. Defaults to None (inferred from name).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "required": false,
+          "description": "Environment to deploy to. Selecting preview, or leaving this as the default None, creates a preview deployment, with one exception: a project's very first deployment is always promoted to production by Vercel regardless of this value, so an omitted target on a project that has no prior deployment still goes live in production.",
+          "enum": [
+            "production",
+            "preview"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "files",
+          "type": "array",
+          "innerType": "json",
+          "required": false,
+          "description": "Source files to deploy inline, without any connected Git repository. Each entry is a file path and its UTF-8 text content. Use this to ship a first deployment for a project that has no Git integration. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "git_repo",
+          "type": "string",
+          "required": false,
+          "description": "Repository to deploy from, as owner/repo. Defaults to None (use files or redeploy_of instead).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "git_ref",
+          "type": "string",
+          "required": false,
+          "description": "Branch name or commit SHA to deploy from the repository. Required whenever git_repo is set (Vercel does not infer a default branch). Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "git_provider",
+          "type": "string",
+          "required": false,
+          "description": "Git host the repository lives on. Defaults to github.",
+          "enum": [
+            "github",
+            "gitlab",
+            "bitbucket"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "redeploy_of",
+          "type": "string",
+          "required": false,
+          "description": "Deployment id to redeploy. Rebuilds that deployment's source while picking up the project's current environment variables and build settings, so use this to roll out config changes (env vars edited after a deployment do not affect the running build until a rebuild). Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.CreateDeployment",
+        "parameters": {
+          "name": {
+            "value": "my-nextjs-app",
+            "type": "string",
+            "required": true
+          },
+          "project": {
+            "value": "prj_abc123XYZ456def789",
+            "type": "string",
+            "required": false
+          },
+          "target": {
+            "value": "production",
+            "type": "string",
+            "required": false
+          },
+          "files": {
+            "value": [
+              {
+                "path": "index.html",
+                "content": "<!DOCTYPE html><html><body><h1>Hello World</h1></body></html>"
+              },
+              {
+                "path": "style.css",
+                "content": "body { font-family: sans-serif; margin: 0; padding: 20px; }"
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
+          "git_repo": {
+            "value": "acme-org/my-nextjs-app",
+            "type": "string",
+            "required": false
+          },
+          "git_ref": {
+            "value": "main",
+            "type": "string",
+            "required": false
+          },
+          "git_provider": {
+            "value": "github",
+            "type": "string",
+            "required": false
+          },
+          "redeploy_of": {
+            "value": "dpl_7gHkJmNpQrStUvWxYz1234567890",
+            "type": "string",
+            "required": false
+          },
+          "team": {
+            "value": "team_aBcDeFgHiJkLmNoPqRsTuVwX",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CreateProject",
+      "qualifiedName": "Vercel.CreateProject",
+      "fullyQualifiedName": "Vercel.CreateProject@0.1.0",
+      "description": "Create a new project, optionally connecting a git repository to deploy from.",
+      "parameters": [
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "Name for the new project (lowercase letters, digits, and hyphens).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "framework",
+          "type": "string",
+          "required": false,
+          "description": "Framework preset slug (e.g. nextjs, vite, sveltekit). Defaults to None (auto-detect).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "git_repository",
+          "type": "string",
+          "required": false,
+          "description": "Repository to connect, as owner/repo (e.g. acme/marketing-site). Connecting a repository is what lets you deploy and scope preview variables to a branch. Defaults to None (no repository connected).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "git_provider",
+          "type": "string",
+          "required": false,
+          "description": "Git host the connected repository lives on. Defaults to github.",
+          "enum": [
+            "github",
+            "gitlab",
+            "bitbucket"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.CreateProject",
+        "parameters": {
+          "name": {
+            "value": "my-awesome-app",
+            "type": "string",
+            "required": true
+          },
+          "framework": {
+            "value": "nextjs",
+            "type": "string",
+            "required": false
+          },
+          "git_repository": {
+            "value": "acme/marketing-site",
+            "type": "string",
+            "required": false
+          },
+          "git_provider": {
+            "value": "github",
+            "type": "string",
+            "required": false
+          },
+          "team": {
+            "value": "team_abc123xyz",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DeleteEnvironmentVariable",
+      "qualifiedName": "Vercel.DeleteEnvironmentVariable",
+      "fullyQualifiedName": "Vercel.DeleteEnvironmentVariable@0.1.0",
+      "description": "Delete an environment variable from a project.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project id (prj_...) or name the variable belongs to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "env_id",
+          "type": "string",
+          "required": true,
+          "description": "Id of the environment variable to delete.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.DeleteEnvironmentVariable",
+        "parameters": {
+          "project": {
+            "value": "prj_abc123XYZ456def789",
+            "type": "string",
+            "required": true
+          },
+          "env_id": {
+            "value": "env_7gHiJkLmNoPqRsTu",
+            "type": "string",
+            "required": true
+          },
+          "team": {
+            "value": "team_myorganization",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DeleteProject",
+      "qualifiedName": "Vercel.DeleteProject",
+      "fullyQualifiedName": "Vercel.DeleteProject@0.1.0",
+      "description": "Permanently delete a project and all of its deployments.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project id (prj_...) or project name to delete.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.DeleteProject",
+        "parameters": {
+          "project": {
+            "value": "prj_abc123XYZ456def789",
+            "type": "string",
+            "required": true
+          },
+          "team": {
+            "value": "team_xyz987uvw654",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetCurrentUser",
+      "qualifiedName": "Vercel.GetCurrentUser",
+      "fullyQualifiedName": "Vercel.GetCurrentUser@0.1.0",
+      "description": "Return the Vercel account the access token authenticates as.\n\nCall this first in a session to confirm which account you are acting on\nbefore making any changes.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.GetCurrentUser",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetDeployment",
+      "qualifiedName": "Vercel.GetDeployment",
+      "fullyQualifiedName": "Vercel.GetDeployment@0.1.0",
+      "description": "Return a single deployment's state and metadata.",
+      "parameters": [
+        {
+          "name": "deployment",
+          "type": "string",
+          "required": true,
+          "description": "Deployment id (dpl_...) or deployment URL to inspect.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.GetDeployment",
+        "parameters": {
+          "deployment": {
+            "value": "dpl_4TxNGKHqnEFh9wR2oVmLcJyB",
+            "type": "string",
+            "required": true
+          },
+          "team": {
+            "value": "team_acme-corp",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetDeploymentLogs",
+      "qualifiedName": "Vercel.GetDeploymentLogs",
+      "fullyQualifiedName": "Vercel.GetDeploymentLogs@0.1.0",
+      "description": "Read a deployment's build and runtime log events to diagnose why it failed.",
+      "parameters": [
+        {
+          "name": "deployment",
+          "type": "string",
+          "required": true,
+          "description": "Deployment id (dpl_...) or deployment URL to read logs for.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of log events to return (1-1000). Defaults to 100.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "direction",
+          "type": "string",
+          "required": false,
+          "description": "Order to read events in. Defaults to forward (oldest first).",
+          "enum": [
+            "forward",
+            "backward"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "since",
+          "type": "integer",
+          "required": false,
+          "description": "Only return events created at or after this epoch-millisecond time. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "until",
+          "type": "integer",
+          "required": false,
+          "description": "Only return events created at or before this epoch-millisecond time. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.GetDeploymentLogs",
+        "parameters": {
+          "deployment": {
+            "value": "dpl_4TxBnGSMeQk7GnzBFWGHzPaD",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 250,
+            "type": "integer",
+            "required": false
+          },
+          "direction": {
+            "value": "forward",
+            "type": "string",
+            "required": false
+          },
+          "since": {
+            "value": 1711929600000,
+            "type": "integer",
+            "required": false
+          },
+          "until": {
+            "value": 1711933200000,
+            "type": "integer",
+            "required": false
+          },
+          "team": {
+            "value": "team_RgcMPBvkKxUmGzVXiRzJsHqW",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetProject",
+      "qualifiedName": "Vercel.GetProject",
+      "fullyQualifiedName": "Vercel.GetProject@0.1.0",
+      "description": "Return a single project's settings and latest deployment state.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project id (prj_...) or project name to inspect.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.GetProject",
+        "parameters": {
+          "project": {
+            "value": "prj_4aBcDeFgHiJkLmNoPqRsTuVwXyZ12345",
+            "type": "string",
+            "required": true
+          },
+          "team": {
+            "value": "team_7xYzAbCdEfGhIjKlMnOpQrSt",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetProjectDomain",
+      "qualifiedName": "Vercel.GetProjectDomain",
+      "fullyQualifiedName": "Vercel.GetProjectDomain@0.1.0",
+      "description": "Return a project domain's verification status and DNS-configuration state.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project id (prj_...) or name the domain is attached to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "required": true,
+          "description": "Fully-qualified domain name to inspect.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.GetProjectDomain",
+        "parameters": {
+          "project": {
+            "value": "prj_abc123XYZexampleProjectId",
+            "type": "string",
+            "required": true
+          },
+          "domain": {
+            "value": "www.example.com",
+            "type": "string",
+            "required": true
+          },
+          "team": {
+            "value": "team_xyz789exampleTeamId",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetTeam",
+      "qualifiedName": "Vercel.GetTeam",
+      "fullyQualifiedName": "Vercel.GetTeam@0.1.0",
+      "description": "Return a team's details, including its billing plan.",
+      "parameters": [
+        {
+          "name": "team",
+          "type": "string",
+          "required": true,
+          "description": "Team id (team_...) or team slug to look up.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.GetTeam",
+        "parameters": {
+          "team": {
+            "value": "team_abc123xyz456",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListDeployments",
+      "qualifiedName": "Vercel.ListDeployments",
+      "fullyQualifiedName": "Vercel.ListDeployments@0.1.0",
+      "description": "List deployments in the active scope, optionally filtered by project, target, and state.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": false,
+          "description": "Project id (prj_...) or name to scope to. Defaults to None (all projects in scope).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "required": false,
+          "description": "Filter to deployments for this environment. Defaults to None (any environment).",
+          "enum": [
+            "production",
+            "preview"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "state",
+          "type": "string",
+          "required": false,
+          "description": "Filter to deployments in this state. Defaults to None (any state).",
+          "enum": [
+            "QUEUED",
+            "INITIALIZING",
+            "BUILDING",
+            "READY",
+            "ERROR",
+            "CANCELED",
+            "DELETED"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of deployments to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from a prior call's next_cursor. Defaults to None (first page).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.ListDeployments",
+        "parameters": {
+          "project": {
+            "value": "prj_abc123XYZ456def789",
+            "type": "string",
+            "required": false
+          },
+          "target": {
+            "value": "production",
+            "type": "string",
+            "required": false
+          },
+          "state": {
+            "value": "READY",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "cursor": {
+            "value": "eyJwYWdlIjoyfQ==",
+            "type": "string",
+            "required": false
+          },
+          "team": {
+            "value": "team_xyz987uvw654",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListEnvironmentVariables",
+      "qualifiedName": "Vercel.ListEnvironmentVariables",
+      "fullyQualifiedName": "Vercel.ListEnvironmentVariables@0.1.0",
+      "description": "List a project's environment variables across all environments.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project id (prj_...) or name to list variables for.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "decrypt",
+          "type": "boolean",
+          "required": false,
+          "description": "Whether to include decrypted plaintext values in the result (only effective when the plan supports decryption). Defaults to False.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.ListEnvironmentVariables",
+        "parameters": {
+          "project": {
+            "value": "prj_abc123XYZ456def789ghi",
+            "type": "string",
+            "required": true
+          },
+          "decrypt": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "team": {
+            "value": "team_xyz987uvw654rst321",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListProjectDomains",
+      "qualifiedName": "Vercel.ListProjectDomains",
+      "fullyQualifiedName": "Vercel.ListProjectDomains@0.1.0",
+      "description": "List the custom domains attached to a project.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project id (prj_...) or name to list domains for.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of domains to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from a prior call's next_cursor. Defaults to None (first page).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.ListProjectDomains",
+        "parameters": {
+          "project": {
+            "value": "prj_abc123XYZ456defGHI789",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "cursor": {
+            "value": "cursor_eyJhbGciOiJIUzI1NiJ9",
+            "type": "string",
+            "required": false
+          },
+          "team": {
+            "value": "team_xyz987uvw654",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListProjects",
+      "qualifiedName": "Vercel.ListProjects",
+      "fullyQualifiedName": "Vercel.ListProjects@0.1.0",
+      "description": "List the projects in the active scope, optionally narrowed by a fuzzy name search.",
+      "parameters": [
+        {
+          "name": "search",
+          "type": "string",
+          "required": false,
+          "description": "Case-insensitive name fragment to filter projects by. Only projects whose name contains this fragment are returned. Defaults to None (no filter).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Number of projects to return (1-100). Without a search filter, a call returns up to this many. With a search filter, the listing is paged until at least this many matches are gathered (a call may return a few more from the last page scanned); use next_cursor for additional matches. Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from a prior call's next_cursor. Defaults to None (first page).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.ListProjects",
+        "parameters": {
+          "search": {
+            "value": "my-app",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "cursor": {
+            "value": "eyJsaW1pdCI6MjUsInN0YXJ0IjoiYWJjMTIzIn0=",
+            "type": "string",
+            "required": false
+          },
+          "team": {
+            "value": "team_abc123xyz",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListTeams",
+      "qualifiedName": "Vercel.ListTeams",
+      "fullyQualifiedName": "Vercel.ListTeams@0.1.0",
+      "description": "List the teams the access token can act on, to discover a valid team scope.",
+      "parameters": [
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of teams to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from a prior call's next_cursor. Defaults to None (first page).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.ListTeams",
+        "parameters": {
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "cursor": {
+            "value": "eyJwYWdlIjoxfQ==",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "PromoteDeployment",
+      "qualifiedName": "Vercel.PromoteDeployment",
+      "fullyQualifiedName": "Vercel.PromoteDeployment@0.1.0",
+      "description": "Make a deployment the project's current production deployment (\"ship this one\").\n\nA deployment that already targeted production (a staged or prior production build) is\npromoted instantly without a rebuild. A preview deployment cannot be aliased to production\ndirectly, because preview and production builds can differ (e.g. environment variables), so\nthis rebuilds the preview's source as a new production deployment — the same complete-rebuild\npath the Vercel dashboard uses to promote a preview. In that case the returned deployment is\nthe new build (still building), not the preview that was passed in.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project id (prj_...) or name whose production to repoint.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "deployment",
+          "type": "string",
+          "required": true,
+          "description": "Deployment id (dpl_...) to make the current production deployment.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.PromoteDeployment",
+        "parameters": {
+          "project": {
+            "value": "prj_4TzGn9xDuTvR8kLmQwPsYjF2cN1oE7aB",
+            "type": "string",
+            "required": true
+          },
+          "deployment": {
+            "value": "dpl_9XkR3mHvTqLpWnCsYbDjF6eA2uG8oZ1",
+            "type": "string",
+            "required": true
+          },
+          "team": {
+            "value": "team_5VcKp7dMxNqWrJtBsYhLfA3eG2iU9oR",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "RemoveProjectDomain",
+      "qualifiedName": "Vercel.RemoveProjectDomain",
+      "fullyQualifiedName": "Vercel.RemoveProjectDomain@0.1.0",
+      "description": "Detach a custom domain from a project.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project id (prj_...) or name the domain is attached to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "required": true,
+          "description": "Fully-qualified domain name to detach.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.RemoveProjectDomain",
+        "parameters": {
+          "project": {
+            "value": "prj_abc123xyz456def789ghi",
+            "type": "string",
+            "required": true
+          },
+          "domain": {
+            "value": "www.example.com",
+            "type": "string",
+            "required": true
+          },
+          "team": {
+            "value": "team_xyz789abc123",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "RollbackDeployment",
+      "qualifiedName": "Vercel.RollbackDeployment",
+      "fullyQualifiedName": "Vercel.RollbackDeployment@0.1.0",
+      "description": "Roll production back to a prior deployment, making it the current production deployment.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project id (prj_...) or name whose production to repoint.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "deployment",
+          "type": "string",
+          "required": true,
+          "description": "Prior deployment id (dpl_...) to roll production back to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.RollbackDeployment",
+        "parameters": {
+          "project": {
+            "value": "prj_abc123XYZdefGHI456jklMNO",
+            "type": "string",
+            "required": true
+          },
+          "deployment": {
+            "value": "dpl_7pQrStUvWxYz1234AbCdEfGh",
+            "type": "string",
+            "required": true
+          },
+          "team": {
+            "value": "team_myorganization",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SaveEnvironmentVariable",
+      "qualifiedName": "Vercel.SaveEnvironmentVariable",
+      "fullyQualifiedName": "Vercel.SaveEnvironmentVariable@0.1.0",
+      "description": "Create or update a project environment variable.\n\nOmit env_id to create (key, value, and target are required); pass env_id to update an existing\nvariable in place, changing only the fields you supply. Saving a variable does not affect\nalready-built deployments: a new deployment must be triggered for the change to take effect.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project id (prj_...) or name the variable belongs to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "env_id",
+          "type": "string",
+          "required": false,
+          "description": "Id of an existing variable to update. Omit to create a new variable.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "required": false,
+          "description": "Variable name. When creating, this is required and sets the name. When updating, it is ignored (the name is fixed). Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "value",
+          "type": "string",
+          "required": false,
+          "description": "Variable value. When creating, this is required. When updating, providing it changes the value; omitting it leaves the value unchanged. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "target",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Environments the variable applies to. When creating, this is required. When updating, providing it replaces the set; omitting it leaves it unchanged. Defaults to None.",
+          "enum": [
+            "production",
+            "preview",
+            "development"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "required": false,
+          "description": "How the value is stored, applied only when creating. Defaults to encrypted.",
+          "enum": [
+            "encrypted",
+            "plain",
+            "sensitive"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "git_branch",
+          "type": "string",
+          "required": false,
+          "description": "Git branch to scope a preview variable to (requires a project with a connected repository). When updating, providing it changes the scope. Defaults to None (all branches).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "comment",
+          "type": "string",
+          "required": false,
+          "description": "Note describing the variable. When updating, providing it changes the note. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "overwrite",
+          "type": "boolean",
+          "required": false,
+          "description": "When creating, whether to overwrite an existing variable with the same key and target instead of returning a conflict. Defaults to False.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.SaveEnvironmentVariable",
+        "parameters": {
+          "project": {
+            "value": "prj_abc123XYZ456defGHI789",
+            "type": "string",
+            "required": true
+          },
+          "env_id": {
+            "value": "env_7gHkLmNpQrStUvWx",
+            "type": "string",
+            "required": false
+          },
+          "key": {
+            "value": "DATABASE_URL",
+            "type": "string",
+            "required": false
+          },
+          "value": {
+            "value": "postgresql://user:pass@host:5432/mydb",
+            "type": "string",
+            "required": false
+          },
+          "target": {
+            "value": [
+              "production",
+              "preview"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "type": {
+            "value": "encrypted",
+            "type": "string",
+            "required": false
+          },
+          "git_branch": {
+            "value": "main",
+            "type": "string",
+            "required": false
+          },
+          "comment": {
+            "value": "Primary database connection string for production use",
+            "type": "string",
+            "required": false
+          },
+          "overwrite": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "team": {
+            "value": "team_exampleSlug123",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "UpdateProjectSettings",
+      "qualifiedName": "Vercel.UpdateProjectSettings",
+      "fullyQualifiedName": "Vercel.UpdateProjectSettings@0.1.0",
+      "description": "Update a project's build and framework settings; unset fields are left unchanged.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project id (prj_...) or project name to update.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "New project name. Defaults to None (unchanged).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "framework",
+          "type": "string",
+          "required": false,
+          "description": "New framework preset slug (e.g. nextjs, vite). Pass an empty string to clear the preset so the project type reverts to no framework (Other / static). Defaults to None (unchanged).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "build_command",
+          "type": "string",
+          "required": false,
+          "description": "Override the build command. Defaults to None (unchanged).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "install_command",
+          "type": "string",
+          "required": false,
+          "description": "Override the install command. Defaults to None (unchanged).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "output_directory",
+          "type": "string",
+          "required": false,
+          "description": "Override the build output directory. Defaults to None (unchanged).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "root_directory",
+          "type": "string",
+          "required": false,
+          "description": "Override the project root directory. Defaults to None (unchanged).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.UpdateProjectSettings",
+        "parameters": {
+          "project": {
+            "value": "prj_abc123XYZ456defGHI789",
+            "type": "string",
+            "required": true
+          },
+          "name": {
+            "value": "my-updated-project",
+            "type": "string",
+            "required": false
+          },
+          "framework": {
+            "value": "nextjs",
+            "type": "string",
+            "required": false
+          },
+          "build_command": {
+            "value": "npm run build",
+            "type": "string",
+            "required": false
+          },
+          "install_command": {
+            "value": "npm install",
+            "type": "string",
+            "required": false
+          },
+          "output_directory": {
+            "value": ".next",
+            "type": "string",
+            "required": false
+          },
+          "root_directory": {
+            "value": "apps/web",
+            "type": "string",
+            "required": false
+          },
+          "team": {
+            "value": "team_xyz789TeamSlug",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "VerifyProjectDomain",
+      "qualifiedName": "Vercel.VerifyProjectDomain",
+      "fullyQualifiedName": "Vercel.VerifyProjectDomain@0.1.0",
+      "description": "Trigger verification of a project domain and return its resulting status.\n\nAn unmet DNS challenge is the normal polling path, not an error: this returns the domain's\nstill-unverified status (with the outstanding challenge records) rather than failing.",
+      "parameters": [
+        {
+          "name": "project",
+          "type": "string",
+          "required": true,
+          "description": "Project id (prj_...) or name the domain is attached to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "required": true,
+          "description": "Fully-qualified domain name to verify.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team id (team_...) or team slug to scope the request to. Defaults to None (the token's own personal scope).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "VERCEL_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "VERCEL_ACCESS_TOKEN",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Vercel.VerifyProjectDomain",
+        "parameters": {
+          "project": {
+            "value": "prj_abc123XYZ456def789",
+            "type": "string",
+            "required": true
+          },
+          "domain": {
+            "value": "example.com",
+            "type": "string",
+            "required": true
+          },
+          "team": {
+            "value": "team_xyz789abc123",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-06-10T12:12:07.252Z",
+  "summary": "The Vercel toolkit lets you manage Vercel projects, deployments, domains, and environment variables programmatically via Arcade. It covers the full project lifecycle — from creation and configuration through deployment, promotion, rollback, and teardown.\n\n## Capabilities\n\n- **Account & team discovery** — resolve the authenticated account, list accessible teams, and inspect team details (including billing plan) to establish the correct scope before making changes.\n- **Project management** — create, retrieve, list, update settings for, and permanently delete projects; optionally connect a Git repository at creation time.\n- **Deployment lifecycle** — trigger deployments from inline source files, connected Git repositories, or prior deployment sources; cancel in-progress builds; inspect state and build/runtime logs; promote a deployment to production; and roll production back to a prior build.\n- **Custom domain management** — attach and detach custom domains, retrieve verification and DNS-configuration status, list all domains on a project, and trigger re-verification against outstanding DNS challenges.\n- **Environment variable management** — list, create, update, and delete project environment variables across all environments.\n\n## Secrets\n\n`VERCEL_ACCESS_TOKEN` is a Vercel personal access token (or team-scoped OAuth token) used to authenticate every API call. To obtain one:\n\n1. Log in to your Vercel account and open **Account Settings → Tokens** (personal token): [https://vercel.com/account/tokens](https://vercel.com/account/tokens). For a team-scoped token, open the team's **Settings → Tokens**.\n2. Click **Create**, give it a name, choose an expiry, and optionally restrict it to a specific team scope.\n3. Copy the token immediately — Vercel only shows it once.\n4. The token needs sufficient permissions for all operations you intend to use (full-access tokens work for all tools; read-only tokens will fail write operations).\n\nFor details on creating tokens see the [Vercel documentation on access tokens](https://vercel.com/docs/accounts/create-and-manage-access-tokens).\n\nStore this value as an Arcade secret. See [Arcade secret configuration docs](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) and manage your secrets at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
+}


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/27275092509

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and generated toolkit metadata only; no application logic or auth changes in the reviewed diff.
> 
> **Overview**
> Scheduled **MCP / integration docs** refresh: Nextra **Optimized** nav entries and regenerated `toolkit-docs-generator` JSON for newly published Arcade toolkits.
> 
> **New optimized integrations in the docs sidebar** include Apollo, Ashby, Customer.io, Freshdesk, Datadog, Vercel, and Discord Bot (plus matching entries under customer-support, sales, productivity, development, and social `_meta.tsx`).
> 
> **New toolkit manifests** add full tool catalogs, secrets, and summaries for integrations such as **Apollo** (enrichment/search), **Ashby** (ATS), **Customer.io** (people/messaging/events), **Datadog** (logs/spans/traces), and **Discord Bot** (channel messaging). Existing **Bright Data** and **ClickHouse** entries are bumped (e.g. `0.5.0`→`0.5.1`, `0.4.0`→`0.4.1`) with updated `generatedAt` timestamps and expanded secrets/summary copy.
> 
> This is documentation and generated metadata only—no runtime product code in the diff shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc38923ff6459c8921f1c332da09705a95fd69b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->