### PR TITLE
chore: update @arcadeai/design-system to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://arcade.dev/",
   "dependencies": {
-    "@arcadeai/design-system": "3.48.0",
+    "@arcadeai/design-system": "3.49.0",
     "@mdx-js/mdx": "3.1.1",
     "@mdx-js/react": "3.1.1",
     "@next/third-parties": "16.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     dependencies:
       '@arcadeai/design-system':
-        specifier: 3.48.0
-        version: 3.48.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)
+        specifier: 3.49.0
+        version: 3.49.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)
       '@mdx-js/mdx':
         specifier: 3.1.1
         version: 3.1.1
@@ -272,8 +272,8 @@ packages:
       zod:
         optional: true
 
-  '@arcadeai/design-system@3.48.0':
-    resolution: {integrity: sha512-OhIs4dBq99k1dCJ4O1ecDBcMcfiupDStelVhX15gWYE61YyG702UVotgn4k8dwaSow90GgELysS2eq7x7Ke7Zg==}
+  '@arcadeai/design-system@3.49.0':
+    resolution: {integrity: sha512-w0ioMMyPZDV2dSiPjUvPfbO4zsvR1dV/d+liZh5Fkp+0jmw0FRhloastVvPDpPLclHOH12jO0j/9qfTHRsz6EA==}
     engines: {bun: '>=1.3.5'}
     peerDependencies:
       '@hookform/resolvers': '>=5.2.1'
@@ -4651,7 +4651,7 @@ snapshots:
     optionalDependencies:
       zod: 4.3.6
 
-  '@arcadeai/design-system@3.48.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)':
+  '@arcadeai/design-system@3.49.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)':
     dependencies:
       '@base-ui/react': 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.16)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@base-ui/utils': 0.2.9(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
This PR updates `@arcadeai/design-system` to the latest published version.

It runs a design-system compatibility test gate before opening this PR.
If that gate fails, the workflow stops and no PR is created.

- Trigger: `workflow_dispatch`
- Run: https://github.com/ArcadeAI/docs/actions/runs/28206192123

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine patch/minor design-system upgrade with no direct code edits; risk is limited to possible UI or API behavior changes from the external package.
> 
> **Overview**
> Bumps **`@arcadeai/design-system`** from **3.48.0** to **3.49.0** in `package.json` and refreshes **`pnpm-lock.yaml`** so the lockfile matches the new version.
> 
> There are **no application source changes** in this diff—only dependency metadata. The update was produced by the automated design-system workflow after its compatibility gate (targeted Vitest runs and `pnpm run build`) passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 065ff37b001360fb1a536e73319f4b822fba9b0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->