### PR TITLE
fix(seo): clear remaining docs audit errors (MARTECH-19)

### DIFF
--- a/app/_components/contact-email.tsx
+++ b/app/_components/contact-email.tsx
@@ -4,6 +4,10 @@ import Link from "next/link";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 
+// TODO(i18n): hardcoded to the English contact page. Docs content is en-only
+// today, so this is the safe target (a /<locale>/ link could 404 for locales
+// without the page). When translated content ships, derive the active locale
+// (e.g. via usePathname) and point at /<locale>/resources/contact-us.
 const CONTACT_PAGE = "/en/resources/contact-us";
 
 type ContactEmailProps = {

--- a/app/_components/contact-email.tsx
+++ b/app/_components/contact-email.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+
+const CONTACT_PAGE = "/en/resources/contact-us";
+
+type ContactEmailProps = {
+  /** Local part of the address, e.g. "security" for security@arcade.dev. */
+  user: string;
+  /** Domain of the address, e.g. "arcade.dev". */
+  domain: string;
+  /** Visible link text. Keep it free of the raw address (see below). */
+  children: ReactNode;
+};
+
+/**
+ * A mailto link whose address is assembled only after hydration.
+ *
+ * Cloudflare's Email Address Obfuscation runs at the edge on the server-rendered
+ * HTML and rewrites any `mailto:`/address it finds into a
+ * `/cdn-cgi/l/email-protection` link, which crawlers report as broken. By keeping
+ * the address out of the SSR markup — we render a plain link to the contact page
+ * until the component mounts — there is nothing for Cloudflare to rewrite, while
+ * real users still get a working `mailto:`. Pass visible text via `children`
+ * (not the literal address) so it isn't exposed server-side either.
+ */
+export function ContactEmail({ user, domain, children }: ContactEmailProps) {
+  const [address, setAddress] = useState<string | null>(null);
+
+  useEffect(() => {
+    setAddress(`${user}@${domain}`);
+  }, [user, domain]);
+
+  if (address) {
+    return <a href={`mailto:${address}`}>{children}</a>;
+  }
+
+  return <Link href={CONTACT_PAGE}>{children}</Link>;
+}

--- a/app/_lib/integration-catalog.ts
+++ b/app/_lib/integration-catalog.ts
@@ -1,0 +1,52 @@
+import type { Toolkit } from "@arcadeai/design-system";
+import { TOOLKITS } from "@arcadeai/design-system/metadata/toolkits";
+import { PARTNER_TOOLKITS } from "@/app/_data/partner-toolkits";
+import { readToolkitData } from "./toolkit-data";
+import { normalizeToolkitId, type ToolkitWithDocsLink } from "./toolkit-slug";
+
+const getToolkitDocsLink = (toolkit: Toolkit): string | undefined => {
+  if ("docsLink" in toolkit) {
+    const value = (toolkit as ToolkitWithDocsLink).docsLink;
+    return value ?? undefined;
+  }
+  return;
+};
+
+/**
+ * The full integrations catalog the index renders: design-system toolkits
+ * (enriched with a `docsLink` from their data file when the catalog entry
+ * lacks one, so the card's slug matches the generated page) plus docs-local
+ * partner toolkits.
+ */
+export const getToolkitsWithDocsLinks = async (): Promise<
+  ToolkitWithDocsLink[]
+> => {
+  const docsLinkById = new Map<string, string>();
+
+  await Promise.all(
+    TOOLKITS.map(async (toolkit) => {
+      const existing = getToolkitDocsLink(toolkit);
+      if (existing) {
+        return;
+      }
+
+      const data = await readToolkitData(toolkit.id);
+      if (data?.metadata?.docsLink) {
+        docsLinkById.set(
+          normalizeToolkitId(toolkit.id),
+          data.metadata.docsLink
+        );
+      }
+    })
+  );
+
+  const dsToolkits: ToolkitWithDocsLink[] = TOOLKITS.map((toolkit) => {
+    const existing = getToolkitDocsLink(toolkit);
+    const docsLink =
+      existing ?? docsLinkById.get(normalizeToolkitId(toolkit.id));
+
+    return docsLink ? { ...toolkit, docsLink } : toolkit;
+  });
+
+  return [...dsToolkits, ...PARTNER_TOOLKITS];
+};

--- a/app/_lib/integration-index.ts
+++ b/app/_lib/integration-index.ts
@@ -1,0 +1,67 @@
+import { getToolkitSlug, type ToolkitWithDocsLink } from "./toolkit-slug";
+
+const INTEGRATIONS_BASE = "/en/resources/integrations";
+
+/**
+ * The integrations link a toolkit card points to: `/en/resources/integrations/
+ * <category>/<slug>`. Mirrors the slug + category logic used to generate the
+ * dynamic `[toolkitId]` routes so cards and pages agree.
+ */
+export function toIntegrationLink(toolkit: {
+  id: string;
+  docsLink?: string | null;
+  category?: string | null;
+}): string {
+  const slug = getToolkitSlug({ id: toolkit.id, docsLink: toolkit.docsLink });
+  const category = toolkit.category ?? "others";
+  return `${INTEGRATIONS_BASE}/${category}/${slug}`;
+}
+
+export type ResolvedIndexToolkit = ToolkitWithDocsLink & { hasPage: boolean };
+
+/**
+ * Decide which catalog toolkits the integrations index should render, and
+ * whether each one links to a real page.
+ *
+ * The design-system catalog carries legacy bare-name entries (e.g. "Datadog"
+ * alongside "DatadogApi") and doc-less placeholders (e.g. "Discord") that have
+ * no generated docs page — linking to them 404s. Given the set of links that
+ * actually resolve (`validLinks`: dynamic toolkit routes + authored static
+ * pages), this:
+ *   - drops a bare entry when its `-api` sibling owns the real page (collapses
+ *     Datadog/DatadogApi, Vercel/VercelApi, Ashby/AshbyApi, Customerio/...),
+ *   - de-dupes entries that resolve to the same URL (e.g. Notion/NotionToolkit),
+ *   - flags the rest with `hasPage` so the caller can render doc-less toolkits
+ *     as non-clickable cards instead of as broken links.
+ */
+export function resolveIndexToolkits(
+  toolkits: ToolkitWithDocsLink[],
+  validLinks: ReadonlySet<string>
+): ResolvedIndexToolkit[] {
+  const seen = new Set<string>();
+  const resolved: ResolvedIndexToolkit[] = [];
+
+  for (const toolkit of toolkits) {
+    // Hidden toolkits never render in the index (matches the client filter).
+    if (toolkit.isHidden) {
+      continue;
+    }
+
+    const link = toIntegrationLink(toolkit);
+    const hasPage = validLinks.has(link);
+
+    // A bare duplicate of a real "-api" toolkit: drop it; the real card stays.
+    if (!hasPage && validLinks.has(`${link}-api`)) {
+      continue;
+    }
+
+    // Collapse multiple catalog entries that point at the same URL.
+    if (seen.has(link)) {
+      continue;
+    }
+    seen.add(link);
+    resolved.push({ ...toolkit, hasPage });
+  }
+
+  return resolved;
+}

--- a/app/_lib/toolkit-static-params.ts
+++ b/app/_lib/toolkit-static-params.ts
@@ -186,3 +186,67 @@ export async function getToolkitStaticParamsForCategory(
     .filter((route) => route.category === category)
     .map((route) => ({ toolkitId: route.toolkitId }));
 }
+
+const INTEGRATIONS_APP_DIR = join(
+  process.cwd(),
+  "app",
+  "en",
+  "resources",
+  "integrations"
+);
+
+const PAGE_FILE_NAMES = new Set(["page.mdx", "page.tsx"]);
+
+/**
+ * Authored static integration pages (e.g. partner pages like `search/tavily`
+ * and `tool-feedback`) live next to the dynamic `[toolkitId]` routes. They are
+ * real pages but are not part of `listToolkitRoutes`, so enumerate them from
+ * disk under the known integration categories.
+ */
+const listStaticIntegrationLinks = async (): Promise<string[]> => {
+  const links: string[] = [];
+
+  for (const category of INTEGRATION_CATEGORIES) {
+    const categoryDir = join(INTEGRATIONS_APP_DIR, category);
+    try {
+      const slugs = await readdir(categoryDir, { withFileTypes: true });
+      for (const slug of slugs) {
+        if (!slug.isDirectory() || slug.name.startsWith("[")) {
+          continue;
+        }
+        const files = await readdir(join(categoryDir, slug.name));
+        if (files.some((file) => PAGE_FILE_NAMES.has(file))) {
+          links.push(`/en/resources/integrations/${category}/${slug.name}`);
+        }
+      }
+    } catch {
+      // Category dir missing or unreadable — skip it.
+    }
+  }
+
+  return links;
+};
+
+/**
+ * The full set of links the integrations index may point at and that actually
+ * resolve: dynamic toolkit routes plus authored static pages. Used to decide
+ * whether a catalog card should be clickable.
+ */
+export async function listValidIntegrationLinks(options?: {
+  dataDir?: string;
+  toolkitsCatalog?: ToolkitCatalogEntry[];
+}): Promise<Set<string>> {
+  const routes = await listToolkitRoutes(options);
+  const links = new Set<string>(
+    routes.map(
+      (route) =>
+        `/en/resources/integrations/${route.category}/${route.toolkitId}`
+    )
+  );
+
+  for (const staticLink of await listStaticIntegrationLinks()) {
+    links.add(staticLink);
+  }
+
+  return links;
+}

--- a/app/en/references/auth-providers/oauth2/page.mdx
+++ b/app/en/references/auth-providers/oauth2/page.mdx
@@ -5,6 +5,7 @@ description: Authorize tools and agents with any OAuth 2.0-compatible provider
 
 import { Tabs, Callout, Steps } from "nextra/components";
 import ToggleContent from "@/app/_components/toggle-content";
+import { ContactEmail } from "@/app/_components/contact-email";
 
 # OAuth 2.0
 
@@ -125,8 +126,11 @@ The ID of the provider (`hooli` in this example) can be any string. It's used to
 Each service expects a slightly different set of values in the `oauth2` section. Refer to the configuration reference below, and to your service's documentation to understand what values are required.
 
 <Callout>
-  If you need help configuring a specific provider, [get in touch with
-  us](mailto:contact@arcade.dev)!
+  If you need help configuring a specific provider,{" "}
+  <ContactEmail domain="arcade.dev" user="contact">
+    get in touch with us
+  </ContactEmail>
+  !
 </Callout>
 
 </Steps>

--- a/app/en/references/auth-providers/page.mdx
+++ b/app/en/references/auth-providers/page.mdx
@@ -6,6 +6,7 @@ description: Registry of all auth providers available in the Arcade ecosystem
 # Auth Providers
 
 import { ToolCard } from "@/app/_components/tool-card";
+import { ContactEmail } from "@/app/_components/contact-email";
 
 Auth providers enable users to seamlessly and securely allow Arcade tools to access their data.
 
@@ -156,7 +157,7 @@ For more information on how to customize your auth provider, select an auth prov
   />
 </div>
 
-If the auth provider you need is not listed, try the [OAuth 2.0](/references/auth-providers/oauth2) provider, or [get in touch](mailto:contact@arcade.dev) with us!
+If the auth provider you need is not listed, try the [OAuth 2.0](/references/auth-providers/oauth2) provider, or <ContactEmail domain="arcade.dev" user="contact">get in touch</ContactEmail> with us!
 
 ## Using multiple providers of the same type
 

--- a/app/en/references/auth-providers/square/page.mdx
+++ b/app/en/references/auth-providers/square/page.mdx
@@ -6,7 +6,7 @@ The Square auth provider enables tools and agents to call [Square APIs](https://
 
 <Callout>
   Want to quickly get started with Square in your agent or AI app? The pre-built
-  [Arcade Square MCP Server](/resources/integrations/productivity/squareupapi)
+  [Arcade Square MCP Server](/resources/integrations/productivity/squareup-api)
   is what you want!
 </Callout>
 
@@ -16,7 +16,7 @@ This page describes how to use and configure Square auth with Arcade.
 
 This auth provider is used by:
 
-- The [Arcade Square MCP Server](/resources/integrations/productivity/squareupapi), which provides pre-built tools for interacting with Square
+- The [Arcade Square MCP Server](/resources/integrations/productivity/squareup-api), which provides pre-built tools for interacting with Square
 - Your [app code](#using-square-auth-in-app-code) that needs to call the Square API
 - Or, your [custom tools](#using-square-auth-in-custom-tools) that need to call the Square API
 
@@ -247,7 +247,7 @@ const token = authResponse.context.token;
 
 ## Using Square auth in custom tools
 
-You can use the pre-built [Arcade Square MCP Server](/resources/integrations/productivity/squareupapi) to quickly build agents and AI apps that interact with Square.
+You can use the pre-built [Arcade Square MCP Server](/resources/integrations/productivity/squareup-api) to quickly build agents and AI apps that interact with Square.
 
 If the pre-built tools in the Square MCP Server don't meet your needs, you can author your own [custom tools](/guides/create-tools/tool-basics/build-mcp-server) that interact with the Square API.
 

--- a/app/en/resources/faq/page.mdx
+++ b/app/en/resources/faq/page.mdx
@@ -7,6 +7,7 @@ import { Button } from "@arcadeai/design-system";
 import { MessagesSquare } from "lucide-react";
 import Link from "next/link";
 import { Tabs } from "nextra/components";
+import { ContactEmail } from "@/app/_components/contact-email";
 
 # Frequently Asked Questions
 
@@ -42,7 +43,7 @@ This is an important observation. Technically, both included and custom provider
 
 ### Can my users connect multiple accounts of the same provider?
 
-Please [contact us](mailto:support@arcade.dev) if you need this feature.
+Please <ContactEmail domain="arcade.dev" user="support">contact us</ContactEmail> if you need this feature.
 
 ### Can I authenticate multiple tools at once?
 

--- a/app/en/resources/integrations/_lib/toolkit-docs-page.tsx
+++ b/app/en/resources/integrations/_lib/toolkit-docs-page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { ToolkitPage } from "@/app/_components/toolkit-docs";
 import { readToolkitData } from "@/app/_lib/toolkit-data";
-import { normalizeToolkitId } from "@/app/_lib/toolkit-slug";
+import { getToolkitSlug, normalizeToolkitId } from "@/app/_lib/toolkit-slug";
 import {
   getToolkitStaticParamsForCategory,
   type IntegrationCategory,
@@ -43,9 +43,20 @@ export function createToolkitDocsPage(category: IntegrationCategory) {
       return {};
     }
 
+    // Canonicalize to the toolkit's preferred slug so any alias that resolves
+    // to the same content (e.g. a normalized id vs. its docsLink slug) points
+    // search engines at one URL.
+    const canonicalSlug = getToolkitSlug({
+      id: data.id,
+      docsLink: data.metadata?.docsLink,
+    });
+
     return {
       title: data.label || data.id,
       description: data.description || "Generated MCP server documentation.",
+      alternates: {
+        canonical: `/en/resources/integrations/${category}/${canonicalSlug}`,
+      },
     };
   };
 

--- a/app/en/resources/integrations/components/toolkits-client.tsx
+++ b/app/en/resources/integrations/components/toolkits-client.tsx
@@ -6,9 +6,9 @@ import { Code2, MessageSquarePlus, Search } from "lucide-react";
 import Link from "next/link";
 import { ComingSoonProvider } from "@/app/_components/coming-soon-context";
 import {
-  getToolkitSlug,
-  type ToolkitWithDocsLink,
-} from "@/app/_lib/toolkit-slug";
+  type ResolvedIndexToolkit,
+  toIntegrationLink,
+} from "@/app/_lib/integration-index";
 import { FiltersBar } from "./filters-bar";
 import { ToolCard } from "./tool-card";
 import { TYPE_CONFIG, TYPE_DESCRIPTIONS } from "./type-config";
@@ -16,20 +16,8 @@ import { useFilters } from "./use-filters";
 import { useToolkitFilters } from "./use-toolkit-filters";
 
 type ToolkitsClientProps = {
-  toolkits: ToolkitWithDocsLink[];
+  toolkits: ResolvedIndexToolkit[];
 };
-
-// Map toolkits to their category page (JSON-rendered pages).
-function mapToToolkitPage(
-  toolkit: { id: string; docsLink?: string | null },
-  category: string
-): string {
-  const slug = getToolkitSlug({
-    id: toolkit.id,
-    docsLink: toolkit.docsLink,
-  });
-  return `/en/resources/integrations/${category}/${slug}`;
-}
 
 /**
  * Get toolkit icon with fallback for API toolkits.
@@ -194,17 +182,16 @@ export default function ToolkitsClient({ toolkits }: ToolkitsClientProps) {
                       icon={IconComponent}
                       iconUrl={iconUrl}
                       isByoc={toolkit.isBYOC}
-                      isComingSoon={toolkit.isComingSoon}
+                      // Doc-less toolkits have no page; render them as
+                      // non-clickable (coming-soon) cards instead of links to
+                      // a 404.
+                      isComingSoon={
+                        toolkit.isComingSoon || toolkit.hasPage === false
+                      }
                       isPartner={toolkit.isPartner}
                       isPro={toolkit.isPro}
                       key={toolkit.id}
-                      link={mapToToolkitPage(
-                        {
-                          id: toolkit.id,
-                          docsLink: toolkit.docsLink,
-                        },
-                        toolkit.category ?? "others"
-                      )}
+                      link={toIntegrationLink(toolkit)}
                       name={toolkit.label}
                       type={toolkit.type}
                     />

--- a/app/en/resources/integrations/components/toolkits.tsx
+++ b/app/en/resources/integrations/components/toolkits.tsx
@@ -1,60 +1,23 @@
-import { TOOLKITS, type Toolkit } from "@arcadeai/design-system";
 import { Suspense } from "react";
-import { PARTNER_TOOLKITS } from "@/app/_data/partner-toolkits";
-import { readToolkitData } from "@/app/_lib/toolkit-data";
-import {
-  normalizeToolkitId,
-  type ToolkitWithDocsLink,
-} from "@/app/_lib/toolkit-slug";
+import { getToolkitsWithDocsLinks } from "@/app/_lib/integration-catalog";
+import { resolveIndexToolkits } from "@/app/_lib/integration-index";
+import { listValidIntegrationLinks } from "@/app/_lib/toolkit-static-params";
 import ToolkitsClient from "./toolkits-client";
 
-const getToolkitDocsLink = (toolkit: Toolkit): string | undefined => {
-  if ("docsLink" in toolkit) {
-    const value = (toolkit as ToolkitWithDocsLink).docsLink;
-    return value ?? undefined;
-  }
-  return;
-};
-
-const getToolkitsWithDocsLinks = async (): Promise<ToolkitWithDocsLink[]> => {
-  const docsLinkById = new Map<string, string>();
-
-  await Promise.all(
-    TOOLKITS.map(async (toolkit) => {
-      const existing = getToolkitDocsLink(toolkit);
-      if (existing) {
-        return;
-      }
-
-      const data = await readToolkitData(toolkit.id);
-      if (data?.metadata?.docsLink) {
-        docsLinkById.set(
-          normalizeToolkitId(toolkit.id),
-          data.metadata.docsLink
-        );
-      }
-    })
-  );
-
-  const dsToolkits: ToolkitWithDocsLink[] = TOOLKITS.map((toolkit) => {
-    const existing = getToolkitDocsLink(toolkit);
-    const docsLink =
-      existing ?? docsLinkById.get(normalizeToolkitId(toolkit.id));
-
-    return docsLink ? { ...toolkit, docsLink } : toolkit;
-  });
-
-  return [...dsToolkits, ...PARTNER_TOOLKITS];
-};
-
 export default async function Toolkits() {
-  const toolkits = await getToolkitsWithDocsLinks();
+  const [toolkits, validLinks] = await Promise.all([
+    getToolkitsWithDocsLinks(),
+    listValidIntegrationLinks(),
+  ]);
+  // Resolve which cards link to a real page. Doc-less catalog entries are kept
+  // but rendered non-clickable; bare duplicates of "-api" toolkits are dropped.
+  const resolvedToolkits = resolveIndexToolkits(toolkits, validLinks);
   // Suspense boundary is required because ToolkitsClient calls
   // useSearchParams(); without it, Next.js bails out of static prerendering
   // for the whole page.
   return (
     <Suspense fallback={null}>
-      <ToolkitsClient toolkits={toolkits} />
+      <ToolkitsClient toolkits={resolvedToolkits} />
     </Suspense>
   );
 }

--- a/app/en/resources/security-research-program/page.mdx
+++ b/app/en/resources/security-research-program/page.mdx
@@ -3,6 +3,8 @@ title: "Security Research Program"
 description: "Report security vulnerabilities and help us build safe and reliable tools"
 ---
 
+import { ContactEmail } from "@/app/_components/contact-email";
+
 # Security Research Program
 
 At Arcade, security is fundamental to our mission of building safe and reliable tools. We recognize that the security research community plays a valuable role in identifying potential vulnerabilities.
@@ -26,7 +28,7 @@ We're interested in reports about:
 
 ## Reporting process
 
-Please email [security@arcade.dev](mailto:security@arcade.dev) with:
+Please email <ContactEmail domain="arcade.dev" user="security">our security team</ContactEmail> with:
 * A clear description of the issue
 * Steps to reproduce
 * Potential impact assessment
@@ -45,5 +47,5 @@ We'll acknowledge receipt within 72 hours and aim to provide an initial assessme
 
 While we're a small team with limited resources, we appreciate the effort researchers put into improving our security. We'll credit researchers (with permission) in our security updates and may provide modest rewards for significant findings on a case-by-case basis.
 
-For questions about this program, please contact [security@arcade.dev](mailto:security@arcade.dev).
+For questions about this program, please contact <ContactEmail domain="arcade.dev" user="security">our security team</ContactEmail>.
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -24,6 +24,13 @@ const nextConfig: NextConfig = withLlmsTxt({
   withNextra({
     async redirects() {
       return [
+        // The toolkit-page breadcrumb links "Resources" -> /resources, which has
+        // no index page. Send it to the integrations registry instead of 404ing.
+        {
+          source: "/:locale/resources",
+          destination: "/:locale/resources/integrations",
+          permanent: true,
+        },
         // Dissolved guides/security section
         {
           source: "/:locale/guides/security/security-research-program",

--- a/tests/chrome-no-mailto.test.ts
+++ b/tests/chrome-no-mailto.test.ts
@@ -18,11 +18,18 @@ const NON_NEWLINE = /[^\n]/g;
  * shared chrome becomes a broken link on every page. Link to
  * /en/resources/contact-us instead. In-content email links on individual pages
  * are fine and are not scanned here.
+ *
+ * Exception: app/_components/contact-email.tsx is the sanctioned helper that
+ * assembles a mailto only on the client (after mount) and renders a plain
+ * contact-page link in SSR, so it never emits a raw email link for crawlers.
  */
 test(
   "shared components contain no mailto: or email-protection links",
   async () => {
-    const files = await fg("app/_components/**/*.{ts,tsx}");
+    const files = await fg("app/_components/**/*.{ts,tsx}", {
+      // The sanctioned client-only mailto helper (see docstring) is exempt.
+      ignore: ["app/_components/contact-email.tsx"],
+    });
     const offenders: Array<{ file: string; line: number; match: string }> = [];
 
     for (const file of files) {

--- a/tests/integration-index-links.test.ts
+++ b/tests/integration-index-links.test.ts
@@ -1,0 +1,159 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { beforeAll, describe, expect, test } from "vitest";
+import { getToolkitsWithDocsLinks } from "@/app/_lib/integration-catalog";
+import {
+  type ResolvedIndexToolkit,
+  resolveIndexToolkits,
+  toIntegrationLink,
+} from "@/app/_lib/integration-index";
+import { listValidIntegrationLinks } from "@/app/_lib/toolkit-static-params";
+
+const TIMEOUT = 30_000;
+const ROOT = process.cwd();
+
+/**
+ * Guards the regression class MARTECH-19 fixed: the integrations index (a TSX
+ * component) and the toolkit breadcrumb produced internal links to pages that
+ * don't exist. tests/broken-link-check.test.ts only scans MDX, so it can't see
+ * component-generated links or dynamic [toolkitId] slugs.
+ */
+describe("integrations index links", () => {
+  let resolved: ResolvedIndexToolkit[];
+  let validLinks: Set<string>;
+  let byLink: Map<string, ResolvedIndexToolkit[]>;
+
+  beforeAll(async () => {
+    const [toolkits, links] = await Promise.all([
+      getToolkitsWithDocsLinks(),
+      listValidIntegrationLinks(),
+    ]);
+    validLinks = links;
+    resolved = resolveIndexToolkits(toolkits, validLinks);
+    byLink = new Map();
+    for (const toolkit of resolved) {
+      const link = toIntegrationLink(toolkit);
+      const bucket = byLink.get(link) ?? [];
+      bucket.push(toolkit);
+      byLink.set(link, bucket);
+    }
+  }, TIMEOUT);
+
+  test("no clickable card links to a page that does not exist", () => {
+    const brokenClickable = resolved
+      .filter((toolkit) => toolkit.hasPage)
+      .map((toolkit) => toIntegrationLink(toolkit))
+      .filter((link) => !validLinks.has(link));
+
+    expect(brokenClickable).toEqual([]);
+  });
+
+  test("doc-less catalog toolkits stay visible but are non-clickable", () => {
+    // "Discord" is in the design-system catalog but has no docs page and no
+    // "-api" sibling — it must be rendered, but not as a link to a 404.
+    const discord = byLink.get("/en/resources/integrations/social/discord");
+    expect(discord, "discord card is present").toBeDefined();
+    expect(discord?.every((toolkit) => toolkit.hasPage === false)).toBe(true);
+  });
+
+  test("bare '-api' duplicates are dropped in favor of the real card", () => {
+    // The catalog carries both "Datadog" (bare, no page) and "DatadogApi".
+    expect(byLink.has("/en/resources/integrations/development/datadog")).toBe(
+      false
+    );
+    const datadogApi = byLink.get(
+      "/en/resources/integrations/development/datadog-api"
+    );
+    expect(datadogApi?.[0]?.hasPage).toBe(true);
+  });
+
+  test("partner toolkits with authored static pages stay clickable", () => {
+    // Tavily is a partner toolkit; its page is an authored static MDX file, not
+    // a generated [toolkitId] route.
+    const tavily = byLink.get("/en/resources/integrations/search/tavily");
+    expect(tavily?.[0]?.hasPage).toBe(true);
+  });
+
+  test("duplicate catalog entries collapse to a single card", () => {
+    // "Notion" and "NotionToolkit" both resolve to /productivity/notion.
+    const notion = byLink.get("/en/resources/integrations/productivity/notion");
+    expect(notion).toHaveLength(1);
+  });
+});
+
+const LOCALE_PREFIX = /^\/(en|es|pt-BR)(?=\/|$)/;
+const HREF_LITERAL = /href="(\/[^"#]+)"/g;
+
+const withEnLocale = (path: string): string =>
+  LOCALE_PREFIX.test(path) ? path : `/en${path}`;
+
+const toLocaleParam = (path: string): string =>
+  withEnLocale(path).replace(LOCALE_PREFIX, "/:locale");
+
+const pageFileExists = (path: string): boolean => {
+  // withEnLocale guarantees a leading "/en"; drop the leading slash to get an
+  // app-relative path like "en/resources/integrations".
+  const rel = withEnLocale(path).slice(1);
+  const base = join(ROOT, "app", rel);
+  return (
+    existsSync(join(base, "page.mdx")) ||
+    existsSync(join(base, "page.tsx")) ||
+    existsSync(`${base}.mdx`)
+  );
+};
+
+const readRedirectSources = async (): Promise<Set<string>> => {
+  const config = await readFile(join(ROOT, "next.config.ts"), "utf-8");
+  const sources = [...config.matchAll(/source:\s*"([^"]+)"/g)].map(
+    (match) => match[1]
+  );
+  return new Set(sources);
+};
+
+const extractInternalHrefs = async (relPath: string): Promise<string[]> => {
+  const content = await readFile(join(ROOT, relPath), "utf-8");
+  const hrefs = [...content.matchAll(HREF_LITERAL)].map((match) => match[1]);
+  // Internal app links only (skip protocol-relative // and external).
+  return [...new Set(hrefs.filter((href) => !href.startsWith("//")))];
+};
+
+// Component files whose hardcoded internal links are not covered by the
+// MDX-only broken-link scan.
+const COMPONENT_FILES = [
+  "app/_components/toolkit-docs/components/toolkit-page.tsx",
+  "app/en/resources/integrations/components/toolkits-client.tsx",
+];
+
+describe("hardcoded internal links in toolkit components resolve", () => {
+  let validLinks: Set<string>;
+  let redirectSources: Set<string>;
+
+  beforeAll(async () => {
+    [validLinks, redirectSources] = await Promise.all([
+      listValidIntegrationLinks(),
+      readRedirectSources(),
+    ]);
+  }, TIMEOUT);
+
+  test(
+    "every hardcoded href points at a real page, route, or redirect",
+    async () => {
+      const broken: string[] = [];
+
+      for (const file of COMPONENT_FILES) {
+        for (const href of await extractInternalHrefs(file)) {
+          const resolvesToPageOrRoute =
+            pageFileExists(href) || validLinks.has(withEnLocale(href));
+          const resolvesToRedirect = redirectSources.has(toLocaleParam(href));
+          if (!(resolvesToPageOrRoute || resolvesToRedirect)) {
+            broken.push(`${file} -> ${href}`);
+          }
+        }
+      }
+
+      expect(broken).toEqual([]);
+    },
+    TIMEOUT
+  );
+});

--- a/tests/integration-index-links.test.ts
+++ b/tests/integration-index-links.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { beforeAll, describe, expect, test } from "vitest";
@@ -9,10 +9,14 @@ import {
   toIntegrationLink,
 } from "@/app/_lib/integration-index";
 import type { ToolkitWithDocsLink } from "@/app/_lib/toolkit-slug";
-import { listValidIntegrationLinks } from "@/app/_lib/toolkit-static-params";
+import {
+  INTEGRATION_CATEGORIES,
+  listValidIntegrationLinks,
+} from "@/app/_lib/toolkit-static-params";
 
 const TIMEOUT = 30_000;
 const ROOT = process.cwd();
+const INTEGRATIONS = "/en/resources/integrations";
 
 /**
  * Guards the regression class MARTECH-19 fixed: the integrations index (a TSX
@@ -20,16 +24,14 @@ const ROOT = process.cwd();
  * don't exist. tests/broken-link-check.test.ts only scans MDX, so it can't see
  * component-generated links or dynamic [toolkitId] slugs.
  *
- * These tests derive their cases from the live catalog + route data rather than
- * hard-coding toolkit names, so they don't break when a toolkit gains or loses
- * its own docs page (which is exactly what happened in CI: `main` shipped real
- * pages for several toolkits this PR treated as doc-less).
+ * Assertions are kept deliberately general — the unit tests use placeholder
+ * toolkits, and the live-data tests derive their cases from the catalog + route
+ * data — so adding/removing real toolkits (or giving one its own page) never
+ * requires editing this file unless behavior actually regresses.
  */
 
-const INTEGRATIONS = "/en/resources/integrations";
-
-// Build a minimal catalog entry for the unit tests. resolveIndexToolkits only
-// reads `id`, `category`, `docsLink`, and `isHidden`.
+// Minimal catalog entry for the unit tests. resolveIndexToolkits only reads
+// `id`, `category`, `docsLink`, and `isHidden`.
 const makeToolkit = (
   id: string,
   category: string,
@@ -49,44 +51,45 @@ const makeToolkit = (
   }) as unknown as ToolkitWithDocsLink;
 
 describe("resolveIndexToolkits (logic)", () => {
-  // A fixed set of "real" pages, independent of the repo's toolkit data.
+  // A fixed set of "real" pages and placeholder toolkits, independent of the
+  // repo's toolkit data. Names are deliberately fake.
   const validLinks = new Set([
-    `${INTEGRATIONS}/development/datadog-api`, // a generated [toolkitId] route
-    `${INTEGRATIONS}/search/tavily`, // an authored static page
+    `${INTEGRATIONS}/development/alpha-api`, // stands in for a generated route
+    `${INTEGRATIONS}/search/gamma`, // stands in for an authored static page
   ]);
   const catalog: ToolkitWithDocsLink[] = [
-    makeToolkit("DatadogApi", "development", "datadog-api"), // real page
-    makeToolkit("Datadog", "development", "datadog"), // bare, no page, has -api sibling -> drop
-    makeToolkit("Discord", "social", "discord"), // no page, no -api sibling -> non-clickable
-    makeToolkit("Tavily", "search", "tavily"), // static page -> clickable
-    makeToolkit("Notion", "productivity", "notion"), // duplicate A (no page)
-    makeToolkit("NotionToolkit", "productivity", "notion"), // duplicate B, same link -> collapse
-    makeToolkit("Hidden", "social", "hidden", true), // hidden -> excluded
+    makeToolkit("AlphaApi", "development", "alpha-api"), // real page
+    makeToolkit("Alpha", "development", "alpha"), // bare, no page, has "-api" sibling -> drop
+    makeToolkit("Beta", "social", "beta"), // no page, no "-api" sibling -> non-clickable
+    makeToolkit("Gamma", "search", "gamma"), // page exists -> clickable
+    makeToolkit("Delta", "productivity", "delta"), // duplicate A (no page)
+    makeToolkit("DeltaPrime", "productivity", "delta"), // duplicate B, same link -> collapse
+    makeToolkit("Zeta", "social", "zeta", true), // hidden -> excluded
   ];
   const resolved = resolveIndexToolkits(catalog, validLinks);
   const byId = (id: string) => resolved.find((toolkit) => toolkit.id === id);
   const links = resolved.map(toIntegrationLink);
 
   test("drops a bare entry when its '-api' sibling owns the page", () => {
-    expect(resolved.some((toolkit) => toolkit.id === "Datadog")).toBe(false);
-    expect(byId("DatadogApi")?.hasPage).toBe(true);
+    expect(resolved.some((toolkit) => toolkit.id === "Alpha")).toBe(false);
+    expect(byId("AlphaApi")?.hasPage).toBe(true);
   });
 
-  test("keeps doc-less toolkits but marks them non-clickable", () => {
-    expect(byId("Discord")?.hasPage).toBe(false);
+  test("keeps a toolkit without a page, but marks it non-clickable", () => {
+    expect(byId("Beta")?.hasPage).toBe(false);
   });
 
-  test("keeps toolkits backed by an authored static page clickable", () => {
-    expect(byId("Tavily")?.hasPage).toBe(true);
+  test("keeps a toolkit whose page exists clickable", () => {
+    expect(byId("Gamma")?.hasPage).toBe(true);
   });
 
   test("excludes hidden toolkits entirely", () => {
-    expect(resolved.some((toolkit) => toolkit.id === "Hidden")).toBe(false);
+    expect(resolved.some((toolkit) => toolkit.id === "Zeta")).toBe(false);
   });
 
   test("collapses entries that resolve to the same link", () => {
     expect(
-      links.filter((link) => link === `${INTEGRATIONS}/productivity/notion`)
+      links.filter((link) => link === `${INTEGRATIONS}/productivity/delta`)
     ).toHaveLength(1);
     expect(links.length).toBe(new Set(links).size);
   });
@@ -119,31 +122,54 @@ describe("integrations index links (live data)", () => {
     expect(links.length).toBe(new Set(links).size);
   });
 
-  test("the index mixes real (clickable) and placeholder (non-clickable) cards", () => {
-    // Guards against a regression that makes everything clickable (re-introducing
-    // broken links) or everything non-clickable.
+  test("the index renders cards and at least one links to a real page", () => {
+    // Guards total breakage (empty catalog, or a validLinks computation that
+    // matches nothing so every card is non-clickable).
+    expect(resolved.length).toBeGreaterThan(0);
     expect(resolved.some((toolkit) => toolkit.hasPage)).toBe(true);
-    expect(resolved.some((toolkit) => !toolkit.hasPage)).toBe(true);
   });
 
-  test("authored static pages are recognized as valid links", () => {
-    // listValidIntegrationLinks must include authored static pages (e.g. the
-    // Tavily partner page), not only generated [toolkitId] routes. Guarded so it
-    // only asserts while that page exists in the tree.
-    const tavilyLink = `${INTEGRATIONS}/search/tavily`;
-    const tavilyPage = join(
-      ROOT,
-      "app/en/resources/integrations/search/tavily/page.mdx"
-    );
-    if (existsSync(tavilyPage)) {
-      expect(validLinks.has(tavilyLink)).toBe(true);
-      const tavily = resolved.find(
-        (toolkit) => toIntegrationLink(toolkit) === tavilyLink
-      );
-      expect(tavily?.hasPage).toBe(true);
+  test("authored static integration pages are recognized as valid links", () => {
+    // listValidIntegrationLinks must include authored static category pages
+    // (e.g. partner pages), not only generated [toolkitId] routes. Discovered
+    // from disk so it covers whatever static pages exist now or later.
+    for (const link of listStaticCategoryPageLinks()) {
+      expect(validLinks.has(link), `${link} should be a valid link`).toBe(true);
     }
   });
 });
+
+// Independently enumerate authored static pages under each integration category
+// (a `<category>/<slug>/page.{mdx,tsx}` that isn't the dynamic [toolkitId] route).
+const listStaticCategoryPageLinks = (): string[] => {
+  const links: string[] = [];
+  for (const category of INTEGRATION_CATEGORIES) {
+    const categoryDir = join(
+      ROOT,
+      "app",
+      "en",
+      "resources",
+      "integrations",
+      category
+    );
+    if (!existsSync(categoryDir)) {
+      continue;
+    }
+    for (const entry of readdirSync(categoryDir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name.startsWith("[")) {
+        continue;
+      }
+      const pageDir = join(categoryDir, entry.name);
+      if (
+        existsSync(join(pageDir, "page.mdx")) ||
+        existsSync(join(pageDir, "page.tsx"))
+      ) {
+        links.push(`${INTEGRATIONS}/${category}/${entry.name}`);
+      }
+    }
+  }
+  return links;
+};
 
 const LOCALE_PREFIX = /^\/(en|es|pt-BR)(?=\/|$)/;
 const HREF_LITERAL = /href="(\/[^"#]+)"/g;

--- a/tests/integration-index-links.test.ts
+++ b/tests/integration-index-links.test.ts
@@ -8,6 +8,7 @@ import {
   resolveIndexToolkits,
   toIntegrationLink,
 } from "@/app/_lib/integration-index";
+import type { ToolkitWithDocsLink } from "@/app/_lib/toolkit-slug";
 import { listValidIntegrationLinks } from "@/app/_lib/toolkit-static-params";
 
 const TIMEOUT = 30_000;
@@ -18,11 +19,82 @@ const ROOT = process.cwd();
  * component) and the toolkit breadcrumb produced internal links to pages that
  * don't exist. tests/broken-link-check.test.ts only scans MDX, so it can't see
  * component-generated links or dynamic [toolkitId] slugs.
+ *
+ * These tests derive their cases from the live catalog + route data rather than
+ * hard-coding toolkit names, so they don't break when a toolkit gains or loses
+ * its own docs page (which is exactly what happened in CI: `main` shipped real
+ * pages for several toolkits this PR treated as doc-less).
  */
-describe("integrations index links", () => {
-  let resolved: ResolvedIndexToolkit[];
+
+const INTEGRATIONS = "/en/resources/integrations";
+
+// Build a minimal catalog entry for the unit tests. resolveIndexToolkits only
+// reads `id`, `category`, `docsLink`, and `isHidden`.
+const makeToolkit = (
+  id: string,
+  category: string,
+  slug: string,
+  isHidden = false
+): ToolkitWithDocsLink =>
+  ({
+    id,
+    label: id,
+    type: "arcade",
+    category,
+    isHidden,
+    isComingSoon: false,
+    isBYOC: false,
+    isPro: false,
+    docsLink: `https://docs.arcade.dev${INTEGRATIONS}/${category}/${slug}`,
+  }) as unknown as ToolkitWithDocsLink;
+
+describe("resolveIndexToolkits (logic)", () => {
+  // A fixed set of "real" pages, independent of the repo's toolkit data.
+  const validLinks = new Set([
+    `${INTEGRATIONS}/development/datadog-api`, // a generated [toolkitId] route
+    `${INTEGRATIONS}/search/tavily`, // an authored static page
+  ]);
+  const catalog: ToolkitWithDocsLink[] = [
+    makeToolkit("DatadogApi", "development", "datadog-api"), // real page
+    makeToolkit("Datadog", "development", "datadog"), // bare, no page, has -api sibling -> drop
+    makeToolkit("Discord", "social", "discord"), // no page, no -api sibling -> non-clickable
+    makeToolkit("Tavily", "search", "tavily"), // static page -> clickable
+    makeToolkit("Notion", "productivity", "notion"), // duplicate A (no page)
+    makeToolkit("NotionToolkit", "productivity", "notion"), // duplicate B, same link -> collapse
+    makeToolkit("Hidden", "social", "hidden", true), // hidden -> excluded
+  ];
+  const resolved = resolveIndexToolkits(catalog, validLinks);
+  const byId = (id: string) => resolved.find((toolkit) => toolkit.id === id);
+  const links = resolved.map(toIntegrationLink);
+
+  test("drops a bare entry when its '-api' sibling owns the page", () => {
+    expect(resolved.some((toolkit) => toolkit.id === "Datadog")).toBe(false);
+    expect(byId("DatadogApi")?.hasPage).toBe(true);
+  });
+
+  test("keeps doc-less toolkits but marks them non-clickable", () => {
+    expect(byId("Discord")?.hasPage).toBe(false);
+  });
+
+  test("keeps toolkits backed by an authored static page clickable", () => {
+    expect(byId("Tavily")?.hasPage).toBe(true);
+  });
+
+  test("excludes hidden toolkits entirely", () => {
+    expect(resolved.some((toolkit) => toolkit.id === "Hidden")).toBe(false);
+  });
+
+  test("collapses entries that resolve to the same link", () => {
+    expect(
+      links.filter((link) => link === `${INTEGRATIONS}/productivity/notion`)
+    ).toHaveLength(1);
+    expect(links.length).toBe(new Set(links).size);
+  });
+});
+
+describe("integrations index links (live data)", () => {
   let validLinks: Set<string>;
-  let byLink: Map<string, ResolvedIndexToolkit[]>;
+  let resolved: ResolvedIndexToolkit[];
 
   beforeAll(async () => {
     const [toolkits, links] = await Promise.all([
@@ -31,13 +103,6 @@ describe("integrations index links", () => {
     ]);
     validLinks = links;
     resolved = resolveIndexToolkits(toolkits, validLinks);
-    byLink = new Map();
-    for (const toolkit of resolved) {
-      const link = toIntegrationLink(toolkit);
-      const bucket = byLink.get(link) ?? [];
-      bucket.push(toolkit);
-      byLink.set(link, bucket);
-    }
   }, TIMEOUT);
 
   test("no clickable card links to a page that does not exist", () => {
@@ -49,36 +114,34 @@ describe("integrations index links", () => {
     expect(brokenClickable).toEqual([]);
   });
 
-  test("doc-less catalog toolkits stay visible but are non-clickable", () => {
-    // "Discord" is in the design-system catalog but has no docs page and no
-    // "-api" sibling — it must be rendered, but not as a link to a 404.
-    const discord = byLink.get("/en/resources/integrations/social/discord");
-    expect(discord, "discord card is present").toBeDefined();
-    expect(discord?.every((toolkit) => toolkit.hasPage === false)).toBe(true);
+  test("every rendered card resolves to a unique link (duplicates collapse)", () => {
+    const links = resolved.map((toolkit) => toIntegrationLink(toolkit));
+    expect(links.length).toBe(new Set(links).size);
   });
 
-  test("bare '-api' duplicates are dropped in favor of the real card", () => {
-    // The catalog carries both "Datadog" (bare, no page) and "DatadogApi".
-    expect(byLink.has("/en/resources/integrations/development/datadog")).toBe(
-      false
+  test("the index mixes real (clickable) and placeholder (non-clickable) cards", () => {
+    // Guards against a regression that makes everything clickable (re-introducing
+    // broken links) or everything non-clickable.
+    expect(resolved.some((toolkit) => toolkit.hasPage)).toBe(true);
+    expect(resolved.some((toolkit) => !toolkit.hasPage)).toBe(true);
+  });
+
+  test("authored static pages are recognized as valid links", () => {
+    // listValidIntegrationLinks must include authored static pages (e.g. the
+    // Tavily partner page), not only generated [toolkitId] routes. Guarded so it
+    // only asserts while that page exists in the tree.
+    const tavilyLink = `${INTEGRATIONS}/search/tavily`;
+    const tavilyPage = join(
+      ROOT,
+      "app/en/resources/integrations/search/tavily/page.mdx"
     );
-    const datadogApi = byLink.get(
-      "/en/resources/integrations/development/datadog-api"
-    );
-    expect(datadogApi?.[0]?.hasPage).toBe(true);
-  });
-
-  test("partner toolkits with authored static pages stay clickable", () => {
-    // Tavily is a partner toolkit; its page is an authored static MDX file, not
-    // a generated [toolkitId] route.
-    const tavily = byLink.get("/en/resources/integrations/search/tavily");
-    expect(tavily?.[0]?.hasPage).toBe(true);
-  });
-
-  test("duplicate catalog entries collapse to a single card", () => {
-    // "Notion" and "NotionToolkit" both resolve to /productivity/notion.
-    const notion = byLink.get("/en/resources/integrations/productivity/notion");
-    expect(notion).toHaveLength(1);
+    if (existsSync(tavilyPage)) {
+      expect(validLinks.has(tavilyLink)).toBe(true);
+      const tavily = resolved.find(
+        (toolkit) => toIntegrationLink(toolkit) === tavilyLink
+      );
+      expect(tavily?.hasPage).toBe(true);
+    }
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,15 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+// Mirror the tsconfig "@/*" -> "./*" path alias so tests can import app modules.
+const rootDir = fileURLToPath(new URL(".", import.meta.url)).replace(/\/$/, "");
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": rootDir,
+    },
+  },
   test: {
     exclude: [
       // Runs in its own workflow — third-party URLs are flaky in the main test run


### PR DESCRIPTION
## What

Follow-up to [MARTECH-16](https://linear.app/arcadedev/issue/MARTECH-16) that clears the remaining Ahrefs Site Audit errors on docs.arcade.dev: "links to broken page", 404/4XX, "duplicate pages without canonical", and "broken redirect". Page-size errors are out of scope ([MARTECH-17](https://linear.app/arcadedev/issue/MARTECH-17)).

Linear: [MARTECH-19](https://linear.app/arcadedev/issue/MARTECH-19)

## Changes

**1. `/en/resources` 404 (~115 incoming links — highest impact)**
The toolkit breadcrumb links "Resources" → `/en/resources`, which has no page. Added a permanent redirect → `/en/resources/integrations`. Breadcrumb left as-is.

**2 & 3. Integrations index linked to non-existent pages + duplicate Notion**
Root cause: the design-system catalog carries bare-name entries (e.g. `Datadog` alongside `DatadogApi`) and doc-less placeholders that have **no generated page** — the index rendered a clickable card for each → 404.
- New `resolveIndexToolkits` (`app/_lib/integration-index.ts`) + `listValidIntegrationLinks` (`app/_lib/toolkit-static-params.ts`) resolve each card against the real route set: dynamic `[toolkitId]` routes **∪** authored static pages (e.g. partner pages, which are static MDX files, not `[toolkitId]` routes).
- Bare `-api` duplicates are dropped (the real card stays); same-URL entries (e.g. Notion ×2) are de-duped; toolkits with no page stay visible but **non-clickable** (existing "coming soon" `<button>` path — no href emitted).
- Added a self-referential `canonical` to every toolkit page.
- `getToolkitsWithDocsLinks` extracted to `app/_lib/integration-catalog.ts`.

The resolver is **data-driven**: a card is clickable iff its page actually exists, so it adapts automatically as toolkits gain or lose pages (see "Kept current with main").

**4. "Broken redirect" (squareup)**
Was actually a broken link — `square/page.mdx` pointed at `…/productivity/squareupapi`; fixed to `squareup-api`.

**5. In-content emails → `/cdn-cgi/l/email-protection`**
> ⚠️ The ticket's `<!--email_off-->` marker is **infeasible in this repo**: raw HTML comments hard-error the Nextra/MDX build (`Unexpected character !`), and the only React way to emit one (`dangerouslySetInnerHTML`) is a banned Biome error (`lint/security/noDangerouslySetInnerHtml`; suppressions are disallowed by CLAUDE.md).

Instead, new `<ContactEmail>` (`app/_components/contact-email.tsx`) assembles the `mailto:` only after mount; SSR/crawlers see a plain `/en/resources/contact-us` link, so Cloudflare has nothing to obfuscate (also aligns with the site's anti-scraping posture). Applied to faq, auth-providers, oauth2, and security-research-program (×2). `chrome-no-mailto.test.ts` exempts this one sanctioned helper.

## Regression guard

`tests/integration-index-links.test.ts` covers the class of links the MDX-only `broken-link-check` test can't see (component-generated links + dynamic `[toolkitId]` slugs). It's intentionally **data-independent** so toolkit-data changes don't make it stale (an early version hard-coded `datadog` and broke once `main` gave it a real page):
- A **unit test** of `resolveIndexToolkits` using placeholder toolkits — deterministically covers drop / de-dup / hidden / non-clickable, with no dependency on real data.
- **Live-data invariants** derived from the catalog + route set: no clickable card points at a missing page, links are unique (dedup), the index renders ≥1 real card, and authored static pages are recognized.
- Validates the breadcrumb's hardcoded internal hrefs against real pages / routes / redirects.

Required adding a `@/` alias to `vitest.config.ts` (no test imported app modules before).
