### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/app/en/resources/integrations/development/_meta.tsx
+++ b/app/en/resources/integrations/development/_meta.tsx
@@ -25,6 +25,10 @@ const meta: MetaRecord = {
     title: "Firecrawl",
     href: "/en/resources/integrations/development/firecrawl",
   },
+  "fly-io": {
+    title: "Fly.io",
+    href: "/en/resources/integrations/development/fly-io",
+  },
   github: {
     title: "GitHub",
     href: "/en/resources/integrations/development/github",

--- a/toolkit-docs-generator/data/toolkits/flyio.json
+++ b/toolkit-docs-generator/data/toolkits/flyio.json
@@ -1,0 +1,2421 @@
+{
+  "id": "Flyio",
+  "label": "Fly.io",
+  "version": "0.1.0",
+  "description": "Arcade tools designed for LLMs to interact with Fly.io",
+  "metadata": {
+    "category": "development",
+    "iconUrl": "https://design-system.arcade.dev/icons/fly-io.svg",
+    "isBYOC": true,
+    "isPro": false,
+    "type": "arcade",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/development/fly-io",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": null,
+  "tools": [
+    {
+      "name": "AddCertificate",
+      "qualifiedName": "Flyio.AddCertificate",
+      "fullyQualifiedName": "Flyio.AddCertificate@0.1.0",
+      "description": "Add a TLS certificate for a hostname and return the DNS records to set.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app to add the certificate to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "hostname",
+          "type": "string",
+          "required": true,
+          "description": "The custom domain hostname to provision TLS for.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.AddCertificate",
+        "parameters": {
+          "app_name": {
+            "value": "my-awesome-app",
+            "type": "string",
+            "required": true
+          },
+          "hostname": {
+            "value": "app.example.com",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "AllocateIpAddress",
+      "qualifiedName": "Flyio.AllocateIpAddress",
+      "fullyQualifiedName": "Flyio.AllocateIpAddress@0.1.0",
+      "description": "Allocate a new IP address for an app.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app to allocate the IP address for.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "ip_type",
+          "type": "string",
+          "required": true,
+          "description": "Kind of IP address to allocate (dedicated v4/v6, shared v4, or private v6).",
+          "enum": [
+            "v4",
+            "v6",
+            "shared_v4",
+            "private_v6"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "region",
+          "type": "string",
+          "required": false,
+          "description": "Three-letter region code for a regional address. Leave empty for a global address.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.AllocateIpAddress",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "ip_type": {
+            "value": "dedicated_v4",
+            "type": "string",
+            "required": true
+          },
+          "region": {
+            "value": "iad",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CheckCertificate",
+      "qualifiedName": "Flyio.CheckCertificate",
+      "fullyQualifiedName": "Flyio.CheckCertificate@0.1.0",
+      "description": "Check a certificate's validation status and any pending DNS records.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app the certificate belongs to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "hostname",
+          "type": "string",
+          "required": true,
+          "description": "The hostname whose certificate to check.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.CheckCertificate",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "hostname": {
+            "value": "app.example.com",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CreateMachine",
+      "qualifiedName": "Flyio.CreateMachine",
+      "fullyQualifiedName": "Flyio.CreateMachine@0.1.0",
+      "description": "Create a new Machine for an app from a container image.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app to add the Machine to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "image",
+          "type": "string",
+          "required": true,
+          "description": "Container image reference to run, including tag.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "region",
+          "type": "string",
+          "required": false,
+          "description": "Three-letter region code to place the Machine in. Leave empty to let Fly.io choose.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Name for the new Machine. Leave empty to auto-generate one.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "vm_size",
+          "type": "string",
+          "required": false,
+          "description": "VM-size preset for the Machine. Leave unset for the Fly.io default size.",
+          "enum": [
+            "shared-cpu-1x",
+            "shared-cpu-2x",
+            "shared-cpu-4x",
+            "shared-cpu-8x",
+            "performance-1x",
+            "performance-2x",
+            "performance-4x",
+            "performance-8x",
+            "performance-16x"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "env",
+          "type": "json",
+          "required": false,
+          "description": "Environment variables to set on the Machine, as name/value pairs.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.CreateMachine",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "image": {
+            "value": "nginx:1.25.3",
+            "type": "string",
+            "required": true
+          },
+          "region": {
+            "value": "iad",
+            "type": "string",
+            "required": false
+          },
+          "name": {
+            "value": "web-machine-01",
+            "type": "string",
+            "required": false
+          },
+          "vm_size": {
+            "value": "shared-cpu-2x",
+            "type": "string",
+            "required": false
+          },
+          "env": {
+            "value": "{\"NODE_ENV\": \"production\", \"PORT\": \"8080\", \"LOG_LEVEL\": \"info\"}",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CreateVolume",
+      "qualifiedName": "Flyio.CreateVolume",
+      "fullyQualifiedName": "Flyio.CreateVolume@0.1.0",
+      "description": "Create a new persistent volume for an app.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app to create the volume for.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "Name for the new volume (letters, numbers, underscores).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "region",
+          "type": "string",
+          "required": true,
+          "description": "Three-letter region code to place the volume in.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "size_gb",
+          "type": "integer",
+          "required": true,
+          "description": "Size of the volume in gigabytes.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.CreateVolume",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "name": {
+            "value": "app_data_volume",
+            "type": "string",
+            "required": true
+          },
+          "region": {
+            "value": "iad",
+            "type": "string",
+            "required": true
+          },
+          "size_gb": {
+            "value": 10,
+            "type": "integer",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DeployApp",
+      "qualifiedName": "Flyio.DeployApp",
+      "fullyQualifiedName": "Flyio.DeployApp@0.1.0",
+      "description": "Roll a new container image out to all of an app's Machines.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app to roll the new image out to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "image",
+          "type": "string",
+          "required": true,
+          "description": "Container image reference to deploy, including tag.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "strategy",
+          "type": "string",
+          "required": false,
+          "description": "How to replace the app's Machines with the new image. Defaults to ROLLING (one Machine at a time).",
+          "enum": [
+            "immediate",
+            "rolling",
+            "canary",
+            "bluegreen"
+          ],
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.DeployApp",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "image": {
+            "value": "registry.fly.io/my-web-app:v2.3.1",
+            "type": "string",
+            "required": true
+          },
+          "strategy": {
+            "value": "ROLLING",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DestroyMachine",
+      "qualifiedName": "Flyio.DestroyMachine",
+      "fullyQualifiedName": "Flyio.DestroyMachine@0.1.0",
+      "description": "Permanently destroy a Machine. Stop it first unless force is set.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app the Machine belongs to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "machine_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the Machine to destroy.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "force",
+          "type": "boolean",
+          "required": false,
+          "description": "Destroy the Machine even if it is still running. When false, a running Machine must be stopped first. Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.DestroyMachine",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "machine_id": {
+            "value": "148ed726c09289",
+            "type": "string",
+            "required": true
+          },
+          "force": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DestroyVolume",
+      "qualifiedName": "Flyio.DestroyVolume",
+      "fullyQualifiedName": "Flyio.DestroyVolume@0.1.0",
+      "description": "Permanently destroy a volume and the data it holds.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app the volume belongs to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "volume_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the volume to destroy.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.DestroyVolume",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "volume_id": {
+            "value": "vol_xk1j2m3n4o5p6q7r",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ExtendVolume",
+      "qualifiedName": "Flyio.ExtendVolume",
+      "fullyQualifiedName": "Flyio.ExtendVolume@0.1.0",
+      "description": "Grow a volume to a larger size. Volumes cannot be shrunk.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app the volume belongs to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "volume_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the volume to extend.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "size_gb",
+          "type": "integer",
+          "required": true,
+          "description": "New size of the volume in gigabytes. Must be larger than the current size.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.ExtendVolume",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "volume_id": {
+            "value": "vol_xk9d2p1q3r7w8v5m",
+            "type": "string",
+            "required": true
+          },
+          "size_gb": {
+            "value": 50,
+            "type": "integer",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetApp",
+      "qualifiedName": "Flyio.GetApp",
+      "fullyQualifiedName": "Flyio.GetApp@0.1.0",
+      "description": "Get the current status of a single Fly.io app.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The name of the app to inspect.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.GetApp",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-service",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetLogs",
+      "qualifiedName": "Flyio.GetLogs",
+      "fullyQualifiedName": "Flyio.GetLogs@0.1.0",
+      "description": "Read recent historical log entries for an app, optionally filtered.\n\nReading logs requires a token granted log-read access, which is a capability\nseparate from app management; a token without it cannot read logs at all. When\nthat access is missing this returns a ``no_access`` result rather than raising,\nso prefer branching on the result's ``status`` over assuming logs are present.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app whose recent logs to read.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "machine_id",
+          "type": "string",
+          "required": false,
+          "description": "Only return logs from this Machine instance. Leave empty for all Machines.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "region",
+          "type": "string",
+          "required": false,
+          "description": "Only return logs from this three-letter region code. Leave empty for all regions.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of log entries to return (1-500). Defaults to 100.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "next_token",
+          "type": "string",
+          "required": false,
+          "description": "Opaque cursor from a previous call to fetch the next page. Leave empty to start from the most recent entries.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.GetLogs",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "machine_id": {
+            "value": "3d8d9285f34538",
+            "type": "string",
+            "required": false
+          },
+          "region": {
+            "value": "iad",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "next_token": {
+            "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXJzb3IiOiIxNjk4NzY1NDMyMTAwIn0.abc123",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetMachine",
+      "qualifiedName": "Flyio.GetMachine",
+      "fullyQualifiedName": "Flyio.GetMachine@0.1.0",
+      "description": "Get the configuration, state, and health of a single Machine.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app the Machine belongs to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "machine_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the Machine to inspect.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.GetMachine",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "machine_id": {
+            "value": "d891de3d190d48",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListApps",
+      "qualifiedName": "Flyio.ListApps",
+      "fullyQualifiedName": "Flyio.ListApps@0.1.0",
+      "description": "List Fly.io apps, optionally scoped to a single organization.\n\nApps are returned in Fly.io's own ordering, with pagination metadata so a\ncaller can tell when more apps exist beyond the returned window.",
+      "parameters": [
+        {
+          "name": "organization_slug",
+          "type": "string",
+          "required": false,
+          "description": "Restrict the listing to apps in this organization (its slug). Leave empty to list every app the configured token can access.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum apps to return (1-200). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed position in the org's app list to start from. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.ListApps",
+        "parameters": {
+          "organization_slug": {
+            "value": "my-startup-org",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListCertificates",
+      "qualifiedName": "Flyio.ListCertificates",
+      "fullyQualifiedName": "Flyio.ListCertificates@0.1.0",
+      "description": "List the custom-domain TLS certificates configured on an app.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app whose certificates to list.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.ListCertificates",
+        "parameters": {
+          "app_name": {
+            "value": "my-production-app",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListIpAddresses",
+      "qualifiedName": "Flyio.ListIpAddresses",
+      "fullyQualifiedName": "Flyio.ListIpAddresses@0.1.0",
+      "description": "List the IP addresses assigned to an app, including the shared IPv4.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app whose IP addresses to list.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.ListIpAddresses",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app-production",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListMachines",
+      "qualifiedName": "Flyio.ListMachines",
+      "fullyQualifiedName": "Flyio.ListMachines@0.1.0",
+      "description": "List the Machines that belong to an app.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app whose Machines to list.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "region",
+          "type": "string",
+          "required": false,
+          "description": "Only include Machines in this three-letter region code. Leave empty for all regions.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "include_deleted",
+          "type": "boolean",
+          "required": false,
+          "description": "Include destroyed Machines in the listing. Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.ListMachines",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "region": {
+            "value": "iad",
+            "type": "string",
+            "required": false
+          },
+          "include_deleted": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListOrganizations",
+      "qualifiedName": "Flyio.ListOrganizations",
+      "fullyQualifiedName": "Flyio.ListOrganizations@0.1.0",
+      "description": "List the Fly.io organizations the configured token can access.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.ListOrganizations",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListRegions",
+      "qualifiedName": "Flyio.ListRegions",
+      "fullyQualifiedName": "Flyio.ListRegions@0.1.0",
+      "description": "List the Fly.io regions available for deploying apps and volumes.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.ListRegions",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListReleases",
+      "qualifiedName": "Flyio.ListReleases",
+      "fullyQualifiedName": "Flyio.ListReleases@0.1.0",
+      "description": "List an app's release history, newest first.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app whose release history to list.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of releases to return (1-100). Defaults to 25. Newest releases are returned first.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.ListReleases",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 10,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListSecrets",
+      "qualifiedName": "Flyio.ListSecrets",
+      "fullyQualifiedName": "Flyio.ListSecrets@0.1.0",
+      "description": "List an app's secret names. Secret values are never returned by Fly.io.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app whose secret names to list.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.ListSecrets",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app-production",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListVolumes",
+      "qualifiedName": "Flyio.ListVolumes",
+      "fullyQualifiedName": "Flyio.ListVolumes@0.1.0",
+      "description": "List the persistent volumes that belong to an app.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app whose volumes to list.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "include_destroyed",
+          "type": "boolean",
+          "required": false,
+          "description": "Include volumes that are being torn down or already destroyed. Defaults to false, so the listing shows only live volumes.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.ListVolumes",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "include_destroyed": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ReleaseIpAddress",
+      "qualifiedName": "Flyio.ReleaseIpAddress",
+      "fullyQualifiedName": "Flyio.ReleaseIpAddress@0.1.0",
+      "description": "Release a dedicated IP address so it is no longer assigned to the app.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app the IP address belongs to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "ip_address_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the IP address to release.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.ReleaseIpAddress",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "ip_address_id": {
+            "value": "ip_abc123xyz456",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "RemoveCertificate",
+      "qualifiedName": "Flyio.RemoveCertificate",
+      "fullyQualifiedName": "Flyio.RemoveCertificate@0.1.0",
+      "description": "Remove a custom-domain TLS certificate from an app.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app the certificate belongs to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "hostname",
+          "type": "string",
+          "required": true,
+          "description": "The hostname whose certificate to remove.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.RemoveCertificate",
+        "parameters": {
+          "app_name": {
+            "value": "my-awesome-app",
+            "type": "string",
+            "required": true
+          },
+          "hostname": {
+            "value": "www.example.com",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "RestartMachine",
+      "qualifiedName": "Flyio.RestartMachine",
+      "fullyQualifiedName": "Flyio.RestartMachine@0.1.0",
+      "description": "Restart a Machine and report its settled state.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app the Machine belongs to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "machine_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the Machine to restart.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.RestartMachine",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "machine_id": {
+            "value": "d8909e9d-4c5b-4f1e-a1d2-3b7e8f9c0d1e",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ScaleMachineCount",
+      "qualifiedName": "Flyio.ScaleMachineCount",
+      "fullyQualifiedName": "Flyio.ScaleMachineCount@0.1.0",
+      "description": "Scale an app to a target Machine count by adding or removing Machines.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app to scale.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "count",
+          "type": "integer",
+          "required": true,
+          "description": "Target number of Machines the app should run (0 or more). Machines are created or destroyed to reach this count.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "region",
+          "type": "string",
+          "required": false,
+          "description": "Scale within this three-letter region code only, leaving other regions untouched. Leave empty to scale the whole app.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.ScaleMachineCount",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "count": {
+            "value": 3,
+            "type": "integer",
+            "required": true
+          },
+          "region": {
+            "value": "iad",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ScaleVmSize",
+      "qualifiedName": "Flyio.ScaleVmSize",
+      "fullyQualifiedName": "Flyio.ScaleVmSize@0.1.0",
+      "description": "Change the VM size or memory of an app's Machines.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app whose Machines to resize.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "vm_size",
+          "type": "string",
+          "required": false,
+          "description": "VM-size preset to apply. Provide this, or memory_mb, or both. Leave unset to keep the current CPU configuration and only change memory.",
+          "enum": [
+            "shared-cpu-1x",
+            "shared-cpu-2x",
+            "shared-cpu-4x",
+            "shared-cpu-8x",
+            "performance-1x",
+            "performance-2x",
+            "performance-4x",
+            "performance-8x",
+            "performance-16x"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "memory_mb",
+          "type": "integer",
+          "required": false,
+          "description": "Override the memory in megabytes, independent of the preset. Leave unset to use the preset's default memory.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "machine_id",
+          "type": "string",
+          "required": false,
+          "description": "Resize only this Machine. Leave empty to resize every Machine in the app.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.ScaleVmSize",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "vm_size": {
+            "value": "performance-2x",
+            "type": "string",
+            "required": false
+          },
+          "memory_mb": {
+            "value": 2048,
+            "type": "integer",
+            "required": false
+          },
+          "machine_id": {
+            "value": "148ed726c35189",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SetSecrets",
+      "qualifiedName": "Flyio.SetSecrets",
+      "fullyQualifiedName": "Flyio.SetSecrets@0.1.0",
+      "description": "Set one or more app secrets, optionally rolling them out immediately.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app to set secrets on.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "secrets",
+          "type": "json",
+          "required": true,
+          "description": "Secret name/value pairs to set. Existing names are overwritten in place.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "deploy",
+          "type": "boolean",
+          "required": false,
+          "description": "Roll the change out immediately by restarting the app's Machines so the new values take effect. When false, the values are stored for the next restart or deploy. Defaults to true.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.SetSecrets",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "secrets": {
+            "value": "{\"DATABASE_URL\": \"postgres://user:password@db.example.com:5432/mydb\", \"API_KEY\": \"sk-abc123xyz789\", \"JWT_SECRET\": \"super-secret-jwt-signing-key\"}",
+            "type": "string",
+            "required": true
+          },
+          "deploy": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "StartMachine",
+      "qualifiedName": "Flyio.StartMachine",
+      "fullyQualifiedName": "Flyio.StartMachine@0.1.0",
+      "description": "Start a stopped Machine and report its settled state.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app the Machine belongs to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "machine_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the Machine to start.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.StartMachine",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "machine_id": {
+            "value": "d8949e25a61238",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "StopMachine",
+      "qualifiedName": "Flyio.StopMachine",
+      "fullyQualifiedName": "Flyio.StopMachine@0.1.0",
+      "description": "Stop a started Machine and report its settled state.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app the Machine belongs to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "machine_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the Machine to stop.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "signal",
+          "type": "string",
+          "required": false,
+          "description": "Signal to send the Machine's main process. Leave unset for the Fly.io default (SIGINT, then SIGKILL).",
+          "enum": [
+            "SIGTERM",
+            "SIGINT",
+            "SIGKILL",
+            "SIGQUIT"
+          ],
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.StopMachine",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "machine_id": {
+            "value": "3d8d413b655e89",
+            "type": "string",
+            "required": true
+          },
+          "signal": {
+            "value": "SIGTERM",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "UnsetSecrets",
+      "qualifiedName": "Flyio.UnsetSecrets",
+      "fullyQualifiedName": "Flyio.UnsetSecrets@0.1.0",
+      "description": "Remove one or more app secrets, optionally rolling the change out immediately.",
+      "parameters": [
+        {
+          "name": "app_name",
+          "type": "string",
+          "required": true,
+          "description": "The app to remove secrets from.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "keys",
+          "type": "array",
+          "innerType": "string",
+          "required": true,
+          "description": "Names of the secrets to remove.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "deploy",
+          "type": "boolean",
+          "required": false,
+          "description": "Roll the change out immediately by restarting the app's Machines so the removal takes effect. When false, the removal is applied on the next restart or deploy. Defaults to true.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FLYIO_ACCESS_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FLYIO_ACCESS_TOKEN",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Flyio.UnsetSecrets",
+        "parameters": {
+          "app_name": {
+            "value": "my-web-app",
+            "type": "string",
+            "required": true
+          },
+          "keys": {
+            "value": [
+              "DATABASE_URL",
+              "API_SECRET_KEY",
+              "SMTP_PASSWORD"
+            ],
+            "type": "array",
+            "required": true
+          },
+          "deploy": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "code_sandbox"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-06-12T12:11:52.523Z",
+  "summary": "Fly.io toolkit for Arcade enables LLMs to fully manage Fly.io infrastructure via the Fly.io API — apps, machines, volumes, networking, secrets, certificates, and deployments.\n\n## Capabilities\n\n- **App & release management:** List, inspect, and deploy apps across organizations; browse full release history and roll out new container images to all machines.\n- **Machine lifecycle:** Create, start, stop, restart, and destroy individual machines; scale machine count or change VM size/memory fleet-wide.\n- **Persistent storage:** Create, extend, and destroy volumes; list volumes per app. (Note: volumes can only grow, not shrink.)\n- **Networking & TLS:** Allocate and release dedicated IP addresses; add, check, and remove custom-domain TLS certificates with DNS record guidance.\n- **Secrets management:** Set, unset, and list app secret names (values are never exposed by Fly.io); optional immediate rollout on changes.\n- **Observability & metadata:** Read recent app logs (requires a log-read–scoped token; returns `no_access` status when access is missing rather than raising), list organizations, regions, and available infrastructure options.\n\n## Secrets\n\n`FLYIO_ACCESS_TOKEN` — A Fly.io personal access token (or scoped deploy/org token) used to authenticate all API calls. Obtain it from the [Fly.io dashboard Tokens page](https://fly.io/user/personal_access_tokens) or by running `fly tokens create deploy -a <app-name>` (for a deploy-scoped token) or `fly auth token` (for your personal token) via the [flyctl CLI](https://fly.io/docs/flyctl/tokens/). For log access (`Flyio.GetLogs`), the token must additionally carry log-read permission; a deploy token without this permission will cause log reads to return a `no_access` status. If you need org-wide access, generate a token scoped to the organization from the Fly.io dashboard under **Organization Settings → Tokens**.\n\nStore the token in Arcade at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets). For details on configuring secrets in Arcade tools, see [https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets)."
+}

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-10T12:12:28.789Z",
+  "generatedAt": "2026-06-12T12:12:05.661Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -270,6 +270,15 @@
       "category": "development",
       "type": "arcade",
       "toolCount": 6,
+      "authType": "none"
+    },
+    {
+      "id": "Flyio",
+      "label": "Fly.io",
+      "version": "0.1.0",
+      "category": "development",
+      "type": "arcade",
+      "toolCount": 30,
       "authType": "none"
     },
     {


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/27414651958

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and generated JSON only; no runtime or auth code changes in this diff.
> 
> **Overview**
> Adds **Fly.io** as a new development integration in the auto-generated docs/toolkit catalog.
> 
> A new **`flyio.json`** toolkit definition (v0.1.0, BYOC, 30 tools) documents Arcade tools for Fly.io via **`FLYIO_ACCESS_TOKEN`**, covering apps and releases, machine lifecycle, volumes, deploys, scaling, IPs/TLS certs, secrets, and logs.
> 
> **`_meta.tsx`** gains a **Fly.io** nav entry under Optimized integrations, and **`index.json`** is refreshed with the Flyio catalog entry and an updated `generatedAt` timestamp.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02ad2a654bbcb281d591d7501fbf89854ed4bdc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->