### PR TITLE
docs(gmail): publish email attachments capability and host coverage (TOO-981)

### DIFF
--- a/toolkit-docs-generator/data/toolkits/gmail.json
+++ b/toolkit-docs-generator/data/toolkits/gmail.json
@@ -1885,6 +1885,14 @@
       "location": "auth",
       "position": "after",
       "content": "The Arcade Gmail MCP Server uses the [Google auth provider](/references/auth-providers/google) to connect to users' Google accounts.\n---"
+    },
+    {
+      "type": "markdown",
+      "location": "after_available_tools",
+      "position": "after",
+      "content": "## Adding attachments to emails\n\nThe Gmail send, draft, and reply tools take an `attachments` parameter for local files. The agent emits only the file path; a client-side `preToolUse` hook swaps in the bytes before the request leaves your machine, so file contents never enter the model's context window.\n\nThe first time you attach a file, your agent installs the one-time hook for you after you approve. Gmail caps total message size at 25 MB.\n\nAttachments work on hosts that support a client-side pre-tool hook. On any other host the tool returns a clear error and sends nothing.\n\n| Host | Status | Notes |\n| --- | --- | --- |\n| Cursor | Supported | App, plus Cursor cloud and background agents. |\n| Claude Code | Supported | v2.0.10+. |\n| Codex CLI | Supported | v0.131+. |\n| VS Code chat (GitHub Copilot) | Supported | 1.112+, agent mode. |\n| Claude Cowork | Documented limitation | Sandboxed to one folder; the hook cannot be installed from inside it. |\n| Claude Desktop | Documented limitation | No client-side hook layer. |\n| ChatGPT desktop | Documented limitation | No client-side hook surface. |\n| Microsoft 365 Copilot | Documented limitation | No host-side rewrite hook. |",
+      "header": "## Adding attachments to emails",
+      "priority": 10
     }
   ],
   "customImports": [


### PR DESCRIPTION
## What

Publishes the Gmail email-attachments docs as a single **Adding attachments to emails** section on the generated Gmail integration page (https://docs.arcade.dev/en/resources/integrations/productivity/gmail), below the tool list. It covers:

- The capability: the Gmail send / draft / reply tools accept an `attachments` parameter for local files; a client-side `preToolUse` hook substitutes the bytes before the request leaves the machine, so file contents never enter the model's context window, and the agent installs the one-time hook for the user on first use.
- A host coverage table: supported hosts vs documented-limitation hosts (Claude Cowork, Claude Desktop, ChatGPT desktop, Microsoft 365 Copilot).

No manual per-host setup instructions: the hook is installed by the agent on first use, not by hand.

Implements Milestone 6's public-docs piece. Linear: [TOO-981](https://linear.app/arcadedev/issue/TOO-981).

## How

The Gmail integration page is generated from `toolkit-docs-generator/data/toolkits/gmail.json`. Hand-authored prose renders on that page via the file's `documentationChunks` (drawn inline by `app/_components/toolkit-docs`, with a sidebar TOC entry). This change adds one `markdown` chunk at `location: after_available_tools` (below the tool reference). Only `gmail.json` changes.

The chunk survives future auto docs regeneration: the `[AUTO]` workflow passes no custom-sections source, and the merger preserves previous-output `documentationChunks` when the source is empty (the same way the existing Auth chunk and ScopePicker import have persisted).

## Verification

- The chunk compiles through the repo's own `@mdx-js/mdx` + `remark-gfm`.
- Diff is +8 lines to one file, with no reformat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a single toolkit JSON file; no runtime, auth, or API behavior is modified.
> 
> **Overview**
> Adds a hand-authored **Adding attachments to emails** section to the generated Gmail integration page by appending a new `documentationChunks` entry in `gmail.json` at `after_available_tools` (below the tool list).
> 
> The new prose explains how send/draft/reply tools use `attachments` with local paths, client-side `preToolUse` byte substitution (keeping file contents out of the model context), one-time hook install on first use, and the 25 MB Gmail limit. It also adds a host support vs documented-limitation table (Cursor, Claude Code, Codex CLI, VS Code Copilot vs Cowork, Desktop, ChatGPT, M365 Copilot).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fae6fe338091dcbe8fbf8f0eaebdc19423f3c83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->