### PR TITLE
fix(deps): upgrade @arcadeai/design-system to 3.45.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://arcade.dev/",
   "dependencies": {
-    "@arcadeai/design-system": "3.45.2",
+    "@arcadeai/design-system": "3.45.3",
     "@mdx-js/mdx": "3.1.1",
     "@mdx-js/react": "3.1.1",
     "@next/third-parties": "16.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     dependencies:
       '@arcadeai/design-system':
-        specifier: 3.45.2
-        version: 3.45.2(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)
+        specifier: 3.45.3
+        version: 3.45.3(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)
       '@mdx-js/mdx':
         specifier: 3.1.1
         version: 3.1.1
@@ -271,8 +271,8 @@ packages:
       zod:
         optional: true
 
-  '@arcadeai/design-system@3.45.2':
-    resolution: {integrity: sha512-UBiEozEGlTVajc2gGYRim1SFxxzgTn5gbGSg9aAydW+MDWa8Q2Lpg33ULIzqMTQ9IcZmusigdeWploe5eLz2EQ==}
+  '@arcadeai/design-system@3.45.3':
+    resolution: {integrity: sha512-gPj0/1XDCoyJE1gE3DkNWrx+y7F+peL7cIG/JLutCBsXb1TmFcfAmObeI6KgQOVKNR1heAKcjc4Bkfu96wnpZg==}
     engines: {bun: '>=1.3.5'}
     peerDependencies:
       '@hookform/resolvers': '>=5.2.1'
@@ -4650,7 +4650,7 @@ snapshots:
     optionalDependencies:
       zod: 4.3.6
 
-  '@arcadeai/design-system@3.45.2(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)':
+  '@arcadeai/design-system@3.45.3(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)':
     dependencies:
       '@base-ui/react': 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.16)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@base-ui/utils': 0.2.9(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -4851,7 +4851,7 @@ snapshots:
 
   '@floating-ui/core@1.7.3':
     dependencies:
-      '@floating-ui/utils': 0.2.10
+      '@floating-ui/utils': 0.2.11
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -4860,7 +4860,7 @@ snapshots:
   '@floating-ui/dom@1.7.4':
     dependencies:
       '@floating-ui/core': 1.7.3
-      '@floating-ui/utils': 0.2.10
+      '@floating-ui/utils': 0.2.11
 
   '@floating-ui/dom@1.7.6':
     dependencies:


### PR DESCRIPTION
## What

Upgrades `@arcadeai/design-system` from **3.45.2 → 3.45.3** and removes the temporary `pnpm` patch.

## Why

3.45.0–3.45.2 were built with Vite 8 (which swapped Rollup for **Rolldown**). For a bundled CJS dependency (React's `use-sync-external-store/shim`, pulled in transitively by Base UI popover/menu components), Rolldown emitted a runtime `require("react")` shim instead of an ESM import. That shim:

- **throws in the browser** (`Uncaught Error: Calling require for "react" in an environment that doesn't expose the require function`), and
- **resolves React to `null` during SSR** → `TypeError: Cannot read properties of null (reading 'useSyncExternalStore')` → HTTP 500.

The result was that every docs page using those components crashed — navigation broke on all pages except the landing page. `pnpm build` passed regardless (both are runtime failures), so it shipped silently.

3.45.3 fixes the Rolldown external handling upstream (via rolldown's `esmExternalRequirePlugin`), so the published `dist` no longer contains the require shim. This lets us run the latest version with **no consumer-side workaround**.

## Verification

- `pnpm build` exits 0
- Installed `dist` and emitted client chunks contain **zero** `rolldown.rs` require-shim markers
- SSR returns **200** on previously-broken pages (`/en/get-started/about-arcade`, `/en/references/changelog`, `/en/resources/faq`); home still 200
- Browser console is clean on the affected pages (no `require`/React error)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no app source changes; risk is limited to possible UI regressions from the design-system patch release.
> 
> **Overview**
> Bumps **`@arcadeai/design-system`** from `3.45.2` to **`3.45.3`** in `package.json` and refreshes **`pnpm-lock.yaml`** to match (including updated integrity and transitive **`@floating-ui/utils`** pins under Floating UI).
> 
> This patch release is meant to pick up upstream fixes for Rolldown-built `dist` output that previously injected browser/SSR-breaking `require("react")` shims in design-system UI (e.g. Base UI popover/menu paths), so docs can run the latest package without consumer workarounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea0b028c2558ff6f8f3455eec02050b5b972de8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->