### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-19T12:28:11.410Z",
+  "generatedAt": "2026-06-23T12:07:49.483Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -592,7 +592,7 @@
       "label": "Jira",
       "version": "3.1.4",
       "category": "productivity",
-      "type": "auth",
+      "type": "arcade",
       "toolCount": 43,
       "authType": "oauth2"
     },

--- a/toolkit-docs-generator/data/toolkits/jira.json
+++ b/toolkit-docs-generator/data/toolkits/jira.json
@@ -8,7 +8,7 @@
     "iconUrl": "https://design-system.arcade.dev/icons/jira.svg",
     "isBYOC": false,
     "isPro": false,
-    "type": "auth",
+    "type": "arcade",
     "docsLink": "https://docs.arcade.dev/en/resources/integrations/productivity/jira",
     "isComingSoon": false,
     "isHidden": false
@@ -4575,6 +4575,6 @@
       "relativePath": "environment-variables/page.mdx"
     }
   ],
-  "generatedAt": "2026-05-28T12:15:52.149Z",
+  "generatedAt": "2026-06-23T12:07:49.216Z",
   "summary": "The Jira toolkit integrates Arcade with Atlassian Jira, enabling LLMs to manage issues, sprints, boards, users, attachments, and project metadata across Jira Cloud instances.\n\n## Capabilities\n\n- **Issue lifecycle management** — Create, update, transition, search (parameterized or JQL), comment on, label, and attach files to issues; move issues between sprints and backlogs.\n- **Sprint & board operations** — List boards and their sprints (with date-range filtering), retrieve backlog and sprint issues, add/move issues to sprints, and access backlog GUI URLs.\n- **Project & metadata discovery** — Browse projects, issue types, priority schemes, labels, and available transitions; resolve names/keys/emails to IDs automatically without requiring pre-lookup calls.\n- **User & identity management** — Look up users by ID, name, or email; list all users; retrieve the authenticated user's profile and available Atlassian Cloud instances.\n- **Attachment handling** — List attachment metadata, download attachment contents, and upload files (string or base64) to issues.\n\n## OAuth\n\nAuthentication uses OAuth 2.0 via the **Atlassian** provider. See the [Atlassian auth provider docs](https://docs.arcade.dev/en/references/auth-providers/atlassian) for setup details, required scopes, and configuration steps."
 }


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/28024791329

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Auto-generated data-only changes; the Jira type relabel may shift sidebar/docs grouping but does not alter runtime code.
> 
> **Overview**
> Scheduled **toolkit-docs-generator** output refresh after a successful Porter deploy, updating `generatedAt` on the toolkit index.
> 
> The meaningful catalog change is **Jira** reclassified from **`auth`** to **`arcade`** in both `index.json` and `jira.json` metadata. That aligns Jira with other full Arcade MCP toolkits and affects how docs navigation treats it (e.g. optimized vs starter grouping via `metadata.type`), without changing tool definitions or version **3.1.4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e66a4fc1ebc32a98616b9a6d3344ef2a05dbadf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->