### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/toolkit-docs-generator/data/toolkits/ashby.json
+++ b/toolkit-docs-generator/data/toolkits/ashby.json
@@ -1,7 +1,7 @@
 {
   "id": "Ashby",
   "label": "Ashby",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Arcade.dev tools for interacting with Ashby",
   "metadata": {
     "category": "productivity",
@@ -18,7 +18,7 @@
     {
       "name": "AddCandidateNote",
       "qualifiedName": "Ashby.AddCandidateNote",
-      "fullyQualifiedName": "Ashby.AddCandidateNote@0.1.0",
+      "fullyQualifiedName": "Ashby.AddCandidateNote@0.2.0",
       "description": "Add a plain-text note to a candidate (e.g. an agent handoff or summary).\n\nCreates a new note each time it runs. Requires the Candidates write permission\non the API key.",
       "parameters": [
         {
@@ -100,9 +100,80 @@
       }
     },
     {
+      "name": "ArchiveApplication",
+      "qualifiedName": "Ashby.ArchiveApplication",
+      "fullyQualifiedName": "Ashby.ArchiveApplication@0.2.0",
+      "description": "Archive (reject) an application, recording why.\n\nThis is how Ashby rejects a candidate for a job: the application moves to its\ninterview plan's archived stage with an archive reason. Resolves the reason name\nto the organization's configured reason id for you — an unknown name errors with\nthe available reasons, and an ambiguous one errors rather than guessing. Does NOT\nemail the candidate. The application's data is preserved, and it can later be\nmoved back to an active stage to un-archive it — though anything the rejection\nalready triggered (notifications, a status visible to humans) is not undone.\nRequires the Candidates write, Interviews read, and hiring-process-metadata read\npermissions on the API key.",
+      "parameters": [
+        {
+          "name": "application_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the application to archive (reject).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "reason",
+          "type": "string",
+          "required": true,
+          "description": "The NAME of the archive reason to record, e.g. 'Candidate withdrew' or 'Not enough experience'. Resolved to the organization's configured reason id for you; if it doesn't match, the error lists the available reasons.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "ASHBY_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ASHBY_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The application after it was archived."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Ashby.ArchiveApplication",
+        "parameters": {
+          "application_id": {
+            "value": "app_4f8c2e1a-9b3d-4710-ae56-7c0d1f832b94",
+            "type": "string",
+            "required": true
+          },
+          "reason": {
+            "value": "Not enough experience",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "ChangeApplicationStage",
       "qualifiedName": "Ashby.ChangeApplicationStage",
-      "fullyQualifiedName": "Ashby.ChangeApplicationStage@0.1.0",
+      "fullyQualifiedName": "Ashby.ChangeApplicationStage@0.2.0",
       "description": "Move an application to a named interview stage, in either direction.\n\nResolves the stage name to its id inside the application's own interview plan,\nthen moves the application — you do not look up stage ids yourself. Works to\nadvance or to move a candidate back; if the name does not match, the error lists\nthe plan's available stage names, and an ambiguous name (two stages share it)\nerrors rather than guessing. Records a transition each time it runs. It cannot\nmove an application into an archived/rejected stage (Ashby requires an archive\nreason this tool does not collect). Requires the Candidates write and Interviews\nread permissions on the API key.",
       "parameters": [
         {
@@ -173,7 +244,7 @@
     {
       "name": "GetCandidate",
       "qualifiedName": "Ashby.GetCandidate",
-      "fullyQualifiedName": "Ashby.GetCandidate@0.1.0",
+      "fullyQualifiedName": "Ashby.GetCandidate@0.2.0",
       "description": "Get a candidate's profile and the ids of their applications.\n\nUse the returned application ids with feedback or application tools; the Ashby\nAPI does not list a candidate's applications directly. Requires the Candidates\nread permission on the API key.",
       "parameters": [
         {
@@ -231,7 +302,7 @@
     {
       "name": "GetCandidateDebrief",
       "qualifiedName": "Ashby.GetCandidateDebrief",
-      "fullyQualifiedName": "Ashby.GetCandidateDebrief@0.1.0",
+      "fullyQualifiedName": "Ashby.GetCandidateDebrief@0.2.0",
       "description": "Gather everything about a candidate for a debrief in one call.\n\nPulls the candidate's profile, the notes on file, and the interview feedback and\nscorecards across each of their applications, then returns them together — you do\nnot chain the candidate, note, and feedback reads yourself. Feedback covers up to\nthe candidate's first applications when there are many; an application whose\nfeedback can't be read is counted in `feedback_failed` rather than failing the\nwhole call. Requires the Candidates read permission on the API key.",
       "parameters": [
         {
@@ -289,7 +360,7 @@
     {
       "name": "ListApplicationFeedback",
       "qualifiedName": "Ashby.ListApplicationFeedback",
-      "fullyQualifiedName": "Ashby.ListApplicationFeedback@0.1.0",
+      "fullyQualifiedName": "Ashby.ListApplicationFeedback@0.2.0",
       "description": "Read the feedback and interview scorecards submitted on an application.\n\nUseful for synthesizing what reviewers said about a candidate before a debrief.\nRequires the Candidates read permission on the API key.",
       "parameters": [
         {
@@ -373,7 +444,7 @@
     {
       "name": "ListApplications",
       "qualifiedName": "Ashby.ListApplications",
-      "fullyQualifiedName": "Ashby.ListApplications@0.1.0",
+      "fullyQualifiedName": "Ashby.ListApplications@0.2.0",
       "description": "List the organization's applications, optionally filtered by job and/or status.\n\nThe Ashby API does not filter applications by candidate; to find a specific\ncandidate's applications, read the candidate first and use its application ids.\nRequires the Candidates read permission on the API key.",
       "parameters": [
         {
@@ -475,7 +546,7 @@
     {
       "name": "ListCandidateNotes",
       "qualifiedName": "Ashby.ListCandidateNotes",
-      "fullyQualifiedName": "Ashby.ListCandidateNotes@0.1.0",
+      "fullyQualifiedName": "Ashby.ListCandidateNotes@0.2.0",
       "description": "Read the notes recorded on a candidate, paginated via the cursor.\n\nRequires the Candidates read permission on the API key.",
       "parameters": [
         {
@@ -559,7 +630,7 @@
     {
       "name": "ListJobs",
       "qualifiedName": "Ashby.ListJobs",
-      "fullyQualifiedName": "Ashby.ListJobs@0.1.0",
+      "fullyQualifiedName": "Ashby.ListJobs@0.2.0",
       "description": "List the organization's jobs (roles), optionally filtered by status.\n\nA job is the role record; headcount slots (\"openings\") are a separate concept\nnot exposed here. Requires the Jobs read permission on the API key.",
       "parameters": [
         {
@@ -652,7 +723,7 @@
     {
       "name": "SearchCandidates",
       "qualifiedName": "Ashby.SearchCandidates",
-      "fullyQualifiedName": "Ashby.SearchCandidates@0.1.0",
+      "fullyQualifiedName": "Ashby.SearchCandidates@0.2.0",
       "description": "Search the organization's candidates by name and/or email.\n\nIntended for narrowing to a small set of known candidates (e.g. re-engaging a\npast applicant). Returns at most 100 matches; provide at least one of name or\nemail, each at least 3 characters. Requires the Candidates read permission on\nthe API key.",
       "parameters": [
         {
@@ -724,6 +795,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-06-10T12:11:44.524Z",
-  "summary": "Ashby is an all-in-one recruiting platform. This toolkit lets Arcade agents read and write recruiting data in Ashby — candidates, applications, jobs, notes, feedback, and interview stage progression.\n\n## Capabilities\n\n- **Candidate management**: Search candidates by name/email, retrieve full profiles (with application IDs), and add plain-text notes (e.g. agent handoffs or summaries).\n- **Application lifecycle**: List applications filtered by job or status, move applications forward or backward through named interview stages, and read submitted feedback/scorecards.\n- **Job listings**: Enumerate the organization's roles, optionally filtered by status.\n- **Debrief aggregation**: Pull a candidate's profile, all notes, and all interview feedback across applications in a single call — no manual chaining required.\n\n## Secrets\n\n- **`ASHBY_API_KEY`** — An Ashby API key scoped to the permissions required by the tools you use. Generate one in your Ashby account under **Settings → Integrations → API Keys**. Each key carries granular permissions; the tools in this toolkit require the following depending on usage:\n  - **Candidates read** — searching, reading profiles, listing notes, listing feedback, listing applications, debrief aggregation.\n  - **Candidates write** — adding notes, changing application stage.\n  - **Interviews read** — changing application stage (stage plan lookup).\n  - **Jobs read** — listing jobs.\n\n  Create and scope the key from the [Ashby API Keys settings page](https://app.ashbyhq.com/settings/api-keys). Note that Ashby API keys are organization-scoped; the key holder can read or write across all candidates and jobs in the org, so apply least-privilege scoping.\n\nSee the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to store secrets, or manage them directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
+  "generatedAt": "2026-06-19T12:27:52.451Z",
+  "summary": "Ashby is a recruiting platform; this toolkit lets Arcade agents read and write recruiting data — candidates, applications, jobs, notes, feedback, and interview stages — via the Ashby REST API.\n\n## Capabilities\n\n- **Candidate management**: Search candidates by name/email, fetch full profiles, read and add plain-text notes, and pull a combined debrief bundle (profile + notes + scorecards) in one call.\n- **Application lifecycle**: List applications (filtered by job and/or status), move applications forward or backward through named interview stages, and archive/reject applications with a resolved reason.\n- **Feedback & scorecards**: Read submitted interview feedback and scorecards on any application — useful for pre-debrief synthesis.\n- **Job listing**: Enumerate the organization's job records, optionally filtered by status.\n\n## Secrets\n\n`ASHBY_API_KEY` — An Ashby API key scoped to the permissions your agent needs. Ashby issues API keys per organization; generate one in **Settings → Integrations → API Keys** inside your Ashby admin panel. Each key carries explicit permission grants — the tools in this toolkit require combinations of **Candidates read**, **Candidates write**, **Interviews read**, and **Jobs read** depending on which tools you use (tool docstrings list the exact permissions required). Keys with insufficient permissions will return authorization errors at call time. See [Ashby's API key documentation](https://developers.ashby.com/docs/authentication) for creation steps.\n\nStore the key in Arcade at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets) and reference it as `ASHBY_API_KEY`. For full guidance on configuring secrets in Arcade, see [https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/gmail.json
+++ b/toolkit-docs-generator/data/toolkits/gmail.json
@@ -1,7 +1,7 @@
 {
   "id": "Gmail",
   "label": "Gmail",
-  "version": "7.3.0",
+  "version": "7.5.0",
   "description": "Arcade.dev LLM tools for Gmail",
   "metadata": {
     "category": "productivity",
@@ -30,7 +30,7 @@
     {
       "name": "ChangeEmailLabels",
       "qualifiedName": "Gmail.ChangeEmailLabels",
-      "fullyQualifiedName": "Gmail.ChangeEmailLabels@7.3.0",
+      "fullyQualifiedName": "Gmail.ChangeEmailLabels@7.5.0",
       "description": "Add and remove labels from an email using the Gmail API.",
       "parameters": [
         {
@@ -124,7 +124,7 @@
     {
       "name": "CreateLabel",
       "qualifiedName": "Gmail.CreateLabel",
-      "fullyQualifiedName": "Gmail.CreateLabel@7.3.0",
+      "fullyQualifiedName": "Gmail.CreateLabel@7.5.0",
       "description": "Create a new label in the user's mailbox.",
       "parameters": [
         {
@@ -184,7 +184,7 @@
     {
       "name": "DeleteDraftEmail",
       "qualifiedName": "Gmail.DeleteDraftEmail",
-      "fullyQualifiedName": "Gmail.DeleteDraftEmail@7.3.0",
+      "fullyQualifiedName": "Gmail.DeleteDraftEmail@7.5.0",
       "description": "Delete a draft email using the Gmail API.",
       "parameters": [
         {
@@ -244,7 +244,7 @@
     {
       "name": "GetThread",
       "qualifiedName": "Gmail.GetThread",
-      "fullyQualifiedName": "Gmail.GetThread@7.3.0",
+      "fullyQualifiedName": "Gmail.GetThread@7.5.0",
       "description": "Get the specified thread by ID.",
       "parameters": [
         {
@@ -304,7 +304,7 @@
     {
       "name": "ListDraftEmails",
       "qualifiedName": "Gmail.ListDraftEmails",
-      "fullyQualifiedName": "Gmail.ListDraftEmails@7.3.0",
+      "fullyQualifiedName": "Gmail.ListDraftEmails@7.5.0",
       "description": "Lists draft emails in the user's draft mailbox using the Gmail API.",
       "parameters": [
         {
@@ -364,7 +364,7 @@
     {
       "name": "ListEmails",
       "qualifiedName": "Gmail.ListEmails",
-      "fullyQualifiedName": "Gmail.ListEmails@7.3.0",
+      "fullyQualifiedName": "Gmail.ListEmails@7.5.0",
       "description": "Read emails from a Gmail account and extract plain text content.\n\nBy default, obvious automated emails are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all emails regardless of source.",
       "parameters": [
         {
@@ -437,7 +437,7 @@
     {
       "name": "ListEmailsByHeader",
       "qualifiedName": "Gmail.ListEmailsByHeader",
-      "fullyQualifiedName": "Gmail.ListEmailsByHeader@7.3.0",
+      "fullyQualifiedName": "Gmail.ListEmailsByHeader@7.5.0",
       "description": "Search for emails by header using the Gmail API.\n\nBy default, obvious automated emails are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all emails regardless of source.",
       "parameters": [
         {
@@ -596,7 +596,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Gmail.ListLabels",
-      "fullyQualifiedName": "Gmail.ListLabels@7.3.0",
+      "fullyQualifiedName": "Gmail.ListLabels@7.5.0",
       "description": "List all the labels in the user's mailbox.",
       "parameters": [],
       "auth": {
@@ -641,7 +641,7 @@
     {
       "name": "ListThreads",
       "qualifiedName": "Gmail.ListThreads",
-      "fullyQualifiedName": "Gmail.ListThreads@7.3.0",
+      "fullyQualifiedName": "Gmail.ListThreads@7.5.0",
       "description": "List threads in the user's mailbox.\n\nBy default, obvious automated threads are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all threads regardless of source.",
       "parameters": [
         {
@@ -740,7 +740,7 @@
     {
       "name": "ReplyToEmail",
       "qualifiedName": "Gmail.ReplyToEmail",
-      "fullyQualifiedName": "Gmail.ReplyToEmail@7.3.0",
+      "fullyQualifiedName": "Gmail.ReplyToEmail@7.5.0",
       "description": "Send a reply to an email message, optionally with one or more file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
@@ -905,7 +905,7 @@
     {
       "name": "SearchThreads",
       "qualifiedName": "Gmail.SearchThreads",
-      "fullyQualifiedName": "Gmail.SearchThreads@7.3.0",
+      "fullyQualifiedName": "Gmail.SearchThreads@7.5.0",
       "description": "Search for threads in the user's mailbox.\n\nBy default, obvious automated threads are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all threads regardless of source.",
       "parameters": [
         {
@@ -1094,7 +1094,7 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "Gmail.SendDraftEmail",
-      "fullyQualifiedName": "Gmail.SendDraftEmail@7.3.0",
+      "fullyQualifiedName": "Gmail.SendDraftEmail@7.5.0",
       "description": "Send a draft email using the Gmail API.",
       "parameters": [
         {
@@ -1154,7 +1154,7 @@
     {
       "name": "SendEmail",
       "qualifiedName": "Gmail.SendEmail",
-      "fullyQualifiedName": "Gmail.SendEmail@7.3.0",
+      "fullyQualifiedName": "Gmail.SendEmail@7.5.0",
       "description": "Send an email using the Gmail API, optionally with one or more file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
@@ -1315,7 +1315,7 @@
     {
       "name": "TrashEmail",
       "qualifiedName": "Gmail.TrashEmail",
-      "fullyQualifiedName": "Gmail.TrashEmail@7.3.0",
+      "fullyQualifiedName": "Gmail.TrashEmail@7.5.0",
       "description": "Move an email to the trash folder using the Gmail API.",
       "parameters": [
         {
@@ -1375,7 +1375,7 @@
     {
       "name": "UpdateDraftEmail",
       "qualifiedName": "Gmail.UpdateDraftEmail",
-      "fullyQualifiedName": "Gmail.UpdateDraftEmail@7.3.0",
+      "fullyQualifiedName": "Gmail.UpdateDraftEmail@7.5.0",
       "description": "Update an existing email draft using the Gmail API.\n\nSingle-part ``text/plain`` and single-part ``text/html`` drafts both support full\nbody replacement; the rebuild follows the existing draft's content type, so a\nplain draft stays plain and an HTML draft stays HTML. Plain-text input supplied\nagainst an HTML draft is auto-converted to HTML, and HTML input supplied against\na plain draft is stored verbatim as ``text/plain``. Reply drafts preserve their\nreply-quote tail (``> `` lines for plain, ``<blockquote>`` for HTML) when the\nbody is supplied as a top-only update.\n\nMultipart drafts and drafts with attachments still fail when the body changes;\nin those cases the tool succeeds only when the effective body is unchanged\n(metadata-only update preserving the existing MIME tree). Edit those drafts in\nGmail directly.\n\nFor each of subject, body, recipient, cc, and bcc, omitting the parameter or passing\n``None`` leaves that part of the draft unchanged (for cc/bcc, existing headers are kept;\npass an empty list to clear).",
       "parameters": [
         {
@@ -1507,7 +1507,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Gmail.WhoAmI",
-      "fullyQualifiedName": "Gmail.WhoAmI@7.3.0",
+      "fullyQualifiedName": "Gmail.WhoAmI@7.5.0",
       "description": "Get comprehensive user profile and Gmail account information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Gmail account statistics, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1554,7 +1554,7 @@
     {
       "name": "WriteDraftEmail",
       "qualifiedName": "Gmail.WriteDraftEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftEmail@7.3.0",
+      "fullyQualifiedName": "Gmail.WriteDraftEmail@7.5.0",
       "description": "Compose a new email draft using the Gmail API, optionally with file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
@@ -1715,7 +1715,7 @@
     {
       "name": "WriteDraftReplyEmail",
       "qualifiedName": "Gmail.WriteDraftReplyEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@7.3.0",
+      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@7.5.0",
       "description": "Compose a draft reply to an email message, optionally with one or more file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
@@ -1891,6 +1891,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-06-17T12:31:26.280Z",
+  "generatedAt": "2026-06-19T12:27:49.684Z",
   "summary": "The Gmail toolkit provides Arcade LLM tools for interacting with a user's Gmail account via the Gmail API. It enables reading, composing, sending, organizing, and searching email — covering the full message and draft lifecycle.\n\n## Capabilities\n\n- **Reading & searching:** List emails, threads, and drafts with built-in automated-email filtering (no-reply senders, non-primary categories); search threads by query or header; retrieve full threads by ID; toggle automated filtering with `exclude_automated=False`.\n- **Composing & sending:** Send emails directly or via draft, reply to messages (including draft replies), with support for file attachments supplied as `file://` URIs — file bytes are read client-side and never pass through the conversation.\n- **Draft management:** Create, update, list, send, and delete drafts; update supports subject, body, recipients, cc, and bcc with partial updates (omit fields to preserve them); body replacement handles plain-text and single-part HTML drafts with auto-conversion; multipart/attachment drafts support metadata-only updates.\n- **Label management:** List, create, and apply/remove labels on messages.\n- **Account info:** Retrieve the authenticated user's profile, email address, Gmail statistics, and profile picture via `WhoAmI`.\n- **Trash:** Move messages to trash.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via Google. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details."
 }

--- a/toolkit-docs-generator/data/toolkits/googleslides.json
+++ b/toolkit-docs-generator/data/toolkits/googleslides.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleSlides",
   "label": "Google Slides",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Arcade.dev LLM tools for Google Slides",
   "metadata": {
     "category": "productivity",
@@ -26,14 +26,14 @@
     {
       "name": "CommentOnPresentation",
       "qualifiedName": "GoogleSlides.CommentOnPresentation",
-      "fullyQualifiedName": "GoogleSlides.CommentOnPresentation@2.0.1",
-      "description": "Comment on a specific slide by its index in a Google Slides presentation.",
+      "fullyQualifiedName": "GoogleSlides.CommentOnPresentation@3.0.0",
+      "description": "Add a comment to a presentation, or reply within an existing comment thread.\n\nComments are file-level, not anchored to a slide; to reference a slide, name it in\nthe text. Pass reply_to_comment_id to post within that thread instead of starting a\nnew comment.",
       "parameters": [
         {
           "name": "presentation_id",
           "type": "string",
           "required": true,
-          "description": "The ID of the presentation to comment on",
+          "description": "The id of the presentation to comment on.",
           "enum": null,
           "inferrable": true
         },
@@ -41,7 +41,15 @@
           "name": "comment_text",
           "type": "string",
           "required": true,
-          "description": "The comment to add to the slide",
+          "description": "The comment text to add.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "reply_to_comment_id",
+          "type": "string",
+          "required": false,
+          "description": "Post the text as a reply within an existing comment thread by passing that comment's id. Leave empty to start a new top-level comment.",
           "enum": null,
           "inferrable": true
         }
@@ -64,7 +72,7 @@
       ],
       "output": {
         "type": "json",
-        "description": "The comment's ID, presentationId, and slideNumber in a dictionary"
+        "description": "No description provided."
       },
       "documentationChunks": [],
       "codeExample": {
@@ -76,80 +84,12 @@
             "required": true
           },
           "comment_text": {
-            "value": "Please update the font size on this slide to improve readability.",
-            "type": "string",
-            "required": true
-          }
-        },
-        "requiresAuth": true,
-        "authProvider": "google",
-        "tabLabel": "Call the Tool with User Authorization"
-      },
-      "metadata": {
-        "classification": {
-          "serviceDomains": [
-            "presentations"
-          ]
-        },
-        "behavior": {
-          "operations": [
-            "create"
-          ],
-          "readOnly": false,
-          "destructive": false,
-          "idempotent": false,
-          "openWorld": true
-        },
-        "extras": null
-      }
-    },
-    {
-      "name": "CreatePresentation",
-      "qualifiedName": "GoogleSlides.CreatePresentation",
-      "fullyQualifiedName": "GoogleSlides.CreatePresentation@2.0.1",
-      "description": "Create a new Google Slides presentation\nThe first slide will be populated with the specified title and subtitle.",
-      "parameters": [
-        {
-          "name": "title",
-          "type": "string",
-          "required": true,
-          "description": "The title of the presentation to create",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "subtitle",
-          "type": "string",
-          "required": false,
-          "description": "The subtitle of the presentation to create",
-          "enum": null,
-          "inferrable": true
-        }
-      ],
-      "auth": {
-        "providerId": "google",
-        "providerType": "oauth2",
-        "scopes": [
-          "https://www.googleapis.com/auth/drive.file"
-        ]
-      },
-      "secrets": [],
-      "secretsInfo": [],
-      "output": {
-        "type": "json",
-        "description": "The created presentation's title, presentationId, and presentationUrl"
-      },
-      "documentationChunks": [],
-      "codeExample": {
-        "toolName": "GoogleSlides.CreatePresentation",
-        "parameters": {
-          "title": {
-            "value": "Q2 Product Roadmap Presentation",
+            "value": "Please review slide 3 — the chart data looks outdated and needs to be updated before the client meeting.",
             "type": "string",
             "required": true
           },
-          "subtitle": {
-            "value": "Goals, Milestones, and Key Metrics",
+          "reply_to_comment_id": {
+            "value": "AAAABmqv3kE",
             "type": "string",
             "required": false
           }
@@ -177,32 +117,77 @@
       }
     },
     {
-      "name": "CreateSlide",
-      "qualifiedName": "GoogleSlides.CreateSlide",
-      "fullyQualifiedName": "GoogleSlides.CreateSlide@2.0.1",
-      "description": "Create a new slide at the end of the specified presentation",
+      "name": "CreateOrEditPresentation",
+      "qualifiedName": "GoogleSlides.CreateOrEditPresentation",
+      "fullyQualifiedName": "GoogleSlides.CreateOrEditPresentation@3.0.0",
+      "description": "Create a deck or apply a batch of edits to one, returning created object ids,\nreplace counts, and a fresh addressable snapshot.\n\nUse this single tool for all deck construction and editing: add, delete, or restyle\nslides and elements, insert and replace text, and brand a deck in one batch. Reorder\nslides with an updateSlidesPosition request; duplicate a slide or element with a\nduplicateObject request. To set speaker notes, insertText into a slide's\nnotes_object_id (surfaced per slide in the snapshot).\n\nTo add a slide into a specific branded layout, first read the deck and consult the\nsnapshot's layout inventory: each layout reports its placeholders (type, index, and\nobject id), so you can pick a layout that already carries the title/body/other\nplaceholders you intend to fill rather than guessing which layout holds what, and\naddress a specific placeholder in placeholderIdMappings (by {type, index} or by\nlayoutPlaceholderObjectId) even when a layout repeats a type. Read the snapshot to\ndiscover the object ids later edits target.\n\nThe batch is atomic: one invalid request rejects the whole batch, so target object\nids that exist in the snapshot. Object ids you assign to new objects are validated\nbefore the batch is sent.",
       "parameters": [
+        {
+          "name": "requests",
+          "type": "array",
+          "innerType": "json",
+          "required": true,
+          "description": "Ordered batchUpdate requests to apply. Each item sets exactly one request key. Pass an empty list to create a blank deck or to re-read an existing one. Any caller-chosen objectId (on createSlide, createShape, createTable, etc.) must be 5-50 characters long and contain only letters, digits, hyphen, underscore, or colon, beginning with a letter, digit, or underscore; it must be unique within the batch and the deck. These ids are validated before the batch is sent.",
+          "enum": null,
+          "inferrable": true
+        },
         {
           "name": "presentation_id",
           "type": "string",
-          "required": true,
-          "description": "The ID of the presentation to create the slide in",
+          "required": false,
+          "description": "Omit to create a new deck; provide a deck id to edit that deck in place.",
           "enum": null,
           "inferrable": true
         },
         {
-          "name": "slide_title",
+          "name": "title",
           "type": "string",
-          "required": true,
-          "description": "The title of the slide to create",
+          "required": false,
+          "description": "Title for a newly created deck. Ignored when editing an existing deck.",
           "enum": null,
           "inferrable": true
         },
         {
-          "name": "slide_body",
+          "name": "keep_default_slide",
+          "type": "boolean",
+          "required": false,
+          "description": "When creating a new deck whose requests add their own slides, the blank slide Google auto-creates is removed so the deck contains only what you built. Set true to keep that auto-created blank first slide. Ignored when editing an existing deck or when no new slides are created. Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "snapshot_detail",
           "type": "string",
-          "required": true,
-          "description": "The body (text) of the slide to create",
+          "required": false,
+          "description": "How much per-slide detail the returned snapshot carries. OUTLINE reports object ids, placeholders, text, and notes; FULL adds per-element geometry. Defaults to OUTLINE.",
+          "enum": [
+            "OUTLINE",
+            "FULL"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "include_layouts",
+          "type": "boolean",
+          "required": false,
+          "description": "Include the deck's layout inventory in the returned snapshot. Omit to use the default, which includes layouts when creating a new deck (their object ids are needed to add slides into branded layouts) and omits them when editing an existing deck (where layouts rarely change between edits and only add tokens). Set true or false to force.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "include_masters",
+          "type": "boolean",
+          "required": false,
+          "description": "Include the deck's master inventory in the returned snapshot. Masters rarely change between edits and are the heaviest part of the snapshot, so they are omitted by default; set true when verifying a master-level branding edit.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "return_slide_ids",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Scope the returned snapshot's slides to these slide object ids (in deck order). Omit (null) to return every slide; pass an empty list to return no slides (the snapshot still reports slide_count and other deck-level fields). Use after a localized edit to get back only the slides you touched instead of the whole deck.",
           "enum": null,
           "inferrable": true
         }
@@ -225,26 +210,87 @@
       ],
       "output": {
         "type": "json",
-        "description": "A URL to the created slide"
+        "description": "No description provided."
       },
       "documentationChunks": [],
       "codeExample": {
-        "toolName": "GoogleSlides.CreateSlide",
+        "toolName": "GoogleSlides.CreateOrEditPresentation",
         "parameters": {
+          "requests": {
+            "value": [
+              {
+                "createSlide": {
+                  "objectId": "slide_001",
+                  "insertionIndex": 0,
+                  "slideLayoutReference": {
+                    "predefinedLayout": "TITLE_AND_BODY"
+                  }
+                }
+              },
+              {
+                "insertText": {
+                  "objectId": "title_placeholder_001",
+                  "text": "Welcome to Our Quarterly Review",
+                  "insertionIndex": 0
+                }
+              },
+              {
+                "updateTextStyle": {
+                  "objectId": "title_placeholder_001",
+                  "style": {
+                    "bold": true,
+                    "fontSize": {
+                      "magnitude": 36,
+                      "unit": "PT"
+                    }
+                  },
+                  "textRange": {
+                    "type": "ALL"
+                  },
+                  "fields": "bold,fontSize"
+                }
+              }
+            ],
+            "type": "array",
+            "required": true
+          },
           "presentation_id": {
             "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
-            "required": true
+            "required": false
           },
-          "slide_title": {
-            "value": "Q3 Sales Performance Overview",
+          "title": {
+            "value": "Q3 2024 Quarterly Business Review",
             "type": "string",
-            "required": true
+            "required": false
           },
-          "slide_body": {
-            "value": "Revenue increased by 24% compared to Q2, driven by strong performance in the enterprise segment and successful product launches in APAC markets.",
+          "keep_default_slide": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "snapshot_detail": {
+            "value": "OUTLINE",
             "type": "string",
-            "required": true
+            "required": false
+          },
+          "include_layouts": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "include_masters": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "return_slide_ids": {
+            "value": [
+              "slide_001",
+              "slide_002"
+            ],
+            "type": "array",
+            "required": false
           }
         },
         "requiresAuth": true,
@@ -259,6 +305,129 @@
         },
         "behavior": {
           "operations": [
+            "create",
+            "update",
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CreatePresentationFromTemplate",
+      "qualifiedName": "GoogleSlides.CreatePresentationFromTemplate",
+      "fullyQualifiedName": "GoogleSlides.CreatePresentationFromTemplate@3.0.0",
+      "description": "Derive a new on-brand deck from an existing branded deck, preserving its\nmasters, layouts, and theme, then optionally filling tokens.\n\nUse this instead of building from scratch when the user wants a deck in their\ncompany template; the new deck inherits the source's branding.",
+      "parameters": [
+        {
+          "name": "source_presentation_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the branded deck to derive the new deck from.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": true,
+          "description": "Title for the new deck.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "text_replacements",
+          "type": "array",
+          "innerType": "json",
+          "required": false,
+          "description": "Token replacements applied to the new deck after copying (e.g. fill {{COMPANY}} with a value). Omit for a verbatim brand copy.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "match_case",
+          "type": "boolean",
+          "required": false,
+          "description": "Whether token matching is case-sensitive. Defaults to true.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "google",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://www.googleapis.com/auth/drive.file"
+        ]
+      },
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "GoogleSlides.CreatePresentationFromTemplate",
+        "parameters": {
+          "source_presentation_id": {
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
+            "type": "string",
+            "required": true
+          },
+          "title": {
+            "value": "Q3 2024 Company Overview Deck",
+            "type": "string",
+            "required": true
+          },
+          "text_replacements": {
+            "value": [
+              {
+                "find": "{{COMPANY}}",
+                "replace": "Acme Corporation"
+              },
+              {
+                "find": "{{QUARTER}}",
+                "replace": "Q3 2024"
+              },
+              {
+                "find": "{{PRESENTER}}",
+                "replace": "Jane Smith"
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
+          "match_case": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "presentations"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read",
             "create"
           ],
           "readOnly": false,
@@ -272,8 +441,8 @@
     {
       "name": "GenerateGoogleFilePickerUrl",
       "qualifiedName": "GoogleSlides.GenerateGoogleFilePickerUrl",
-      "fullyQualifiedName": "GoogleSlides.GenerateGoogleFilePickerUrl@2.0.1",
-      "description": "Generate a URL where the user can grant this app access to specific Drive files.\n\nOpens Google's first-party Drive picker. The user selects which files to share\nwith this application — it is not a sign-in or credential prompt.\n\nUse this when a prior tool reported that a file was not found or access was denied,\nand the user expects the file to exist. After the user completes the picker flow,\nretry the prior tool.",
+      "fullyQualifiedName": "GoogleSlides.GenerateGoogleFilePickerUrl@3.0.0",
+      "description": "Generate a URL where the user grants this app access to specific Drive files.\n\nUse this when a prior tool reported a file was not found or access was denied and\nthe user expects the file to exist; after the user completes the picker, retry the\nprior tool. Opens Google's first-party Drive picker, not a sign-in prompt.\n\nReturns a soft envelope: an \"unavailable\" status (not an error) means the picker is\nnot configured in this environment and will not work here, so do not retry it.",
       "parameters": [],
       "auth": {
         "providerId": "google",
@@ -284,7 +453,7 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "Google File Picker URL for user file selection and permission granting"
+        "description": "No description provided."
       },
       "documentationChunks": [],
       "codeExample": {
@@ -313,16 +482,59 @@
       }
     },
     {
-      "name": "GetPresentationAsMarkdown",
-      "qualifiedName": "GoogleSlides.GetPresentationAsMarkdown",
-      "fullyQualifiedName": "GoogleSlides.GetPresentationAsMarkdown@2.0.1",
-      "description": "Get the specified Google Slides presentation and convert it to markdown.\n\nOnly retrieves the text content of the presentation and formats it as markdown.",
+      "name": "GetPresentation",
+      "qualifiedName": "GoogleSlides.GetPresentation",
+      "fullyQualifiedName": "GoogleSlides.GetPresentation@3.0.0",
+      "description": "Return an addressable snapshot of a deck: slide and element object ids,\nplaceholder types, text, speaker notes, and the layout and master inventory.\n\nThis is the read side of the read-edit loop: the object ids it returns are the\naddresses create_or_edit_presentation targets. Each layout in the inventory\nreports its placeholders with type, index, and object id, the identity a\ncreateSlide placeholderIdMappings entry needs (by {type, index} or by\nlayoutPlaceholderObjectId), even when a layout repeats a placeholder type.",
       "parameters": [
         {
           "name": "presentation_id",
           "type": "string",
           "required": true,
-          "description": "The ID of the presentation to retrieve.",
+          "description": "The id of the presentation to read.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "detail",
+          "type": "string",
+          "required": false,
+          "description": "OUTLINE reports object ids, placeholders, text, notes, and the layout/master inventory. FULL adds per-element geometry. Defaults to OUTLINE.",
+          "enum": [
+            "OUTLINE",
+            "FULL"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed first slide to return. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_slides",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum slides to return in this read (1-50). Defaults to 50; use offset to page.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "include_layouts",
+          "type": "boolean",
+          "required": false,
+          "description": "Include the layout inventory. Defaults to true.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "include_masters",
+          "type": "boolean",
+          "required": false,
+          "description": "Include the master inventory. Defaults to true.",
           "enum": null,
           "inferrable": true
         }
@@ -340,21 +552,143 @@
       "secretsInfo": [
         {
           "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
-          "type": "unknown"
+          "type": "api_key"
         }
       ],
       "output": {
-        "type": "string",
-        "description": "The presentation textual content as markdown"
+        "type": "json",
+        "description": "No description provided."
       },
       "documentationChunks": [],
       "codeExample": {
-        "toolName": "GoogleSlides.GetPresentationAsMarkdown",
+        "toolName": "GoogleSlides.GetPresentation",
         "parameters": {
           "presentation_id": {
             "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
             "type": "string",
             "required": true
+          },
+          "detail": {
+            "value": "OUTLINE",
+            "type": "string",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          },
+          "max_slides": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "include_layouts": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "include_masters": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "presentations"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetSlideThumbnail",
+      "qualifiedName": "GoogleSlides.GetSlideThumbnail",
+      "fullyQualifiedName": "GoogleSlides.GetSlideThumbnail@3.0.0",
+      "description": "Render one slide to an image and return its content URL, for visually\nconfirming a deck looks right before sharing.",
+      "parameters": [
+        {
+          "name": "presentation_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the presentation.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "slide_object_id",
+          "type": "string",
+          "required": true,
+          "description": "The object id of the slide (page) to render, from a read.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "size",
+          "type": "string",
+          "required": false,
+          "description": "Rendered size: LARGE (~1600px), MEDIUM (~800px), or SMALL (~200px). Defaults to MEDIUM.",
+          "enum": [
+            "LARGE",
+            "MEDIUM",
+            "SMALL"
+          ],
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "google",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://www.googleapis.com/auth/drive.file"
+        ]
+      },
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "GoogleSlides.GetSlideThumbnail",
+        "parameters": {
+          "presentation_id": {
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
+            "type": "string",
+            "required": true
+          },
+          "slide_object_id": {
+            "value": "g1f2a3b4c5d_0_0",
+            "type": "string",
+            "required": true
+          },
+          "size": {
+            "value": "LARGE",
+            "type": "string",
+            "required": false
           }
         },
         "requiresAuth": true,
@@ -382,14 +716,14 @@
     {
       "name": "ListPresentationComments",
       "qualifiedName": "GoogleSlides.ListPresentationComments",
-      "fullyQualifiedName": "GoogleSlides.ListPresentationComments@2.0.1",
-      "description": "List all comments on the specified Google Slides presentation.",
+      "fullyQualifiedName": "GoogleSlides.ListPresentationComments@3.0.0",
+      "description": "List a page of comments and their replies on a presentation, newest first.",
       "parameters": [
         {
           "name": "presentation_id",
           "type": "string",
           "required": true,
-          "description": "The ID of the presentation to list comments for",
+          "description": "The id of the presentation to list comments for.",
           "enum": null,
           "inferrable": true
         },
@@ -397,7 +731,23 @@
           "name": "include_deleted",
           "type": "boolean",
           "required": false,
-          "description": "Whether to include deleted comments in the results. Defaults to False.",
+          "description": "Include deleted comments. Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum comments to return per page (1-100). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "page_token",
+          "type": "string",
+          "required": false,
+          "description": "Cursor for the next page, taken from a prior response's next_page_token. Leave empty to fetch the first page.",
           "enum": null,
           "inferrable": true
         }
@@ -420,7 +770,7 @@
       ],
       "output": {
         "type": "json",
-        "description": "A dictionary containing the comments"
+        "description": "No description provided."
       },
       "documentationChunks": [],
       "codeExample": {
@@ -434,6 +784,16 @@
           "include_deleted": {
             "value": false,
             "type": "boolean",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "page_token": {
+            "value": "CAESFjFCeGlNVnMwWFJBNW5GTURLdkJkQlp",
+            "type": "string",
             "required": false
           }
         },
@@ -460,17 +820,113 @@
       }
     },
     {
+      "name": "ResolveComment",
+      "qualifiedName": "GoogleSlides.ResolveComment",
+      "fullyQualifiedName": "GoogleSlides.ResolveComment@3.0.0",
+      "description": "Close (resolve) or reopen a comment thread on a presentation.\n\nPosts an action reply on the thread, so the lifecycle change is attributed to the\nconnected account; the thread's existing comments and replies are preserved.",
+      "parameters": [
+        {
+          "name": "presentation_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the presentation the comment is on.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the comment thread to resolve or reopen.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "action",
+          "type": "string",
+          "required": false,
+          "description": "Whether to resolve (close) the thread or reopen a resolved one. Defaults to RESOLVE.",
+          "enum": [
+            "resolve",
+            "reopen"
+          ],
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "google",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://www.googleapis.com/auth/drive.file"
+        ]
+      },
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "GoogleSlides.ResolveComment",
+        "parameters": {
+          "presentation_id": {
+            "value": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
+            "type": "string",
+            "required": true
+          },
+          "comment_id": {
+            "value": "AAAABmXyZ1k",
+            "type": "string",
+            "required": true
+          },
+          "action": {
+            "value": "RESOLVE",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "presentations"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "SearchPresentations",
       "qualifiedName": "GoogleSlides.SearchPresentations",
-      "fullyQualifiedName": "GoogleSlides.SearchPresentations@2.0.1",
-      "description": "Searches for presentations in the user's Google Drive.\nExcludes presentations that are in the trash.",
+      "fullyQualifiedName": "GoogleSlides.SearchPresentations@3.0.0",
+      "description": "Search the user's Drive for presentations, newest first by default.\n\nKeyword matching is full-text: a keyword matches a deck's body content as well\nas its title, so a deck can match on words that never appear in its title. A\nkeyword search that matches nothing returns an empty list (not an error).",
       "parameters": [
         {
           "name": "presentation_contains",
           "type": "array",
           "innerType": "string",
           "required": false,
-          "description": "Keywords or phrases that must be in the presentation title or content. Provide a list of keywords or phrases if needed.",
+          "description": "Keywords that must appear in the presentation title or content. Omit to list all.",
           "enum": null,
           "inferrable": true
         },
@@ -479,7 +935,7 @@
           "type": "array",
           "innerType": "string",
           "required": false,
-          "description": "Keywords or phrases that must NOT be in the presentation title or content. Provide a list of keywords or phrases if needed.",
+          "description": "Keywords that must NOT appear in the presentation title or content.",
           "enum": null,
           "inferrable": true
         },
@@ -487,7 +943,7 @@
           "name": "search_only_in_shared_drive_id",
           "type": "string",
           "required": false,
-          "description": "The ID of the shared drive to restrict the search to. If provided, the search will only return presentations from this drive. Defaults to None, which searches across all drives.",
+          "description": "Restrict the search to this shared drive. Omit to search across the user's drives.",
           "enum": null,
           "inferrable": true
         },
@@ -495,7 +951,7 @@
           "name": "include_shared_drives",
           "type": "boolean",
           "required": false,
-          "description": "Whether to include presentations from shared drives. Defaults to False (searches only in the user's 'My Drive').",
+          "description": "Include presentations from shared drives. Defaults to false (My Drive only).",
           "enum": null,
           "inferrable": true
         },
@@ -503,7 +959,7 @@
           "name": "include_organization_domain_presentations",
           "type": "boolean",
           "required": false,
-          "description": "Whether to include presentations from the organization's domain. This is applicable to admin users who have permissions to view organization-wide presentations in a Google Workspace account. Defaults to False.",
+          "description": "Include organization-wide presentations (admin accounts only). Defaults to false.",
           "enum": null,
           "inferrable": true
         },
@@ -512,7 +968,7 @@
           "type": "array",
           "innerType": "string",
           "required": false,
-          "description": "Sort order. Defaults to listing the most recently modified presentations first. If presentation_contains or presentation_not_contains is provided, then the order_by will be ignored.",
+          "description": "Sort order. Defaults to most recently modified first. Ignored when a keyword filter is provided.",
           "enum": [
             "createdTime",
             "createdTime desc",
@@ -526,12 +982,8 @@
             "name desc",
             "name_natural",
             "name_natural desc",
-            "quotaBytesUsed",
-            "quotaBytesUsed desc",
             "recency",
             "recency desc",
-            "sharedWithMeTime",
-            "sharedWithMeTime desc",
             "starred",
             "starred desc",
             "viewedByMeTime",
@@ -543,7 +995,7 @@
           "name": "limit",
           "type": "integer",
           "required": false,
-          "description": "The number of presentations to list",
+          "description": "Maximum presentations to return (1-100). Defaults to 20.",
           "enum": null,
           "inferrable": true
         },
@@ -551,7 +1003,7 @@
           "name": "pagination_token",
           "type": "string",
           "required": false,
-          "description": "The pagination token to continue a previous request",
+          "description": "Token from a prior result's next_page_token to fetch the next page.",
           "enum": null,
           "inferrable": true
         }
@@ -574,7 +1026,7 @@
       ],
       "output": {
         "type": "json",
-        "description": "A dictionary containing 'presentations_count' (number of presentations returned) and 'presentations' (a list of presentation details including 'kind', 'mimeType', 'id', and 'name' for each presentation)"
+        "description": "No description provided."
       },
       "documentationChunks": [],
       "codeExample": {
@@ -591,13 +1043,13 @@
           "presentation_not_contains": {
             "value": [
               "draft",
-              "archived"
+              "archive"
             ],
             "type": "array",
             "required": false
           },
           "search_only_in_shared_drive_id": {
-            "value": "0AHv3zDrXYZ123abc456",
+            "value": "0ABCdEfGhIjKlUk9PVA",
             "type": "string",
             "required": false
           },
@@ -620,12 +1072,12 @@
             "required": false
           },
           "limit": {
-            "value": 10,
+            "value": 25,
             "type": "integer",
             "required": false
           },
           "pagination_token": {
-            "value": "eyJzdGFydEluZGV4IjoxMCwicGFnZVNpemUiOjEwfQ==",
+            "value": "eyJzdGFydEluZGV4IjoyNX0=",
             "type": "string",
             "required": false
           }
@@ -655,8 +1107,8 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleSlides.WhoAmI",
-      "fullyQualifiedName": "GoogleSlides.WhoAmI@2.0.1",
-      "description": "Get comprehensive user profile and Google Slides environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Slides access permissions, and other\nimportant profile details from Google services.",
+      "fullyQualifiedName": "GoogleSlides.WhoAmI@3.0.0",
+      "description": "Return the connected Google account's profile (name, email, picture).",
       "parameters": [],
       "auth": {
         "providerId": "google",
@@ -671,7 +1123,7 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "Get comprehensive user profile and Google Slides environment information."
+        "description": "No description provided."
       },
       "documentationChunks": [],
       "codeExample": {
@@ -713,6 +1165,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-06-05T12:07:56.906Z",
-  "summary": "The Google Slides toolkit lets Arcade-powered LLMs create, read, search, and annotate Google Slides presentations on behalf of authenticated users.\n\n## Capabilities\n\n- **Presentation management**: Create new presentations with a title and subtitle, or retrieve the full text content of any accessible presentation as Markdown.\n- **Slide & comment authoring**: Add slides to an existing presentation and post comments on specific slides by index; list all comments on a presentation.\n- **Search & discovery**: Search the authenticated user's Google Drive for presentations (trash excluded) and resolve access issues via the Google Drive inline file picker.\n- **Identity & environment inspection**: Retrieve the authenticated user's profile, email, permissions, and Google Slides environment details.\n\n## OAuth\n\nUses OAuth 2.0 via Google. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details.\n\n## Secrets\n\n- **`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL`**: Controls whether the `GoogleSlides.GenerateGoogleFilePickerUrl` tool is available. This secret is expected to be a URL (or a flag value) that enables the Google Drive inline picker flow — the mechanism that lets a user grant the app access to specific Drive files without a full re-authentication. This is not a standard Google API credential; it is an application-level configuration value specific to your Arcade deployment. Set this in your Arcade secrets store. Consult the [Arcade secrets documentation](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to configure it, and manage your values at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
+  "generatedAt": "2026-06-19T12:27:56.611Z",
+  "summary": "Google Slides toolkit for Arcade provides LLM-callable tools that create, read, edit, and manage Google Slides presentations via the Google Slides and Drive APIs.\n\n## Capabilities\n\n- **Presentation creation & editing:** Create new decks from scratch or from branded templates, apply atomic batches of edits (add/delete/restyle slides and elements, insert/replace text, reorder slides, duplicate objects, set speaker notes), and inspect addressable snapshots to discover object IDs and layout inventories before targeting them.\n- **Reading & visual inspection:** Retrieve full addressable snapshots (slide/element IDs, placeholder types, text, speaker notes, layout/master inventory) and render individual slides to thumbnail images for visual confirmation.\n- **Search & discovery:** Full-text search across a user's Drive presentations (matches body content and title); returns results newest-first.\n- **Comments & collaboration:** Add top-level comments or reply within threads, list comments/replies with pagination, and resolve or reopen comment threads — all attributed to the connected account.\n- **File access & identity:** Generate a Google Drive inline file picker URL to grant access to specific files when a file is not found or access is denied; look up the connected Google account's profile (name, email, picture).\n\n## OAuth\n\nThis toolkit authenticates via **OAuth 2.0** with Google as the provider. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details, required scopes, and configuration steps.\n\n## Secrets\n\n- **`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL`** — An API key that enables the `GoogleSlides.GenerateGoogleFilePickerUrl` tool to open Google's first-party Drive file picker. This is a **Google Maps/Picker API key** with the [Google Picker API](https://developers.google.com/drive/picker/guides/overview) enabled. To obtain it:\n  1. Open the [Google Cloud Console → APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials) for the same project used for your OAuth client.\n  2. Click **Create Credentials → API key**.\n  3. Enable the **Google Picker API** on the project under [APIs & Services → Library](https://console.cloud.google.com/apis/library).\n  4. Restrict the key to the Picker API (and optionally to your app's domain) to limit exposure.\n  5. Copy the key value and register it as this secret.\n  If this secret is absent or invalid, `GenerateGoogleFilePickerUrl` returns an `\"unavailable\"` status rather than an error — do not retry the picker in that case.\n\nSee the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to register secrets, or manage them directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-17T12:31:46.596Z",
+  "generatedAt": "2026-06-19T12:28:11.410Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -50,10 +50,10 @@
     {
       "id": "Ashby",
       "label": "Ashby",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "category": "productivity",
       "type": "arcade",
-      "toolCount": 9,
+      "toolCount": 10,
       "authType": "none"
     },
     {
@@ -347,7 +347,7 @@
     {
       "id": "Gmail",
       "label": "Gmail",
-      "version": "7.3.0",
+      "version": "7.5.0",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 18,
@@ -473,10 +473,10 @@
     {
       "id": "GoogleSlides",
       "label": "Google Slides",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "category": "productivity",
       "type": "arcade",
-      "toolCount": 8,
+      "toolCount": 10,
       "authType": "oauth2"
     },
     {
@@ -950,10 +950,10 @@
     {
       "id": "X",
       "label": "X",
-      "version": "1.4.2",
+      "version": "2.0.0",
       "category": "social",
       "type": "arcade",
-      "toolCount": 8,
+      "toolCount": 33,
       "authType": "oauth2"
     },
     {

--- a/toolkit-docs-generator/data/toolkits/x.json
+++ b/toolkit-docs-generator/data/toolkits/x.json
@@ -1,8 +1,8 @@
 {
   "id": "X",
   "label": "X",
-  "version": "1.4.2",
-  "description": "Arcade.dev LLM tools for X (Twitter)",
+  "version": "2.0.0",
+  "description": "Arcade.dev LLM tools for X (Twitter).",
   "metadata": {
     "category": "social",
     "iconUrl": "https://design-system.arcade.dev/icons/x.svg",
@@ -17,6 +17,11 @@
     "type": "oauth2",
     "providerId": "x",
     "allScopes": [
+      "like.read",
+      "like.write",
+      "list.read",
+      "list.write",
+      "space.read",
       "tweet.read",
       "tweet.write",
       "users.read"
@@ -24,10 +29,261 @@
   },
   "tools": [
     {
+      "name": "AddListMember",
+      "qualifiedName": "X.AddListMember",
+      "fullyQualifiedName": "X.AddListMember@2.0.0",
+      "description": "Add one or more users to an X List owned by the authenticated user.\n\nProvide ``user_ids``, ``usernames``, or both. Adding a user who is already\na member is treated as success.\n\nOn a mid-loop rate-limit, the run short-circuits and remaining targets\nare marked as not attempted. On retry, drop the targets that already\nsucceeded; otherwise polling re-arms X's bucket and extends the lockout.\n\nX is eventually consistent on list membership: a success status here\ndoes not mean a subsequent ``GetListMembers`` will immediately return\nthe new member. Allow a few seconds before relying on the read endpoint\nto reflect the mutation.\n\nSerialize dependent list mutations: do not fire ``AddListMember`` in\nparallel with ``DeleteList``, ``RemoveListMember``, or ``UpdateList``\nagainst the same ``list_id``. Concurrent dependent mutations race and\nsurface spurious ``not_found`` errors when the member call lands after\nthe list is gone. Await each mutation before issuing the next one on\nthe same list.",
+      "parameters": [
+        {
+          "name": "list_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the list to add members to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "user_ids",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Numeric X user ids (snowflake ids, 1-19 digits) of the members to add. Up to 100 targets per call (combined with ``usernames``). Prefer this over ``usernames`` when you already have stable ids — the toolkit skips the username-resolution hop, which is rate-limited by X. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "usernames",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Handles of the members to add. Leading '@' is optional and stripped automatically. Up to 100 targets per call (combined with ``user_ids``). Handles are resolved to ids in batched ``/2/users/by`` calls (one round-trip per 100 handles) instead of one resolve-per-target. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "list.read",
+          "list.write",
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.AddListMember",
+        "parameters": {
+          "list_id": {
+            "value": "1674392847561023489",
+            "type": "string",
+            "required": true
+          },
+          "user_ids": {
+            "value": [
+              "783214",
+              "6253282",
+              "17919972"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "usernames": {
+            "value": [
+              "elonmusk",
+              "@jack",
+              "TwitterDev"
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CreateList",
+      "qualifiedName": "X.CreateList",
+      "fullyQualifiedName": "X.CreateList@2.0.0",
+      "description": "Create a new X List owned by the authenticated user.",
+      "parameters": [
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "The display name of the list. Must be non-empty and at most 25 characters (X API limit).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "required": false,
+          "description": "A short description of the list. Leave empty for no description. Defaults to empty.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "private",
+          "type": "boolean",
+          "required": false,
+          "description": "Whether the list is private (only visible to its owner) or public. Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "list.read",
+          "list.write",
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The id, name, description, resolved ``private`` value, and status of the newly created list."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.CreateList",
+        "parameters": {
+          "name": {
+            "value": "Tech News Highlights",
+            "type": "string",
+            "required": true
+          },
+          "description": {
+            "value": "Top tech news curated daily",
+            "type": "string",
+            "required": false
+          },
+          "private": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DeleteList",
+      "qualifiedName": "X.DeleteList",
+      "fullyQualifiedName": "X.DeleteList@2.0.0",
+      "description": "Delete an X List owned by the authenticated user.\n\nThe list and its memberships are removed. The tool distinguishes \"I just\ndeleted it\" from \"it was already gone\" rather than collapsing both into\nthe same idempotent-success envelope.\n\nSerialize dependent list mutations: do not fire ``DeleteList`` in\nparallel with ``AddListMember`` / ``RemoveListMember`` / ``UpdateList``\n/ ``PinList`` against the same ``list_id``. The list-membership endpoints\nwill race against the delete and surface a spurious ``not_found`` when\nthe member call lands after the list is gone. Await each mutation before\nissuing the next one on the same list.",
+      "parameters": [
+        {
+          "name": "list_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the list to delete.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "list.read",
+          "list.write",
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The id of the deleted list and a status string."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.DeleteList",
+        "parameters": {
+          "list_id": {
+            "value": "1674839201045876736",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "DeleteTweetById",
       "qualifiedName": "X.DeleteTweetById",
-      "fullyQualifiedName": "X.DeleteTweetById@1.4.2",
-      "description": "Delete a tweet on X (Twitter).",
+      "fullyQualifiedName": "X.DeleteTweetById@2.0.0",
+      "description": "Delete one of the authenticated user's tweets.\n\nThe tool distinguishes \"I just deleted it\" from \"it was already gone\"\nrather than collapsing both into the same idempotent-success envelope.",
       "parameters": [
         {
           "name": "tweet_id",
@@ -50,8 +306,8 @@
       "secrets": [],
       "secretsInfo": [],
       "output": {
-        "type": "string",
-        "description": "Success string confirming the tweet deletion"
+        "type": "json",
+        "description": "The id and status of the deleted tweet"
       },
       "documentationChunks": [],
       "codeExample": {
@@ -86,16 +342,1442 @@
       }
     },
     {
-      "name": "LookupSingleUserByUsername",
-      "qualifiedName": "X.LookupSingleUserByUsername",
-      "fullyQualifiedName": "X.LookupSingleUserByUsername@1.4.2",
-      "description": "Look up a user on X (Twitter) by their username.",
+      "name": "GetConversation",
+      "qualifiedName": "X.GetConversation",
+      "fullyQualifiedName": "X.GetConversation@2.0.0",
+      "description": "Fetch the conversation thread containing ``tweet_id``.\n\nReturns every tweet that shares the same ``conversation_id`` as the\ngiven tweet, ordered oldest-first so a caller can render the thread top\nto bottom. The conversation root sits at position 0 whenever accessible.\n\nReplies are pulled from the recent-search index (~7-day window) which\ncan lag real time by several minutes. To verify a specific reply, look\nit up by id instead.",
+      "parameters": [
+        {
+          "name": "tweet_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of any tweet in the conversation. The conversation_id will be resolved from this tweet (the conversation root is the original tweet).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_results",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of conversation tweets to return (1-100). Values above 100 are lowered to 100. Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "next_token",
+          "type": "string",
+          "required": false,
+          "description": "Pagination token from a prior response's ``next_token``. Leave None to start at the first page. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The conversation surrounding ``tweet_id`` (root + replies), ordered with the conversation root first followed by replies in chronological order. Restricted to the last ~7 days by X's recent-search endpoint."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.GetConversation",
+        "parameters": {
+          "tweet_id": {
+            "value": "1712345678901234567",
+            "type": "string",
+            "required": true
+          },
+          "max_results": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "next_token": {
+            "value": "7140dibdnow9c7btw3w29n4v1mtf9",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetHomeTimeline",
+      "qualifiedName": "X.GetHomeTimeline",
+      "fullyQualifiedName": "X.GetHomeTimeline@2.0.0",
+      "description": "Fetch the authenticated user's reverse-chronological home timeline.\n\nReturns recent tweets from accounts the user follows.",
+      "parameters": [
+        {
+          "name": "max_results",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of tweets to return (1-100). Values above 100 are lowered to 100. Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "next_token",
+          "type": "string",
+          "required": false,
+          "description": "Pagination token from a prior response's ``next_token``. Leave None to start at the first page. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The authenticated user's reverse-chronological home timeline. ``next_token`` is null when there are no more pages."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.GetHomeTimeline",
+        "parameters": {
+          "max_results": {
+            "value": 42,
+            "type": "integer",
+            "required": false
+          },
+          "next_token": {
+            "value": "7140dibdnow9c7btw3w29n4v1mtap9bzt7y41g",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetListMembers",
+      "qualifiedName": "X.GetListMembers",
+      "fullyQualifiedName": "X.GetListMembers@2.0.0",
+      "description": "List members of an X List.\n\nThe members endpoint is eventually consistent: after ``AddListMember`` or\n``RemoveListMember`` returns success, the membership read endpoints\n(``GetListMembers``, ``GetListMembershipsForUser``) can take several\nseconds to surface the change. The list-tweets endpoint\n(``GetListTweets``) is typically refreshed faster than the members\nendpoint, so an empty page immediately after an add is more likely a\nconsistency window than a genuine empty list. Re-query after a brief\nwait when verifying a just-applied mutation.",
+      "parameters": [
+        {
+          "name": "list_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the list whose members you want to fetch.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_results",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of members to return per page. The X API enforces a minimum of 1 and a maximum of 100; values below 1 are silently raised to 1 and values above 100 are silently lowered to 100. Defaults to 100.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "next_token",
+          "type": "string",
+          "required": false,
+          "description": "Pagination token from a prior response's ``next_token``. Leave None to start at the first page. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "list.read",
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Members of the list. ``next_token`` is null when there are no more pages; ``result_count`` is always the count on this page."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.GetListMembers",
+        "parameters": {
+          "list_id": {
+            "value": "1234567890123456789",
+            "type": "string",
+            "required": true
+          },
+          "max_results": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "next_token": {
+            "value": "7140dibdnow9c7btw421dyz6jism75z99gyxd8egarsc4",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetListMembershipsForUser",
+      "qualifiedName": "X.GetListMembershipsForUser",
+      "fullyQualifiedName": "X.GetListMembershipsForUser@2.0.0",
+      "description": "List the X Lists the target user is a member of.\n\nPass ``user_id`` or ``username`` (exactly one). With ``username``, the\nhandle is resolved to a numeric id first; passing ``user_id`` skips\nthat hop.",
       "parameters": [
         {
           "name": "username",
           "type": "string",
+          "required": false,
+          "description": "The username (handle) whose list memberships to fetch. Leading '@' is optional and stripped automatically. Provide exactly one of ``user_id`` or ``username``. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "user_id",
+          "type": "string",
+          "required": false,
+          "description": "The numeric X user id (snowflake id, 1-19 digits) whose list memberships to fetch. Provide exactly one of ``user_id`` or ``username``. Prefer this when you already have a stable id — it avoids a username-to-id lookup hop, which is rate-limited by X. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_results",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of memberships to return per page. The X API enforces a minimum of 1 and a maximum of 100; values below 1 are silently raised to 1 and values above 100 are silently lowered to 100. Defaults to 100.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "next_token",
+          "type": "string",
+          "required": false,
+          "description": "Pagination token from a prior response's ``next_token``. Leave None to start at the first page. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "list.read",
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Lists the user belongs to. ``next_token`` is null when there are no more pages; ``result_count`` is always the count on this page."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.GetListMembershipsForUser",
+        "parameters": {
+          "username": {
+            "value": "elonmusk",
+            "type": "string",
+            "required": false
+          },
+          "user_id": {
+            "value": "44196397",
+            "type": "string",
+            "required": false
+          },
+          "max_results": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "next_token": {
+            "value": "7140dibdnow9c7btw421dz57xs3b2z9gk4k4h25tkf9oc",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetListTweets",
+      "qualifiedName": "X.GetListTweets",
+      "fullyQualifiedName": "X.GetListTweets@2.0.0",
+      "description": "List recent tweets from members of an X List, newest first.",
+      "parameters": [
+        {
+          "name": "list_id",
+          "type": "string",
           "required": true,
-          "description": "The username of the X (Twitter) user to look up",
+          "description": "The ID of the list whose tweets you want to fetch.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_results",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of tweets to return per page. The X API enforces a minimum of 1 and a maximum of 100; values below 1 are silently raised to 1 and values above 100 are silently lowered to 100. Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "next_token",
+          "type": "string",
+          "required": false,
+          "description": "Pagination token from a prior response's ``next_token``. Leave None to start at the first page. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "list.read",
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Tweets from members of the list, ordered most-recent first. ``next_token`` is null when there are no more pages."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.GetListTweets",
+        "parameters": {
+          "list_id": {
+            "value": "1234567890123456789",
+            "type": "string",
+            "required": true
+          },
+          "max_results": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "next_token": {
+            "value": "avdjfk47sksl99dkslf0q",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetMyMentions",
+      "qualifiedName": "X.GetMyMentions",
+      "fullyQualifiedName": "X.GetMyMentions@2.0.0",
+      "description": "Fetch recent @-mentions of the authenticated user, newest first.",
+      "parameters": [
+        {
+          "name": "max_results",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of mentions to return (1-100). Values above 100 are lowered to 100. Defaults to 10.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "next_token",
+          "type": "string",
+          "required": false,
+          "description": "Pagination token from a prior response's ``next_token``. Leave None to start at the first page. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Mentions of the authenticated user, ordered most-recent first. ``next_token`` is null when there are no more pages."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.GetMyMentions",
+        "parameters": {
+          "max_results": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "next_token": {
+            "value": "7140dibdnow9c7btw3w29n4v1mtag9kd0s6v7t4yz8w",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetOwnedLists",
+      "qualifiedName": "X.GetOwnedLists",
+      "fullyQualifiedName": "X.GetOwnedLists@2.0.0",
+      "description": "List the X Lists a user owns.\n\nOmitting both ``user_id`` and ``username`` defaults to the authenticated\nuser (the common \"show me my lists\" workflow after creating a list).\nEach list record carries ``id``, ``name``, ``private``, ``description``,\n``member_count``, ``follower_count``, ``owner_id``, and ``created_at``.",
+      "parameters": [
+        {
+          "name": "user_id",
+          "type": "string",
+          "required": false,
+          "description": "Numeric X user id whose owned lists to fetch (snowflake id, 1-19 digits). Provide at most one of ``user_id`` or ``username``; omit both to default to the authenticated user — the common 'show me my lists' workflow. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "username",
+          "type": "string",
+          "required": false,
+          "description": "Handle whose owned lists to fetch. Leading '@' is optional and stripped automatically. Provide at most one of ``user_id`` or ``username``; omit both to default to the authenticated user. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_results",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of lists to return per page. The X API enforces a minimum of 1 and a maximum of 100; values outside that range are silently clamped. Defaults to 100.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "next_token",
+          "type": "string",
+          "required": false,
+          "description": "Pagination token from a prior response's ``next_token``. Leave None to start at the first page. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "list.read",
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Lists the target user owns (newest-first). ``next_token`` is null when there are no more pages; ``result_count`` is always the count on this page. ``errors`` carries a structured envelope when the target user is missing or the input is malformed."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.GetOwnedLists",
+        "parameters": {
+          "user_id": {
+            "value": "1234567890123456789",
+            "type": "string",
+            "required": false
+          },
+          "username": {
+            "value": "@johndoe",
+            "type": "string",
+            "required": false
+          },
+          "max_results": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "next_token": {
+            "value": "7140dibdnow9c7btw422dl6zl",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetQuoteTweets",
+      "qualifiedName": "X.GetQuoteTweets",
+      "fullyQualifiedName": "X.GetQuoteTweets@2.0.0",
+      "description": "Fetch public quote tweets of the given tweet.",
+      "parameters": [
+        {
+          "name": "tweet_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the tweet whose quote tweets you want to fetch.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_results",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of quote tweets to return (1-100). Values above 100 are lowered to 100. Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "next_token",
+          "type": "string",
+          "required": false,
+          "description": "Pagination token from a prior response's ``next_token``. Leave None to start at the first page. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Public quote tweets of the given tweet."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.GetQuoteTweets",
+        "parameters": {
+          "tweet_id": {
+            "value": "1748293847562910720",
+            "type": "string",
+            "required": true
+          },
+          "max_results": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "next_token": {
+            "value": "7140dibdnow9c7btw423b4zcwf9lc7btw9c7btw",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetRepliesToTweet",
+      "qualifiedName": "X.GetRepliesToTweet",
+      "fullyQualifiedName": "X.GetRepliesToTweet@2.0.0",
+      "description": "Fetch public DIRECT replies to a given tweet (last ~7 days).\n\nReturns only tweets whose ``referenced_tweets`` carry a ``replied_to``\nedge pointing at ``tweet_id`` -- not the whole conversation thread.\nSibling replies and nested replies further down the tree are filtered\nout so the result reflects what a reader would see when expanding\n\"replies to this tweet\" in the X UI. Use the conversation tool to get\nthe full thread surrounding a tweet instead.\n\nThe recent-search index can lag real time by several minutes, so a\njust-posted reply may not appear yet. To verify a reply you just\nposted, look it up by id instead.\n\nPagination note: each page is fetched as ``max_results`` from X's\nrecent-search index, then locally filtered down to direct replies.\nPages where every tweet is an indirect reply (sibling or nested) come\nback with ``data=[]`` plus a ``next_token`` -- continue paginating to\nsurface the direct replies further into the conversation.",
+      "parameters": [
+        {
+          "name": "tweet_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the tweet whose direct replies you want to fetch.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_results",
+          "type": "integer",
+          "required": false,
+          "description": "Upper bound on the upstream search page size (1-100; values above 100 are lowered to 100). The X recent-search endpoint enforces a per-page minimum of 10, so values below 10 are raised to 10 for the upstream call. Each page is filtered locally to direct replies, so the actual returned count can be lower than this bound (some tweets on the page may be sibling or nested replies) or, for sub-10 values, slightly higher when the filter happens to surface more direct replies on the page. Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "next_token",
+          "type": "string",
+          "required": false,
+          "description": "Pagination token from a prior response's ``next_token``. Leave None to start at the first page. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Public direct replies to the given tweet, restricted to the last ~7 days by X's recent-search endpoint."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.GetRepliesToTweet",
+        "parameters": {
+          "tweet_id": {
+            "value": "1782345678901234567",
+            "type": "string",
+            "required": true
+          },
+          "max_results": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "next_token": {
+            "value": "7140dibdnow9c7btw423z8k5j9tr9",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetSpacesByCreator",
+      "qualifiedName": "X.GetSpacesByCreator",
+      "fullyQualifiedName": "X.GetSpacesByCreator@2.0.0",
+      "description": "List the live or scheduled X Spaces created by a set of users.\n\nUseful for monitoring whether a set of accounts has any Space currently\nairing or queued. Ended Spaces are not returned.",
+      "parameters": [
+        {
+          "name": "user_ids",
+          "type": "array",
+          "innerType": "string",
+          "required": true,
+          "description": "Numeric X user ids (snowflake ids) whose live or scheduled Spaces to list. Up to 100 ids per call. Ids that don't match X's snowflake format are reported per-id in ``errors`` rather than aborting the call.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "space.read",
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Live or scheduled Spaces created by any of the supplied user ids. ``result_count`` is the number of Spaces returned (always present, even when zero)."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.GetSpacesByCreator",
+        "parameters": {
+          "user_ids": {
+            "value": [
+              "44196397",
+              "783214",
+              "6253282",
+              "17919972",
+              "1339835893"
+            ],
+            "type": "array",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetUserLikedTweets",
+      "qualifiedName": "X.GetUserLikedTweets",
+      "fullyQualifiedName": "X.GetUserLikedTweets@2.0.0",
+      "description": "List tweets a user has liked, newest-liked first.\n\nOmitting both ``user_id`` and ``username`` defaults to the authenticated\nuser. Each tweet carries ``tweet_url``, ``author_username``,\n``author_name``, and any media or poll enrichment.\n\nWhen the target user's likes are private, the response is an empty page\nindistinguishable from \"no liked tweets.\"",
+      "parameters": [
+        {
+          "name": "user_id",
+          "type": "string",
+          "required": false,
+          "description": "Numeric X user id whose liked-tweets you want to list (snowflake id, 1-19 digits). Provide at most one of ``user_id`` or ``username``; omit both to default to the authenticated user. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "username",
+          "type": "string",
+          "required": false,
+          "description": "Handle of the user whose liked-tweets you want to list. Leading '@' is optional and stripped automatically. Provide at most one of ``user_id`` or ``username``; omit both to default to the authenticated user. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_results",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of liked tweets to return per page (1-100). Values above 100 are lowered to 100. Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "next_token",
+          "type": "string",
+          "required": false,
+          "description": "Pagination token from a prior response's ``next_token``. Leave None to start at the first page. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "tweet.read",
+          "users.read",
+          "like.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.GetUserLikedTweets",
+        "parameters": {
+          "user_id": {
+            "value": "783214",
+            "type": "string",
+            "required": false
+          },
+          "username": {
+            "value": "@elonmusk",
+            "type": "string",
+            "required": false
+          },
+          "max_results": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "next_token": {
+            "value": "avdjfk34kdf93kd0293kdlw",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetUserTweets",
+      "qualifiedName": "X.GetUserTweets",
+      "fullyQualifiedName": "X.GetUserTweets@2.0.0",
+      "description": "Fetch tweets authored by a specific X user, newest first.\n\nPaginates through the author's full tweet history (no 7-day window).\nResults include original tweets, replies (unless ``exclude_replies=True``),\nretweets (unless ``exclude_retweets=True``), and quote tweets. Author\nhandle, name, and media or poll details are flattened onto each tweet.",
+      "parameters": [
+        {
+          "name": "user_id",
+          "type": "string",
+          "required": false,
+          "description": "Numeric X user id of the author whose tweets you want to fetch (snowflake id, 1-19 digits). Provide exactly one of ``user_id`` or ``username``. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "username",
+          "type": "string",
+          "required": false,
+          "description": "Handle of the author whose tweets you want to fetch. Leading '@' is optional and stripped automatically. Provide exactly one of ``user_id`` or ``username``. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_results",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of tweets to return per page (1-100). Values above 100 are lowered to 100. Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "next_token",
+          "type": "string",
+          "required": false,
+          "description": "Pagination token from a prior response's ``next_token``. Leave None to start at the first page. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "exclude_replies",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, excludes tweets the author posted as replies to other tweets. Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "exclude_retweets",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, excludes retweets the author has performed (only original tweets and quote tweets remain). Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "start_time",
+          "type": "string",
+          "required": false,
+          "description": "Lower bound (inclusive) on tweet creation time, in ISO-8601 / RFC-3339 UTC format (YYYY-MM-DDTHH:MM:SSZ). Leave None for no lower bound. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "end_time",
+          "type": "string",
+          "required": false,
+          "description": "Upper bound (exclusive) on tweet creation time, in ISO-8601 / RFC-3339 UTC format (YYYY-MM-DDTHH:MM:SSZ). Leave None for no upper bound. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "A user's authored tweets, newest first. ``next_token`` is null when there are no more pages."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.GetUserTweets",
+        "parameters": {
+          "user_id": {
+            "value": "783214",
+            "type": "string",
+            "required": false
+          },
+          "username": {
+            "value": "TwitterDev",
+            "type": "string",
+            "required": false
+          },
+          "max_results": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "next_token": {
+            "value": "7140dibdnow9c7btw3w29n4v1mtf9",
+            "type": "string",
+            "required": false
+          },
+          "exclude_replies": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "exclude_retweets": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "start_time": {
+            "value": "2024-01-01T00:00:00Z",
+            "type": "string",
+            "required": false
+          },
+          "end_time": {
+            "value": "2024-06-30T23:59:59Z",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "LikeTweet",
+      "qualifiedName": "X.LikeTweet",
+      "fullyQualifiedName": "X.LikeTweet@2.0.0",
+      "description": "Like a tweet as the authenticated user.\n\nIdempotent: liking an already-liked tweet succeeds.",
+      "parameters": [
+        {
+          "name": "tweet_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the tweet to like.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "tweet.read",
+          "users.read",
+          "like.write"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The id of the liked tweet and a status string."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.LikeTweet",
+        "parameters": {
+          "tweet_id": {
+            "value": "1234567890123456789",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "LookupSpaceById",
+      "qualifiedName": "X.LookupSpaceById",
+      "fullyQualifiedName": "X.LookupSpaceById@2.0.0",
+      "description": "Look up a single X Space by its id.\n\nReturns the Space's lifecycle state, title, creator, host and speaker\nids, language, and participant and subscriber counts.\n\nX gates several Space metadata fields behind ownership: most non-host\ncallers cannot read a Space's full metadata, even when the Space surfaces\nin a search or by-creator listing.",
+      "parameters": [
+        {
+          "name": "space_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the X Space to look up. X Space ids are 13-character alphanumeric strings (e.g. '1OdJrBZNNOPGB').",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "space.read",
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.LookupSpaceById",
+        "parameters": {
+          "space_id": {
+            "value": "1OdJrBZNNOPGB",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "LookupTweetEngagers",
+      "qualifiedName": "X.LookupTweetEngagers",
+      "fullyQualifiedName": "X.LookupTweetEngagers@2.0.0",
+      "description": "List the users who liked or retweeted a tweet.\n\nEach user record carries the standard handle, name, and profile metadata so\ncallers can render an engager row without a follow-up lookup.\n\nWhen the tweet shows non-zero engagement in ``public_metrics`` but X's\nengagers endpoint returns zero users on the first page, the call returns\nan ``errors[0].type = \"data_unavailable\"`` envelope. This signals that\nthe account's X access tier does not expose engager lists for this\ntweet; treat ``public_metrics.like_count`` / ``retweet_count`` from\n``LookupTweetById`` as the authoritative engagement total in that case.",
+      "parameters": [
+        {
+          "name": "tweet_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the tweet whose engagers you want to list.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "kind",
+          "type": "string",
+          "required": false,
+          "description": "Which engagement audience to fetch — users who liked vs. retweeted the tweet. Defaults to liking.",
+          "enum": [
+            "liking",
+            "retweeting"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "max_results",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of engagers to return per page (1-100). Values above 100 are lowered to 100. Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "next_token",
+          "type": "string",
+          "required": false,
+          "description": "Pagination token from a prior response's ``next_token``. Leave None to start at the first page. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "tweet.read",
+          "users.read",
+          "like.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.LookupTweetEngagers",
+        "parameters": {
+          "tweet_id": {
+            "value": "1674837291048734720",
+            "type": "string",
+            "required": true
+          },
+          "kind": {
+            "value": "liking",
+            "type": "string",
+            "required": false
+          },
+          "max_results": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "next_token": {
+            "value": "7140dibdnow9c7btw423r74yz8ama",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "LookupTweets",
+      "qualifiedName": "X.LookupTweets",
+      "fullyQualifiedName": "X.LookupTweets@2.0.0",
+      "description": "Look up tweets by id (single or batched) on X.\n\nPass one id or up to 100 ids; the response is always a list. Each entry\ncarries ``referenced_tweets`` (``type`` of ``replied_to``, ``quoted``, or\n``retweeted`` plus the parent ``id``), ``conversation_id``, and the\nconvenience fields ``tweet_url`` / ``author_username`` / ``author_name``.\n\nSet ``include_author_only_metrics=True`` to retrieve ``non_public_metrics``\n(impressions, user_profile_clicks, url_link_clicks) and ``organic_metrics``\nfor tweets the authenticated caller authored. X drops third-party tweets\nfrom ``data`` when those fields are requested, so leave the flag false\nunless every id in the batch is known to be authored by the caller.",
+      "parameters": [
+        {
+          "name": "tweet_ids",
+          "type": "array",
+          "innerType": "string",
+          "required": true,
+          "description": "Tweet ids to look up. One or many, up to 100 per call. Each id must be a numeric snowflake id: a string of up to 19 digits whose value fits in a signed 64-bit integer (at most 9223372036854775807). Ids that don't match X's syntax are reported per-id in ``errors`` rather than aborting the call. Empty entries are ignored.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "include_author_only_metrics",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, request X's author-only analytics fields (``non_public_metrics`` and ``organic_metrics`` — impression counts, profile clicks, url-link clicks, etc.) alongside ``public_metrics``. These fields are only returned for tweets the authenticated caller authored; for any other tweet, X drops it from ``data`` and emits a Field Authorization Error which the toolkit filters out of ``errors``. Leave false to fetch the same public fields for every tweet uniformly regardless of authorship. Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.LookupTweets",
+        "parameters": {
+          "tweet_ids": {
+            "value": [
+              "1547898732145602560",
+              "1623456789012345678",
+              "920999516662317056"
+            ],
+            "type": "array",
+            "required": true
+          },
+          "include_author_only_metrics": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "LookupUsers",
+      "qualifiedName": "X.LookupUsers",
+      "fullyQualifiedName": "X.LookupUsers@2.0.0",
+      "description": "Look up X (Twitter) users by handle and/or numeric user id.\n\nProvide ``usernames``, ``user_ids``, or both. Up to 100 of each per call.",
+      "parameters": [
+        {
+          "name": "usernames",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "X (Twitter) handles to look up. Leading '@' is optional and stripped automatically. Empty entries are ignored. Handles that don't match X's syntax (1-15 letters, digits, or underscores) are reported per-handle in ``errors`` rather than aborting the call. Up to 100 handles per call (combined with ``user_ids``). Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "user_ids",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Numeric X user ids (snowflake ids) to look up. Empty entries are ignored. Ids that don't match X's snowflake format are reported per-id in ``errors`` rather than aborting the call. Up to 100 ids per call (combined with ``usernames``). Defaults to None.",
           "enum": null,
           "inferrable": true
         }
@@ -112,16 +1794,33 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "User information including id, name, username, and description"
+        "description": "No description provided."
       },
       "documentationChunks": [],
       "codeExample": {
-        "toolName": "X.LookupSingleUserByUsername",
+        "toolName": "X.LookupUsers",
         "parameters": {
-          "username": {
-            "value": "example_user123",
-            "type": "string",
-            "required": true
+          "usernames": {
+            "value": [
+              "elonmusk",
+              "jack",
+              "TwitterDev",
+              "NASA",
+              "BBCBreaking"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "user_ids": {
+            "value": [
+              "44196397",
+              "12",
+              "2244994945",
+              "11348282",
+              "742143"
+            ],
+            "type": "array",
+            "required": false
           }
         },
         "requiresAuth": true,
@@ -147,16 +1846,125 @@
       }
     },
     {
-      "name": "LookupTweetById",
-      "qualifiedName": "X.LookupTweetById",
-      "fullyQualifiedName": "X.LookupTweetById@1.4.2",
-      "description": "Look up a tweet on X (Twitter) by tweet ID.",
+      "name": "PinList",
+      "qualifiedName": "X.PinList",
+      "fullyQualifiedName": "X.PinList@2.0.0",
+      "description": "Pin an X List to the authenticated user's profile.\n\nIdempotent: pinning an already-pinned list succeeds.",
       "parameters": [
         {
-          "name": "tweet_id",
+          "name": "list_id",
           "type": "string",
           "required": true,
-          "description": "The ID of the tweet you want to look up",
+          "description": "The ID of the list to pin to the authenticated user's profile.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "list.write",
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The list id and a status string."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.PinList",
+        "parameters": {
+          "list_id": {
+            "value": "1234567890123456789",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "PostThread",
+      "qualifiedName": "X.PostThread",
+      "fullyQualifiedName": "X.PostThread@2.0.0",
+      "description": "Post a multi-tweet thread as the authenticated user.\n\nPosts the first tweet, then chains every subsequent entry as a reply to\nthe prior tweet's id. ``tweets`` must contain 2-25 entries when posting a\nnew thread, or 1-25 entries when resuming an existing thread via\n``parent_tweet_id`` (the 1-entry case lets a caller append one more reply\nto the tail of a prior thread).\n``poll_options`` / ``poll_duration_minutes`` / ``quote_tweet_id`` /\n``reply_settings`` apply to the head tweet only.\n\nPre-flight validation runs on every entry before any post is created. If\nany entry fails validation, the call posts nothing.\n\nOn a mid-thread interruption, ``posted`` carries the rows that landed\nand ``next_position`` is the 1-based index of the first non-posted\nentry (0 when every entry posted). Resume the chain with::\n\n    tweets = (tweets[next_position - 1 :],)\n    parent_tweet_id = posted[-1][\"tweet_id\"]  # from the prior call\n\nWithout ``parent_tweet_id``, a resume call would re-create a fresh head\ntweet and silently split the thread into two disconnected chains.\n\nX also rejects mid-thread entries with ``status='invalid_input'`` when\nthe text passes local validation but contains codepoints that X counts\nas multiple weighted characters (emoji, many CJK glyphs) pushing the\nweighted total above 280, or when the text contains control characters\nX disallows. Simplify the entry at ``tweets[next_position - 1]`` (plain\nASCII is the safest reset) and resume.",
+      "parameters": [
+        {
+          "name": "tweets",
+          "type": "array",
+          "innerType": "json",
+          "required": true,
+          "description": "Ordered list of tweets to post as a thread. Allowed length is 2-25 entries when posting a new thread; 1-25 entries when resuming an existing thread via ``parent_tweet_id`` (the single-entry case lets a caller append one more reply to the prior thread tail). Each entry is an object with required ``text`` (1-280 chars). The first entry is the head tweet (or the resume entry when ``parent_tweet_id`` is set); each subsequent entry is posted as a reply to the prior entry's id. Empty/whitespace-only text fails validation per-entry and aborts the thread before any post is created.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "quote_tweet_id",
+          "type": "string",
+          "required": false,
+          "description": "Tweet id quoted by the head tweet only (subsequent thread entries cannot quote). Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "reply_settings",
+          "type": "string",
+          "required": false,
+          "description": "Reply restriction applied to the head tweet only (X applies the head's setting to the entire thread). Leave None for X's default (everyone). Defaults to None.",
+          "enum": [
+            "everyone",
+            "mentionedUsers",
+            "following",
+            "subscribers"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "poll_options",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Attach a poll to the head tweet only (subsequent thread entries cannot include a poll). When set, must be 2-4 short answer options (each <=25 chars) and ``poll_duration_minutes`` must also be set. Polls are incompatible with ``quote_tweet_id`` (X rejects the combination). Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "poll_duration_minutes",
+          "type": "integer",
+          "required": false,
+          "description": "How long the head poll stays open, in minutes (5-10080). Required when ``poll_options`` is set; ignored otherwise. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "parent_tweet_id",
+          "type": "string",
+          "required": false,
+          "description": "Numeric tweet id to chain the first ``tweets`` entry under as a reply (snowflake id, 1-19 digits). Use this to resume an interrupted thread: pass the ``tweet_id`` of the last entry that successfully posted (i.e. ``posted[-1].tweet_id`` from the prior call). When set, every entry chains as a reply (no head tweet is created), so head-only options (``quote_tweet_id``, ``poll_options`` / ``poll_duration_minutes``, ``reply_settings``) cannot be combined with this parameter. Defaults to None.",
           "enum": null,
           "inferrable": true
         }
@@ -166,6 +1974,7 @@
         "providerType": "oauth2",
         "scopes": [
           "tweet.read",
+          "tweet.write",
           "users.read"
         ]
       },
@@ -173,16 +1982,59 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "Dictionary containing the tweet data"
+        "description": "No description provided."
       },
       "documentationChunks": [],
       "codeExample": {
-        "toolName": "X.LookupTweetById",
+        "toolName": "X.PostThread",
         "parameters": {
-          "tweet_id": {
-            "value": "1456789012345678901",
-            "type": "string",
+          "tweets": {
+            "value": [
+              {
+                "text": "🧵 Let's talk about the future of AI and how it's reshaping the way we work. Thread incoming! (1/4)"
+              },
+              {
+                "text": "First, AI is automating repetitive tasks — freeing up humans to focus on creativity and critical thinking. This shift is already happening across industries. (2/4)"
+              },
+              {
+                "text": "Second, AI-powered tools are lowering the barrier to entry for developers, designers, and entrepreneurs. Building sophisticated products no longer requires massive teams. (3/4)"
+              },
+              {
+                "text": "Finally, the ethical implications matter more than ever. Transparency, fairness, and accountability in AI systems must be a priority — not an afterthought. (4/4) What do you think?"
+              }
+            ],
+            "type": "array",
             "required": true
+          },
+          "quote_tweet_id": {
+            "value": "1778234567890123456",
+            "type": "string",
+            "required": false
+          },
+          "reply_settings": {
+            "value": "mentionedUsers",
+            "type": "string",
+            "required": false
+          },
+          "poll_options": {
+            "value": [
+              "Strongly agree",
+              "Somewhat agree",
+              "Neutral",
+              "Disagree"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "poll_duration_minutes": {
+            "value": 1440,
+            "type": "integer",
+            "required": false
+          },
+          "parent_tweet_id": {
+            "value": null,
+            "type": "string",
+            "required": false
           }
         },
         "requiresAuth": true,
@@ -197,11 +2049,11 @@
         },
         "behavior": {
           "operations": [
-            "read"
+            "create"
           ],
-          "readOnly": true,
+          "readOnly": false,
           "destructive": false,
-          "idempotent": true,
+          "idempotent": false,
           "openWorld": true
         },
         "extras": null
@@ -210,14 +2062,22 @@
     {
       "name": "PostTweet",
       "qualifiedName": "X.PostTweet",
-      "fullyQualifiedName": "X.PostTweet@1.4.2",
-      "description": "Post a tweet to X (Twitter).\n\nIMPORTANT NOTE:\nUse this tool ONLY when posting a tweet that is not a reply.\nIf you need to reply to a tweet, use the ReplyToTweet tool instead.\nIf you need to quote a tweet, you must include the quote_tweet_id parameter.",
+      "fullyQualifiedName": "X.PostTweet@2.0.0",
+      "description": "Post a new tweet as the authenticated user.\n\nThe same tool covers top-level posts, replies, and quote tweets. Supply\n``reply_to_tweet_id`` to post the new tweet as a reply; supply\n``quote_tweet_id`` to quote another tweet; supply both to post a reply\nthat also quotes a tweet. Pass ``reply_settings`` to restrict who can\nreply. Pass ``poll_options`` plus ``poll_duration_minutes`` to attach a\npoll (polls cannot be combined with ``quote_tweet_id``).\n\nFor multi-tweet threads, use the post-thread tool.",
       "parameters": [
         {
           "name": "tweet_text",
           "type": "string",
           "required": true,
-          "description": "The text content of the tweet you want to post",
+          "description": "The text content of the tweet you want to post. Must be non-empty. Standard X accounts have a 280 character limit, which this toolkit enforces; Premium accounts can post longer text but the toolkit conservatively rejects anything over 280 characters.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "reply_to_tweet_id",
+          "type": "string",
+          "required": false,
+          "description": "The id of an existing tweet to reply to. When set, the new tweet is posted as a reply in that conversation. Leave None to post a top-level tweet. Defaults to None.",
           "enum": null,
           "inferrable": true
         },
@@ -228,6 +2088,36 @@
           "description": "The ID of the tweet you want to quote. It must be a valid integer as a string. Default is None.",
           "enum": null,
           "inferrable": true
+        },
+        {
+          "name": "reply_settings",
+          "type": "string",
+          "required": false,
+          "description": "Restrict who can reply to the new tweet. Leave None for X's default (everyone). Defaults to None.",
+          "enum": [
+            "everyone",
+            "mentionedUsers",
+            "following",
+            "subscribers"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "poll_options",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Attach a poll to the new tweet. When provided, must be a list of 2-4 short answer options; each option is at most 25 characters (X API limit). When set, ``poll_duration_minutes`` must also be set. Polls are incompatible with ``quote_tweet_id`` (X rejects the combination). Leave None for no poll. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "poll_duration_minutes",
+          "type": "integer",
+          "required": false,
+          "description": "How long the poll stays open, in minutes. Required when ``poll_options`` is set; ignored otherwise. Must be between 5 and 10080 (7 days), per X's API limits. Defaults to None.",
+          "enum": null,
+          "inferrable": true
         }
       ],
       "auth": {
@@ -242,21 +2132,46 @@
       "secrets": [],
       "secretsInfo": [],
       "output": {
-        "type": "string",
-        "description": "Success string and the URL of the tweet"
+        "type": "json",
+        "description": "The id, URL, and status of the new tweet"
       },
       "documentationChunks": [],
       "codeExample": {
         "toolName": "X.PostTweet",
         "parameters": {
           "tweet_text": {
-            "value": "Excited to share my latest project! Check it out! #innovation #tech",
+            "value": "Just discovered an amazing new coffee shop downtown — the cold brew is absolutely incredible! ☕ #CoffeeLovers #MondayVibes",
             "type": "string",
             "required": true
           },
-          "quote_tweet_id": {
-            "value": "1234567890",
+          "reply_to_tweet_id": {
+            "value": "1782345678901234567",
             "type": "string",
+            "required": false
+          },
+          "quote_tweet_id": {
+            "value": "1781234567890123456",
+            "type": "string",
+            "required": false
+          },
+          "reply_settings": {
+            "value": "mentionedUsers",
+            "type": "string",
+            "required": false
+          },
+          "poll_options": {
+            "value": [
+              "Absolutely yes!",
+              "Probably not",
+              "Need more info",
+              "No opinion"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "poll_duration_minutes": {
+            "value": 1440,
+            "type": "integer",
             "required": false
           }
         },
@@ -283,32 +2198,115 @@
       }
     },
     {
-      "name": "ReplyToTweet",
-      "qualifiedName": "X.ReplyToTweet",
-      "fullyQualifiedName": "X.ReplyToTweet@1.4.2",
-      "description": "Reply to a tweet on X (Twitter).\n\nIMPORTANT NOTE:\nUse this tool ONLY when replying to a tweet directly.\nIf you need to post a tweet that is not a reply, use the PostTweet tool instead.\nIf you need to quote a tweet on your reply, you must include the quote_tweet_id parameter.",
+      "name": "RemoveListMember",
+      "qualifiedName": "X.RemoveListMember",
+      "fullyQualifiedName": "X.RemoveListMember@2.0.0",
+      "description": "Remove one or more users from an X List owned by the authenticated user.\n\nProvide ``user_ids``, ``usernames``, or both. Removing a user who is not\na member is treated as success.\n\nOn a mid-loop rate-limit, the run short-circuits and remaining targets\nare marked as not attempted. On retry, drop the targets that already\nsucceeded; otherwise polling re-arms X's bucket and extends the lockout.\n\nX is eventually consistent on list membership: a success status here\ndoes not mean a subsequent ``GetListMembers`` will immediately stop\nreturning the removed member. Allow a few seconds before relying on the\nread endpoint to reflect the mutation.\n\nSerialize dependent list mutations: do not fire ``RemoveListMember`` in\nparallel with ``DeleteList`` on the same ``list_id`` (a known race that\nproduces spurious ``not_found`` when the remove lands after the delete).\nAwait each mutation before issuing the next one on the same list.",
+      "parameters": [
+        {
+          "name": "list_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the list to remove members from.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "user_ids",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Numeric X user ids (snowflake ids, 1-19 digits) of the members to remove. Up to 100 targets per call (combined with ``usernames``). Prefer this over ``usernames`` when you already have stable ids — the toolkit skips the username-resolution hop, which is rate-limited by X. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "usernames",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Handles of the members to remove. Leading '@' is optional and stripped automatically. Up to 100 targets per call (combined with ``user_ids``). Handles are resolved to ids in batched ``/2/users/by`` calls (one round-trip per 100 handles) instead of one resolve-per-target. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "list.read",
+          "list.write",
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.RemoveListMember",
+        "parameters": {
+          "list_id": {
+            "value": "1623489012345678901",
+            "type": "string",
+            "required": true
+          },
+          "user_ids": {
+            "value": [
+              "783214",
+              "6253282",
+              "17874544"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "usernames": {
+            "value": [
+              "elonmusk",
+              "@jack",
+              "biz"
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "Retweet",
+      "qualifiedName": "X.Retweet",
+      "fullyQualifiedName": "X.Retweet@2.0.0",
+      "description": "Retweet a tweet as the authenticated user.\n\nIdempotent: retweeting an already-retweeted tweet succeeds.",
       "parameters": [
         {
           "name": "tweet_id",
           "type": "string",
           "required": true,
-          "description": "The ID of the tweet you want to reply to. It must be a valid integer as a string.",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "tweet_text",
-          "type": "string",
-          "required": true,
-          "description": "The text content of the tweet you want to post",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "quote_tweet_id",
-          "type": "string",
-          "required": false,
-          "description": "The ID of the tweet you want to quote. It must be a valid integer as a string. Optional.",
+          "description": "The ID of the tweet to retweet.",
           "enum": null,
           "inferrable": true
         }
@@ -325,27 +2323,17 @@
       "secrets": [],
       "secretsInfo": [],
       "output": {
-        "type": "string",
-        "description": "Success string and the URL of the tweet"
+        "type": "json",
+        "description": "The id of the retweeted tweet and a status string."
       },
       "documentationChunks": [],
       "codeExample": {
-        "toolName": "X.ReplyToTweet",
+        "toolName": "X.Retweet",
         "parameters": {
           "tweet_id": {
-            "value": "1234567890123456789",
+            "value": "1649857302948765184",
             "type": "string",
             "required": true
-          },
-          "tweet_text": {
-            "value": "Thanks for the update! I really appreciate it.",
-            "type": "string",
-            "required": true
-          },
-          "quote_tweet_id": {
-            "value": "9876543210987654321",
-            "type": "string",
-            "required": false
           }
         },
         "requiresAuth": true,
@@ -364,24 +2352,116 @@
           ],
           "readOnly": false,
           "destructive": false,
-          "idempotent": false,
+          "idempotent": true,
           "openWorld": true
         },
         "extras": null
       }
     },
     {
-      "name": "SearchRecentTweetsByKeywords",
-      "qualifiedName": "X.SearchRecentTweetsByKeywords",
-      "fullyQualifiedName": "X.SearchRecentTweetsByKeywords@1.4.2",
-      "description": "Search for recent tweets (last 7 days) on X (Twitter) by required keywords and phrases.\nIncludes replies and reposts.\nOne of the following input parameters MUST be provided: keywords, phrases",
+      "name": "SearchSpaces",
+      "qualifiedName": "X.SearchSpaces",
+      "fullyQualifiedName": "X.SearchSpaces@2.0.0",
+      "description": "Search live and scheduled X Spaces by title.\n\nMatches the query against Space titles only (not transcripts). Filter\n``state`` controls whether to return live, scheduled, or both.\n\nThis endpoint does not paginate; ``max_results`` is the maximum page\nsize.",
+      "parameters": [
+        {
+          "name": "query",
+          "type": "string",
+          "required": true,
+          "description": "Free-text search query to match against Space titles. Required and non-empty.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "state",
+          "type": "string",
+          "required": false,
+          "description": "Filter results by Space lifecycle state — currently-live, scheduled upcoming, or both. Defaults to all.",
+          "enum": [
+            "live",
+            "scheduled",
+            "all"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "max_results",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of Spaces to return. The X API allows 1-100; values outside that range are silently clamped. Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "space.read",
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Spaces whose titles match the query, with their lifecycle metadata. ``result_count`` is the number of Spaces returned (always present, even when zero)."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.SearchSpaces",
+        "parameters": {
+          "query": {
+            "value": "AI and technology trends",
+            "type": "string",
+            "required": true
+          },
+          "state": {
+            "value": "live",
+            "type": "string",
+            "required": false
+          },
+          "max_results": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchTweetsByKeywords",
+      "qualifiedName": "X.SearchTweetsByKeywords",
+      "fullyQualifiedName": "X.SearchTweetsByKeywords@2.0.0",
+      "description": "Search tweets on X by structured filters across X's recent ~7-day index.\n\nSearches the last ~7 days of public tweets. For deeper historical\nwindows, X gates the full-archive search endpoint behind a paid plan;\nthis toolkit only offers the recent variant.\n\nAll supplied filters are ANDed together. At least one positive filter\nis required: a non-empty keyword or phrase, a non-empty\n``from_username`` / ``to_username``, or a ``has_*`` / ``is_*`` flag set\nto True. ``lang``, ``exclude_replies``, ``sort_order``, ``start_time`` /\n``end_time``, and False-valued flags are qualifiers, not positive filters.\n\nPagination: X's cursor is inclusive at the boundary, so consecutive\npages may overlap by one tweet. De-duplicate by tweet id when merging\npages. X's sharded search backend sometimes returns ``data=[]`` with a\nnon-null ``next_token`` when the slice it scanned produced no hits;\n``auto_follow_empty_pages`` controls how many such empty pages the tool\nfollows internally before returning, and ``pages_scanned`` in the\nresponse reports how far it scanned.",
       "parameters": [
         {
           "name": "keywords",
           "type": "array",
           "innerType": "string",
           "required": false,
-          "description": "List of keywords that must be present in the tweet",
+          "description": "Single keywords that must ALL be present in matching tweets (AND semantics). Example: ['anthropic', 'claude'] matches tweets containing both words. Defaults to None.",
           "enum": null,
           "inferrable": true
         },
@@ -390,7 +2470,7 @@
           "type": "array",
           "innerType": "string",
           "required": false,
-          "description": "List of phrases that must be present in the tweet",
+          "description": "Multi-word phrases that must ALL be present in matching tweets (AND semantics). Each phrase is matched as a contiguous quoted string. Defaults to None.",
           "enum": null,
           "inferrable": true
         },
@@ -398,7 +2478,7 @@
           "name": "max_results",
           "type": "integer",
           "required": false,
-          "description": "The maximum number of results to return. Must be in range [1, 100] inclusive",
+          "description": "The maximum number of results to return (1-100). Values above 100 are lowered to 100. Defaults to 10.",
           "enum": null,
           "inferrable": true
         },
@@ -406,8 +2486,147 @@
           "name": "next_token",
           "type": "string",
           "required": false,
-          "description": "The pagination token starting from which to return results",
+          "description": "Pagination token from a prior response's ``next_token``. Leave None to start at the first page. Defaults to None.",
           "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "auto_follow_empty_pages",
+          "type": "integer",
+          "required": false,
+          "description": "When X returns ``data=[]`` with a non-null ``next_token`` (its sharded recent-search index produced no hits in the slice it scanned), the toolkit will automatically follow the cursor up to this many additional pages and return the first non-empty page (or the final empty page when the cap is hit). Helpful because high-volume keywords often need 3-5 follow-ups before a slice yields hits. Set 0 to disable auto-follow and return the first response verbatim — caller-managed paging. Clamped to [0, 10]. Defaults to 5.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "lang",
+          "type": "string",
+          "required": false,
+          "description": "BCP-47 language code (e.g. 'en', 'ja', 'es') to restrict matches to tweets X classified as that language. Leave None for no language filter. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "exclude_replies",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, excludes replies (tweets that reply to another tweet) from the results. Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "from_username",
+          "type": "string",
+          "required": false,
+          "description": "Restrict to tweets authored by this handle. Leading '@' is optional and stripped automatically. Leave None for no author restriction. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "to_username",
+          "type": "string",
+          "required": false,
+          "description": "Restrict to tweets that reply to this handle. Leading '@' is optional and stripped automatically. Leave None for no recipient restriction. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "has_media",
+          "type": "boolean",
+          "required": false,
+          "description": "Filter on whether tweets contain any media attachment. True requires media; False excludes media; None leaves the filter unset. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "has_images",
+          "type": "boolean",
+          "required": false,
+          "description": "Filter on whether tweets contain image attachments. True requires images; False excludes them; None leaves the filter unset. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "has_videos",
+          "type": "boolean",
+          "required": false,
+          "description": "Filter on whether tweets contain native (non-GIF) videos. True requires videos; False excludes them; None leaves the filter unset. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "has_links",
+          "type": "boolean",
+          "required": false,
+          "description": "Filter on whether tweets contain links/URLs. True requires links; False excludes them; None leaves the filter unset. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "has_mentions",
+          "type": "boolean",
+          "required": false,
+          "description": "Filter on whether tweets mention at least one user. True requires mentions; False excludes them; None leaves the filter unset. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "has_hashtags",
+          "type": "boolean",
+          "required": false,
+          "description": "Filter on whether tweets contain at least one hashtag. True requires hashtags; False excludes them; None leaves the filter unset. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "is_verified",
+          "type": "boolean",
+          "required": false,
+          "description": "Filter on whether the tweet author is verified. True requires verified authors; False excludes them; None leaves the filter unset. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "is_retweet",
+          "type": "boolean",
+          "required": false,
+          "description": "Filter on whether the tweet is a retweet. True requires retweets; False excludes retweets; None leaves the filter unset. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "is_quote",
+          "type": "boolean",
+          "required": false,
+          "description": "Filter on whether the tweet is a quote tweet. True requires quote tweets; False excludes them; None leaves the filter unset. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "start_time",
+          "type": "string",
+          "required": false,
+          "description": "Lower bound (inclusive) on tweet creation time, in ISO-8601 / RFC-3339 UTC format (YYYY-MM-DDTHH:MM:SSZ). Must fall within X's ~7-day recent index window; values older than 7 days surface as ``invalid_input``. Leave None for no lower bound. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "end_time",
+          "type": "string",
+          "required": false,
+          "description": "Upper bound (exclusive) on tweet creation time, in ISO-8601 / RFC-3339 UTC format (YYYY-MM-DDTHH:MM:SSZ). Must fall within X's ~7-day recent index window. Leave None for no upper bound. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "sort_order",
+          "type": "string",
+          "required": false,
+          "description": "Order in which X returns matching tweets — newest-first or by X's relevance score. Use relevance for keyword/topic discovery where the freshest match isn't necessarily the most useful one. Defaults to recency.",
+          "enum": [
+            "recency",
+            "relevancy"
+          ],
           "inferrable": true
         }
       ],
@@ -423,36 +2642,120 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "Dictionary containing the search results"
+        "description": "No description provided."
       },
       "documentationChunks": [],
       "codeExample": {
-        "toolName": "X.SearchRecentTweetsByKeywords",
+        "toolName": "X.SearchTweetsByKeywords",
         "parameters": {
           "keywords": {
             "value": [
-              "technology",
               "AI",
-              "innovation"
+              "machinelearning"
             ],
             "type": "array",
             "required": false
           },
           "phrases": {
             "value": [
-              "machine learning",
-              "data science"
+              "large language model",
+              "generative AI"
             ],
             "type": "array",
             "required": false
           },
           "max_results": {
-            "value": 50,
+            "value": 25,
             "type": "integer",
             "required": false
           },
           "next_token": {
-            "value": "abc123xyz",
+            "value": "7140dibdnow9c7btw422kk1bksxgj7nl8vy9en7z9w9c",
+            "type": "string",
+            "required": false
+          },
+          "auto_follow_empty_pages": {
+            "value": 3,
+            "type": "integer",
+            "required": false
+          },
+          "lang": {
+            "value": "en",
+            "type": "string",
+            "required": false
+          },
+          "exclude_replies": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "from_username": {
+            "value": "OpenAI",
+            "type": "string",
+            "required": false
+          },
+          "to_username": {
+            "value": "elonmusk",
+            "type": "string",
+            "required": false
+          },
+          "has_media": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "has_images": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "has_videos": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "has_links": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "has_mentions": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "has_hashtags": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "is_verified": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "is_retweet": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "is_quote": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "start_time": {
+            "value": "2025-01-20T00:00:00Z",
+            "type": "string",
+            "required": false
+          },
+          "end_time": {
+            "value": "2025-01-27T23:59:59Z",
+            "type": "string",
+            "required": false
+          },
+          "sort_order": {
+            "value": "relevancy",
             "type": "string",
             "required": false
           }
@@ -480,32 +2783,16 @@
       }
     },
     {
-      "name": "SearchRecentTweetsByUsername",
-      "qualifiedName": "X.SearchRecentTweetsByUsername",
-      "fullyQualifiedName": "X.SearchRecentTweetsByUsername@1.4.2",
-      "description": "Search for recent tweets (last 7 days) on X (Twitter) by username.\nIncludes replies and reposts.",
+      "name": "UndoRetweet",
+      "qualifiedName": "X.UndoRetweet",
+      "fullyQualifiedName": "X.UndoRetweet@2.0.0",
+      "description": "Undo a previous retweet by the authenticated user.\n\nIdempotent: undoing a retweet that doesn't exist succeeds.",
       "parameters": [
         {
-          "name": "username",
+          "name": "tweet_id",
           "type": "string",
           "required": true,
-          "description": "The username of the X (Twitter) user to look up",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "max_results",
-          "type": "integer",
-          "required": false,
-          "description": "The maximum number of results to return. Must be in range [1, 100] inclusive",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "next_token",
-          "type": "string",
-          "required": false,
-          "description": "The pagination token starting from which to return results",
+          "description": "The ID of the original tweet whose retweet you want to undo.",
           "enum": null,
           "inferrable": true
         }
@@ -515,6 +2802,7 @@
         "providerType": "oauth2",
         "scopes": [
           "tweet.read",
+          "tweet.write",
           "users.read"
         ]
       },
@@ -522,25 +2810,242 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "Dictionary containing the search results"
+        "description": "The id of the original tweet and a status string."
       },
       "documentationChunks": [],
       "codeExample": {
-        "toolName": "X.SearchRecentTweetsByUsername",
+        "toolName": "X.UndoRetweet",
         "parameters": {
-          "username": {
-            "value": "example_user",
+          "tweet_id": {
+            "value": "1234567890123456789",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "UnlikeTweet",
+      "qualifiedName": "X.UnlikeTweet",
+      "fullyQualifiedName": "X.UnlikeTweet@2.0.0",
+      "description": "Remove the authenticated user's like from a tweet.\n\nThe tweet itself is unaffected; only the like relationship is removed.\nIdempotent: unliking a tweet that isn't liked succeeds.",
+      "parameters": [
+        {
+          "name": "tweet_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the tweet to unlike.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "tweet.read",
+          "users.read",
+          "like.write"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The id of the unliked tweet and a status string."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.UnlikeTweet",
+        "parameters": {
+          "tweet_id": {
+            "value": "1674832910482345984",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "UnpinList",
+      "qualifiedName": "X.UnpinList",
+      "fullyQualifiedName": "X.UnpinList@2.0.0",
+      "description": "Unpin an X List from the authenticated user's profile.\n\nIdempotent: unpinning a list that isn't pinned succeeds.",
+      "parameters": [
+        {
+          "name": "list_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the list to unpin from the authenticated user's profile.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "list.read",
+          "list.write",
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The list id and a status string."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.UnpinList",
+        "parameters": {
+          "list_id": {
+            "value": "1234567890123456789",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "x",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "social_media"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "UpdateList",
+      "qualifiedName": "X.UpdateList",
+      "fullyQualifiedName": "X.UpdateList@2.0.0",
+      "description": "Rename a list, edit its description, or toggle its visibility.\n\nAt least one of ``name``, ``description``, or ``private`` must be\nprovided. Unchanged fields keep their pre-existing values.\n\nSerialize dependent list mutations: do not fire ``UpdateList`` in\nparallel with ``DeleteList``, ``AddListMember``, ``RemoveListMember``,\nor another ``UpdateList`` against the same ``list_id``. Concurrent\ndependent mutations race against X's distributed state and surface\nspurious ``not_found`` errors. Await each mutation before issuing the\nnext one on the same list.",
+      "parameters": [
+        {
+          "name": "list_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the list to update.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "New display name for the list. Provide a non-empty string of at most 25 characters to rename. Leave None to leave the existing name unchanged. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "required": false,
+          "description": "New description for the list. Provide any string (including empty) to overwrite the existing description; an empty string clears it. Leave None to leave the existing description unchanged. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "private",
+          "type": "boolean",
+          "required": false,
+          "description": "Visibility flag. True makes the list private (only visible to its owner); False makes it public. Leave None to leave the existing visibility unchanged. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "x",
+        "providerType": "oauth2",
+        "scopes": [
+          "list.read",
+          "list.write",
+          "tweet.read",
+          "users.read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "X.UpdateList",
+        "parameters": {
+          "list_id": {
+            "value": "1234567890123456789",
             "type": "string",
             "required": true
           },
-          "max_results": {
-            "value": 50,
-            "type": "integer",
+          "name": {
+            "value": "Tech Influencers",
+            "type": "string",
             "required": false
           },
-          "next_token": {
-            "value": "abc123",
+          "description": {
+            "value": "A curated list of top tech voices",
             "type": "string",
+            "required": false
+          },
+          "private": {
+            "value": false,
+            "type": "boolean",
             "required": false
           }
         },
@@ -556,9 +3061,9 @@
         },
         "behavior": {
           "operations": [
-            "read"
+            "update"
           ],
-          "readOnly": true,
+          "readOnly": false,
           "destructive": false,
           "idempotent": true,
           "openWorld": true
@@ -569,8 +3074,8 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "X.WhoAmI",
-      "fullyQualifiedName": "X.WhoAmI@1.4.2",
-      "description": "Get information about the authenticated X (Twitter) user.\n\nReturns the current user's profile including their username, name, description,\nfollower counts, and other account information.",
+      "fullyQualifiedName": "X.WhoAmI@2.0.0",
+      "description": "Get the authenticated X (Twitter) user's profile.",
       "parameters": [],
       "auth": {
         "providerId": "x",
@@ -616,6 +3121,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-26T20:45:10.438Z",
-  "summary": "X provider toolkit enables programmatic access to X (Twitter) for reading and managing tweets and user profiles, optimized for LLM-driven flows. It supports posting, replying, deleting, searching recent tweets, and retrieving the authenticated account.\n\n**Capabilities**\n- Query and filter recent tweets and user timelines with keyword and username search.\n- Compose and manage tweet lifecycle: create non-reply posts, reply/quote responsibly, and delete owned tweets.\n- Access authenticated identity and act on behalf of the user within granted scopes.\n- Enforce action constraints and parameter validation (e.g., use Post for non-replies, Reply for replies, include quote_tweet_id when quoting).\n\n**OAuth**\nProvider: x\nScopes: tweet.read, tweet.write, users.read"
+  "generatedAt": "2026-06-19T12:27:59.752Z",
+  "summary": "The X toolkit provides Arcade tools for interacting with the X (Twitter) platform, enabling LLMs to read and write tweets, manage lists, search content, and inspect user and Space metadata on behalf of an authenticated user.\n\n## Capabilities\n\n- **Tweeting & threads:** Post, delete, like, unlike, retweet, undo-retweet, and quote tweets; compose multi-tweet threads with mid-thread resume support; attach polls and control reply permissions.\n- **Timeline & search:** Fetch the home timeline, @-mentions, quote tweets, direct replies, and full conversation threads; search the recent (~7-day) tweet index by structured keyword filters with pagination and empty-page auto-follow.\n- **User & engagement data:** Look up users by handle or numeric ID; retrieve liked tweets, authored tweets (full history), and engager lists (likers/retweeters); fetch the authenticated user's own profile.\n- **List management:** Create, update, delete, pin, and unpin lists; add and remove members (with eventual-consistency and serialization caveats); read list members, list memberships for a user, and recent tweets from a list.\n- **Spaces:** Look up a Space by ID, list live/scheduled Spaces by creator, and search Spaces by title.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 with X as the identity provider. See the [Arcade X auth provider docs](https://docs.arcade.dev/en/references/auth-providers/x) for setup details."
 }


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/27825461274

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are generated documentation metadata only; the main impact is agents or docs referencing old fully qualified tool names (especially Google Slides 3.0.0 and X 2.0.0).
> 
> **Overview**
> Auto-generated refresh of `toolkit-docs-generator/data/toolkits` after a successful deploy. **`index.json`** picks up new versions and tool counts for the touched integrations.
> 
> **Ashby (0.2.0)** adds **`ArchiveApplication`** (reject/archive with a named reason) and bumps all tool FQNs; the toolkit summary now calls out archive/reject in the application lifecycle.
> 
> **Gmail (7.5.0)** is a version-only bump across existing tools (no new tools in this diff).
> 
> **Google Slides (3.0.0)** is a breaking catalog change: granular create/read tools are replaced by **`CreateOrEditPresentation`** (atomic batch edits + snapshot), **`CreatePresentationFromTemplate`**, **`GetPresentation`** (addressable snapshot instead of markdown export), **`GetSlideThumbnail`**, and **`ResolveComment`**. **`CommentOnPresentation`** gains optional thread replies and no longer targets a slide by index.
> 
> **X (2.0.0)** expands from 8 to **33** tools: list CRUD and membership, likes/retweets, home timeline and mentions, conversation/reply/quote reads, Spaces search/lookup, **`PostThread`**, batched **`LookupTweets`** / **`LookupUsers`**, and a richer **`SearchTweetsByKeywords`** filter set. OAuth scopes now include list, like, and space permissions. **`PostTweet`** subsumes the old separate reply tool via **`reply_to_tweet_id`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d44a9039f5c838c9c1ab3712dea370d701054954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->