### PR TITLE
updated the changelog

### DIFF
--- a/app/en/references/changelog/page.mdx
+++ b/app/en/references/changelog/page.mdx
@@ -9,6 +9,35 @@ import { Callout } from "nextra/components";
 
 _Here's what's new at Arcade.dev!_
 
+## 2026-06-12
+
+**Arcade MCP Servers**
+
+- `[feature - 🚀]` Add Freshdesk customer-support toolkit with API-key authentication for helpdesk services.
+- `[feature - 🚀]` Add Ashby recruiting/ATS toolkit for core recruiting operations.
+- `[feature - 🚀]` Adds Vercel toolkit for managing accounts via the REST API.
+- `[feature - 🚀]` Add GetSpreadsheetEditHistory tool to google_sheets toolkit.
+- `[feature - 🚀]` Add Datadog observability toolkit for log and trace investigation.
+- `[feature - 🚀]` Adds project-milestone assignment to the Linear toolkit's create and update issue tools.
+- `[feature - 🚀]` Add inspect_spreadsheet tool and remove legacy read tools in the worker's Google Sheets integration.
+- `[feature - 🚀]` Add a first-party Discord toolkit for bot functionality in worker applications.
+- `[feature - 🚀]` Return deep links to the booking page for Google Flights in the worker implementation.
+- `[feature - 🚀]` Adds support for attaching local files to emails in Gmail via new attachments parameter.
+- `[feature - 🚀]` Add Fly.io toolkit with tools for managing Fly.io apps and infrastructure.
+- `[feature - 🚀]` Add new read-only Apollo.io sales-intelligence toolkit for prospecting and account research.
+- `[feature - 🚀]` Adds an Arcade MCP toolkit for Customer.io to assist agents with customer engagement.
+- `[bugfix - 🐛]` Fix BrightData cross-tenant credential bleed.
+
+
+**Platform and Engine**
+
+- `[maintenance - 🔧]` Make user sources unconditionally available.
+- `[feature - 🚀]` Add empty-state page with hero and functional 'Create' button for MCP gateways.
+
+**Misc**
+
+- `[documentation - 📝]` Update build-mcp-server guide to swap Reddit demo for GitHub star.
+
 ## 2026-06-05
 
 **Arcade MCP Servers**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only changelog update with no runtime or configuration changes.
> 
> **Overview**
> Adds a **2026-06-12** section at the top of the public changelog documenting that week’s shipped work.
> 
> **Arcade MCP Servers** lists many new or expanded toolkits (Freshdesk, Ashby, Vercel, Datadog, Fly.io, Apollo.io, Customer.io, Discord, etc.) plus Google Sheets, Linear, Gmail attachments, and Google Flights deep links, along with a **BrightData cross-tenant credential bleed** bugfix.
> 
> **Platform and Engine** covers unconditional user sources and an MCP gateway empty state with create flow. **Misc** notes a build-mcp-server guide demo swap (Reddit → GitHub star).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0d44a5bf526e7f9169974827d87f73e57a523cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->