### PR TITLE
Fix glossary auto-linker nesting buttons (hydration error)

### DIFF
--- a/lib/remark-glossary.ts
+++ b/lib/remark-glossary.ts
@@ -78,6 +78,17 @@ export function remarkGlossary(options: RemarkGlossaryOptions) {
             return SKIP;
           }
 
+          // Skip text already inside a GlossaryTerm we inserted. After a term
+          // is wrapped mid-sentence the visitor descends into the new node;
+          // re-wrapping a shorter term here nests a <button> inside a
+          // <button> (invalid HTML that triggers a React hydration error).
+          if (
+            parent.type === "mdxJsxTextElement" &&
+            parent.name === "GlossaryTerm"
+          ) {
+            return SKIP;
+          }
+
           const markedTerms =
             markedTermsPerParagraph.get(paragraphNode) || new Set();
           let text = textNode.value;

--- a/tests/fixtures/glossary-nesting.mdx
+++ b/tests/fixtures/glossary-nesting.mdx
@@ -1,0 +1,9 @@
+## Glossary
+
+### agent runtime
+
+The runtime that hosts and runs an agent.
+
+### agent
+
+An autonomous program that pursues a goal.

--- a/tests/remark-glossary.test.ts
+++ b/tests/remark-glossary.test.ts
@@ -1,0 +1,66 @@
+import type { Root } from "mdast";
+import { visit } from "unist-util-visit";
+import { describe, expect, test } from "vitest";
+import { remarkGlossary } from "@/lib/remark-glossary";
+
+// A fixture glossary where one term ("agent runtime") contains a shorter
+// term ("agent"). When the longer term is matched mid-sentence, the plugin
+// must NOT then wrap "agent" inside the GlossaryTerm it just created —
+// GlossaryTerm renders a <button>, and a button inside a button is invalid
+// HTML that triggers a React hydration error.
+const GLOSSARY_FIXTURE = "tests/fixtures/glossary-nesting.mdx";
+
+type JsxNode = { type: string; name?: string };
+
+function buildParagraph(text: string): Root {
+  return {
+    type: "root",
+    children: [
+      { type: "paragraph", children: [{ type: "text", value: text }] },
+    ],
+  } as Root;
+}
+
+function countGlossaryTerms(tree: Root): { total: number; nested: number } {
+  let total = 0;
+  let nested = 0;
+  visit(tree, (node) => {
+    const outer = node as JsxNode;
+    if (outer.type === "mdxJsxTextElement" && outer.name === "GlossaryTerm") {
+      total += 1;
+      visit(node, (descendant) => {
+        if (descendant === node) {
+          return;
+        }
+        const inner = descendant as JsxNode;
+        if (
+          inner.type === "mdxJsxTextElement" &&
+          inner.name === "GlossaryTerm"
+        ) {
+          nested += 1;
+        }
+      });
+    }
+  });
+  return { total, nested };
+}
+
+describe("remarkGlossary", () => {
+  test("links a glossary term that appears mid-sentence", () => {
+    const tree = buildParagraph("Use the agent runtime here.");
+    remarkGlossary({ glossaryPath: GLOSSARY_FIXTURE })(tree, {
+      history: ["/tmp/test-page.mdx"],
+    });
+    const { total } = countGlossaryTerms(tree);
+    expect(total).toBeGreaterThan(0);
+  });
+
+  test("never nests one GlossaryTerm inside another (no button-in-button)", () => {
+    const tree = buildParagraph("Use the agent runtime here.");
+    remarkGlossary({ glossaryPath: GLOSSARY_FIXTURE })(tree, {
+      history: ["/tmp/test-page.mdx"],
+    });
+    const { nested } = countGlossaryTerms(tree);
+    expect(nested).toBe(0);
+  });
+});


### PR DESCRIPTION
## What this PR does

Fixes a bug in the glossary auto-linker (`lib/remark-glossary.ts`) that produces a `<button>` nested inside a `<button>` — invalid HTML that throws a **React hydration error** in the browser.

## Root cause

`remarkGlossary` wraps each matched glossary term in a `<GlossaryTerm>`, which renders a `<button>` (the popover trigger). The text visitor matches a term, splices `[before, <GlossaryTerm>, after]` into the parent's children, and returns a bare `SKIP`.

When the term is matched **mid-sentence** (non-empty leading text), `SKIP` lands `unist-util-visit` on the newly-inserted `<GlossaryTerm>` node and descends **into** it. Its inner text is then re-scanned, and a shorter term contained in the matched text gets wrapped again — e.g. `agent` inside `agent runtime` — nesting one `GlossaryTerm` (button) inside another.

This only triggers when a multi-word term that contains a shorter term appears mid-sentence, which is why most pages don't hit it but a term-dense page can hit it several times.

## The fix

Guard the text visitor so it never re-processes text already inside a `GlossaryTerm` it just inserted:

```ts
if (parent.type === "mdxJsxTextElement" && parent.name === "GlossaryTerm") {
  return SKIP;
}
```

This preserves existing behavior (trailing text after a wrapped term is still scanned for other terms) and only prevents the invalid nesting.

## Test

Adds `tests/remark-glossary.test.ts` with a fixture glossary (`tests/fixtures/glossary-nesting.mdx`) where `agent runtime` contains `agent`. Two cases:

- a glossary term that appears mid-sentence is still linked;
- no `GlossaryTerm` is ever nested inside another.

The second test fails on the current code (reproduces the bug) and passes with the fix. Full suite stays green.

> Surfaced while adding a term-dense framework guide (the reciprocal of [CopilotKit/CopilotKit#5514](https://github.com/CopilotKit/CopilotKit/pull/5514)); filing the infra fix separately so that PR stays scoped to docs content. Verified via the unit test — a live-render check was impractical because `next dev --webpack` was crash-prone in my environment (Node 24 vs the repo's Node 22), so please confirm in CI / a normal dev run.

cc @thierrypdamiba

🤖 Generated with [Claude Code](https://claude.com/claude-code)
