### PR TITLE
fix(seo): clear residual audit errors — squareup redirect + contact email (MARTECH-19 follow-up)

### DIFF
--- a/app/en/resources/contact-us/contact-cards.tsx
+++ b/app/en/resources/contact-us/contact-cards.tsx
@@ -20,7 +20,7 @@ import {
   Users,
 } from "lucide-react";
 import posthog from "posthog-js";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { QuickStartCard } from "../../../_components/quick-start-card";
 
@@ -264,6 +264,14 @@ function SuccessMessage({ onClose }: { onClose: () => void }) {
 export function ContactCards() {
   const [isSalesModalOpen, setIsSalesModalOpen] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
+  // Assemble the support mailto only after mount so the SSR/crawled markup
+  // shows a plain contact-page link — Cloudflare's email obfuscation then has
+  // nothing to rewrite into a broken /cdn-cgi/l/email-protection link. Mirrors
+  // <ContactEmail> (see app/_components/contact-email.tsx).
+  const [supportHref, setSupportHref] = useState("/en/resources/contact-us");
+  useEffect(() => {
+    setSupportHref("mailto:support@arcade.dev");
+  }, []);
 
   const handleContactSalesClick = () => {
     posthog.capture("Contact sales modal opened", {
@@ -282,7 +290,7 @@ export function ContactCards() {
       <div className="mt-16 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
         <QuickStartCard
           description="Get help with technical issues, account questions, and general inquiries from our support team.  Email support is available for customers on paid plans."
-          href="mailto:support@arcade.dev"
+          href={supportHref}
           icon={Mail}
           title="Email Support"
         />

--- a/next.config.ts
+++ b/next.config.ts
@@ -31,6 +31,13 @@ const nextConfig: NextConfig = withLlmsTxt({
           destination: "/:locale/resources/integrations",
           permanent: true,
         },
+        // The auth provider is "square"; an external/stale link points at the
+        // old "squareup" slug, which 404s. Send it to the real page.
+        {
+          source: "/:locale/references/auth-providers/squareup",
+          destination: "/:locale/references/auth-providers/square",
+          permanent: true,
+        },
         // Dissolved guides/security section
         {
           source: "/:locale/guides/security/security-research-program",

--- a/tests/integration-index-links.test.ts
+++ b/tests/integration-index-links.test.ts
@@ -8,8 +8,13 @@ import {
   resolveIndexToolkits,
   toIntegrationLink,
 } from "@/app/_lib/integration-index";
-import type { ToolkitWithDocsLink } from "@/app/_lib/toolkit-slug";
+import { readToolkitData } from "@/app/_lib/toolkit-data";
 import {
+  getToolkitSlug,
+  type ToolkitWithDocsLink,
+} from "@/app/_lib/toolkit-slug";
+import {
+  getToolkitStaticParamsForCategory,
   INTEGRATION_CATEGORIES,
   listValidIntegrationLinks,
 } from "@/app/_lib/toolkit-static-params";
@@ -245,4 +250,99 @@ describe("hardcoded internal links in toolkit components resolve", () => {
     },
     TIMEOUT
   );
+});
+
+// ---------------------------------------------------------------------------
+// Toolkit page canonical hygiene
+//
+// docs' only page-level <link rel="canonical"> comes from the generated toolkit
+// pages (toolkit-docs-page.tsx → generateMetadata, which emits
+// `/en/resources/integrations/<category>/<getToolkitSlug(data)>`). This guards
+// that canonical class — the docs analog of the www canonical guard, and
+// specifically the "Duplicate pages without canonical" finding MARTECH-19 fixed
+// (notion): every toolkit page's canonical points at its own URL, canonicals are
+// unique (no two pages share one), and none points at a redirect source or a
+// non-generated route. We re-derive the canonical with the same pure helpers the
+// page uses (static params + readToolkitData + getToolkitSlug) rather than
+// importing the page module, which pulls in browser-only render code.
+//
+// (The docs sitemap — app/sitemap.ts, static MDX pages only — is guarded in
+// tests/sitemap.test.ts: no redirect-source URLs, no duplicates.)
+// ---------------------------------------------------------------------------
+
+describe("toolkit page canonical hygiene", () => {
+  let canonicals: Array<{ page: string; canonical: string }>;
+  let validLinks: Set<string>;
+  let redirectSources: Set<string>;
+
+  beforeAll(async () => {
+    [validLinks, redirectSources] = await Promise.all([
+      listValidIntegrationLinks(),
+      readRedirectSources(),
+    ]);
+    canonicals = [];
+    for (const category of INTEGRATION_CATEGORIES) {
+      for (const { toolkitId } of await getToolkitStaticParamsForCategory(
+        category
+      )) {
+        const data = await readToolkitData(toolkitId);
+        const canonical = data
+          ? `${INTEGRATIONS}/${category}/${getToolkitSlug({
+              id: data.id,
+              docsLink: data.metadata?.docsLink,
+            })}`
+          : "";
+        canonicals.push({
+          page: `${INTEGRATIONS}/${category}/${toolkitId}`,
+          canonical,
+        });
+      }
+    }
+  }, TIMEOUT);
+
+  test("every generated toolkit page emits a canonical", () => {
+    expect(canonicals.length).toBeGreaterThan(0);
+    expect(canonicals.filter((c) => !c.canonical).map((c) => c.page)).toEqual(
+      []
+    );
+  });
+
+  test("each toolkit canonical points at the page's own URL", () => {
+    const mismatched = canonicals
+      .filter((c) => c.canonical && c.canonical !== c.page)
+      .map((c) => `${c.page} → ${c.canonical}`);
+    expect(mismatched).toEqual([]);
+  });
+
+  test("toolkit canonicals are unique (no duplicate-canonical pages)", () => {
+    const byCanonical = new Map<string, string>();
+    const duplicates: string[] = [];
+    for (const { page, canonical } of canonicals) {
+      if (!canonical) {
+        continue;
+      }
+      const prior = byCanonical.get(canonical);
+      if (prior) {
+        duplicates.push(`${canonical} ← ${prior} + ${page}`);
+      } else {
+        byCanonical.set(canonical, page);
+      }
+    }
+    expect(duplicates).toEqual([]);
+  });
+
+  test("no toolkit canonical points at a redirect or a missing route", () => {
+    const offenders: string[] = [];
+    for (const { canonical } of canonicals) {
+      if (!canonical) {
+        continue;
+      }
+      if (redirectSources.has(toLocaleParam(canonical))) {
+        offenders.push(`${canonical}: redirect source`);
+      } else if (!validLinks.has(withEnLocale(canonical))) {
+        offenders.push(`${canonical}: not a generated route`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
 });

--- a/tests/integration-index-links.test.ts
+++ b/tests/integration-index-links.test.ts
@@ -14,8 +14,8 @@ import {
   type ToolkitWithDocsLink,
 } from "@/app/_lib/toolkit-slug";
 import {
-  getToolkitStaticParamsForCategory,
   INTEGRATION_CATEGORIES,
+  listToolkitRoutes,
   listValidIntegrationLinks,
 } from "@/app/_lib/toolkit-static-params";
 
@@ -263,7 +263,7 @@ describe("hardcoded internal links in toolkit components resolve", () => {
 // (notion): every toolkit page's canonical points at its own URL, canonicals are
 // unique (no two pages share one), and none points at a redirect source or a
 // non-generated route. We re-derive the canonical with the same pure helpers the
-// page uses (static params + readToolkitData + getToolkitSlug) rather than
+// page uses (listToolkitRoutes + readToolkitData + getToolkitSlug) rather than
 // importing the page module, which pulls in browser-only render code.
 //
 // (The docs sitemap — app/sitemap.ts, static MDX pages only — is guarded in
@@ -281,22 +281,22 @@ describe("toolkit page canonical hygiene", () => {
       readRedirectSources(),
     ]);
     canonicals = [];
-    for (const category of INTEGRATION_CATEGORIES) {
-      for (const { toolkitId } of await getToolkitStaticParamsForCategory(
-        category
-      )) {
-        const data = await readToolkitData(toolkitId);
-        const canonical = data
-          ? `${INTEGRATIONS}/${category}/${getToolkitSlug({
-              id: data.id,
-              docsLink: data.metadata?.docsLink,
-            })}`
-          : "";
-        canonicals.push({
-          page: `${INTEGRATIONS}/${category}/${toolkitId}`,
-          canonical,
-        });
-      }
+    // Fetch the route list ONCE. getToolkitStaticParamsForCategory() recomputes
+    // listToolkitRoutes() (toolkit index + every data file) internally, so
+    // looping it over all categories re-read the whole catalog once per category.
+    // listToolkitRoutes() already yields both category and toolkitId.
+    for (const { category, toolkitId } of await listToolkitRoutes()) {
+      const data = await readToolkitData(toolkitId);
+      const canonical = data
+        ? `${INTEGRATIONS}/${category}/${getToolkitSlug({
+            id: data.id,
+            docsLink: data.metadata?.docsLink,
+          })}`
+        : "";
+      canonicals.push({
+        page: `${INTEGRATIONS}/${category}/${toolkitId}`,
+        canonical,
+      });
     }
   }, TIMEOUT);
 


### PR DESCRIPTION
## What

Follow-up cleanup after the MARTECH-19 re-crawl (docs.arcade.dev health **81 → 95**, errors **143 → 39 URLs**). Clears two of the residual error rows that are fixable in-repo.

Related: [MARTECH-19](https://linear.app/arcadedev/issue/MARTECH-19) (merged), [MARTECH-17](https://linear.app/arcadedev/issue/MARTECH-17) (page-size, separate).

## Changes

**1. Stale `squareup` auth-provider link → redirect**
The crawl's "Broken redirect" + one of the 404/4XX rows is `/references/auth-providers/squareup` → 307 → `/en/...squareup` (404; the real page is `square`). There's **no internal link** to it in the repo, so it's an external/stale backlink. Added a redirect `/:locale/references/auth-providers/squareup → /:locale/references/auth-providers/square`, which turns it into 308 → 200 and clears the broken-redirect + that 404/4XX.

**2. contact-us "Email Support" card → client-deferred mailto**
`contact-cards.tsx` was the last raw `mailto:` (the flagged MARTECH-19 follow-up). It now assembles the `mailto:` after mount (same approach as `<ContactEmail>`), so the SSR/crawled markup is a plain `/en/resources/contact-us` link and Cloudflare has nothing to rewrite into a broken `/cdn-cgi/l/email-protection` link.

## Deliberately NOT in this PR

- **"Canonical URL has no incoming internal links" (2: `pagerduty-api`, `notion`)** — these are **transient data-churn artifacts**, not a code bug: `notiontoolkit.json` is now `isHidden`, and `pagerdutyapi.json`'s category moved to `customer-support`, so the crawled `…/development/pagerduty-api` and `…/productivity/notion` pages won't be generated by the current data. They self-heal on the next build/deploy + crawl. No code change made (forcing one would be fixing a non-bug).
- **The rest of the email-protection cluster (~14 "links to broken page")** — these come from **auto-generated content** Cloudflare reads as emails: connection strings in tool docs (e.g. `mongodb+srv://user:p@ss@host`) and example addresses in guide code blocks. The only clean fix is the **Cloudflare Email Obfuscation toggle**, which we've decided not to flip; an in-repo workaround would mean mangling generated tool data / example code, which isn't worth it.
