### PR TITLE
docs: align positioning to "actions runtime for enterprise AI agents"

### DIFF
--- a/app/en/get-started/about-arcade/page.mdx
+++ b/app/en/get-started/about-arcade/page.mdx
@@ -1,6 +1,6 @@
 ---
-title: "About Arcade: the actions runtime for enterprise AI agents"
-description: "Arcade is the actions runtime for enterprise AI agents — enforce security on every action (agent authorization), execute reliably across any system, and govern agents centrally."
+title: "About Arcade: the enterprise-ready actions runtime for AI agents"
+description: "Arcade is the enterprise-ready actions runtime for AI agents — enforce security on every action (agent authorization), execute reliably across any system, and govern agents centrally."
 ---
 
 import { Tabs } from "nextra/components";
@@ -8,7 +8,7 @@ import Image from "next/image";
 
 # About Arcade
 
-Arcade is the actions runtime for enterprise AI agents. An agent isn't an agent if it can't take actions — and the moment an agent acts, three problems hit at once. Arcade solves all three at runtime, so teams ship production agents without rebuilding plumbing every time:
+Arcade is the enterprise-ready actions runtime for AI agents. An agent isn't an agent if it can't take actions — and the moment an agent acts, three problems hit at once. Arcade solves all three at runtime, so teams ship production agents without rebuilding plumbing every time:
 
 - **Enforce — Agent Authorization:** Deploy agents your security team approves. Arcade handles OAuth and manages user tokens, API keys, and secrets, then enforces your existing IdP, DLP, SIEM, and compliance policies plus per-action authorization at runtime.
 - **Execute — Agent-Optimized Tools:** Agents that work across every business system, with 7,500+ agent-optimized tools across 81 MCP servers, built for reliable execution at scale — not thin API wrappers.

--- a/app/en/get-started/about-arcade/page.mdx
+++ b/app/en/get-started/about-arcade/page.mdx
@@ -10,7 +10,7 @@ import Image from "next/image";
 
 Arcade is the actions runtime for enterprise AI agents. An agent isn't an agent if it can't take actions — and the moment an agent acts, three problems hit at once. Arcade solves all three at runtime, so teams ship production agents without rebuilding plumbing every time:
 
-- **Enforce — Agent Authorization:** Deploy agents your security team approves. Your existing IdP, DLP, SIEM, and compliance policies, plus per-action authorization, are enforced at runtime.
+- **Enforce — Agent Authorization:** Deploy agents your security team approves. Arcade handles OAuth and manages user tokens, API keys, and secrets, then enforces your existing IdP, DLP, SIEM, and compliance policies plus per-action authorization at runtime.
 - **Execute — Agent-Optimized Tools:** Agents that work across every business system, with 7,500+ agent-optimized tools across 81 MCP servers, built for reliable execution at scale — not thin API wrappers.
 - **Govern — Agent Lifecycle Governance:** Scale agents across the org from a central control plane: shared registry, version control, visibility filtering, and OpenTelemetry audit logs.
 

--- a/app/en/get-started/about-arcade/page.mdx
+++ b/app/en/get-started/about-arcade/page.mdx
@@ -1,12 +1,24 @@
 ---
-title: "How Arcade helps with Agent Authorization"
-description: "Learn how Arcade helps with auth and tool calling"
+title: "About Arcade: the actions runtime for enterprise AI agents"
+description: "Arcade is the actions runtime for enterprise AI agents — enforce security on every action (agent authorization), execute reliably across any system, and govern agents centrally."
 ---
 
 import { Tabs } from "nextra/components";
 import Image from "next/image";
 
 # About Arcade
+
+Arcade is the actions runtime for enterprise AI agents. An agent isn't an agent if it can't take actions — and the moment an agent acts, three problems hit at once. Arcade solves all three at runtime, so teams ship production agents without rebuilding plumbing every time:
+
+- **Enforce — Agent Authorization:** Deploy agents your security team approves. Your existing IdP, DLP, SIEM, and compliance policies, plus per-action authorization, are enforced at runtime.
+- **Execute — Agent-Optimized Tools:** Agents that work across every business system, with 7,500+ agent-optimized tools across 81 MCP servers, built for reliable execution at scale — not thin API wrappers.
+- **Govern — Agent Lifecycle Governance:** Scale agents across the org from a central control plane: shared registry, version control, visibility filtering, and OpenTelemetry audit logs.
+
+Configure once and use any model, framework, and client. Deploy the first agent the same way you deploy the hundredth.
+
+The rest of this page focuses on the first pillar — **agent authorization** — which is where most agentic applications hit their first wall.
+
+## Why agent authorization matters
 
 Applications that use models to perform tasks (_agentic applications_) commonly require access to sensitive data and services. Authentication complexities often hinder AI from performing tasks that require user-specific information, like what emails were recently received or what's coming up on a calendar.
 

--- a/app/en/get-started/agent-frameworks/google-adk/overview/page.mdx
+++ b/app/en/get-started/agent-frameworks/google-adk/overview/page.mdx
@@ -5,7 +5,7 @@ description: "Integrate Arcade tools with Google ADK agents"
 
 # Arcade with Google ADK
 
-[Google ADK](https://github.com/google/adk-python/) is a modular framework for building and deploying AI agents. It's optimized for Gemini and the Google ecosystem. Arcade integrates with both the Python and TypeScript versions, giving your agents access to Gmail, GitHub, Slack, and 7,000+ other tools.
+[Google ADK](https://github.com/google/adk-python/) is a modular framework for building and deploying AI agents. It's optimized for Gemini and the Google ecosystem. Arcade integrates with both the Python and TypeScript versions, giving your agents access to Gmail, GitHub, Slack, and 7,500+ other tools.
 
 ## Get started
 
@@ -22,6 +22,6 @@ With Arcade and Google ADK, your agents can:
 - Post messages to Slack channels
 - Create GitHub issues and pull requests
 - Search the web and extract content
-- Access 7,000+ other integrations
+- Access 7,500+ other integrations
 
 Browse the [full MCP server catalog](/resources/integrations) to see all available tools.

--- a/app/en/get-started/agent-frameworks/google-adk/setup-typescript/page.mdx
+++ b/app/en/get-started/agent-frameworks/google-adk/setup-typescript/page.mdx
@@ -7,7 +7,7 @@ import { Steps, Tabs, Callout } from "nextra/components";
 
 # Setup Arcade with Google ADK (TypeScript)
 
-[Google ADK for TypeScript](https://github.com/google/adk-js) provides a framework for building AI agents in TypeScript. Arcade's `@arcadeai/arcadejs` library provides the tools integration, allowing your agents to access Gmail, GitHub, Slack, and 7,000+ other services.
+[Google ADK for TypeScript](https://github.com/google/adk-js) provides a framework for building AI agents in TypeScript. Arcade's `@arcadeai/arcadejs` library provides the tools integration, allowing your agents to access Gmail, GitHub, Slack, and 7,500+ other services.
 
 <GuideOverview>
 <GuideOverview.Outcomes>

--- a/app/en/get-started/agent-frameworks/langchain/overview/page.mdx
+++ b/app/en/get-started/agent-frameworks/langchain/overview/page.mdx
@@ -5,7 +5,7 @@ description: "Integrate Arcade tools with LangChain agents"
 
 # Arcade with LangChain
 
-[LangChain](https://www.langchain.com/) is a popular framework for building AI agents that abstracts much of the complexity of agent development. Arcade integrates with both the Python and JavaScript versions, giving your agents access to Gmail, GitHub, Slack, and 7,000+ other tools.
+[LangChain](https://www.langchain.com/) is a popular framework for building AI agents that abstracts much of the complexity of agent development. Arcade integrates with both the Python and JavaScript versions, giving your agents access to Gmail, GitHub, Slack, and 7,500+ other tools.
 
 ## Get started
 
@@ -22,7 +22,7 @@ With Arcade and LangChain, your agents can:
 - Post messages to Slack channels
 - Create GitHub issues and pull requests
 - Search the web and extract content
-- Access 7,000+ other integrations
+- Access 7,500+ other integrations
 
 Browse the [full MCP server catalog](/resources/integrations) to see all available tools.
 

--- a/app/en/get-started/agent-frameworks/openai-agents/overview/page.mdx
+++ b/app/en/get-started/agent-frameworks/openai-agents/overview/page.mdx
@@ -5,7 +5,7 @@ description: "Integrate Arcade tools with the OpenAI Agents SDK"
 
 # Arcade with OpenAI Agents
 
-The [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) provides a framework for building AI agents. Arcade integrates with both the Python and JavaScript versions, giving your agents access to Gmail, GitHub, Slack, and 7,000+ other tools.
+The [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) provides a framework for building AI agents. Arcade integrates with both the Python and JavaScript versions, giving your agents access to Gmail, GitHub, Slack, and 7,500+ other tools.
 
 ## Get started
 
@@ -22,6 +22,6 @@ With Arcade and OpenAI Agents, your agents can:
 - Post messages to Slack channels
 - Create GitHub issues and pull requests
 - Search the web and extract content
-- Access 7,000+ other integrations
+- Access 7,500+ other integrations
 
 Browse the [full MCP server catalog](/resources/integrations) to see all available tools.

--- a/app/en/home/landing-page.tsx
+++ b/app/en/home/landing-page.tsx
@@ -240,9 +240,10 @@ export function LandingPage() {
                 delay: ANIMATION_DELAYS.initial,
               }}
             >
-              Enforce your security policies on every action, execute reliably
-              across 7,500+ agent-optimized tools, and govern agents centrally —
-              so your agents take real action in production.
+              Arcade handles OAuth and manages user tokens, enforces your
+              security policies on every action, executes reliably across 7,500+
+              agent-optimized tools, and governs agents centrally — so your
+              agents take real action in production.
             </motion.p>
             <motion.div
               animate={{ opacity: 1, y: 0 }}
@@ -579,7 +580,7 @@ export function LandingPage() {
           </div>
           <div className="mt-12 grid grid-cols-1 gap-8 min-[1062px]:grid-cols-3">
             <QuickStartCard
-              description="Deploy agents your security team approves. Enforce your existing IdP, DLP, and compliance policies plus per-action agent authorization at runtime — handling OAuth, API keys, and tokens for tools like Gmail and Google Drive."
+              description="Deploy agents your security team approves. Arcade handles OAuth and manages user tokens, API keys, and secrets for tools like Gmail and Google Drive — then enforces your existing IdP, DLP, and compliance policies plus per-action authorization at runtime."
               href="/guides/tool-calling/custom-apps/auth-tool-calling"
               icon={Shield}
               title="Enforce — Agent Authorization"

--- a/app/en/home/landing-page.tsx
+++ b/app/en/home/landing-page.tsx
@@ -229,7 +229,7 @@ export function LandingPage() {
               initial={{ opacity: 0, y: 20 }}
               transition={{ duration: ANIMATION_DURATION }}
             >
-              The actions runtime for enterprise AI agents.
+              The enterprise-ready actions runtime for AI agents.
             </motion.h1>
             <motion.p
               animate={{ opacity: 1, y: 0 }}
@@ -575,7 +575,7 @@ export function LandingPage() {
               How Arcade Works
             </h2>
             <p className="text-gray-600 dark:text-gray-300">
-              Three pillars that power enterprise AI agents.
+              Three pillars that power AI agents in production.
             </p>
           </div>
           <div className="mt-12 grid grid-cols-1 gap-8 min-[1062px]:grid-cols-3">

--- a/app/en/home/landing-page.tsx
+++ b/app/en/home/landing-page.tsx
@@ -229,7 +229,7 @@ export function LandingPage() {
               initial={{ opacity: 0, y: 20 }}
               transition={{ duration: ANIMATION_DURATION }}
             >
-              MCP Runtime for AI agents that get things done.
+              The actions runtime for enterprise AI agents.
             </motion.h1>
             <motion.p
               animate={{ opacity: 1, y: 0 }}
@@ -240,9 +240,9 @@ export function LandingPage() {
                 delay: ANIMATION_DELAYS.initial,
               }}
             >
-              Arcade handles OAuth, manages user tokens, and gives you 7,000+
-              pre-built integrations so your agents can take real action in
-              production.
+              Enforce your security policies on every action, execute reliably
+              across 7,500+ agent-optimized tools, and govern agents centrally —
+              so your agents take real action in production.
             </motion.p>
             <motion.div
               animate={{ opacity: 1, y: 0 }}
@@ -319,7 +319,7 @@ export function LandingPage() {
             {/* Pre-built Integrations — desktop: col 1 row 2 */}
             <div className="min-[1062px]:col-start-1 min-[1062px]:row-start-2">
               <QuickStartCard
-                description="Browse 7,000+ ready-to-use integrations for Gmail, Slack, GitHub, and more."
+                description="Browse 7,500+ ready-to-use integrations for Gmail, Slack, GitHub, and more."
                 href={INTEGRATIONS_PAGE_HREF}
                 icon={Puzzle}
                 logos={[
@@ -459,7 +459,7 @@ export function LandingPage() {
               }
               variant="outline"
             >
-              See all 7,000+
+              See all 7,500+
               <ArrowRight className="ml-2 h-4 w-4" />
             </Button>
           </div>
@@ -574,27 +574,27 @@ export function LandingPage() {
               How Arcade Works
             </h2>
             <p className="text-gray-600 dark:text-gray-300">
-              Three core components that power your AI agents.
+              Three pillars that power enterprise AI agents.
             </p>
           </div>
           <div className="mt-12 grid grid-cols-1 gap-8 min-[1062px]:grid-cols-3">
             <QuickStartCard
-              description="Your MCP server and agentic tool provider. Manages authentication, tool registration, and execution."
-              href="/get-started/about-arcade"
-              icon={Cog}
-              title="Runtime"
-            />
-            <QuickStartCard
-              description="Catalog of pre-built tools and integrations. Browse 7,000+ ready-to-use MCP servers."
-              href={INTEGRATIONS_PAGE_HREF}
-              icon={ToolCase}
-              title="Tool Catalog"
-            />
-            <QuickStartCard
-              description="Let agents act on behalf of users. Handle OAuth, API keys, and tokens for tools like Gmail and Google Drive."
+              description="Deploy agents your security team approves. Enforce your existing IdP, DLP, and compliance policies plus per-action agent authorization at runtime — handling OAuth, API keys, and tokens for tools like Gmail and Google Drive."
               href="/guides/tool-calling/custom-apps/auth-tool-calling"
               icon={Shield}
-              title="Agent Authorization"
+              title="Enforce — Agent Authorization"
+            />
+            <QuickStartCard
+              description="Agents that work across every business system. Browse 7,500+ agent-optimized tools across 81 MCP servers, built for reliable execution at scale — not thin API wrappers."
+              href={INTEGRATIONS_PAGE_HREF}
+              icon={ToolCase}
+              title="Execute — Agent-Optimized Tools"
+            />
+            <QuickStartCard
+              description="Scale agents across your org from a central control plane. Shared registry, version control, visibility filtering, and OpenTelemetry audit logs."
+              href="/get-started/about-arcade"
+              icon={Cog}
+              title="Govern — Agent Lifecycle Governance"
             />
           </div>
         </div>

--- a/app/en/home/page.mdx
+++ b/app/en/home/page.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Arcade Docs"
-description: "Guides, resources, sample agents, and references for Arcade auth providers and MCP servers for agents and developers."
+description: "Arcade is the actions runtime for enterprise AI agents. Guides, resources, sample agents, and references for agent authorization, agent-optimized tools (MCP servers), and agent lifecycle governance."
 ---
 
 import { LandingPage } from "./landing-page";

--- a/app/en/home/page.mdx
+++ b/app/en/home/page.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Arcade Docs"
-description: "Arcade is the actions runtime for enterprise AI agents. Guides, resources, sample agents, and references for agent authorization, agent-optimized tools (MCP servers), and agent lifecycle governance."
+description: "Arcade is the enterprise-ready actions runtime for AI agents. Guides, resources, sample agents, and references for agent authorization, agent-optimized tools (MCP servers), and agent lifecycle governance."
 ---
 
 import { LandingPage } from "./landing-page";

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -50,7 +50,8 @@ export function generateMetadata() {
       default: "Arcade Docs",
       template: "%s | Arcade Docs",
     },
-    description: "Arcade - AI platform for developers",
+    description:
+      "Arcade is the actions runtime for enterprise AI agents — enforce your security policies on every action, execute reliably across any system, and govern agents centrally in production.",
     metadataBase: new URL("https://docs.arcade.dev"),
     manifest: "/site.webmanifest",
     icons: {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -51,7 +51,7 @@ export function generateMetadata() {
       template: "%s | Arcade Docs",
     },
     description:
-      "Arcade is the actions runtime for enterprise AI agents — enforce your security policies on every action, execute reliably across any system, and govern agents centrally in production.",
+      "Arcade is the enterprise-ready actions runtime for AI agents — enforce your security policies on every action, execute reliably across any system, and govern agents centrally in production.",
     metadataBase: new URL("https://docs.arcade.dev"),
     manifest: "/site.webmanifest",
     icons: {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,7 +6,7 @@
 
 Arcade is the actions runtime for enterprise AI agents. We enforce your security policies on every action, execute reliably across any system, and govern agents centrally in production. Configure once and use any model, framework, and client — deploy the first agent the same way you deploy the hundredth.
 
-Arcade delivers three capabilities. Enforce (Agent Authorization): deploy agents your security team approves — your existing IdP, DLP, SIEM, and compliance policies plus per-action authorization enforced at runtime. Execute (Agent-Optimized Tools): the largest catalog of agent-optimized tools — 7,500+ across 81 MCP servers, built for reliable execution at scale, not thin API wrappers. Govern (Agent Lifecycle Governance): a central control plane with a shared registry, version control, visibility filtering, and OpenTelemetry audit logs.
+Arcade delivers three capabilities. Enforce (Agent Authorization): deploy agents your security team approves — Arcade handles OAuth and manages user tokens, API keys, and secrets, then enforces your existing IdP, DLP, SIEM, and compliance policies plus per-action authorization at runtime. Execute (Agent-Optimized Tools): the largest catalog of agent-optimized tools — 7,500+ across 81 MCP servers, built for reliable execution at scale, not thin API wrappers. Govern (Agent Lifecycle Governance): a central control plane with a shared registry, version control, visibility filtering, and OpenTelemetry audit logs.
 
 ## Getting Started
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,11 +2,11 @@
 
 # Arcade
 
-> Arcade is the only runtime for MCP
+> Arcade is the actions runtime for enterprise AI agents.
 
-As the MCP runtime, Arcade is the only one able to deliver secure agent authorization, high-accuracy tools, and centralized governance. Deploy multi-user AI agents that take actions across any system with granular permissions and complete visibility. No complex infrastructure required. Ship faster and scale with control.
+Arcade is the actions runtime for enterprise AI agents. We enforce your security policies on every action, execute reliably across any system, and govern agents centrally in production. Configure once and use any model, framework, and client — deploy the first agent the same way you deploy the hundredth.
 
-Arcade delivers three core capabilities: Deploy agents even your security team will love with authorization-first architecture. Unlock highest accuracy actions across all MCP tools with agent-optimized integrations and the Arcade TDK. Maintain centralized control over production MCP without slowing down AI development. Access 1000s of pre-built MCP servers or bring your own, with unified governance across all tools.
+Arcade delivers three capabilities. Enforce (Agent Authorization): deploy agents your security team approves — your existing IdP, DLP, SIEM, and compliance policies plus per-action authorization enforced at runtime. Execute (Agent-Optimized Tools): the largest catalog of agent-optimized tools — 7,500+ across 81 MCP servers, built for reliable execution at scale, not thin API wrappers. Govern (Agent Lifecycle Governance): a central control plane with a shared registry, version control, visibility filtering, and OpenTelemetry audit logs.
 
 ## Getting Started
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,9 +2,9 @@
 
 # Arcade
 
-> Arcade is the actions runtime for enterprise AI agents.
+> Arcade is the enterprise-ready actions runtime for AI agents.
 
-Arcade is the actions runtime for enterprise AI agents. We enforce your security policies on every action, execute reliably across any system, and govern agents centrally in production. Configure once and use any model, framework, and client — deploy the first agent the same way you deploy the hundredth.
+Arcade is the enterprise-ready actions runtime for AI agents. We enforce your security policies on every action, execute reliably across any system, and govern agents centrally in production. Configure once and use any model, framework, and client — deploy the first agent the same way you deploy the hundredth.
 
 Arcade delivers three capabilities. Enforce (Agent Authorization): deploy agents your security team approves — Arcade handles OAuth and manages user tokens, API keys, and secrets, then enforces your existing IdP, DLP, SIEM, and compliance policies plus per-action authorization at runtime. Execute (Agent-Optimized Tools): the largest catalog of agent-optimized tools — 7,500+ across 81 MCP servers, built for reliable execution at scale, not thin API wrappers. Govern (Agent Lifecycle Governance): a central control plane with a shared registry, version control, visibility filtering, and OpenTelemetry audit logs.
 

--- a/scripts/generate-llmstxt.ts
+++ b/scripts/generate-llmstxt.ts
@@ -354,14 +354,14 @@ function generateLlmsTxt(
   // Header
   lines.push("# Arcade");
   lines.push("");
-  lines.push("> Arcade is the only runtime for MCP");
+  lines.push("> Arcade is the actions runtime for enterprise AI agents.");
   lines.push("");
   lines.push(
-    "As the MCP runtime, Arcade is the only one able to deliver secure agent authorization, high-accuracy tools, and centralized governance. Deploy multi-user AI agents that take actions across any system with granular permissions and complete visibility. No complex infrastructure required. Ship faster and scale with control."
+    "Arcade is the actions runtime for enterprise AI agents. We enforce your security policies on every action, execute reliably across any system, and govern agents centrally in production. Configure once and use any model, framework, and client — deploy the first agent the same way you deploy the hundredth."
   );
   lines.push("");
   lines.push(
-    "Arcade delivers three core capabilities: Deploy agents even your security team will love with authorization-first architecture. Unlock highest accuracy actions across all MCP tools with agent-optimized integrations and the Arcade TDK. Maintain centralized control over production MCP without slowing down AI development. Access 1000s of pre-built MCP servers or bring your own, with unified governance across all tools."
+    "Arcade delivers three capabilities. Enforce (Agent Authorization): deploy agents your security team approves — your existing IdP, DLP, SIEM, and compliance policies plus per-action authorization enforced at runtime. Execute (Agent-Optimized Tools): the largest catalog of agent-optimized tools — 7,500+ across 81 MCP servers, built for reliable execution at scale, not thin API wrappers. Govern (Agent Lifecycle Governance): a central control plane with a shared registry, version control, visibility filtering, and OpenTelemetry audit logs."
   );
   lines.push("");
 

--- a/scripts/generate-llmstxt.ts
+++ b/scripts/generate-llmstxt.ts
@@ -361,7 +361,7 @@ function generateLlmsTxt(
   );
   lines.push("");
   lines.push(
-    "Arcade delivers three capabilities. Enforce (Agent Authorization): deploy agents your security team approves — your existing IdP, DLP, SIEM, and compliance policies plus per-action authorization enforced at runtime. Execute (Agent-Optimized Tools): the largest catalog of agent-optimized tools — 7,500+ across 81 MCP servers, built for reliable execution at scale, not thin API wrappers. Govern (Agent Lifecycle Governance): a central control plane with a shared registry, version control, visibility filtering, and OpenTelemetry audit logs."
+    "Arcade delivers three capabilities. Enforce (Agent Authorization): deploy agents your security team approves — Arcade handles OAuth and manages user tokens, API keys, and secrets, then enforces your existing IdP, DLP, SIEM, and compliance policies plus per-action authorization at runtime. Execute (Agent-Optimized Tools): the largest catalog of agent-optimized tools — 7,500+ across 81 MCP servers, built for reliable execution at scale, not thin API wrappers. Govern (Agent Lifecycle Governance): a central control plane with a shared registry, version control, visibility filtering, and OpenTelemetry audit logs."
   );
   lines.push("");
 

--- a/scripts/generate-llmstxt.ts
+++ b/scripts/generate-llmstxt.ts
@@ -354,10 +354,10 @@ function generateLlmsTxt(
   // Header
   lines.push("# Arcade");
   lines.push("");
-  lines.push("> Arcade is the actions runtime for enterprise AI agents.");
+  lines.push("> Arcade is the enterprise-ready actions runtime for AI agents.");
   lines.push("");
   lines.push(
-    "Arcade is the actions runtime for enterprise AI agents. We enforce your security policies on every action, execute reliably across any system, and govern agents centrally in production. Configure once and use any model, framework, and client — deploy the first agent the same way you deploy the hundredth."
+    "Arcade is the enterprise-ready actions runtime for AI agents. We enforce your security policies on every action, execute reliably across any system, and govern agents centrally in production. Configure once and use any model, framework, and client — deploy the first agent the same way you deploy the hundredth."
   );
   lines.push("");
   lines.push(


### PR DESCRIPTION
## What

Aligns the docs' top-of-funnel and machine-readable copy with the canonical **Arcade Product Messaging Framework** ([Google Doc](https://docs.google.com/document/d/11BRNC2G0PI5AIxu6tbjRWMkDiZn5bNyTkb_JEHP_us0/edit)).

Canonical positioning applied:
- **Tagline:** "Arcade is the actions runtime for enterprise AI agents" (drops "the only runtime for MCP" / "MCP Runtime" — MCP is the protocol, not the positioning; scope is **enterprise**).
- **Pillars:** Enforce / Execute / Govern, paired with the searchable capability terms (Agent Authorization, Agent-Optimized Tools, Agent Lifecycle Governance) so keyword retrieval is preserved.
- **Enforce framed broadly** — existing security stack (IdP/DLP/SIEM/compliance) **plus** per-action authorization, not just OAuth.

## Changes

| Finding | File | Change |
|---|---|---|
| P0 #1–3 | `scripts/generate-llmstxt.ts` | Rewrote the `>` blockquote + description to lead with "actions runtime for enterprise AI agents"; named Enforce/Execute/Govern; replaced `1000s` with `7,500+ across 81 MCP servers` |
| P1 #4–5 | `app/en/home/landing-page.tsx` | Hero H1 "MCP Runtime…" → "The actions runtime for enterprise AI agents."; reframed subhead to Enforce/Execute/Govern |
| P2 #7 | `app/en/home/landing-page.tsx` | "How Arcade Works" cards relabeled to **Enforce — Agent Authorization / Execute — Agent-Optimized Tools / Govern — Agent Lifecycle Governance** |
| P2 #6 | `app/en/get-started/about-arcade/page.mdx` | Broadened from auth-only to the three pillars; kept agent authorization as the Enforce deep-dive |
| P3 #8 | `app/layout.tsx` | Root meta description now carries the positioning sentence |
| P3 #10 | `app/en/home/page.mdx` | Home frontmatter description carries positioning + pillar keywords |
| #9 | landing page + 4 agent-framework MDX overviews | Tool count `7,000+` → `7,500+` repo-wide |

## Notes
- **`public/llms.txt` not edited directly** — it's generated from `scripts/generate-llmstxt.ts` and regenerates on the next build (source-only change, per review decision).
- **No asserted `XX%` proof points** were introduced — the framework lists those as unfilled placeholders.
- Vale style check runs in CI (the binary isn't installed in this environment, so it was skipped locally; lint/format hooks passed).
- The `<Button render=…>` TypeScript diagnostics in `landing-page.tsx` are pre-existing (untouched design-system JSX), not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and copy-only changes with no application logic, auth, or API behavior modified.
> 
> **Overview**
> Repositions docs and marketing copy from **MCP runtime** framing to **enterprise-ready actions runtime for AI agents**, using the **Enforce / Execute / Govern** pillars (Agent Authorization, Agent-Optimized Tools, Agent Lifecycle Governance).
> 
> The **home landing page** hero, subhead, integration counts, and **How Arcade Works** cards are rewritten with new titles, descriptions, and links (e.g. Enforce → auth tool-calling, Govern → about Arcade). **About Arcade** front matter and intro now cover all three pillars before the existing authorization deep-dive. **Root and home metadata** descriptions carry the same positioning for SEO.
> 
> **Agent framework** overview/setup pages bump **7,000+** to **7,500+** tools. **`scripts/generate-llmstxt.ts`** (and regenerated **`public/llms.txt`**) update the LLM-facing header to match, including **7,500+ across 81 MCP servers** instead of vague “1000s” and “only runtime for MCP” language.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 169a6834c28f82e69ff3f49f4d75c5c753f0fd2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->