### PR TITLE
chore: update @arcadeai/design-system to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://arcade.dev/",
   "dependencies": {
-    "@arcadeai/design-system": "3.49.0",
+    "@arcadeai/design-system": "4.1.0",
     "@mdx-js/mdx": "3.1.1",
     "@mdx-js/react": "3.1.1",
     "@next/third-parties": "16.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     dependencies:
       '@arcadeai/design-system':
-        specifier: 3.49.0
-        version: 3.49.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)
+        specifier: 4.1.0
+        version: 4.1.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)
       '@mdx-js/mdx':
         specifier: 3.1.1
         version: 3.1.1
@@ -272,8 +272,8 @@ packages:
       zod:
         optional: true
 
-  '@arcadeai/design-system@3.49.0':
-    resolution: {integrity: sha512-w0ioMMyPZDV2dSiPjUvPfbO4zsvR1dV/d+liZh5Fkp+0jmw0FRhloastVvPDpPLclHOH12jO0j/9qfTHRsz6EA==}
+  '@arcadeai/design-system@4.1.0':
+    resolution: {integrity: sha512-NARhgXof7Z5orPMIaU0ZAMqx7evELtIZFw+WfC65P4SpYBR/p/U8t78AidKXeKonaWyzRBEgOvE0Ai9r0crrbQ==}
     engines: {bun: '>=1.3.5'}
     peerDependencies:
       '@hookform/resolvers': '>=5.2.1'
@@ -4651,7 +4651,7 @@ snapshots:
     optionalDependencies:
       zod: 4.3.6
 
-  '@arcadeai/design-system@3.49.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)':
+  '@arcadeai/design-system@4.1.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)':
     dependencies:
       '@base-ui/react': 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.16)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@base-ui/utils': 0.2.9(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
This PR updates `@arcadeai/design-system` to the latest published version.

It runs a design-system compatibility test gate before opening this PR.
If that gate fails, the workflow stops and no PR is created.

- Trigger: `workflow_dispatch`
- Run: https://github.com/ArcadeAI/docs/actions/runs/28623088770

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> A major design-system version bump can change component APIs, styling, or tokens site-wide even without local code edits; risk is mitigated if the compatibility gate passed but visual/regression checks on docs UI are still worth doing.
> 
> **Overview**
> Bumps **`@arcadeai/design-system`** from **3.49.0** to **4.1.0** in `package.json`, with the matching lockfile resolution updates in `pnpm-lock.yaml`. There are no application source changes in this diff—only the dependency version and lock metadata.
> 
> This aligns the docs site with the latest published design system (a major minor jump from 3.x to 4.x), after the automated compatibility test gate described in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9751385d9b23462213f59627b9c05bd2f2bcacd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->