### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/toolkit-docs-generator/data/toolkits/gmail.json
+++ b/toolkit-docs-generator/data/toolkits/gmail.json
@@ -1,7 +1,7 @@
 {
   "id": "Gmail",
   "label": "Gmail",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "description": "Arcade.dev LLM tools for Gmail",
   "metadata": {
     "category": "productivity",
@@ -30,7 +30,7 @@
     {
       "name": "ChangeEmailLabels",
       "qualifiedName": "Gmail.ChangeEmailLabels",
-      "fullyQualifiedName": "Gmail.ChangeEmailLabels@7.5.0",
+      "fullyQualifiedName": "Gmail.ChangeEmailLabels@7.5.1",
       "description": "Add and remove labels from an email using the Gmail API.",
       "parameters": [
         {
@@ -124,7 +124,7 @@
     {
       "name": "CreateLabel",
       "qualifiedName": "Gmail.CreateLabel",
-      "fullyQualifiedName": "Gmail.CreateLabel@7.5.0",
+      "fullyQualifiedName": "Gmail.CreateLabel@7.5.1",
       "description": "Create a new label in the user's mailbox.",
       "parameters": [
         {
@@ -184,7 +184,7 @@
     {
       "name": "DeleteDraftEmail",
       "qualifiedName": "Gmail.DeleteDraftEmail",
-      "fullyQualifiedName": "Gmail.DeleteDraftEmail@7.5.0",
+      "fullyQualifiedName": "Gmail.DeleteDraftEmail@7.5.1",
       "description": "Delete a draft email using the Gmail API.",
       "parameters": [
         {
@@ -244,7 +244,7 @@
     {
       "name": "GetThread",
       "qualifiedName": "Gmail.GetThread",
-      "fullyQualifiedName": "Gmail.GetThread@7.5.0",
+      "fullyQualifiedName": "Gmail.GetThread@7.5.1",
       "description": "Get the specified thread by ID.",
       "parameters": [
         {
@@ -304,7 +304,7 @@
     {
       "name": "ListDraftEmails",
       "qualifiedName": "Gmail.ListDraftEmails",
-      "fullyQualifiedName": "Gmail.ListDraftEmails@7.5.0",
+      "fullyQualifiedName": "Gmail.ListDraftEmails@7.5.1",
       "description": "Lists draft emails in the user's draft mailbox using the Gmail API.",
       "parameters": [
         {
@@ -364,7 +364,7 @@
     {
       "name": "ListEmails",
       "qualifiedName": "Gmail.ListEmails",
-      "fullyQualifiedName": "Gmail.ListEmails@7.5.0",
+      "fullyQualifiedName": "Gmail.ListEmails@7.5.1",
       "description": "Read emails from a Gmail account and extract plain text content.\n\nBy default, obvious automated emails are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all emails regardless of source.",
       "parameters": [
         {
@@ -437,7 +437,7 @@
     {
       "name": "ListEmailsByHeader",
       "qualifiedName": "Gmail.ListEmailsByHeader",
-      "fullyQualifiedName": "Gmail.ListEmailsByHeader@7.5.0",
+      "fullyQualifiedName": "Gmail.ListEmailsByHeader@7.5.1",
       "description": "Search for emails by header using the Gmail API.\n\nBy default, obvious automated emails are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all emails regardless of source.",
       "parameters": [
         {
@@ -596,7 +596,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Gmail.ListLabels",
-      "fullyQualifiedName": "Gmail.ListLabels@7.5.0",
+      "fullyQualifiedName": "Gmail.ListLabels@7.5.1",
       "description": "List all the labels in the user's mailbox.",
       "parameters": [],
       "auth": {
@@ -641,7 +641,7 @@
     {
       "name": "ListThreads",
       "qualifiedName": "Gmail.ListThreads",
-      "fullyQualifiedName": "Gmail.ListThreads@7.5.0",
+      "fullyQualifiedName": "Gmail.ListThreads@7.5.1",
       "description": "List threads in the user's mailbox.\n\nBy default, obvious automated threads are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all threads regardless of source.",
       "parameters": [
         {
@@ -740,7 +740,7 @@
     {
       "name": "ReplyToEmail",
       "qualifiedName": "Gmail.ReplyToEmail",
-      "fullyQualifiedName": "Gmail.ReplyToEmail@7.5.0",
+      "fullyQualifiedName": "Gmail.ReplyToEmail@7.5.1",
       "description": "Send a reply to an email message, optionally with one or more file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
@@ -905,7 +905,7 @@
     {
       "name": "SearchThreads",
       "qualifiedName": "Gmail.SearchThreads",
-      "fullyQualifiedName": "Gmail.SearchThreads@7.5.0",
+      "fullyQualifiedName": "Gmail.SearchThreads@7.5.1",
       "description": "Search for threads in the user's mailbox.\n\nBy default, obvious automated threads are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all threads regardless of source.",
       "parameters": [
         {
@@ -1094,7 +1094,7 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "Gmail.SendDraftEmail",
-      "fullyQualifiedName": "Gmail.SendDraftEmail@7.5.0",
+      "fullyQualifiedName": "Gmail.SendDraftEmail@7.5.1",
       "description": "Send a draft email using the Gmail API.",
       "parameters": [
         {
@@ -1154,7 +1154,7 @@
     {
       "name": "SendEmail",
       "qualifiedName": "Gmail.SendEmail",
-      "fullyQualifiedName": "Gmail.SendEmail@7.5.0",
+      "fullyQualifiedName": "Gmail.SendEmail@7.5.1",
       "description": "Send an email using the Gmail API, optionally with one or more file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
@@ -1315,7 +1315,7 @@
     {
       "name": "TrashEmail",
       "qualifiedName": "Gmail.TrashEmail",
-      "fullyQualifiedName": "Gmail.TrashEmail@7.5.0",
+      "fullyQualifiedName": "Gmail.TrashEmail@7.5.1",
       "description": "Move an email to the trash folder using the Gmail API.",
       "parameters": [
         {
@@ -1375,7 +1375,7 @@
     {
       "name": "UpdateDraftEmail",
       "qualifiedName": "Gmail.UpdateDraftEmail",
-      "fullyQualifiedName": "Gmail.UpdateDraftEmail@7.5.0",
+      "fullyQualifiedName": "Gmail.UpdateDraftEmail@7.5.1",
       "description": "Update an existing email draft using the Gmail API.\n\nSingle-part ``text/plain`` and single-part ``text/html`` drafts both support full\nbody replacement; the rebuild follows the existing draft's content type, so a\nplain draft stays plain and an HTML draft stays HTML. Plain-text input supplied\nagainst an HTML draft is auto-converted to HTML, and HTML input supplied against\na plain draft is stored verbatim as ``text/plain``. Reply drafts preserve their\nreply-quote tail (``> `` lines for plain, ``<blockquote>`` for HTML) when the\nbody is supplied as a top-only update.\n\nMultipart drafts and drafts with attachments still fail when the body changes;\nin those cases the tool succeeds only when the effective body is unchanged\n(metadata-only update preserving the existing MIME tree). Edit those drafts in\nGmail directly.\n\nFor each of subject, body, recipient, cc, and bcc, omitting the parameter or passing\n``None`` leaves that part of the draft unchanged (for cc/bcc, existing headers are kept;\npass an empty list to clear).",
       "parameters": [
         {
@@ -1398,7 +1398,7 @@
           "name": "body",
           "type": "string",
           "required": false,
-          "description": "Updated body for the draft. There is no `content_type` argument — the body is encoded to match the existing draft, and reply drafts re-attach their existing reply-quote tail. Omit or pass None to leave the body unchanged.",
+          "description": "Updated body for the draft. There is no `content_type` argument — the body is encoded to match the existing draft, and reply drafts re-attach their existing reply-quote tail. For multipart drafts or drafts with attachments, omit body and update only subject, recipient, cc, or bcc. Omit or pass None to leave the body unchanged.",
           "enum": null,
           "inferrable": true
         },
@@ -1507,7 +1507,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Gmail.WhoAmI",
-      "fullyQualifiedName": "Gmail.WhoAmI@7.5.0",
+      "fullyQualifiedName": "Gmail.WhoAmI@7.5.1",
       "description": "Get comprehensive user profile and Gmail account information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Gmail account statistics, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1554,7 +1554,7 @@
     {
       "name": "WriteDraftEmail",
       "qualifiedName": "Gmail.WriteDraftEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftEmail@7.5.0",
+      "fullyQualifiedName": "Gmail.WriteDraftEmail@7.5.1",
       "description": "Compose a new email draft using the Gmail API, optionally with file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
@@ -1715,7 +1715,7 @@
     {
       "name": "WriteDraftReplyEmail",
       "qualifiedName": "Gmail.WriteDraftReplyEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@7.5.0",
+      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@7.5.1",
       "description": "Compose a draft reply to an email message, optionally with one or more file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
@@ -1899,6 +1899,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-06-19T12:27:49.684Z",
-  "summary": "The Gmail toolkit provides Arcade LLM tools for interacting with a user's Gmail account via the Gmail API. It enables reading, composing, sending, organizing, and searching email — covering the full message and draft lifecycle.\n\n## Capabilities\n\n- **Reading & searching:** List emails, threads, and drafts with built-in automated-email filtering (no-reply senders, non-primary categories); search threads by query or header; retrieve full threads by ID; toggle automated filtering with `exclude_automated=False`.\n- **Composing & sending:** Send emails directly or via draft, reply to messages (including draft replies), with support for file attachments supplied as `file://` URIs — file bytes are read client-side and never pass through the conversation.\n- **Draft management:** Create, update, list, send, and delete drafts; update supports subject, body, recipients, cc, and bcc with partial updates (omit fields to preserve them); body replacement handles plain-text and single-part HTML drafts with auto-conversion; multipart/attachment drafts support metadata-only updates.\n- **Label management:** List, create, and apply/remove labels on messages.\n- **Account info:** Retrieve the authenticated user's profile, email address, Gmail statistics, and profile picture via `WhoAmI`.\n- **Trash:** Move messages to trash.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via Google. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details."
+  "generatedAt": "2026-06-29T12:37:13.647Z",
+  "summary": "# Gmail Toolkit\n\nArcade's Gmail toolkit provides LLM-ready tools for interacting with Gmail via the Gmail API, enabling agents to read, compose, send, organize, and search email on behalf of authenticated users.\n\n## Capabilities\n\n- **Reading & searching:** List and search emails, threads, and drafts with built-in automated-email filtering (no-reply senders, non-primary categories); filtering can be disabled via `exclude_automated=False`. Retrieve threads by ID and search by header.\n- **Composing & drafts:** Create, update, and delete drafts (plain-text or HTML, with smart body-replacement rules); compose draft replies with preserved reply-quote tails.\n- **Sending:** Send new emails or existing drafts; reply to messages directly. All send operations support file attachments via `file://` URIs — file bytes are resolved client-side before the request, never passed through the conversation.\n- **Label management:** List, create, and apply or remove labels on messages; move messages to trash.\n- **Account introspection:** Retrieve the authenticated user's profile, email address, Gmail statistics, and profile picture via `WhoAmI`.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via Google. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details."
 }

--- a/toolkit-docs-generator/data/toolkits/googlecontacts.json
+++ b/toolkit-docs-generator/data/toolkits/googlecontacts.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleContacts",
   "label": "Google Contacts",
-  "version": "3.5.3",
+  "version": "3.6.0",
   "description": "Arcade.dev LLM tools for Google Contacts",
   "metadata": {
     "category": "productivity",
@@ -19,6 +19,7 @@
     "allScopes": [
       "https://www.googleapis.com/auth/contacts",
       "https://www.googleapis.com/auth/contacts.readonly",
+      "https://www.googleapis.com/auth/directory.readonly",
       "https://www.googleapis.com/auth/userinfo.email",
       "https://www.googleapis.com/auth/userinfo.profile"
     ]
@@ -27,7 +28,7 @@
     {
       "name": "CreateContact",
       "qualifiedName": "GoogleContacts.CreateContact",
-      "fullyQualifiedName": "GoogleContacts.CreateContact@3.5.3",
+      "fullyQualifiedName": "GoogleContacts.CreateContact@3.6.0",
       "description": "Create a new contact record in Google Contacts.\n\nExamples:\n```\ncreate_contact(given_name=\"Alice\")\ncreate_contact(given_name=\"Alice\", family_name=\"Smith\")\ncreate_contact(given_name=\"Alice\", email=\"alice@example.com\")\ncreate_contact(given_name=\"Alice\", phone_number=\"+1234567890\")\ncreate_contact(\n    given_name=\"Alice\",\n    family_name=\"Smith\",\n    email=\"alice@example.com\",\n    phone_number=\"+1234567890\",\n)\n```",
       "parameters": [
         {
@@ -74,7 +75,7 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "A dictionary containing the details of the created contact"
+        "description": "No description provided."
       },
       "documentationChunks": [],
       "codeExample": {
@@ -124,7 +125,7 @@
     {
       "name": "SearchContactsByEmail",
       "qualifiedName": "GoogleContacts.SearchContactsByEmail",
-      "fullyQualifiedName": "GoogleContacts.SearchContactsByEmail@3.5.3",
+      "fullyQualifiedName": "GoogleContacts.SearchContactsByEmail@3.6.0",
       "description": "Search the user's contacts in Google Contacts by email address.",
       "parameters": [
         {
@@ -155,7 +156,7 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "A dictionary containing the list of matching contacts"
+        "description": "No description provided."
       },
       "documentationChunks": [],
       "codeExample": {
@@ -195,7 +196,7 @@
     {
       "name": "SearchContactsByName",
       "qualifiedName": "GoogleContacts.SearchContactsByName",
-      "fullyQualifiedName": "GoogleContacts.SearchContactsByName@3.5.3",
+      "fullyQualifiedName": "GoogleContacts.SearchContactsByName@3.6.0",
       "description": "Search the user's contacts in Google Contacts by name.",
       "parameters": [
         {
@@ -226,7 +227,7 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "A dictionary containing the list of matching contacts"
+        "description": "No description provided."
       },
       "documentationChunks": [],
       "codeExample": {
@@ -266,7 +267,7 @@
     {
       "name": "SearchContactsByPhoneNumber",
       "qualifiedName": "GoogleContacts.SearchContactsByPhoneNumber",
-      "fullyQualifiedName": "GoogleContacts.SearchContactsByPhoneNumber@3.5.3",
+      "fullyQualifiedName": "GoogleContacts.SearchContactsByPhoneNumber@3.6.0",
       "description": "Search the user's contacts in Google Contacts by phone number.",
       "parameters": [
         {
@@ -297,7 +298,7 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "A dictionary containing the list of matching contacts"
+        "description": "No description provided."
       },
       "documentationChunks": [],
       "codeExample": {
@@ -335,9 +336,93 @@
       }
     },
     {
+      "name": "SearchDirectoryPeople",
+      "qualifiedName": "GoogleContacts.SearchDirectoryPeople",
+      "fullyQualifiedName": "GoogleContacts.SearchDirectoryPeople@3.6.0",
+      "description": "Search the user's Google Workspace organization directory by name or email.\nUse this to resolve a colleague's email address when they are not in the\nuser's personal Contacts (e.g. someone elsewhere in the same company).\n\nReturns one page of people. When has_next_page is true, call again with the same\nquery and limit plus the returned next_page_token to fetch the next page — Google\nrejects a continuation whose query or limit differs from the original call.",
+      "parameters": [
+        {
+          "name": "query",
+          "type": "string",
+          "required": true,
+          "description": "Name or email to search for in the organization's directory",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of people to return per page (1-100). Defaults to 30. Keep this value unchanged across paginated calls.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "page_token",
+          "type": "string",
+          "required": false,
+          "description": "Token from a previous response's next_page_token to fetch the next page. Leave empty to fetch the first page.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "google",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://www.googleapis.com/auth/directory.readonly"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "GoogleContacts.SearchDirectoryPeople",
+        "parameters": {
+          "query": {
+            "value": "jane.doe@example.com",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "page_token": {
+            "value": "CAESAhAB",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "WhoAmI",
       "qualifiedName": "GoogleContacts.WhoAmI",
-      "fullyQualifiedName": "GoogleContacts.WhoAmI@3.5.3",
+      "fullyQualifiedName": "GoogleContacts.WhoAmI@3.6.0",
       "description": "Get comprehensive user profile and Google Contacts environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Contacts access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -392,6 +477,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-06-05T12:07:56.906Z",
-  "summary": "Google Contacts (Arcade.dev) toolkit enables LLM-driven apps to read, create, and manage a user's Google Contacts and profile data with OAuth-backed access. It provides consolidated contact operations and user environment insights for chatbots, CRMs, and automation.\n\n**Capabilities**\n- Create and update structured contact records (names, emails, phones) and return normalized contact payloads.\n- Search and retrieve contacts by name, email, or phone with consistent result formatting and paging support.\n- Access authenticated user profile and Contacts environment metadata (permissions, profile picture, email).\n- Field validation, normalization, and merge/deduplication-ready metadata to aid downstream workflows.\n\n**OAuth**\nProvider: google\nScopes:\n- https://www.googleapis.com/auth/contacts\n- https://www.googleapis.com/auth/contacts.readonly\n- https://www.googleapis.com/auth/userinfo.email\n- https://www.googleapis.com/auth/userinfo.profile"
+  "generatedAt": "2026-06-29T12:37:19.426Z",
+  "summary": "The Google Contacts toolkit provides Arcade tools for managing personal contacts and querying Google Workspace organization directories via the Google People API.\n\n## Capabilities\n\n- **Contact creation** — Create new contact records with any combination of name, email, and phone number fields.\n- **Multi-field contact search** — Look up contacts in the authenticated user's personal Google Contacts by name, email address, or phone number.\n- **Directory search** — Search the user's Google Workspace organization directory by name or email to resolve colleagues not in personal contacts; supports paginated results via `next_page_token`.\n- **User profile introspection** — Retrieve the authenticated user's profile details, permissions, and Google Contacts environment context.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via Google. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details."
 }

--- a/toolkit-docs-generator/data/toolkits/googledocs.json
+++ b/toolkit-docs-generator/data/toolkits/googledocs.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleDocs",
   "label": "Google Docs",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Arcade.dev LLM tools for Google Docs",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "CommentOnDocument",
       "qualifiedName": "GoogleDocs.CommentOnDocument",
-      "fullyQualifiedName": "GoogleDocs.CommentOnDocument@7.0.1",
+      "fullyQualifiedName": "GoogleDocs.CommentOnDocument@7.0.2",
       "description": "Comment on a specific document by its ID.",
       "parameters": [
         {
@@ -106,7 +106,7 @@
     {
       "name": "CreateBlankDocument",
       "qualifiedName": "GoogleDocs.CreateBlankDocument",
-      "fullyQualifiedName": "GoogleDocs.CreateBlankDocument@7.0.1",
+      "fullyQualifiedName": "GoogleDocs.CreateBlankDocument@7.0.2",
       "description": "Create a blank Google Docs document with the specified title.",
       "parameters": [
         {
@@ -166,7 +166,7 @@
     {
       "name": "CreateDocumentFromText",
       "qualifiedName": "GoogleDocs.CreateDocumentFromText",
-      "fullyQualifiedName": "GoogleDocs.CreateDocumentFromText@7.0.1",
+      "fullyQualifiedName": "GoogleDocs.CreateDocumentFromText@7.0.2",
       "description": "Create a Google Docs document with the specified title and text content.\n\nWhen input_format is MARKDOWN, the text_content is parsed as Markdown and the resulting\ndocument is formatted with headings, bold, italic, bullet lists, and numbered lists.",
       "parameters": [
         {
@@ -255,7 +255,7 @@
     {
       "name": "EditDocument",
       "qualifiedName": "GoogleDocs.EditDocument",
-      "fullyQualifiedName": "GoogleDocs.EditDocument@7.0.1",
+      "fullyQualifiedName": "GoogleDocs.EditDocument@7.0.2",
       "description": "Read or edit a Google Docs document using structured batchUpdate requests.\n\nWhen called without requests, returns the document content in DocMD format (block IDs,\ncharacter indices, and text styles). When called with requests, applies the edits and\nreturns the updated DocMD. Use the DocMD indices from the response to construct\nrequests for subsequent calls.",
       "parameters": [
         {
@@ -442,7 +442,7 @@
     {
       "name": "GenerateGoogleFilePickerUrl",
       "qualifiedName": "GoogleDocs.GenerateGoogleFilePickerUrl",
-      "fullyQualifiedName": "GoogleDocs.GenerateGoogleFilePickerUrl@7.0.1",
+      "fullyQualifiedName": "GoogleDocs.GenerateGoogleFilePickerUrl@7.0.2",
       "description": "Generate a URL where the user can grant this app access to specific Drive files.\n\nOpens Google's first-party Drive picker. The user selects which files to share\nwith this application — it is not a sign-in or credential prompt.\n\nUse this when a prior tool reported that a file was not found or access was denied,\nand the user expects the file to exist. After the user completes the picker flow,\nretry the prior tool.",
       "parameters": [],
       "auth": {
@@ -485,7 +485,7 @@
     {
       "name": "GetDocumentAsDocmd",
       "qualifiedName": "GoogleDocs.GetDocumentAsDocmd",
-      "fullyQualifiedName": "GoogleDocs.GetDocumentAsDocmd@7.0.1",
+      "fullyQualifiedName": "GoogleDocs.GetDocumentAsDocmd@7.0.2",
       "description": "Get the latest version of the specified Google Docs document as DocMD.\nThe DocMD output will include tags that can be used to annotate the document with location\ninformation, the type of block, block IDs, and other metadata. If the document has tabs,\nall tabs are included in sequential order unless a specific tab_id is provided.",
       "parameters": [
         {
@@ -565,7 +565,7 @@
     {
       "name": "GetDocumentById",
       "qualifiedName": "GoogleDocs.GetDocumentById",
-      "fullyQualifiedName": "GoogleDocs.GetDocumentById@7.0.1",
+      "fullyQualifiedName": "GoogleDocs.GetDocumentById@7.0.2",
       "description": "DEPRECATED DO NOT USE THIS TOOL\nGet the latest version of the specified Google Docs document.",
       "parameters": [
         {
@@ -632,7 +632,7 @@
     {
       "name": "GetDocumentMetadata",
       "qualifiedName": "GoogleDocs.GetDocumentMetadata",
-      "fullyQualifiedName": "GoogleDocs.GetDocumentMetadata@7.0.1",
+      "fullyQualifiedName": "GoogleDocs.GetDocumentMetadata@7.0.2",
       "description": "Get metadata for a Google Docs document including hierarchical tab structure.\nReturns document title, ID, URL, total character count, and nested tab information\nwith character counts for each tab.",
       "parameters": [
         {
@@ -699,7 +699,7 @@
     {
       "name": "InsertTextAtEndOfDocument",
       "qualifiedName": "GoogleDocs.InsertTextAtEndOfDocument",
-      "fullyQualifiedName": "GoogleDocs.InsertTextAtEndOfDocument@7.0.1",
+      "fullyQualifiedName": "GoogleDocs.InsertTextAtEndOfDocument@7.0.2",
       "description": "Updates an existing Google Docs document using the batchUpdate API endpoint.",
       "parameters": [
         {
@@ -779,7 +779,7 @@
     {
       "name": "ListDocumentComments",
       "qualifiedName": "GoogleDocs.ListDocumentComments",
-      "fullyQualifiedName": "GoogleDocs.ListDocumentComments@7.0.1",
+      "fullyQualifiedName": "GoogleDocs.ListDocumentComments@7.0.2",
       "description": "List all comments on the specified Google Docs document.",
       "parameters": [
         {
@@ -859,7 +859,7 @@
     {
       "name": "SearchAndRetrieveDocuments",
       "qualifiedName": "GoogleDocs.SearchAndRetrieveDocuments",
-      "fullyQualifiedName": "GoogleDocs.SearchAndRetrieveDocuments@7.0.1",
+      "fullyQualifiedName": "GoogleDocs.SearchAndRetrieveDocuments@7.0.2",
       "description": "Searches for documents in the user's Google Drive and returns documents with their main body\ncontent and tab metadata. Excludes documents that are in the trash.\n\nReturns main body content only with metadata about tabs. Use get_document_as_docmd() to retrieve\nfull tab content for specific documents. Use search_documents() for metadata-only searches.",
       "parameters": [
         {
@@ -953,7 +953,7 @@
           "name": "limit",
           "type": "integer",
           "required": false,
-          "description": "The number of documents to list",
+          "description": "The number of documents to search and retrieve (max 50). Defaults to 10.",
           "enum": null,
           "inferrable": true
         },
@@ -1070,7 +1070,7 @@
     {
       "name": "SearchDocuments",
       "qualifiedName": "GoogleDocs.SearchDocuments",
-      "fullyQualifiedName": "GoogleDocs.SearchDocuments@7.0.1",
+      "fullyQualifiedName": "GoogleDocs.SearchDocuments@7.0.2",
       "description": "Searches for documents in the user's Google Drive. Excludes documents in trash.\nReturns metadata only. Use get_document_metadata or get_document_as_docmd for content.",
       "parameters": [
         {
@@ -1263,7 +1263,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleDocs.WhoAmI",
-      "fullyQualifiedName": "GoogleDocs.WhoAmI@7.0.1",
+      "fullyQualifiedName": "GoogleDocs.WhoAmI@7.0.2",
       "description": "Get comprehensive user profile and Google Docs environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Docs access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1334,6 +1334,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-06-05T12:07:56.906Z",
-  "summary": "## Google Docs Toolkit\n\nThe Google Docs toolkit lets LLM agents create, read, edit, search, and annotate Google Docs documents through the Google Docs and Drive APIs via Arcade.\n\n## Capabilities\n\n- **Document creation:** Create blank documents or populate them from plain text or Markdown (with automatic heading, bold, italic, and list formatting).\n- **Document reading & metadata:** Retrieve full document content in DocMD format (block IDs, character indices, text styles, tab structure) or fetch metadata-only (title, ID, URL, character counts, tab hierarchy).\n- **Structured editing:** Apply batchUpdate requests using DocMD indices for precise in-document edits; append text to document ends.\n- **Search & discovery:** Search Drive for documents by query, with options to return metadata only or include full body content; trash is automatically excluded.\n- **Comments:** Add new comments to a document or list all existing comments.\n- **User & access management:** Retrieve authenticated user profile and permissions; generate a Google Drive inline file picker URL to grant per-file access when a document is not found or access is denied.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 with **Google** as the provider. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details.\n\n## Secrets\n\n- **`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL`** — A flag/URL secret that activates the `GenerateGoogleFilePickerUrl` tool, which opens Google's first-party Drive file picker so users can grant the app access to specific files without a full re-authentication flow. To obtain or configure this value, you set it in your Arcade environment to enable the picker endpoint. Refer to the [Arcade secrets documentation](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to define secrets, and manage them at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
+  "generatedAt": "2026-06-29T12:37:13.641Z",
+  "summary": "**Google Docs toolkit** connects Arcade to the Google Docs and Drive APIs, enabling LLMs to create, read, edit, search, and annotate Docs documents on behalf of authenticated users.\n\n## Capabilities\n\n- **Document creation** — create blank documents or documents pre-populated with plain text or Markdown (headings, bold, italic, lists auto-formatted).\n- **Document reading** — retrieve full document content in DocMD format (block IDs, character indices, text styles, tab structure) or metadata-only (title, ID, URL, character counts, tab hierarchy).\n- **Structured editing** — apply `batchUpdate` requests using DocMD indices to make precise in-place edits; append text to the end of a document.\n- **Search & discovery** — search Google Drive for Docs by query, returning metadata only or combined metadata + body content; trash is always excluded.\n- **Comments** — add new comments to a document and list all existing comments.\n- **Identity & access** — inspect the authenticated user's profile and permissions; generate a Google Drive inline file picker URL so users can grant the app access to specific files when a prior tool reported not-found or access-denied.\n\n## OAuth\n\nThis toolkit uses **OAuth 2.0** via the [Arcade Google provider](https://docs.arcade.dev/en/references/auth-providers/google). Arcade manages token acquisition and refresh; no manual credential handling is required.\n\n## Secrets\n\n`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL` — an API key that gates the `GoogleDocs.GenerateGoogleFilePickerUrl` tool. This key enables the embedded Google Drive file picker flow, which lets users grant the application access to specific Drive files without a full re-auth. To obtain it, contact Arcade support or retrieve it from your [Arcade dashboard](https://api.arcade.dev/dashboard/auth/secrets) once the feature is provisioned for your account.\n\nFor general guidance on configuring secrets in Arcade, see the [Tool Secrets docs](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/googledrive.json
+++ b/toolkit-docs-generator/data/toolkits/googledrive.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleDrive",
   "label": "Google Drive",
-  "version": "6.0.1",
+  "version": "6.2.0",
   "description": "Arcade.dev LLM tools for Google Drive",
   "metadata": {
     "category": "productivity",
@@ -18,15 +18,90 @@
     "providerId": "google",
     "allScopes": [
       "https://www.googleapis.com/auth/drive.file",
+      "https://www.googleapis.com/auth/drive.readonly",
       "https://www.googleapis.com/auth/userinfo.email",
       "https://www.googleapis.com/auth/userinfo.profile"
     ]
   },
   "tools": [
     {
+      "name": "CheckFileAccess",
+      "qualifiedName": "GoogleDrive.CheckFileAccess",
+      "fullyQualifiedName": "GoogleDrive.CheckFileAccess@6.2.0",
+      "description": "Check whether this app can already read each of several Drive files, in one batched\npre-flight call, before attempting to read them.\n\nUse this when the user references multiple files so any that are not yet accessible can\nbe granted together in a single picker step, instead of hitting a separate access error\nand grant prompt for each one. Each input may be a bare file id or a full Google\nDrive/Workspace URL (documents, spreadsheets, slides, PDFs, images, folders — any type).\n\nReturns ``files`` (a per-id list with ``accessible``, the ``title`` and ``mime_type``\nwhen the file was read, and a ``reason`` when not usable), ``all_accessible`` (true only\nwhen every id is already accessible), ``connected_account_email`` (the connected Google\naccount, empty when unknown), and a ``grant`` block. ``grant`` is empty when nothing needs\ngranting; otherwise it lists the ungranted ids (``ungranted_ids``) plus, when the inline\npicker is enabled, a single picker URL covering them all.\n\nA ``reason`` of ``not_accessible_or_not_found`` is either a file not granted to this app\nyet or one that does not exist (indistinguishable here) — the picker resolves the former.\n``invalid_reference`` is an input that is not a Drive id or link at all; ask the user to\nre-check it. ``error`` is a transient server-side failure (a timeout or 5xx) that the\npicker cannot fix; the same inputs may be retried later.",
+      "parameters": [
+        {
+          "name": "files",
+          "type": "array",
+          "innerType": "string",
+          "required": true,
+          "description": "The files to check access for, each given as a bare Drive file id or a full Google Drive/Workspace URL (the id is extracted from the URL). Provide at most 50 per call; split larger lists across multiple calls.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "google",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://www.googleapis.com/auth/drive.file"
+        ]
+      },
+      "secrets": [
+        "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL",
+          "type": "token"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Per-id accessibility (`files`), an `all_accessible` flag, the `connected_account_email` (the Google account this app is connected through), and a `grant` block — empty when nothing needs granting, otherwise listing the ungranted ids with one consolidated picker URL covering them all."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "GoogleDrive.CheckFileAccess",
+        "parameters": {
+          "files": {
+            "value": [
+              "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
+              "https://docs.google.com/spreadsheets/d/1v2t3r4e5x6a7m8p9l0eid/edit",
+              "https://drive.google.com/file/d/1A2B3C4D5E6F7G8H9I0JkLmNoPqRsTuV/view?usp=sharing",
+              "https://docs.google.com/presentation/d/1z2y3x4w5v6u7t8s9r0qpOnMlKjIhGfEd/edit#slide=id.p",
+              "https://docs.google.com/document/d/1aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890/edit"
+            ],
+            "type": "array",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "cloud_storage"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "CreateFolder",
       "qualifiedName": "GoogleDrive.CreateFolder",
-      "fullyQualifiedName": "GoogleDrive.CreateFolder@6.0.1",
+      "fullyQualifiedName": "GoogleDrive.CreateFolder@6.2.0",
       "description": "Create a new folder in Google Drive.\n\nBy default, parent folder paths are resolved in My Drive. For shared drives, use folder IDs\nor provide shared_drive_id.",
       "parameters": [
         {
@@ -119,7 +194,7 @@
     {
       "name": "DownloadFile",
       "qualifiedName": "GoogleDrive.DownloadFile",
-      "fullyQualifiedName": "GoogleDrive.DownloadFile@6.0.1",
+      "fullyQualifiedName": "GoogleDrive.DownloadFile@6.2.0",
       "description": "Download a blob file (non-workspace file) from Google Drive as base64 encoded content.\n\nFor small files (under ~5MB raw), returns the file content directly in the response as base64.\nFor large files, returns metadata with requires_chunked_download=True - use download_file_chunk\nto retrieve the file in parts.\n\nBy default, paths are resolved in My Drive. For shared drives, use file IDs or provide\nshared_drive_id.",
       "parameters": [
         {
@@ -199,7 +274,7 @@
     {
       "name": "DownloadFileChunk",
       "qualifiedName": "GoogleDrive.DownloadFileChunk",
-      "fullyQualifiedName": "GoogleDrive.DownloadFileChunk@6.0.1",
+      "fullyQualifiedName": "GoogleDrive.DownloadFileChunk@6.2.0",
       "description": "Download a specific byte range of a file from Google Drive.\n\nUse this for large files that require chunked download (when download_file returns\nrequires_chunked_download=True). Call repeatedly with increasing start_byte values\nto retrieve the complete file.\n\nReturns the chunk content as base64, along with progress information including\nwhether this is the final chunk.",
       "parameters": [
         {
@@ -305,9 +380,32 @@
     {
       "name": "GenerateGoogleFilePickerUrl",
       "qualifiedName": "GoogleDrive.GenerateGoogleFilePickerUrl",
-      "fullyQualifiedName": "GoogleDrive.GenerateGoogleFilePickerUrl@6.0.1",
-      "description": "Generate a URL where the user can grant this app access to specific Drive files.\n\nOpens Google's first-party Drive picker. The user selects which files to share\nwith this application — it is not a sign-in or credential prompt.\n\nUse this when a prior tool reported that a file was not found or access was denied,\nand the user expects the file to exist. After the user completes the picker flow,\nretry the prior tool.",
-      "parameters": [],
+      "fullyQualifiedName": "GoogleDrive.GenerateGoogleFilePickerUrl@6.2.0",
+      "description": "Generate a URL where the user can grant this app access to specific Drive files.\n\nOpens Google's first-party Drive picker. The user selects which files to share\nwith this application — it is not a sign-in or credential prompt. By default the picker\nshows files of all types; pass ``file_types`` to restrict it to specific types.\n\nUse this when a prior tool reported that a file was not found or access was denied,\nand the user expects the file to exist. After the user completes the picker flow,\nretry the prior tool.",
+      "parameters": [
+        {
+          "name": "file_types",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Restrict the picker to these Google Drive file types. Defaults to None, which lets the user pick files of any type.",
+          "enum": [
+            "spreadsheet",
+            "slides",
+            "document",
+            "drawing",
+            "form",
+            "folder",
+            "image",
+            "video",
+            "audio",
+            "script",
+            "sites",
+            "pdf"
+          ],
+          "inferrable": true
+        }
+      ],
       "auth": {
         "providerId": "google",
         "providerType": "oauth2",
@@ -322,7 +420,17 @@
       "documentationChunks": [],
       "codeExample": {
         "toolName": "GoogleDrive.GenerateGoogleFilePickerUrl",
-        "parameters": {},
+        "parameters": {
+          "file_types": {
+            "value": [
+              "application/vnd.google-apps.document",
+              "application/vnd.google-apps.spreadsheet",
+              "application/pdf"
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
         "requiresAuth": true,
         "authProvider": "google",
         "tabLabel": "Call the Tool with User Authorization"
@@ -348,7 +456,7 @@
     {
       "name": "GetFileTreeStructure",
       "qualifiedName": "GoogleDrive.GetFileTreeStructure",
-      "fullyQualifiedName": "GoogleDrive.GetFileTreeStructure@6.0.1",
+      "fullyQualifiedName": "GoogleDrive.GetFileTreeStructure@6.2.0",
       "description": "Get the file/folder tree structure of the user's entire Google Drive.\nVery inefficient for large drives. Use with caution.",
       "parameters": [
         {
@@ -494,7 +602,7 @@
     {
       "name": "ListFilePermissions",
       "qualifiedName": "GoogleDrive.ListFilePermissions",
-      "fullyQualifiedName": "GoogleDrive.ListFilePermissions@6.0.1",
+      "fullyQualifiedName": "GoogleDrive.ListFilePermissions@6.2.0",
       "description": "List permissions on a Google Drive file or folder.\n\nReturns the individual people (and groups) with access and the current General access\n(link sharing) state. `general_access` is computed across the ENTIRE file regardless of\nfiltering -- so \"is this doc public?\" is always answered authoritatively.\n\nWhen `roles` is provided, `people` and `total_people` reflect only collaborators whose\nrole matches the filter. Truncated collaborators beyond `limit` are not returned;\n`has_more` indicates whether truncation occurred.",
       "parameters": [
         {
@@ -609,7 +717,7 @@
     {
       "name": "MoveFile",
       "qualifiedName": "GoogleDrive.MoveFile",
-      "fullyQualifiedName": "GoogleDrive.MoveFile@6.0.1",
+      "fullyQualifiedName": "GoogleDrive.MoveFile@6.2.0",
       "description": "Move a file or folder to a different folder within the same Google Drive.\n\nCan move to a folder (keeping name), or move and rename in one operation. By default, paths\nare resolved in My Drive. For shared drives, use file IDs or provide shared_drive_id.",
       "parameters": [
         {
@@ -715,7 +823,7 @@
     {
       "name": "RemoveAllCollaborators",
       "qualifiedName": "GoogleDrive.RemoveAllCollaborators",
-      "fullyQualifiedName": "GoogleDrive.RemoveAllCollaborators@6.0.1",
+      "fullyQualifiedName": "GoogleDrive.RemoveAllCollaborators@6.2.0",
       "description": "Remove all user collaborators (and optionally groups) from a Google Drive file.\n\nThe file owner and the calling user are always preserved. Groups are preserved by default\nbecause the Drive API cannot verify group membership -- pass include_groups=True to opt in.\nInherited shared-drive permissions are never removable from the file level and are skipped.\n\nUse except_people to preserve additional people or groups by email or name. Ambiguous or\nunmatched except_people entries raise an error to avoid accidentally removing someone the\ncaller meant to keep.",
       "parameters": [
         {
@@ -825,7 +933,7 @@
     {
       "name": "RenameFile",
       "qualifiedName": "GoogleDrive.RenameFile",
-      "fullyQualifiedName": "GoogleDrive.RenameFile@6.0.1",
+      "fullyQualifiedName": "GoogleDrive.RenameFile@6.2.0",
       "description": "Rename a file or folder in Google Drive.\n\nBy default, paths are resolved in My Drive. For files in shared drives, either use the file ID\ndirectly or provide the shared_drive_id parameter.",
       "parameters": [
         {
@@ -918,7 +1026,7 @@
     {
       "name": "RevokeFileAccess",
       "qualifiedName": "GoogleDrive.RevokeFileAccess",
-      "fullyQualifiedName": "GoogleDrive.RevokeFileAccess@6.0.1",
+      "fullyQualifiedName": "GoogleDrive.RevokeFileAccess@6.2.0",
       "description": "Revoke access for specific people or groups on a Google Drive file.\n\nIdentifies matches by email (exact, case-insensitive) or display name. When an input\nmatches multiple people, the clear matches are still revoked and the ambiguous input is\nsurfaced in the `ambiguous` response field with candidate details so the agent can\nre-prompt the user for just the uncertain ones. Inputs that don't match any collaborator\nare returned in `not_found`. Pending-owner matches (mid-ownership-transfer) are skipped\nand surfaced in `skipped_pending_owner` so the clean revokes in the batch still land.\nOwner permissions cannot be revoked -- transfer ownership first.\n\nWhen a grantee has both a direct and an inherited permission (e.g., shared-drive member\nalso granted directly on the file), revoking the direct row leaves the inherited access\nintact. The inherited row is surfaced in `skipped_inherited` so callers don't assume the\ngrantee is fully removed -- inherited access must be adjusted at the shared drive level.",
       "parameters": [
         {
@@ -1014,9 +1122,192 @@
       }
     },
     {
+      "name": "SearchDrive",
+      "qualifiedName": "GoogleDrive.SearchDrive",
+      "fullyQualifiedName": "GoogleDrive.SearchDrive@6.2.0",
+      "description": "Search the user's entire Google Drive, including files they created or\nreceived directly in Drive — not only files created through this app.\n\nReads across the user's whole Drive, so it requires broad read access to\ntheir files. The provided 'query' should contain only the search terms; the\ntool builds the full Drive query for you, matching file names and contents.",
+      "parameters": [
+        {
+          "name": "query",
+          "type": "string",
+          "required": true,
+          "description": "The terms to search for in Google Drive. The tool builds the full Drive query for you, matching file names and file contents — provide only the search terms, not Drive query syntax.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "folder_path_or_id",
+          "type": "string",
+          "required": false,
+          "description": "Search only within this specific folder. Provide either a path like folder/subfolder or a folder ID. If None, searches across all accessible locations. Defaults to None.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "shared_drive_id",
+          "type": "string",
+          "required": false,
+          "description": "If provided, search only within this shared drive. Defaults to None (searches My Drive and optionally all shared drives).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "include_shared_drives",
+          "type": "boolean",
+          "required": false,
+          "description": "If True and shared_drive_id is not set, include all shared drives in search. Defaults to False (My Drive only).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "order_by",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Sort order for search results. Defaults to listing the most recently modified documents first. If the query contains 'fullText', then the order_by will be ignored.",
+          "enum": [
+            "createdTime",
+            "createdTime desc",
+            "folder",
+            "folder desc",
+            "modifiedByMeTime",
+            "modifiedByMeTime desc",
+            "modifiedTime",
+            "modifiedTime desc",
+            "name",
+            "name desc",
+            "name_natural",
+            "name_natural desc",
+            "quotaBytesUsed",
+            "quotaBytesUsed desc",
+            "recency",
+            "recency desc",
+            "sharedWithMeTime",
+            "sharedWithMeTime desc",
+            "starred",
+            "starred desc",
+            "viewedByMeTime",
+            "viewedByMeTime desc"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "The maximum number of search results to return (1-50). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "file_types",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Filter by specific file types. Defaults to None, which includes all file types.",
+          "enum": [
+            "spreadsheet",
+            "slides",
+            "document",
+            "drawing",
+            "form",
+            "folder",
+            "image",
+            "video",
+            "audio",
+            "script",
+            "sites",
+            "pdf"
+          ],
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "google",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://www.googleapis.com/auth/drive.readonly"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Search results containing matching files from Google Drive with metadata and file information"
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "GoogleDrive.SearchDrive",
+        "parameters": {
+          "query": {
+            "value": "quarterly budget report 2024",
+            "type": "string",
+            "required": true
+          },
+          "folder_path_or_id": {
+            "value": "Finance/Reports",
+            "type": "string",
+            "required": false
+          },
+          "shared_drive_id": {
+            "value": "0AHx3k9vBmXYZUk9PVA",
+            "type": "string",
+            "required": false
+          },
+          "include_shared_drives": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "order_by": {
+            "value": [
+              "modifiedTime desc",
+              "name asc"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "limit": {
+            "value": 15,
+            "type": "integer",
+            "required": false
+          },
+          "file_types": {
+            "value": [
+              "document",
+              "spreadsheet",
+              "pdf"
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "cloud_storage"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "SearchFiles",
       "qualifiedName": "GoogleDrive.SearchFiles",
-      "fullyQualifiedName": "GoogleDrive.SearchFiles@6.0.1",
+      "fullyQualifiedName": "GoogleDrive.SearchFiles@6.2.0",
       "description": "Search for files in Google Drive.\n\nThe provided 'query' should only contain the search terms.\nThe tool will construct the full search query for you.",
       "parameters": [
         {
@@ -1219,7 +1510,7 @@
     {
       "name": "SetGeneralAccess",
       "qualifiedName": "GoogleDrive.SetGeneralAccess",
-      "fullyQualifiedName": "GoogleDrive.SetGeneralAccess@6.0.1",
+      "fullyQualifiedName": "GoogleDrive.SetGeneralAccess@6.2.0",
       "description": "Change the 'General access' (link sharing) setting on a Google Drive file.\n\nIdempotent: calling with the same state as the current configuration is a no-op. When access\nis 'domain', the link is scoped to the caller's email domain -- NOT the file owner's domain.\nFor cross-org collaboration (e.g., editing a file owned by another organization), confirm\nwith the user which domain they intend before calling. Google will reject domain sharing\nfor personal accounts (gmail.com, outlook.com, etc.) -- the tool translates that rejection\ninto a friendly error.\n\nThe response's `access` and `role` fields report the EFFECTIVE state after the transition,\nnot the requested state. For files on shared drives, inherited link permissions cannot be\nchanged from the file level -- if the request would have required removing an inherited\npermission, the effective state will reflect the inherited permission that remained. When\n`skipped_inherited` is non-empty, inspect it to understand why effective state may differ\nfrom what was requested.",
       "parameters": [
         {
@@ -1346,7 +1637,7 @@
     {
       "name": "ShareFile",
       "qualifiedName": "GoogleDrive.ShareFile",
-      "fullyQualifiedName": "GoogleDrive.ShareFile@6.0.1",
+      "fullyQualifiedName": "GoogleDrive.ShareFile@6.2.0",
       "description": "Share a file or folder in Google Drive with specific people by granting them permissions.\n\nIf a user already has permission on the file, their role will be updated to the new role.\nBy default, paths are resolved in My Drive. For shared drives, use file IDs or provide\nshared_drive_id.",
       "parameters": [
         {
@@ -1487,7 +1778,7 @@
     {
       "name": "UploadFile",
       "qualifiedName": "GoogleDrive.UploadFile",
-      "fullyQualifiedName": "GoogleDrive.UploadFile@6.0.1",
+      "fullyQualifiedName": "GoogleDrive.UploadFile@6.2.0",
       "description": "Upload a file to Google Drive from a URL.\n\nFetches the file content from the provided URL and uploads it to Google Drive.\nSupports files of any size - uses resumable upload internally for large files.\n\nCANNOT upload Google Workspace files (Google Docs, Sheets, Slides)\nCANNOT upload files larger than 25MB",
       "parameters": [
         {
@@ -1618,7 +1909,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleDrive.WhoAmI",
-      "fullyQualifiedName": "GoogleDrive.WhoAmI@6.0.1",
+      "fullyQualifiedName": "GoogleDrive.WhoAmI@6.2.0",
       "description": "Get comprehensive user profile and Google Drive environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Drive storage information, the shared\ndrives (and their IDs) the user has access to, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1668,6 +1959,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-06-05T12:07:56.906Z",
-  "summary": "# Google Drive Toolkit\n\nThe Google Drive toolkit connects Arcade to Google Drive via OAuth, enabling LLMs to manage files, folders, sharing, and permissions on behalf of authenticated users.\n\n## Capabilities\n\n- **File & folder management:** Create folders, move, rename, and search files across My Drive and shared drives (by path or ID).\n- **Upload & download:** Upload files to Drive from a URL (up to 25 MB, non-Workspace formats); download blob files directly or in byte-range chunks for large files.\n- **Permissions & sharing:** Share files with specific people, revoke or bulk-remove collaborators, set general/link-sharing access (including domain scoping), and list all permissions with role filtering.\n- **Drive introspection:** Retrieve the full file/folder tree, look up authenticated user profile and storage info, and enumerate accessible shared drives and their IDs.\n- **File picker integration:** Generate a Google-hosted Drive Picker URL so users can grant the app access to specific files when a prior tool reports not-found or access-denied.\n\n## OAuth\n\nAuthentication uses OAuth 2.0 via the **Google** provider. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details.\n\n## Secrets\n\n- **`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL`** — Controls whether the `GoogleDrive.GenerateGoogleFilePickerUrl` tool surfaces an inline Google Drive Picker URL. This is an Arcade-side feature flag, not a credential issued by Google. Set its value in the Arcade secrets manager to enable the picker flow. There is no external provider dashboard for this secret; it is configured entirely within Arcade.\n\nSee the [Arcade secrets documentation](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to store and reference secrets, or manage them directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
+  "generatedAt": "2026-06-29T12:37:20.082Z",
+  "summary": "The Google Drive toolkit lets agents read, organize, share, and manage files in a user's Google Drive (including Shared Drives) via Arcade. It covers the full file lifecycle — discovery, access control, upload/download, and folder management.\n\n## Capabilities\n\n- **File discovery & search** — search across all of Drive (names + content), retrieve folder/file trees, resolve bare IDs or full Google Drive/Workspace URLs, and batch-check accessibility before attempting reads.\n- **File & folder management** — create folders, move/rename files, upload files from URLs (up to 25 MB), and download blob files directly or in byte-range chunks for large files.\n- **Access control & sharing** — share files with specific people, revoke individual or all collaborators, set general/link-sharing access (restricted, domain, anyone), list all permissions with role filtering, and generate a first-party Google Drive picker URL when files aren't yet granted to the app.\n- **Account & environment info** — retrieve the authenticated user's profile, email, storage quota, and the IDs of all Shared Drives they can access.\n\n## OAuth\n\nThis toolkit authenticates via OAuth 2.0 using the **Google** provider. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup instructions, required scopes, and configuration details.\n\n## Secrets\n\n`ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL` — A flag/URL secret that enables the inline Google Drive file picker feature. When set, tools such as `CheckFileAccess` and `GenerateGoogleFilePickerUrl` can return a picker URL directly in their responses, allowing users to grant file access without a separate redirect flow. To obtain or configure this value, you set it in your Arcade environment as a secret — it is not issued by Google but rather configured in your Arcade deployment to point to (or enable) the inline picker endpoint your app exposes. Refer to the [Arcade secrets documentation](https://docs.arcade.dev/en/guides/create-tools/tool-secrets/create-tool-secrets) for instructions on creating and managing tool secrets, and use the [Arcade dashboard](https://api.arcade.dev/dashboard/auth/secrets) to store the value."
 }

--- a/toolkit-docs-generator/data/toolkits/googlesheets.json
+++ b/toolkit-docs-generator/data/toolkits/googlesheets.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleSheets",
   "label": "Google Sheets",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "description": "Arcade.dev LLM tools for Google Sheets.",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "CheckSpreadsheetAccess",
       "qualifiedName": "GoogleSheets.CheckSpreadsheetAccess",
-      "fullyQualifiedName": "GoogleSheets.CheckSpreadsheetAccess@8.2.0",
+      "fullyQualifiedName": "GoogleSheets.CheckSpreadsheetAccess@8.2.1",
       "description": "Check whether this app can already read each of several spreadsheets, in one\nbatched pre-flight call, before attempting to read them.\n\nUse this when the user references multiple spreadsheets so any that are not yet\naccessible can be granted together in a single picker step, instead of hitting a\nseparate access error and grant prompt for each one. Each input may be a bare file id\nor a full Google Sheets/Drive URL.\n\nReturns ``spreadsheets`` (a per-id list with ``accessible``, the ``title`` and\n``mime_type`` when the file was read, and a ``reason`` when not usable),\n``all_accessible`` (true only when every id is an already-accessible spreadsheet),\n``connected_account_email`` (the connected Google account, empty when unknown), and a\n``grant`` block. ``grant`` is empty when nothing needs granting; otherwise it lists the\nungranted ids (``ungranted_ids``) plus, when the inline picker is enabled, a single\npicker URL covering them all.\n\nA ``reason`` of ``not_accessible_or_not_found`` is either a file not granted to this app\nyet or one that does not exist (indistinguishable here) — the picker resolves the\nformer. ``not_a_spreadsheet`` is an accessible file of another type (a Doc, PDF, image,\nor Excel/CSV file); granting cannot change a type, so for an Excel/CSV file ask the user\nto open it in Google Sheets and use File, Save as Google Sheets, then share the\nconverted file. ``invalid_reference`` is an input that is not a Drive id or link at all;\nask the user to re-check it.",
       "parameters": [
         {
@@ -99,7 +99,7 @@
     {
       "name": "CommentOnSpreadsheet",
       "qualifiedName": "GoogleSheets.CommentOnSpreadsheet",
-      "fullyQualifiedName": "GoogleSheets.CommentOnSpreadsheet@8.2.0",
+      "fullyQualifiedName": "GoogleSheets.CommentOnSpreadsheet@8.2.1",
       "description": "Create a comment on a spreadsheet, edit a comment's body, or resolve/reopen it.\n\nComments are created at the file level: the Drive API cannot anchor a NEW Sheets comment to a\nspecific cell or range. Cell/range-anchored comments made in the Sheets UI are still readable\nvia list_spreadsheet_comments (which returns their anchor). Editing a comment's body is\nallowed only for the comment's author.",
       "parameters": [
         {
@@ -209,7 +209,7 @@
     {
       "name": "CreateOrEditSpreadsheet",
       "qualifiedName": "GoogleSheets.CreateOrEditSpreadsheet",
-      "fullyQualifiedName": "GoogleSheets.CreateOrEditSpreadsheet@8.2.0",
+      "fullyQualifiedName": "GoogleSheets.CreateOrEditSpreadsheet@8.2.1",
       "description": "Create a new spreadsheet or batch-edit an existing one.\n\nOmit `spreadsheet_id` to create; provide it to edit. All writes flow through\n`requests[]` — typed operations like updateCells, addSheet, sortRange,\naddConditionalFormatRule, autoResizeDimensions, and more.\n\nFor updateCells use ExtendedValue with an explicit type field (stringValue,\nnumberValue, boolValue, formulaValue).\n\nBy default, build clean, professional-looking tables with restrained, consistent\nformatting and plain-text tab names/headers (no emojis); only use emojis or\ndecorative styling when the user explicitly asks for it.",
       "parameters": [
         {
@@ -660,7 +660,7 @@
     {
       "name": "DeleteComment",
       "qualifiedName": "GoogleSheets.DeleteComment",
-      "fullyQualifiedName": "GoogleSheets.DeleteComment@8.2.0",
+      "fullyQualifiedName": "GoogleSheets.DeleteComment@8.2.1",
       "description": "Delete a comment from a spreadsheet.\n\nOnly the comment's author can delete it (enforced by Google Drive); deleting marks the\nwhole thread (the comment and its replies) as deleted.",
       "parameters": [
         {
@@ -740,7 +740,7 @@
     {
       "name": "GenerateGoogleFilePickerUrl",
       "qualifiedName": "GoogleSheets.GenerateGoogleFilePickerUrl",
-      "fullyQualifiedName": "GoogleSheets.GenerateGoogleFilePickerUrl@8.2.0",
+      "fullyQualifiedName": "GoogleSheets.GenerateGoogleFilePickerUrl@8.2.1",
       "description": "Generate a URL where the user can grant this app access to spreadsheets.\n\nOpens Google's first-party Drive picker, filtered to Google Sheets, where the user\nbrowses and selects which spreadsheets to share with this application — it is not a\nsign-in or credential prompt.\n\nUse this when a prior tool reported that a file was not found or access was denied, and\nthe user expects the file to exist. After the user completes the picker flow, retry the\nprior operation.",
       "parameters": [],
       "auth": {
@@ -783,7 +783,7 @@
     {
       "name": "GetSpreadsheetEditHistory",
       "qualifiedName": "GoogleSheets.GetSpreadsheetEditHistory",
-      "fullyQualifiedName": "GoogleSheets.GetSpreadsheetEditHistory@8.2.0",
+      "fullyQualifiedName": "GoogleSheets.GetSpreadsheetEditHistory@8.2.1",
       "description": "Report who edited a spreadsheet and when, from Google Drive revisions.\n\nReports the \"who\" and \"when\" only — not which cells changed, and it can't revert.\n\n'summary' (default) answers \"who last edited this and when\" (read from the file's head,\nso always accurate), plus per-window aggregates (revisions read, contributors, first\nedit) and a preview of recent edits — computed over a bounded window of history per call.\nThese aggregates describe the whole history only when `is_incomplete` is false; it is\ntrue when the scan was resumed from a token and/or more history remains. To answer\n\"when was this first edited?\" or \"who contributed?\" reliably, call from the beginning\n(no `pagination_token`) and check `is_incomplete` is false. `pagination_token` is\nreturned when more pages remain so you can resume.\n\n'list' returns one page of individual revisions, oldest first. Drive can't sort\nnewest-first, so the most recent individual revisions are on the final page.",
       "parameters": [
         {
@@ -892,7 +892,7 @@
     {
       "name": "InspectSpreadsheet",
       "qualifiedName": "GoogleSheets.InspectSpreadsheet",
-      "fullyQualifiedName": "GoogleSheets.InspectSpreadsheet@8.2.0",
+      "fullyQualifiedName": "GoogleSheets.InspectSpreadsheet@8.2.1",
       "description": "Inspect a Google Sheets spreadsheet's structure or read a range of cells.\n\nUse the default 'structure' mode to understand a workbook cheaply before reading.\nSwitch to 'read' mode to pull a range as a grid of rows, optionally with\nper-cell annotations and a rendered markdown/csv/tsv export.\n\nIn 'read' mode the response's per-tab 'sheets' block reports only tab identity and\nthe allocated grid; its scan-derived fields (used_range, populated_cell_count,\nformula_cell_count, first_row, table_regions) are placeholders (0/empty) because read\nmode does not scan the tab — they do NOT mean the tab is empty or that it has no\ntables. The data you read is in the top-level 'range' and 'rows'. Call 'structure'\nmode for those aggregates and for the workbook's charts, merges, protected ranges, and\nconditional formats.\n\nWorkflow for a tab that holds multiple tables, or a table that does not start at A1:\ncall 'structure' first and use that tab's estimated 'table_regions' to choose the\na1_range to read or filter, so you target one table instead of a glued multi-table\nrange.\n\nAlways check the response's top-level 'warnings' list: read mode reports there when a\nresult was capped or trimmed (cell budget, the per-cell annotation cap, or an empty\nfilter scan) and tells you how to recover (page 'next_range', narrow 'a1_range',\n'select_columns', or request fewer annotation kinds).",
       "parameters": [
         {
@@ -1174,7 +1174,7 @@
     {
       "name": "ListSpreadsheetComments",
       "qualifiedName": "GoogleSheets.ListSpreadsheetComments",
-      "fullyQualifiedName": "GoogleSheets.ListSpreadsheetComments@8.2.0",
+      "fullyQualifiedName": "GoogleSheets.ListSpreadsheetComments@8.2.1",
       "description": "List a spreadsheet's comment threads, or the full replies of a single comment.\n\nIn 'comments' mode each comment includes up to a few trimmed reply previews plus the total reply_count; use 'thread' mode for a comment's complete reply list. Without filters/ordering, pagination walks every comment. Client-side filters (has_replies, resolved) and order_by are applied only within a bounded scan of the first 500 comments, so on larger sheets drop them and page through everything with the native (unbounded) pagination. Each comment's Drive anchor is returned when it was cell/range-anchored in the Sheets UI; comments created via the API are file-level. Filtering, ordering, and offset pagination are best-effort: results can drift if comments are added or removed between paginated calls.",
       "parameters": [
         {
@@ -1397,7 +1397,7 @@
     {
       "name": "ReplyToComment",
       "qualifiedName": "GoogleSheets.ReplyToComment",
-      "fullyQualifiedName": "GoogleSheets.ReplyToComment@8.2.0",
+      "fullyQualifiedName": "GoogleSheets.ReplyToComment@8.2.1",
       "description": "Add a reply to an existing comment on a spreadsheet.\n\nTo resolve or reopen the comment instead, use comment_on_spreadsheet with a status.",
       "parameters": [
         {
@@ -1490,7 +1490,7 @@
     {
       "name": "ScanForDataIssues",
       "qualifiedName": "GoogleSheets.ScanForDataIssues",
-      "fullyQualifiedName": "GoogleSheets.ScanForDataIssues@8.2.0",
+      "fullyQualifiedName": "GoogleSheets.ScanForDataIssues@8.2.1",
       "description": "Deterministically flag 'weird'/bad cells in spreadsheet data.\n\nNo LLM judgement: the same input always returns the same flags. Each cell-level finding\ncarries a coord, a 0-based row_index/column_index (ready for a Sheets GridRange), the rule,\na severity (high -> red, medium/low -> yellow), and a note-ready reason — so the output\ndrops straight into an annotate/format recipe. In the default `mode='grouped'` these are\naggregated per rule+column within each table into `groups` (with A1 `coords`); use\n`mode='list'` to get every flagged cell in `flags` with its 0-based indices.\n\nProvide `spreadsheet_id` to scan a live sheet (scan one tab via sheet_id/sheet_title, or\nevery tab when both are omitted). Set `orientation='rows'` for transposed tables whose\nfields run down a column instead of across a row. Findings come back as flags (cell-level,\nhigh certainty) and alerts (table-level, lower certainty), grouped sheet -> table -> rule.\n\nIn all-sheets mode an unreadable tab never aborts the scan: its title is collected in\n`failed_sheets` (and echoed as a `warnings` entry) while every other tab still returns.\n`failed_sheets` is empty for a single-tab scan and whenever every tab reads cleanly.",
       "parameters": [
         {
@@ -1712,7 +1712,7 @@
     {
       "name": "SearchSpreadsheets",
       "qualifiedName": "GoogleSheets.SearchSpreadsheets",
-      "fullyQualifiedName": "GoogleSheets.SearchSpreadsheets@8.2.0",
+      "fullyQualifiedName": "GoogleSheets.SearchSpreadsheets@8.2.1",
       "description": "Searches for spreadsheets in the user's Google Drive based on the titles and content and\nreturns the title, ID, and URL for each matching spreadsheet.\n\nDoes not return the content/data of the sheets in the spreadsheets - only the metadata.\nExcludes spreadsheets that are in the trash.",
       "parameters": [
         {
@@ -1905,7 +1905,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleSheets.WhoAmI",
-      "fullyQualifiedName": "GoogleSheets.WhoAmI@8.2.0",
+      "fullyQualifiedName": "GoogleSheets.WhoAmI@8.2.1",
       "description": "Get comprehensive user profile and Google Sheets environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Sheets access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1955,6 +1955,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-06-17T12:31:32.590Z",
+  "generatedAt": "2026-06-29T12:37:13.641Z",
   "summary": "**Google Sheets toolkit** integrates Arcade with Google Sheets and Google Drive, enabling LLM-powered agents to read, write, comment on, audit, and search spreadsheets on behalf of authenticated users.\n\n## Capabilities\n\n- **Access pre-flight & file discovery:** Batch-check spreadsheet accessibility before reading, generate Drive picker URLs to grant access, and search spreadsheets by title/content across a user's Drive.\n- **Read & inspect spreadsheets:** Retrieve workbook structure (tabs, charts, merges, protected ranges, conditional formats) or read specific cell ranges with optional markdown/CSV/TSV export and per-cell annotations.\n- **Write & edit spreadsheets:** Create new spreadsheets or apply batch edits to existing ones using typed operations (cell updates, sheet additions, sort, conditional formatting, auto-resize, and more).\n- **Comments & collaboration:** List, create, edit, resolve/reopen, reply to, and delete comment threads; supports both file-level and cell/range-anchored comments.\n- **Data quality scanning:** Deterministically flag bad/weird cells by rule and severity with zero-based grid coordinates ready for downstream annotation or formatting recipes.\n- **Edit history & identity:** Inspect Drive revision history (contributors, timestamps, pagination) and retrieve the authenticated user's profile and permissions.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via the **Google** provider. Arcade handles the OAuth flow automatically. See the [Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details.\n\n## Secrets\n\n### `ENABLE_GOOGLE_DRIVE_INLINE_PICKER_URL`\n\nThis secret controls whether the inline Google Drive picker URL feature is enabled. When set, `CheckSpreadsheetAccess` and `GenerateGoogleFilePickerUrl` will return a ready-to-use picker URL inside the tool response instead of requiring a separate step to generate one. This is a feature-flag-style value configured in your Arcade environment — it is not a credential issued by Google.\n\nObtain or configure this value through your Arcade dashboard at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets).\n\nFor full details on defining and using secrets in Arcade tools, see the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets)."
 }

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-23T12:07:49.483Z",
+  "generatedAt": "2026-06-29T12:37:34.138Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -347,7 +347,7 @@
     {
       "id": "Gmail",
       "label": "Gmail",
-      "version": "7.5.0",
+      "version": "7.5.1",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 18,
@@ -365,16 +365,16 @@
     {
       "id": "GoogleContacts",
       "label": "Google Contacts",
-      "version": "3.5.3",
+      "version": "3.6.0",
       "category": "productivity",
       "type": "arcade",
-      "toolCount": 5,
+      "toolCount": 6,
       "authType": "oauth2"
     },
     {
       "id": "GoogleDocs",
       "label": "Google Docs",
-      "version": "7.0.1",
+      "version": "7.0.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 13,
@@ -383,10 +383,10 @@
     {
       "id": "GoogleDrive",
       "label": "Google Drive",
-      "version": "6.0.1",
+      "version": "6.2.0",
       "category": "productivity",
       "type": "arcade",
-      "toolCount": 15,
+      "toolCount": 17,
       "authType": "oauth2"
     },
     {
@@ -455,7 +455,7 @@
     {
       "id": "GoogleSheets",
       "label": "Google Sheets",
-      "version": "8.2.0",
+      "version": "8.2.1",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 12,
@@ -599,7 +599,7 @@
     {
       "id": "Linear",
       "label": "Linear",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 42,
@@ -608,7 +608,7 @@
     {
       "id": "Linkedin",
       "label": "LinkedIn",
-      "version": "1.1.0",
+      "version": "1.1.3",
       "category": "social",
       "type": "arcade",
       "toolCount": 1,
@@ -653,10 +653,10 @@
     {
       "id": "MicrosoftOnedrive",
       "label": "Microsoft OneDrive",
-      "version": "0.3.0",
+      "version": "1.0.0",
       "category": "productivity",
       "type": "arcade",
-      "toolCount": 11,
+      "toolCount": 16,
       "authType": "oauth2"
     },
     {

--- a/toolkit-docs-generator/data/toolkits/linear.json
+++ b/toolkit-docs-generator/data/toolkits/linear.json
@@ -1,7 +1,7 @@
 {
   "id": "Linear",
   "label": "Linear",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Arcade tools designed for LLMs to interact with Linear",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "AddComment",
       "qualifiedName": "Linear.AddComment",
-      "fullyQualifiedName": "Linear.AddComment@3.5.0",
+      "fullyQualifiedName": "Linear.AddComment@3.6.0",
       "description": "Add a comment to an issue.",
       "parameters": [
         {
@@ -99,7 +99,7 @@
     {
       "name": "AddProjectComment",
       "qualifiedName": "Linear.AddProjectComment",
-      "fullyQualifiedName": "Linear.AddProjectComment@3.5.0",
+      "fullyQualifiedName": "Linear.AddProjectComment@3.6.0",
       "description": "Add a comment to a project's document content.\n\nIMPORTANT: Due to Linear API limitations, comments created via the API will NOT\nappear visually anchored inline in the document (no yellow highlight on text).\nThe comment will be stored and can be retrieved via list_project_comments, but\nit will appear in the comments panel rather than inline in the document.\n\nFor true inline comments that are visually anchored to text, users should create\nthem directly in the Linear UI by selecting text and adding a comment.\n\nThe quoted_text parameter stores metadata about what text the comment references,\nwhich is useful for context even though the comment won't be visually anchored.",
       "parameters": [
         {
@@ -198,7 +198,7 @@
     {
       "name": "AddProjectToInitiative",
       "qualifiedName": "Linear.AddProjectToInitiative",
-      "fullyQualifiedName": "Linear.AddProjectToInitiative@3.5.0",
+      "fullyQualifiedName": "Linear.AddProjectToInitiative@3.6.0",
       "description": "Link a project to an initiative.\n\nBoth initiative and project can be specified by ID or name.\nIf a name is provided, fuzzy matching is used to resolve it.",
       "parameters": [
         {
@@ -284,7 +284,7 @@
     {
       "name": "ArchiveInitiative",
       "qualifiedName": "Linear.ArchiveInitiative",
-      "fullyQualifiedName": "Linear.ArchiveInitiative@3.5.0",
+      "fullyQualifiedName": "Linear.ArchiveInitiative@3.6.0",
       "description": "Archive an initiative.\n\nArchived initiatives are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -357,7 +357,7 @@
     {
       "name": "ArchiveIssue",
       "qualifiedName": "Linear.ArchiveIssue",
-      "fullyQualifiedName": "Linear.ArchiveIssue@3.5.0",
+      "fullyQualifiedName": "Linear.ArchiveIssue@3.6.0",
       "description": "Archive an issue.\n\nArchived issues are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -417,7 +417,7 @@
     {
       "name": "ArchiveProject",
       "qualifiedName": "Linear.ArchiveProject",
-      "fullyQualifiedName": "Linear.ArchiveProject@3.5.0",
+      "fullyQualifiedName": "Linear.ArchiveProject@3.6.0",
       "description": "Archive a project.\n\nArchived projects are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -490,7 +490,7 @@
     {
       "name": "CreateInitiative",
       "qualifiedName": "Linear.CreateInitiative",
-      "fullyQualifiedName": "Linear.CreateInitiative@3.5.0",
+      "fullyQualifiedName": "Linear.CreateInitiative@3.6.0",
       "description": "Create a new Linear initiative.\n\nInitiatives are high-level strategic goals that group related projects.",
       "parameters": [
         {
@@ -596,7 +596,7 @@
     {
       "name": "CreateIssue",
       "qualifiedName": "Linear.CreateIssue",
-      "fullyQualifiedName": "Linear.CreateIssue@3.5.0",
+      "fullyQualifiedName": "Linear.CreateIssue@3.6.0",
       "description": "Create a new Linear issue with validation.\n\nWhen assignee is None or '@me', the issue is assigned to the authenticated user.\nAll entity references (team, assignee, labels, state, project, cycle, parent)\nare validated before creation. If an entity is not found, suggestions are\nreturned to help correct the input.",
       "parameters": [
         {
@@ -690,7 +690,7 @@
           "name": "parent_issue",
           "type": "string",
           "required": false,
-          "description": "Parent issue identifier to make this a sub-issue. Default is None.",
+          "description": "Parent issue (UUID or identifier of the form <UPPERCASE_TEAM_KEY>-<ISSUE_NUMBER>) to nest the new issue under as a sub-issue. Default is None (no parent).",
           "enum": null,
           "inferrable": true
         },
@@ -861,7 +861,7 @@
     {
       "name": "CreateIssueRelation",
       "qualifiedName": "Linear.CreateIssueRelation",
-      "fullyQualifiedName": "Linear.CreateIssueRelation@3.5.0",
+      "fullyQualifiedName": "Linear.CreateIssueRelation@3.6.0",
       "description": "Create a relation between two issues.\n\nRelation types define the relationship from the source issue's perspective:\n- blocks: Source issue blocks the related issue\n- blockedBy: Source issue is blocked by the related issue\n- duplicate: Source issue is a duplicate of the related issue\n- related: Issues are related (bidirectional)",
       "parameters": [
         {
@@ -952,7 +952,7 @@
     {
       "name": "CreateProject",
       "qualifiedName": "Linear.CreateProject",
-      "fullyQualifiedName": "Linear.CreateProject@3.5.0",
+      "fullyQualifiedName": "Linear.CreateProject@3.6.0",
       "description": "Create a new Linear project.\n\nTeam is validated before creation. If team is not found, suggestions are\nreturned to help correct the input. Lead is validated if provided.",
       "parameters": [
         {
@@ -1123,7 +1123,7 @@
     {
       "name": "CreateProjectUpdate",
       "qualifiedName": "Linear.CreateProjectUpdate",
-      "fullyQualifiedName": "Linear.CreateProjectUpdate@3.5.0",
+      "fullyQualifiedName": "Linear.CreateProjectUpdate@3.6.0",
       "description": "Create a project status update.\n\nProject updates are posts that communicate progress, blockers, or status\nchanges to stakeholders. They appear in the project's Updates tab and\ncan include a health status indicator.",
       "parameters": [
         {
@@ -1213,7 +1213,7 @@
     {
       "name": "GetCycle",
       "qualifiedName": "Linear.GetCycle",
-      "fullyQualifiedName": "Linear.GetCycle@3.5.0",
+      "fullyQualifiedName": "Linear.GetCycle@3.6.0",
       "description": "Get detailed information about a specific Linear cycle.",
       "parameters": [
         {
@@ -1273,7 +1273,7 @@
     {
       "name": "GetInitiative",
       "qualifiedName": "Linear.GetInitiative",
-      "fullyQualifiedName": "Linear.GetInitiative@3.5.0",
+      "fullyQualifiedName": "Linear.GetInitiative@3.6.0",
       "description": "Get detailed information about a specific Linear initiative.\n\nSupports lookup by ID or name (with fuzzy matching for name).",
       "parameters": [
         {
@@ -1375,7 +1375,7 @@
     {
       "name": "GetInitiativeDescription",
       "qualifiedName": "Linear.GetInitiativeDescription",
-      "fullyQualifiedName": "Linear.GetInitiativeDescription@3.5.0",
+      "fullyQualifiedName": "Linear.GetInitiativeDescription@3.6.0",
       "description": "Get an initiative's full description with pagination support.\n\nUse this tool when you need the complete description of an initiative that\nwas truncated in the get_initiative response. Supports chunked reading for\nvery large descriptions.",
       "parameters": [
         {
@@ -1461,7 +1461,7 @@
     {
       "name": "GetIssue",
       "qualifiedName": "Linear.GetIssue",
-      "fullyQualifiedName": "Linear.GetIssue@3.5.0",
+      "fullyQualifiedName": "Linear.GetIssue@3.6.0",
       "description": "Get detailed information about a specific Linear issue.\n\nAccepts either the issue UUID or the human-readable identifier (like TOO-123).",
       "parameters": [
         {
@@ -1573,7 +1573,7 @@
     {
       "name": "GetMilestone",
       "qualifiedName": "Linear.GetMilestone",
-      "fullyQualifiedName": "Linear.GetMilestone@3.5.0",
+      "fullyQualifiedName": "Linear.GetMilestone@3.6.0",
       "description": "Get a milestone by ID or name inside a project.",
       "parameters": [
         {
@@ -1659,7 +1659,7 @@
     {
       "name": "GetNotifications",
       "qualifiedName": "Linear.GetNotifications",
-      "fullyQualifiedName": "Linear.GetNotifications@3.5.0",
+      "fullyQualifiedName": "Linear.GetNotifications@3.6.0",
       "description": "Get the authenticated user's notifications.\n\nReturns notifications including issue mentions, comments, assignments,\nand state changes.",
       "parameters": [
         {
@@ -1745,7 +1745,7 @@
     {
       "name": "GetProject",
       "qualifiedName": "Linear.GetProject",
-      "fullyQualifiedName": "Linear.GetProject@3.5.0",
+      "fullyQualifiedName": "Linear.GetProject@3.6.0",
       "description": "Get detailed information about a specific Linear project.\n\nSupports lookup by ID, slug_id, or name (with fuzzy matching for name).",
       "parameters": [
         {
@@ -1861,7 +1861,7 @@
     {
       "name": "GetProjectDescription",
       "qualifiedName": "Linear.GetProjectDescription",
-      "fullyQualifiedName": "Linear.GetProjectDescription@3.5.0",
+      "fullyQualifiedName": "Linear.GetProjectDescription@3.6.0",
       "description": "Get a project's full description with pagination support.\n\nUse this tool when you need the complete description of a project that\nwas truncated in the get_project response. Supports chunked reading for\nvery large descriptions.",
       "parameters": [
         {
@@ -1947,7 +1947,7 @@
     {
       "name": "GetRecentActivity",
       "qualifiedName": "Linear.GetRecentActivity",
-      "fullyQualifiedName": "Linear.GetRecentActivity@3.5.0",
+      "fullyQualifiedName": "Linear.GetRecentActivity@3.6.0",
       "description": "Get the authenticated user's recent issue activity.\n\nReturns issues the user has recently created or been assigned to\nwithin the specified time period.",
       "parameters": [
         {
@@ -2020,7 +2020,7 @@
     {
       "name": "GetTeam",
       "qualifiedName": "Linear.GetTeam",
-      "fullyQualifiedName": "Linear.GetTeam@3.5.0",
+      "fullyQualifiedName": "Linear.GetTeam@3.6.0",
       "description": "Get detailed information about a specific Linear team.\n\nSupports lookup by ID, key (like TOO, ENG), or name (with fuzzy matching).",
       "parameters": [
         {
@@ -2110,7 +2110,7 @@
     {
       "name": "LinkGithubToIssue",
       "qualifiedName": "Linear.LinkGithubToIssue",
-      "fullyQualifiedName": "Linear.LinkGithubToIssue@3.5.0",
+      "fullyQualifiedName": "Linear.LinkGithubToIssue@3.6.0",
       "description": "Link a GitHub PR, commit, or issue to a Linear issue.\n\nAutomatically detects the artifact type from the URL and generates\nan appropriate title if not provided.",
       "parameters": [
         {
@@ -2196,7 +2196,7 @@
     {
       "name": "ListComments",
       "qualifiedName": "Linear.ListComments",
-      "fullyQualifiedName": "Linear.ListComments@3.5.0",
+      "fullyQualifiedName": "Linear.ListComments@3.6.0",
       "description": "List comments on an issue.\n\nReturns comments with user info, timestamps, and reply threading info.",
       "parameters": [
         {
@@ -2282,7 +2282,7 @@
     {
       "name": "ListCycles",
       "qualifiedName": "Linear.ListCycles",
-      "fullyQualifiedName": "Linear.ListCycles@3.5.0",
+      "fullyQualifiedName": "Linear.ListCycles@3.6.0",
       "description": "List Linear cycles, optionally filtered by team and status.\n\nCycles are time-boxed iterations (like sprints) for organizing work.",
       "parameters": [
         {
@@ -2394,7 +2394,7 @@
     {
       "name": "ListInitiatives",
       "qualifiedName": "Linear.ListInitiatives",
-      "fullyQualifiedName": "Linear.ListInitiatives@3.5.0",
+      "fullyQualifiedName": "Linear.ListInitiatives@3.6.0",
       "description": "List Linear initiatives, optionally filtered by keywords and other criteria.\n\nReturns all initiatives when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2500,7 +2500,7 @@
     {
       "name": "ListIssues",
       "qualifiedName": "Linear.ListIssues",
-      "fullyQualifiedName": "Linear.ListIssues@3.5.0",
+      "fullyQualifiedName": "Linear.ListIssues@3.6.0",
       "description": "List Linear issues, optionally filtered by keywords and other criteria.\n\nReturns all issues when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2683,7 +2683,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Linear.ListLabels",
-      "fullyQualifiedName": "Linear.ListLabels@3.5.0",
+      "fullyQualifiedName": "Linear.ListLabels@3.6.0",
       "description": "List available issue labels in the workspace.\n\nReturns labels that can be applied to issues. Use label IDs or names\nwhen creating or updating issues.",
       "parameters": [
         {
@@ -2743,7 +2743,7 @@
     {
       "name": "ListMilestones",
       "qualifiedName": "Linear.ListMilestones",
-      "fullyQualifiedName": "Linear.ListMilestones@3.5.0",
+      "fullyQualifiedName": "Linear.ListMilestones@3.6.0",
       "description": "List milestones in a Linear project.",
       "parameters": [
         {
@@ -2842,7 +2842,7 @@
     {
       "name": "ListProjectComments",
       "qualifiedName": "Linear.ListProjectComments",
-      "fullyQualifiedName": "Linear.ListProjectComments@3.5.0",
+      "fullyQualifiedName": "Linear.ListProjectComments@3.6.0",
       "description": "List comments on a project's document content.\n\nReturns comments with user info, timestamps, quoted text for inline comments,\nand reply threading info. Replies are nested under their parent comments.\n\nUse comment_filter to control which comments are returned:\n- only_quoted (default): Only comments attached to a quote in the text\n- only_unquoted: Only comments not attached to a particular quote\n- all: All comments regardless of being attached to a quote or not",
       "parameters": [
         {
@@ -2971,7 +2971,7 @@
     {
       "name": "ListProjects",
       "qualifiedName": "Linear.ListProjects",
-      "fullyQualifiedName": "Linear.ListProjects@3.5.0",
+      "fullyQualifiedName": "Linear.ListProjects@3.6.0",
       "description": "List Linear projects, optionally filtered by keywords and other criteria.\n\nReturns all projects when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -3096,7 +3096,7 @@
     {
       "name": "ListTeams",
       "qualifiedName": "Linear.ListTeams",
-      "fullyQualifiedName": "Linear.ListTeams@3.5.0",
+      "fullyQualifiedName": "Linear.ListTeams@3.6.0",
       "description": "List Linear teams, optionally filtered by keywords and other criteria.\n\nReturns all teams when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -3208,7 +3208,7 @@
     {
       "name": "ListWorkflowStates",
       "qualifiedName": "Linear.ListWorkflowStates",
-      "fullyQualifiedName": "Linear.ListWorkflowStates@3.5.0",
+      "fullyQualifiedName": "Linear.ListWorkflowStates@3.6.0",
       "description": "List available workflow states in the workspace.\n\nReturns workflow states that can be used for issue transitions.\nStates are team-specific and have different types.",
       "parameters": [
         {
@@ -3301,7 +3301,7 @@
     {
       "name": "ManageIssueSubscription",
       "qualifiedName": "Linear.ManageIssueSubscription",
-      "fullyQualifiedName": "Linear.ManageIssueSubscription@3.5.0",
+      "fullyQualifiedName": "Linear.ManageIssueSubscription@3.6.0",
       "description": "Subscribe to or unsubscribe from an issue's notifications.",
       "parameters": [
         {
@@ -3374,7 +3374,7 @@
     {
       "name": "ReplyToComment",
       "qualifiedName": "Linear.ReplyToComment",
-      "fullyQualifiedName": "Linear.ReplyToComment@3.5.0",
+      "fullyQualifiedName": "Linear.ReplyToComment@3.6.0",
       "description": "Reply to an existing comment on an issue.\n\nCreates a threaded reply to the specified parent comment.",
       "parameters": [
         {
@@ -3460,7 +3460,7 @@
     {
       "name": "ReplyToProjectComment",
       "qualifiedName": "Linear.ReplyToProjectComment",
-      "fullyQualifiedName": "Linear.ReplyToProjectComment@3.5.0",
+      "fullyQualifiedName": "Linear.ReplyToProjectComment@3.6.0",
       "description": "Reply to an existing comment on a project document.\n\nCreates a threaded reply to the specified parent comment.",
       "parameters": [
         {
@@ -3559,7 +3559,7 @@
     {
       "name": "TransitionIssueState",
       "qualifiedName": "Linear.TransitionIssueState",
-      "fullyQualifiedName": "Linear.TransitionIssueState@3.5.0",
+      "fullyQualifiedName": "Linear.TransitionIssueState@3.6.0",
       "description": "Transition a Linear issue to a new workflow state.\n\nThe target state is validated against the team's available states.",
       "parameters": [
         {
@@ -3645,7 +3645,7 @@
     {
       "name": "UpdateComment",
       "qualifiedName": "Linear.UpdateComment",
-      "fullyQualifiedName": "Linear.UpdateComment@3.5.0",
+      "fullyQualifiedName": "Linear.UpdateComment@3.6.0",
       "description": "Update an existing comment.",
       "parameters": [
         {
@@ -3718,7 +3718,7 @@
     {
       "name": "UpdateInitiative",
       "qualifiedName": "Linear.UpdateInitiative",
-      "fullyQualifiedName": "Linear.UpdateInitiative@3.5.0",
+      "fullyQualifiedName": "Linear.UpdateInitiative@3.6.0",
       "description": "Update a Linear initiative with partial updates.\n\nOnly fields that are explicitly provided will be updated.",
       "parameters": [
         {
@@ -3837,7 +3837,7 @@
     {
       "name": "UpdateIssue",
       "qualifiedName": "Linear.UpdateIssue",
-      "fullyQualifiedName": "Linear.UpdateIssue@3.5.0",
+      "fullyQualifiedName": "Linear.UpdateIssue@3.6.0",
       "description": "Update a Linear issue with partial updates.\n\nOnly fields that are explicitly provided will be updated. All entity\nreferences are validated before update.",
       "parameters": [
         {
@@ -3937,6 +3937,14 @@
           "inferrable": true
         },
         {
+          "name": "parent_issue",
+          "type": "string",
+          "required": false,
+          "description": "Parent issue (UUID or identifier of the form <UPPERCASE_TEAM_KEY>-<ISSUE_NUMBER>) to nest this issue under as a sub-issue. Providing it re-parents the issue; omitting it leaves the existing parent unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
           "name": "estimate",
           "type": "integer",
           "required": false,
@@ -4000,12 +4008,12 @@
             "required": true
           },
           "title": {
-            "value": "Fix login button alignment on mobile",
+            "value": "Fix login page crash on mobile devices",
             "type": "string",
             "required": false
           },
           "description": {
-            "value": "## Bug Description\n\nThe login button is misaligned on screens smaller than 375px.\n\n**Steps to reproduce:**\n1. Open the app on a mobile device\n2. Navigate to the login page\n3. Observe the button position",
+            "value": "## Summary\n\nThe login page crashes when users attempt to sign in on iOS devices running version 16 or later.\n\n## Steps to Reproduce\n1. Open the app on an iOS 16+ device\n2. Enter credentials\n3. Tap 'Sign In'\n\n## Expected Behavior\nUser is authenticated and redirected to dashboard.\n\n## Actual Behavior\nApp crashes immediately.",
             "type": "string",
             "required": false
           },
@@ -4031,7 +4039,7 @@
             "required": false
           },
           "priority": {
-            "value": "high",
+            "value": "urgent",
             "type": "string",
             "required": false
           },
@@ -4041,17 +4049,22 @@
             "required": false
           },
           "project": {
-            "value": "mobile-redesign",
+            "value": "Mobile App Overhaul",
             "type": "string",
             "required": false
           },
           "cycle": {
-            "value": "Sprint 14",
+            "value": "Sprint 42",
             "type": "string",
             "required": false
           },
           "milestone": {
-            "value": "Q2 Release",
+            "value": "Q3 Release",
+            "type": "string",
+            "required": false
+          },
+          "parent_issue": {
+            "value": "TOO-100",
             "type": "string",
             "required": false
           },
@@ -4061,17 +4074,17 @@
             "required": false
           },
           "due_date": {
-            "value": "2025-08-15",
+            "value": "2025-09-15",
             "type": "string",
             "required": false
           },
           "attachment_url": {
-            "value": "https://www.figma.com/file/abc123/login-button-fix",
+            "value": "https://github.com/example-org/repo/issues/456",
             "type": "string",
             "required": false
           },
           "attachment_title": {
-            "value": "Figma Design Reference",
+            "value": "Related GitHub Issue #456",
             "type": "string",
             "required": false
           },
@@ -4106,7 +4119,7 @@
     {
       "name": "UpdateProject",
       "qualifiedName": "Linear.UpdateProject",
-      "fullyQualifiedName": "Linear.UpdateProject@3.5.0",
+      "fullyQualifiedName": "Linear.UpdateProject@3.6.0",
       "description": "Update a Linear project with partial updates.\n\nOnly fields that are explicitly provided will be updated. All entity\nreferences are validated before update.\n\nIMPORTANT: Updating the 'content' field will break any existing inline\ncomment anchoring. The comments will still exist and be retrievable via\nlist_project_comments, but they will no longer appear visually anchored\nto text in the Linear UI. The 'description' field can be safely updated\nwithout affecting inline comments.",
       "parameters": [
         {
@@ -4310,7 +4323,7 @@
     {
       "name": "UpsertMilestone",
       "qualifiedName": "Linear.UpsertMilestone",
-      "fullyQualifiedName": "Linear.UpsertMilestone@3.5.0",
+      "fullyQualifiedName": "Linear.UpsertMilestone@3.6.0",
       "description": "Upsert a project's milestone.",
       "parameters": [
         {
@@ -4436,7 +4449,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Linear.WhoAmI",
-      "fullyQualifiedName": "Linear.WhoAmI@3.5.0",
+      "fullyQualifiedName": "Linear.WhoAmI@3.6.0",
       "description": "Get the authenticated user's profile and team memberships.\n\nReturns the current user's information including their name, email,\norganization, and the teams they belong to.",
       "parameters": [],
       "auth": {
@@ -4490,6 +4503,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-06-10T12:12:02.745Z",
-  "summary": "# Linear Toolkit\n\nThe Linear toolkit connects LLMs to [Linear](https://linear.app) via the Arcade platform, enabling agents to fully manage issues, projects, initiatives, cycles, and team workflows programmatically.\n\n## Capabilities\n\n- **Issue lifecycle**: Create, update, archive, transition workflow states, manage relations (blocks/blocked-by/duplicate/related), subscribe to notifications, and link GitHub PRs/commits/issues.\n- **Projects & milestones**: Create, update, archive, and retrieve projects; add/list/upsert milestones; post and read project document comments with threading and quote metadata.\n- **Initiatives**: Create, update, archive, and list high-level strategic initiatives; link projects to initiatives; retrieve full paginated descriptions.\n- **Cycles & teams**: List time-boxed cycles filtered by team/status; inspect and list teams, workflow states, and issue labels across the workspace.\n- **Comments & threading**: Add, update, list, and reply to comments on both issues and project documents; retrieve threaded replies and quoted-text metadata (note: API-created project comments appear in the comments panel only, not visually anchored inline in the Linear UI).\n- **User context**: Retrieve the authenticated user's profile, team memberships, recent activity, and notifications.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via the **Linear** provider. See the [Arcade Linear auth provider docs](https://docs.arcade.dev/en/references/auth-providers/linear) for configuration details."
+  "generatedAt": "2026-06-29T12:37:19.654Z",
+  "summary": "The **Linear** toolkit connects LLMs to the [Linear](https://linear.app) project management platform, enabling agents to fully manage issues, projects, initiatives, cycles, comments, and team workflows through the Linear API.\n\n## Capabilities\n\n- **Issue lifecycle management** — create, update, archive, transition workflow states, manage relations (blocks/blocked-by/duplicate/related), link GitHub PRs/commits, subscribe to notifications, and retrieve detailed issue data or recent activity.\n- **Projects & milestones** — create, update, archive, and list projects; upsert and retrieve milestones; post and list project status updates; read full paginated project descriptions.\n- **Initiatives** — create, update, archive, and list high-level strategic initiatives; link projects to initiatives; read full paginated initiative descriptions.\n- **Cycles, teams & workflow states** — list time-boxed cycles filtered by team/status; look up teams by ID, key, or fuzzy name; enumerate workspace-wide labels and team-specific workflow states.\n- **Comments & threading** — add, update, list, and reply to threaded comments on both issues and project documents; retrieve project comments filtered by inline-quote anchoring status (note: API-created project comments appear in the comments panel only, not visually anchored to text in the Linear UI).\n- **User & workspace context** — retrieve the authenticated user's profile, team memberships, and notifications.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via the **Linear** provider. Arcade manages token acquisition and refresh automatically. See the [Linear auth provider docs](https://docs.arcade.dev/en/references/auth-providers/linear) for configuration details."
 }

--- a/toolkit-docs-generator/data/toolkits/linkedin.json
+++ b/toolkit-docs-generator/data/toolkits/linkedin.json
@@ -1,7 +1,7 @@
 {
   "id": "Linkedin",
   "label": "LinkedIn",
-  "version": "1.1.0",
+  "version": "1.1.3",
   "description": "Arcade.dev LLM tools for LinkedIn",
   "metadata": {
     "category": "social",
@@ -24,7 +24,7 @@
     {
       "name": "CreateTextPost",
       "qualifiedName": "Linkedin.CreateTextPost",
-      "fullyQualifiedName": "Linkedin.CreateTextPost@1.1.0",
+      "fullyQualifiedName": "Linkedin.CreateTextPost@1.1.3",
       "description": "Share a new text post to LinkedIn.",
       "parameters": [
         {
@@ -92,6 +92,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-03-01T11:12:08.065Z",
+  "generatedAt": "2026-06-29T12:37:13.641Z",
   "summary": "Arcade.dev provides a toolkit for integrating with LinkedIn, enabling developers to streamline interactions with the platform's API. This toolkit allows for the creation of content directly on LinkedIn, enhancing user engagement and social sharing capabilities.\n\n**Capabilities**  \n- Seamless integration with LinkedIn's API for enhanced social interactions.  \n- Efficiently share content such as text posts to drive engagement.  \n- Simplified authentication process through OAuth2, ensuring secure access to user data.  \n\n**OAuth**  \n- Provider: LinkedIn  \n- Scopes: w_member_social  \n\n**Secrets**  \n- No secrets required for use with this toolkit."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftonedrive.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftonedrive.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftOnedrive",
   "label": "Microsoft OneDrive",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Arcade.dev LLM tools for Microsoft OneDrive",
   "metadata": {
     "category": "productivity",
@@ -18,16 +18,15 @@
     "providerId": "microsoft",
     "allScopes": [
       "Files.Read",
-      "Files.ReadWrite",
-      "User.Read"
+      "Files.ReadWrite"
     ]
   },
   "tools": [
     {
       "name": "CopyItem",
       "qualifiedName": "MicrosoftOnedrive.CopyItem",
-      "fullyQualifiedName": "MicrosoftOnedrive.CopyItem@0.3.0",
-      "description": "Copy a file or folder. Returns a completed item or an operation id.",
+      "fullyQualifiedName": "MicrosoftOnedrive.CopyItem@1.0.0",
+      "description": "Copy a file or folder and wait for the copy to finish, returning the new item.\n\nMicrosoft Graph performs copies asynchronously; this tool polls the operation to\ncompletion within a bounded budget so the caller receives the finished item directly.\nA stale or mistyped source id returns a structured not_found envelope (status\n\"not_found\", retryable false) rather than a fatal error, so the caller can branch on\nthe field.",
       "parameters": [
         {
           "name": "item_id",
@@ -52,6 +51,18 @@
           "description": "Optional new name for the copied item.",
           "enum": null,
           "inferrable": true
+        },
+        {
+          "name": "conflict_behavior",
+          "type": "string",
+          "required": false,
+          "description": "How to resolve a name that already exists in the destination folder. Defaults to FAIL (report the conflict without copying).",
+          "enum": [
+            "fail",
+            "replace",
+            "rename"
+          ],
+          "inferrable": true
         }
       ],
       "auth": {
@@ -65,24 +76,29 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "Copy status and result."
+        "description": "Copy result."
       },
       "documentationChunks": [],
       "codeExample": {
         "toolName": "MicrosoftOnedrive.CopyItem",
         "parameters": {
           "item_id": {
-            "value": "0123456789ABCDEF!123",
+            "value": "01BYE5RZ6QN3ZWBTUFOFD3GSPGOHDJD36K",
             "type": "string",
             "required": true
           },
           "destination_folder_id": {
-            "value": "67890ABCDEF!456",
+            "value": "01BYE5RZ74Y2GOVW7725BZO354PWSELRRZ",
             "type": "string",
             "required": false
           },
           "new_name": {
-            "value": "Project Plan - Copy.docx",
+            "value": "Project_Report_Copy.docx",
+            "type": "string",
+            "required": false
+          },
+          "conflict_behavior": {
+            "value": "rename",
             "type": "string",
             "required": false
           }
@@ -103,7 +119,7 @@
             "create"
           ],
           "readOnly": false,
-          "destructive": false,
+          "destructive": true,
           "idempotent": false,
           "openWorld": true
         },
@@ -113,7 +129,7 @@
     {
       "name": "CreateFolder",
       "qualifiedName": "MicrosoftOnedrive.CreateFolder",
-      "fullyQualifiedName": "MicrosoftOnedrive.CreateFolder@0.3.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.CreateFolder@1.0.0",
       "description": "Create a new folder in OneDrive.",
       "parameters": [
         {
@@ -186,14 +202,52 @@
     {
       "name": "CreateShareLink",
       "qualifiedName": "MicrosoftOnedrive.CreateShareLink",
-      "fullyQualifiedName": "MicrosoftOnedrive.CreateShareLink@0.3.0",
-      "description": "Create a share link for a OneDrive item.",
+      "fullyQualifiedName": "MicrosoftOnedrive.CreateShareLink@1.0.0",
+      "description": "Create a share link for a OneDrive item.\n\nSet link_type to EDIT to let recipients change the item; use scope ORGANIZATION to keep\nthe link inside the tenant instead of anyone-with-the-link.",
       "parameters": [
         {
           "name": "item_id",
           "type": "string",
           "required": true,
           "description": "The ID of the file or folder to share.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "link_type",
+          "type": "string",
+          "required": false,
+          "description": "Whether the link grants read-only (view) or read-write (edit) access. Defaults to VIEW.",
+          "enum": [
+            "view",
+            "edit"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "scope",
+          "type": "string",
+          "required": false,
+          "description": "Who can use the link: anyone with the link (anonymous) or only people inside the organization (organization). Defaults to ANONYMOUS.",
+          "enum": [
+            "anonymous",
+            "organization"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "expiration_date",
+          "type": "string",
+          "required": false,
+          "description": "Date the link stops working (YYYY-MM-DD). Omit for a link that never expires.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "password",
+          "type": "string",
+          "required": false,
+          "description": "Password required to open the link. Omit for no password. Only honored on anonymous links.",
           "enum": null,
           "inferrable": true
         }
@@ -216,9 +270,29 @@
         "toolName": "MicrosoftOnedrive.CreateShareLink",
         "parameters": {
           "item_id": {
-            "value": "0123456789abcdef!12345",
+            "value": "01BYE5RZ6QN3ZWBTUFOFD3GSPGOHDJD36K",
             "type": "string",
             "required": true
+          },
+          "link_type": {
+            "value": "EDIT",
+            "type": "string",
+            "required": false
+          },
+          "scope": {
+            "value": "ORGANIZATION",
+            "type": "string",
+            "required": false
+          },
+          "expiration_date": {
+            "value": "2025-12-31",
+            "type": "string",
+            "required": false
+          },
+          "password": {
+            "value": "SecurePass@2025",
+            "type": "string",
+            "required": false
           }
         },
         "requiresAuth": true,
@@ -246,14 +320,15 @@
     {
       "name": "DeleteItem",
       "qualifiedName": "MicrosoftOnedrive.DeleteItem",
-      "fullyQualifiedName": "MicrosoftOnedrive.DeleteItem@0.3.0",
-      "description": "Delete a file or folder from OneDrive.",
+      "fullyQualifiedName": "MicrosoftOnedrive.DeleteItem@1.0.0",
+      "description": "Delete one or more files or folders from OneDrive in a single call.\n\nAn item open for editing elsewhere is reported as locked and retryable rather than\nfailing the whole batch; every requested id is attempted.",
       "parameters": [
         {
-          "name": "item_id",
-          "type": "string",
+          "name": "item_ids",
+          "type": "array",
+          "innerType": "string",
           "required": true,
-          "description": "The ID of the file or folder to delete.",
+          "description": "IDs of the files or folders to delete. Pass one id or many; each is attempted independently so one locked item never aborts the rest.",
           "enum": null,
           "inferrable": true
         }
@@ -269,15 +344,19 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "Deletion confirmation."
+        "description": "Per-item deletion outcomes."
       },
       "documentationChunks": [],
       "codeExample": {
         "toolName": "MicrosoftOnedrive.DeleteItem",
         "parameters": {
-          "item_id": {
-            "value": "0123456789ABCDEF!123",
-            "type": "string",
+          "item_ids": {
+            "value": [
+              "01BYE5RZ6QN3ZWBTUFOFD3GSPGOHDJD36K",
+              "01BYE5RZ74XHSXKGZSBJCLHPKM2F5YQJXM",
+              "01BYE5RZ5NX5OCDZE3XBCYQWKZNLPV3SY7"
+            ],
+            "type": "array",
             "required": true
           }
         },
@@ -304,9 +383,207 @@
       }
     },
     {
+      "name": "DownloadFile",
+      "qualifiedName": "MicrosoftOnedrive.DownloadFile",
+      "fullyQualifiedName": "MicrosoftOnedrive.DownloadFile@1.0.0",
+      "description": "Download a OneDrive file's content as base64, paging large files by byte offset.\n\nFiles at or under the per-call cap return fully in one call; for larger files, re-call\nwith offset set to the returned next_offset until is_final is true. A stale or mistyped\nid returns a structured not_found envelope (status \"not_found\", retryable false) rather\nthan a fatal error, so the caller can branch on the field.",
+      "parameters": [
+        {
+          "name": "item_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the file to download.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "drive_id",
+          "type": "string",
+          "required": false,
+          "description": "The drive containing the file. Omit to use the current user's OneDrive.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed byte offset of the page to fetch. Defaults to 0 (start of file).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_bytes",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum raw bytes to return on this call (1 to 5242880). Defaults to 16384 (16 KiB), sized so the base64 page fits an agent's tool-result budget; raise it to fetch a larger window per call, lower it for a tighter budget.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "Files.Read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "A page of the file's content as base64."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOnedrive.DownloadFile",
+        "parameters": {
+          "item_id": {
+            "value": "01BYE5RZ6QN3ZWBTUFOFD3GSPGOHNOU25O",
+            "type": "string",
+            "required": true
+          },
+          "drive_id": {
+            "value": "b!dGVzdC1kcml2ZS1pZC0xMjM0NTY3ODkw",
+            "type": "string",
+            "required": false
+          },
+          "offset": {
+            "value": 16384,
+            "type": "integer",
+            "required": false
+          },
+          "max_bytes": {
+            "value": 524288,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "cloud_storage"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "FindDuplicateFiles",
+      "qualifiedName": "MicrosoftOnedrive.FindDuplicateFiles",
+      "fullyQualifiedName": "MicrosoftOnedrive.FindDuplicateFiles@1.0.0",
+      "description": "Find files that are byte-identical copies of each other across folders in one call.\n\nGroups examined files by content fingerprint and returns only the fingerprints with two\nor more copies, each group flagging the copy to keep and the rest as deletion candidates,\nso a de-dup cleanup can act without listing and grouping by hash manually.\nThe scan walks the drive directly rather than the search index, so a file copied moments\nago is seen immediately. Supply folder_id to scope the scan to a subtree (much more likely to\nbe complete, though still bounded by limit and an internal walk cap); keywords further\nrestrict to files whose name contains the term.\nWhen truncated is true, truncated_warning explains what was missed and how to refocus.",
+      "parameters": [
+        {
+          "name": "keywords",
+          "type": "string",
+          "required": false,
+          "description": "Case-insensitive substring matched against file names; only files whose name contains it are examined, so a focused term finds copies of a specific file. Leave empty to scan every file regardless of name (a whole-drive de-dup audit), bounded by the same scan cap. Can be combined with folder_id to restrict to files matching this term within a specific subtree — the two filters are applied simultaneously. The scan walks the drive directly rather than the search index, so files written moments ago are included.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum files to examine in one scan (1 to 200). Defaults to 200. Lower it to speed up a focused scan; the response flags when this cap truncated the scan.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "folder_id",
+          "type": "string",
+          "required": false,
+          "description": "Scope the scan to a specific folder's subtree. When provided, only files within that folder and its subfolders are examined, which makes a complete result far more likely for a focused subtree. The scan is still bounded by limit and an internal walk cap, so a very large subtree can still be truncated — check the truncated flag. Omit to scan from the drive root.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "keep_by_name_contains",
+          "type": "string",
+          "required": false,
+          "description": "Override the default newest-copy keep heuristic: within each duplicate group, the copy whose name contains this string (case-insensitive) is flagged as keep_item_id. If no copy in a group matches, the newest copy is kept. Leave empty to always keep the newest copy.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "Files.Read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Groups of byte-identical files found among the matches."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOnedrive.FindDuplicateFiles",
+        "parameters": {
+          "keywords": {
+            "value": "report",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "folder_id": {
+            "value": "01BYE5RZ6QN3ZWBTUBIFDCZSQTJGC7NS5Y",
+            "type": "string",
+            "required": false
+          },
+          "keep_by_name_contains": {
+            "value": "final",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "cloud_storage"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "GetCopyStatus",
       "qualifiedName": "MicrosoftOnedrive.GetCopyStatus",
-      "fullyQualifiedName": "MicrosoftOnedrive.GetCopyStatus@0.3.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.GetCopyStatus@1.0.0",
       "description": "Check status of an async copy operation using the token returned by copy_item.",
       "parameters": [
         {
@@ -364,9 +641,69 @@
       }
     },
     {
+      "name": "GetItem",
+      "qualifiedName": "MicrosoftOnedrive.GetItem",
+      "fullyQualifiedName": "MicrosoftOnedrive.GetItem@1.0.0",
+      "description": "Resolve a single OneDrive file or folder's metadata directly from its id.\n\nA stale or mistyped id returns a structured not_found envelope (status \"not_found\",\nretryable false) rather than a fatal error, so the caller can branch on the field.",
+      "parameters": [
+        {
+          "name": "item_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the file or folder to resolve.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "Files.Read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The resolved item's metadata."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOnedrive.GetItem",
+        "parameters": {
+          "item_id": {
+            "value": "01BYE5RZ6QN3ZWBTUFOFD3GSPGOHDJD36K",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "cloud_storage"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "GetMyDrive",
       "qualifiedName": "MicrosoftOnedrive.GetMyDrive",
-      "fullyQualifiedName": "MicrosoftOnedrive.GetMyDrive@0.3.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.GetMyDrive@1.0.0",
       "description": "Get metadata about the user's OneDrive (id, name, quota, owner).",
       "parameters": [],
       "auth": {
@@ -411,14 +748,14 @@
     {
       "name": "GetSharedWithMe",
       "qualifiedName": "MicrosoftOnedrive.GetSharedWithMe",
-      "fullyQualifiedName": "MicrosoftOnedrive.GetSharedWithMe@0.3.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.GetSharedWithMe@1.0.0",
       "description": "List files shared with the current user.",
       "parameters": [
         {
           "name": "limit",
           "type": "integer",
           "required": false,
-          "description": "The number of items to list. Defaults to 100, max is 500.",
+          "description": "The number of items to return in this page (1 to 50). Defaults to 25.",
           "enum": null,
           "inferrable": true
         },
@@ -426,7 +763,7 @@
           "name": "next_token",
           "type": "string",
           "required": false,
-          "description": "The next_token value returned by a previous request.",
+          "description": "Opaque cursor from a previous response's next_token to fetch the next page. Pass it back unchanged; omit for the first page.",
           "enum": null,
           "inferrable": true
         }
@@ -484,7 +821,7 @@
     {
       "name": "ListFolderItems",
       "qualifiedName": "MicrosoftOnedrive.ListFolderItems",
-      "fullyQualifiedName": "MicrosoftOnedrive.ListFolderItems@0.3.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.ListFolderItems@1.0.0",
       "description": "List files and folders in a OneDrive folder. Lists root if folder_id is omitted.",
       "parameters": [
         {
@@ -499,7 +836,7 @@
           "name": "limit",
           "type": "integer",
           "required": false,
-          "description": "The number of items to list. Defaults to 100, max is 500.",
+          "description": "The number of items to return in this page (1 to 50). Defaults to 25.",
           "enum": null,
           "inferrable": true
         },
@@ -507,7 +844,7 @@
           "name": "next_token",
           "type": "string",
           "required": false,
-          "description": "The next_token value returned by a previous request.",
+          "description": "Opaque cursor from a previous response's next_token to fetch the next page. Pass it back unchanged; omit for the first page.",
           "enum": null,
           "inferrable": true
         }
@@ -568,24 +905,106 @@
       }
     },
     {
-      "name": "MoveItem",
-      "qualifiedName": "MicrosoftOnedrive.MoveItem",
-      "fullyQualifiedName": "MicrosoftOnedrive.MoveItem@0.3.0",
-      "description": "Move a file or folder to a new location in OneDrive.",
+      "name": "ListItemPermissions",
+      "qualifiedName": "MicrosoftOnedrive.ListItemPermissions",
+      "fullyQualifiedName": "MicrosoftOnedrive.ListItemPermissions@1.0.0",
+      "description": "List who can currently access a OneDrive item: every share link and direct grant on it.\n\nUse this to answer \"who can see this?\" and to find the permission_id needed to revoke a\ngrant. A stale or mistyped id returns a structured not_found envelope (status \"not_found\",\nretryable false) rather than a fatal error, so the caller can branch on the field. When\nhas_more is true, pass next_token back unchanged to fetch the remaining grants.",
       "parameters": [
         {
           "name": "item_id",
           "type": "string",
           "required": true,
-          "description": "The ID of the item to move.",
+          "description": "The ID of the file or folder whose sharing grants to list.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "next_token",
+          "type": "string",
+          "required": false,
+          "description": "Opaque cursor from a previous response's next_token to fetch the next page of grants. Pass it back unchanged; omit for the first page.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "Files.Read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The item's current sharing grants."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOnedrive.ListItemPermissions",
+        "parameters": {
+          "item_id": {
+            "value": "01BYE5RZ6QN3ZWBTUFOFD3GSPGOHDJD36K",
+            "type": "string",
+            "required": true
+          },
+          "next_token": {
+            "value": "eyJza2lwVG9rZW4iOiJSRlNwdE9wbEVJSXBMQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQSJ9",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "cloud_storage"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "MoveItem",
+      "qualifiedName": "MicrosoftOnedrive.MoveItem",
+      "fullyQualifiedName": "MicrosoftOnedrive.MoveItem@1.0.0",
+      "description": "Move and/or rename one or more files or folders in OneDrive in a single call.\n\nProvide new_parent_id to relocate items, new_name (single item only) to rename in place,\nor both. At least one must be supplied. An item open for editing elsewhere is reported as\nlocked and retryable rather than failing the whole batch.",
+      "parameters": [
+        {
+          "name": "item_ids",
+          "type": "array",
+          "innerType": "string",
+          "required": true,
+          "description": "IDs of the items to move and/or rename. Pass one id or many; every listed item is moved into the same new_parent_id.",
           "enum": null,
           "inferrable": true
         },
         {
           "name": "new_parent_id",
           "type": "string",
-          "required": true,
-          "description": "The ID of the destination folder.",
+          "required": false,
+          "description": "Destination folder ID to move every listed item into. Omit to leave items in their current folder (rename only).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "new_name",
+          "type": "string",
+          "required": false,
+          "description": "New name for the item, including its extension. Only valid when exactly one id is given; omit to leave names unchanged.",
           "enum": null,
           "inferrable": true
         }
@@ -601,21 +1020,29 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "The updated item metadata."
+        "description": "Per-item move/rename outcomes."
       },
       "documentationChunks": [],
       "codeExample": {
         "toolName": "MicrosoftOnedrive.MoveItem",
         "parameters": {
-          "item_id": {
-            "value": "01ZYXWVUTSRQ!123",
-            "type": "string",
+          "item_ids": {
+            "value": [
+              "01BYE5RZ6QN3ZWBTUFOFD3GSPGOHNOU25O",
+              "01BYE5RZ74GVHSOM4FHDAK52DQMRA5Y3J"
+            ],
+            "type": "array",
             "required": true
           },
           "new_parent_id": {
-            "value": "01ZYXWVUTSRQ!999",
+            "value": "01BYE5RZ5YNGQLLAOCVFE2QDQPEZQWETQV",
             "type": "string",
-            "required": true
+            "required": false
+          },
+          "new_name": {
+            "value": "Project_Final_Report.docx",
+            "type": "string",
+            "required": false
           }
         },
         "requiresAuth": true,
@@ -641,9 +1068,95 @@
       }
     },
     {
+      "name": "RevokeItemPermission",
+      "qualifiedName": "MicrosoftOnedrive.RevokeItemPermission",
+      "fullyQualifiedName": "MicrosoftOnedrive.RevokeItemPermission@1.0.0",
+      "description": "Revoke one or all anonymous sharing grants on a OneDrive item.\n\nSingle-grant mode (revoke_all_anonymous=false): removes the grant identified by\npermission_id. An unknown item or permission id returns a structured not_found envelope\nrather than a fatal error. To revoke an inherited grant, target the parent folder instead.\n\nBulk mode (revoke_all_anonymous=true): removes every anonymous (anyone-with-the-link) grant\non the item in one call. revoked_count reports how many were removed; 0 means none existed.",
+      "parameters": [
+        {
+          "name": "item_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the file or folder the permission is on.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "permission_id",
+          "type": "string",
+          "required": false,
+          "description": "The ID of the sharing grant to revoke. Required unless revoke_all_anonymous is true.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "revoke_all_anonymous",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, revokes every anonymous sharing link on the item in one call. A common job is removing all open-web links from a file; this makes that a single call instead of one revoke per link — list the item's permissions first to see what will be removed. When true, permission_id is ignored. Defaults to false (single-grant mode, permission_id required).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "Files.ReadWrite"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Outcome of revoking the sharing grant(s)."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOnedrive.RevokeItemPermission",
+        "parameters": {
+          "item_id": {
+            "value": "01BYE5RZ6QN3ZWBTUFOFD3GSPGOHDJD36K",
+            "type": "string",
+            "required": true
+          },
+          "permission_id": {
+            "value": "aGVhbGx5LXVuaXF1ZS1wZXJtaXNzaW9uLWlk",
+            "type": "string",
+            "required": false
+          },
+          "revoke_all_anonymous": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "cloud_storage"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "SearchItems",
       "qualifiedName": "MicrosoftOnedrive.SearchItems",
-      "fullyQualifiedName": "MicrosoftOnedrive.SearchItems@0.3.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.SearchItems@1.0.0",
       "description": "Search for files and folders in the user's OneDrive.\n\nIt may take a few seconds to minutes for the search index to update with newly created items.",
       "parameters": [
         {
@@ -658,7 +1171,7 @@
           "name": "limit",
           "type": "integer",
           "required": false,
-          "description": "The number of items to list. Defaults to 50, max is 200.",
+          "description": "The number of items to return in this page (1 to 50). Defaults to 25.",
           "enum": null,
           "inferrable": true
         },
@@ -666,7 +1179,7 @@
           "name": "next_token",
           "type": "string",
           "required": false,
-          "description": "The next_token value returned by a previous request.",
+          "description": "Opaque cursor from a previous response's next_token to fetch the next page. Pass it back unchanged; omit for the first page.",
           "enum": null,
           "inferrable": true
         }
@@ -729,21 +1242,21 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftOnedrive.WhoAmI",
-      "fullyQualifiedName": "MicrosoftOnedrive.WhoAmI@0.3.0",
-      "description": "Get information about the current user and their OneDrive environment.",
+      "fullyQualifiedName": "MicrosoftOnedrive.WhoAmI@1.0.0",
+      "description": "Identify the current user and confirm OneDrive access for orientation.",
       "parameters": [],
       "auth": {
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "User.Read"
+          "Files.Read"
         ]
       },
       "secrets": [],
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "Get comprehensive user profile and OneDrive environment information."
+        "description": "The current user's identity and OneDrive environment."
       },
       "documentationChunks": [],
       "codeExample": {
@@ -775,6 +1288,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-03-24T11:24:51.308Z",
-  "summary": "Microsoft OneDrive provider for Arcade.dev exposes LLM-accessible operations to manage files, folders, sharing, search, and drive/user metadata in a user's OneDrive. It enables automation of common workflows—creating, moving, copying, deleting, listing, searching, and sharing items—plus monitoring async operations like large-file copies.\n\n**Capabilities**\n- Unified file and folder lifecycle management (create/move/copy/delete/list) with async copy status tracking.\n- Content discovery and indexing-aware search across the user's drive and items shared with them.\n- Share link creation and shared-item workflows without exposing individual tool signatures.\n- Drive and user metadata introspection (quota, owner, environment).\n\n**OAuth**\n- Provider: microsoft\n- Scopes: Files.Read, Files.ReadWrite, User.Read"
+  "generatedAt": "2026-06-29T12:37:18.560Z",
+  "summary": "Microsoft OneDrive toolkit for Arcade provides LLM-ready tools for managing files, folders, permissions, and sharing in a user's OneDrive via Microsoft Graph.\n\n## Capabilities\n\n- **File & folder operations:** Create folders, copy (with async polling to completion), move/rename (single or batch), delete (single or batch), and download files (with byte-offset paging for large files).\n- **Browse & search:** List folder contents, list files shared with the current user, search the drive index, and retrieve metadata for a single item or the drive itself.\n- **Permissions & sharing:** Create share links (view/edit, user/organization scope), list all grants on an item (links and direct grants), and revoke a single grant or all anonymous links in bulk.\n- **Duplicate detection:** Scan a drive or subtree for byte-identical files, grouped by content fingerprint, with deletion candidates flagged — no manual hashing required.\n- **Resilient error handling:** Stale or missing item IDs return structured `not_found` envelopes (with a `retryable` flag) instead of fatal errors; locked items in batch operations are reported individually without aborting the batch.\n- **Identity & orientation:** Confirm the authenticated user's identity and validate OneDrive access before performing operations.\n\n## OAuth\n\nThis toolkit authenticates via OAuth 2.0 using **Microsoft** as the provider. See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for setup details."
 }


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/28372254320

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are generated toolkit documentation/metadata only; no application source in the diff. OneDrive 1.0.0 documents new destructive/batch APIs but does not alter runtime code in this repo.
> 
> **Overview**
> **Automated MCP server docs refresh** after a successful Porter deploy — updates `toolkit-docs-generator/data/toolkits/*.json` and the toolkit **index** (versions, tool counts, `generatedAt`).
> 
> **Google Contacts 3.6.0** adds **`SearchDirectoryPeople`** (Workspace directory lookup with pagination) and the **`directory.readonly`** OAuth scope; several tool output descriptions now use the generic “No description provided.” placeholder.
> 
> **Google Drive 6.2.0** adds **`CheckFileAccess`** (batched pre-flight access + consolidated picker grant) and **`SearchDrive`** (whole-drive search via **`drive.readonly`**), and extends **`GenerateGoogleFilePickerUrl`** with optional **`file_types`** filtering.
> 
> **Microsoft OneDrive 1.0.0** is a large metadata bump: new tools (**`DownloadFile`**, **`FindDuplicateFiles`**, **`GetItem`**, **`ListItemPermissions`**, **`RevokeItemPermission`**), batch **delete/move**, richer **share links** and **copy** behavior (conflict handling, async poll-to-completion), pagination defaults (25/page), structured **`not_found`** responses, and auth scope cleanup (**`User.Read`** dropped from toolkit scopes; **`WhoAmI`** uses **`Files.Read`**).
> 
> Smaller bumps: **Gmail 7.5.1** clarifies **`UpdateDraftEmail`** `body` for multipart/attachment drafts; **Google Docs 7.0.2** documents **`SearchAndRetrieveDocuments`** `limit` (default 10, max 50); **Linear 3.6.0** adds **`parent_issue`** on **`UpdateIssue`** and tightens sub-issue parameter docs; **Gmail/LinkedIn/Google Sheets** are mostly version + summary timestamp refreshes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53afb866b19be2ad021a135667063a606f9b3630. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->