### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/toolkit-docs-generator/data/toolkits/googlecalendar.json
+++ b/toolkit-docs-generator/data/toolkits/googlecalendar.json
@@ -1,7 +1,7 @@
 {
   "id": "GoogleCalendar",
   "label": "Google Calendar",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Arcade.dev LLM tools for Google Calendar",
   "metadata": {
     "category": "productivity",
@@ -27,7 +27,7 @@
     {
       "name": "CreateEvent",
       "qualifiedName": "GoogleCalendar.CreateEvent",
-      "fullyQualifiedName": "GoogleCalendar.CreateEvent@3.4.0",
+      "fullyQualifiedName": "GoogleCalendar.CreateEvent@3.5.0",
       "description": "Create a new event/meeting/sync/meetup in the specified calendar.\n\nPass `recurrence` to create a repeating event.",
       "parameters": [
         {
@@ -235,7 +235,7 @@
     {
       "name": "DeleteEvent",
       "qualifiedName": "GoogleCalendar.DeleteEvent",
-      "fullyQualifiedName": "GoogleCalendar.DeleteEvent@3.4.0",
+      "fullyQualifiedName": "GoogleCalendar.DeleteEvent@3.5.0",
       "description": "Delete an event from Google Calendar.",
       "parameters": [
         {
@@ -325,7 +325,7 @@
     {
       "name": "FindTimeSlotsWhenEveryoneIsFree",
       "qualifiedName": "GoogleCalendar.FindTimeSlotsWhenEveryoneIsFree",
-      "fullyQualifiedName": "GoogleCalendar.FindTimeSlotsWhenEveryoneIsFree@3.4.0",
+      "fullyQualifiedName": "GoogleCalendar.FindTimeSlotsWhenEveryoneIsFree@3.5.0",
       "description": "Provides time slots when everyone is free within a given date range and time boundaries.",
       "parameters": [
         {
@@ -441,7 +441,7 @@
     {
       "name": "ListCalendars",
       "qualifiedName": "GoogleCalendar.ListCalendars",
-      "fullyQualifiedName": "GoogleCalendar.ListCalendars@3.4.0",
+      "fullyQualifiedName": "GoogleCalendar.ListCalendars@3.5.0",
       "description": "List all calendars accessible by the user.",
       "parameters": [
         {
@@ -541,7 +541,7 @@
     {
       "name": "ListEvents",
       "qualifiedName": "GoogleCalendar.ListEvents",
-      "fullyQualifiedName": "GoogleCalendar.ListEvents@3.4.0",
+      "fullyQualifiedName": "GoogleCalendar.ListEvents@3.5.0",
       "description": "List events from the specified calendar within the given datetime range.\n\nmin_end_datetime serves as the lower bound (exclusive) for an event's end time.\nmax_start_datetime serves as the upper bound (exclusive) for an event's start time.\n\nFor example:\nIf min_end_datetime is set to 2024-09-15T09:00:00 and max_start_datetime\nis set to 2024-09-16T17:00:00, the function will return events that:\n1. End after 09:00 on September 15, 2024 (exclusive)\n2. Start before 17:00 on September 16, 2024 (exclusive)\nThis means an event starting at 08:00 on September 15 and\nending at 10:00 on September 15 would be included, but an\nevent starting at 17:00 on September 16 would not be included.",
       "parameters": [
         {
@@ -639,9 +639,115 @@
       }
     },
     {
+      "name": "RespondToEvent",
+      "qualifiedName": "GoogleCalendar.RespondToEvent",
+      "fullyQualifiedName": "GoogleCalendar.RespondToEvent@3.5.0",
+      "description": "Accept or decline (RSVP to) a meeting invitation on the authenticated user's behalf.\n\nSets the user's responseStatus for an event they were invited to.",
+      "parameters": [
+        {
+          "name": "event_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the event to respond to. Use the event id from list_events to respond to a single occurrence of a recurring event, or its recurringEventId to respond to the whole series.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "response",
+          "type": "string",
+          "required": true,
+          "description": "The RSVP response: accepted or declined.",
+          "enum": [
+            "accepted",
+            "declined"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "calendar_id",
+          "type": "string",
+          "required": false,
+          "description": "The ID of the calendar containing the event",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "send_updates",
+          "type": "string",
+          "required": false,
+          "description": "Should attendees be notified of the response? (none, all, external_only)",
+          "enum": [
+            "none",
+            "all",
+            "externalOnly"
+          ],
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "google",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://www.googleapis.com/auth/calendar.events"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "string",
+        "description": "A confirmation message with the new RSVP status and event details"
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "GoogleCalendar.RespondToEvent",
+        "parameters": {
+          "event_id": {
+            "value": "7q3k2p1abc456def789ghi_20240315T140000Z",
+            "type": "string",
+            "required": true
+          },
+          "response": {
+            "value": "accepted",
+            "type": "string",
+            "required": true
+          },
+          "calendar_id": {
+            "value": "user@example.com",
+            "type": "string",
+            "required": false
+          },
+          "send_updates": {
+            "value": "all",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "calendar"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "UpdateEvent",
       "qualifiedName": "GoogleCalendar.UpdateEvent",
-      "fullyQualifiedName": "GoogleCalendar.UpdateEvent@3.4.0",
+      "fullyQualifiedName": "GoogleCalendar.UpdateEvent@3.5.0",
       "description": "Update an existing event in the specified calendar with the provided details.\nOnly the provided fields will be updated; others will remain unchanged.\n\n`updated_start_datetime` and `updated_end_datetime` are\nindependent and can be provided separately.",
       "parameters": [
         {
@@ -880,7 +986,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "GoogleCalendar.WhoAmI",
-      "fullyQualifiedName": "GoogleCalendar.WhoAmI@3.4.0",
+      "fullyQualifiedName": "GoogleCalendar.WhoAmI@3.5.0",
       "description": "Get comprehensive user profile and Google Calendar environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Google Calendar access permissions, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -945,6 +1051,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-06-05T12:08:01.475Z",
-  "summary": "The Google Calendar toolkit for Arcade integrates with Google Calendar via OAuth, enabling LLMs to read, create, update, and delete calendar data on behalf of authenticated users.\n\n## Capabilities\n\n- **Calendar discovery & user context:** List all calendars accessible to the user and retrieve the authenticated user's profile, email, and Calendar access permissions.\n- **Event querying:** List events within a datetime range using precise exclusive bounds on both start and end times, supporting complex filtering across one or more days.\n- **Event management:** Create single or recurring events (via recurrence rules), update individual fields of existing events without overwriting unchanged fields, and delete events.\n- **Scheduling assistance:** Find available time slots when all specified participants are free within a given date range and time boundaries.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via the **Google** provider. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details, required API enablement, and scope coverage."
+  "generatedAt": "2026-07-01T12:07:52.574Z",
+  "summary": "**Google Calendar toolkit** connects Arcade-powered LLMs to Google Calendar, enabling agents to read, create, modify, and delete calendar data on behalf of authenticated users.\n\n## Capabilities\n\n- **Calendar discovery & user context** — list all accessible calendars and retrieve the authenticated user's profile, email, permissions, and environment details.\n- **Event querying** — list events within precise datetime ranges using independent lower/upper bounds on end and start times, supporting complex overlap queries.\n- **Event creation & recurrence** — create one-off or repeating events/meetings with full recurrence rule support.\n- **Event management** — update individual fields of existing events (start/end times are independently settable), delete events, and RSVP (accept or decline) on the user's behalf.\n- **Availability analysis** — find free time slots across multiple attendees within a specified date range and daily time boundaries.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via the **Google** provider. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for configuration details, required scopes, and setup instructions."
 }

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-29T12:37:34.138Z",
+  "generatedAt": "2026-07-01T12:08:11.358Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -356,10 +356,10 @@
     {
       "id": "GoogleCalendar",
       "label": "Google Calendar",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "category": "productivity",
       "type": "arcade",
-      "toolCount": 7,
+      "toolCount": 8,
       "authType": "oauth2"
     },
     {
@@ -590,7 +590,7 @@
     {
       "id": "Jira",
       "label": "Jira",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 43,
@@ -599,7 +599,7 @@
     {
       "id": "Linear",
       "label": "Linear",
-      "version": "3.6.0",
+      "version": "3.6.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 42,
@@ -887,10 +887,10 @@
     {
       "id": "Telegram",
       "label": "Telegram",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "category": "social",
       "type": "arcade",
-      "toolCount": 5,
+      "toolCount": 7,
       "authType": "none"
     },
     {

--- a/toolkit-docs-generator/data/toolkits/jira.json
+++ b/toolkit-docs-generator/data/toolkits/jira.json
@@ -1,7 +1,7 @@
 {
   "id": "Jira",
   "label": "Jira",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Arcade.dev LLM tools for interacting with Atlassian Jira",
   "metadata": {
     "category": "productivity",
@@ -35,7 +35,7 @@
     {
       "name": "AddCommentToIssue",
       "qualifiedName": "Jira.AddCommentToIssue",
-      "fullyQualifiedName": "Jira.AddCommentToIssue@3.1.4",
+      "fullyQualifiedName": "Jira.AddCommentToIssue@3.1.5",
       "description": "Add a comment to a Jira issue.",
       "parameters": [
         {
@@ -154,7 +154,7 @@
     {
       "name": "AddIssuesToSprint",
       "qualifiedName": "Jira.AddIssuesToSprint",
-      "fullyQualifiedName": "Jira.AddIssuesToSprint@3.1.4",
+      "fullyQualifiedName": "Jira.AddIssuesToSprint@3.1.5",
       "description": "Add a list of issues to a sprint.\nMaximum of 50 issues per operation.",
       "parameters": [
         {
@@ -249,7 +249,7 @@
     {
       "name": "AddLabelsToIssue",
       "qualifiedName": "Jira.AddLabelsToIssue",
-      "fullyQualifiedName": "Jira.AddLabelsToIssue@3.1.4",
+      "fullyQualifiedName": "Jira.AddLabelsToIssue@3.1.5",
       "description": "Add labels to an existing Jira issue.",
       "parameters": [
         {
@@ -356,7 +356,7 @@
     {
       "name": "AttachFileToIssue",
       "qualifiedName": "Jira.AttachFileToIssue",
-      "fullyQualifiedName": "Jira.AttachFileToIssue@3.1.4",
+      "fullyQualifiedName": "Jira.AttachFileToIssue@3.1.5",
       "description": "Add an attachment to an issue.\n\nMust provide exactly one of file_content_str or file_content_base64.",
       "parameters": [
         {
@@ -495,7 +495,7 @@
     {
       "name": "CreateIssue",
       "qualifiedName": "Jira.CreateIssue",
-      "fullyQualifiedName": "Jira.CreateIssue@3.1.4",
+      "fullyQualifiedName": "Jira.CreateIssue@3.1.5",
       "description": "Create a new Jira issue.\n\nProvide a value to one of `project` or `parent_issue` arguments. If `project` and\n`parent_issue` are not provided, the tool will select the single project available.\nIf the user has multiple, an error will be returned with the available projects to choose from.\n\nIf you have an issue type name, or a project key/name, a priority name, an assignee\nname/key/email, or a reporter name/key/email, DO NOT CALL OTHER TOOLS only to list available\nprojects, priorities, issue types, or users. Provide the name, key, or email and the tool\nwill figure out the ID.",
       "parameters": [
         {
@@ -706,7 +706,7 @@
     {
       "name": "DownloadAttachment",
       "qualifiedName": "Jira.DownloadAttachment",
-      "fullyQualifiedName": "Jira.DownloadAttachment@3.1.4",
+      "fullyQualifiedName": "Jira.DownloadAttachment@3.1.5",
       "description": "Download the contents of an attachment associated with an issue.",
       "parameters": [
         {
@@ -780,7 +780,7 @@
     {
       "name": "GetAttachmentMetadata",
       "qualifiedName": "Jira.GetAttachmentMetadata",
-      "fullyQualifiedName": "Jira.GetAttachmentMetadata@3.1.4",
+      "fullyQualifiedName": "Jira.GetAttachmentMetadata@3.1.5",
       "description": "Get the metadata of an attachment.",
       "parameters": [
         {
@@ -854,7 +854,7 @@
     {
       "name": "GetAvailableAtlassianClouds",
       "qualifiedName": "Jira.GetAvailableAtlassianClouds",
-      "fullyQualifiedName": "Jira.GetAvailableAtlassianClouds@3.1.4",
+      "fullyQualifiedName": "Jira.GetAvailableAtlassianClouds@3.1.5",
       "description": "Get available Atlassian Clouds.",
       "parameters": [],
       "auth": {
@@ -899,7 +899,7 @@
     {
       "name": "GetBoardBacklogIssues",
       "qualifiedName": "Jira.GetBoardBacklogIssues",
-      "fullyQualifiedName": "Jira.GetBoardBacklogIssues@3.1.4",
+      "fullyQualifiedName": "Jira.GetBoardBacklogIssues@3.1.5",
       "description": "Get all issues in a board's backlog with pagination support.\nReturns issues that are not currently assigned to any active sprint.\n\nThe backlog contains issues that are ready to be planned into future sprints.\nOnly boards that support backlogs (like Scrum and Kanban boards) will return results.",
       "parameters": [
         {
@@ -999,7 +999,7 @@
     {
       "name": "GetBoards",
       "qualifiedName": "Jira.GetBoards",
-      "fullyQualifiedName": "Jira.GetBoards@3.1.4",
+      "fullyQualifiedName": "Jira.GetBoards@3.1.5",
       "description": "Retrieve Jira boards either by specifying their names or IDs, or get all\navailable boards.\nAll requests support offset and limit with a maximum of 50 boards returned per call.\n\nMANDATORY ACTION: ALWAYS when you need to get multiple boards, you must\ninclude all the board identifiers in a single call rather than making\nmultiple separate tool calls, as this provides much better performance, not doing that will\nbring huge performance penalties.\n\nThe tool automatically handles mixed identifier types (names and IDs), deduplicates results, and\nfalls back from ID lookup to name lookup when needed.",
       "parameters": [
         {
@@ -1107,7 +1107,7 @@
     {
       "name": "GetCommentById",
       "qualifiedName": "Jira.GetCommentById",
-      "fullyQualifiedName": "Jira.GetCommentById@3.1.4",
+      "fullyQualifiedName": "Jira.GetCommentById@3.1.5",
       "description": "Get a comment by its ID.",
       "parameters": [
         {
@@ -1207,7 +1207,7 @@
     {
       "name": "GetIssueById",
       "qualifiedName": "Jira.GetIssueById",
-      "fullyQualifiedName": "Jira.GetIssueById@3.1.4",
+      "fullyQualifiedName": "Jira.GetIssueById@3.1.5",
       "description": "Get the details of a Jira issue by its ID.",
       "parameters": [
         {
@@ -1281,7 +1281,7 @@
     {
       "name": "GetIssueComments",
       "qualifiedName": "Jira.GetIssueComments",
-      "fullyQualifiedName": "Jira.GetIssueComments@3.1.4",
+      "fullyQualifiedName": "Jira.GetIssueComments@3.1.5",
       "description": "Get the comments of a Jira issue by its ID.",
       "parameters": [
         {
@@ -1410,7 +1410,7 @@
     {
       "name": "GetIssuesWithoutId",
       "qualifiedName": "Jira.GetIssuesWithoutId",
-      "fullyQualifiedName": "Jira.GetIssuesWithoutId@3.1.4",
+      "fullyQualifiedName": "Jira.GetIssuesWithoutId@3.1.5",
       "description": "Search for Jira issues when you don't have the issue ID(s).\n\nAll text-based arguments (keywords, assignee, project, labels) are case-insensitive.\n\nALWAYS PREFER THIS TOOL OVER THE `Jira.SearchIssuesWithJql` TOOL, UNLESS IT'S ABSOLUTELY\nNECESSARY TO USE A JQL QUERY TO FILTER IN A WAY THAT IS NOT SUPPORTED BY THIS TOOL.",
       "parameters": [
         {
@@ -1632,7 +1632,7 @@
     {
       "name": "GetIssueTypeById",
       "qualifiedName": "Jira.GetIssueTypeById",
-      "fullyQualifiedName": "Jira.GetIssueTypeById@3.1.4",
+      "fullyQualifiedName": "Jira.GetIssueTypeById@3.1.5",
       "description": "Get the details of a Jira issue type by its ID.",
       "parameters": [
         {
@@ -1706,7 +1706,7 @@
     {
       "name": "GetPriorityById",
       "qualifiedName": "Jira.GetPriorityById",
-      "fullyQualifiedName": "Jira.GetPriorityById@3.1.4",
+      "fullyQualifiedName": "Jira.GetPriorityById@3.1.5",
       "description": "Get the details of a priority by its ID.",
       "parameters": [
         {
@@ -1780,7 +1780,7 @@
     {
       "name": "GetProjectById",
       "qualifiedName": "Jira.GetProjectById",
-      "fullyQualifiedName": "Jira.GetProjectById@3.1.4",
+      "fullyQualifiedName": "Jira.GetProjectById@3.1.5",
       "description": "Get the details of a Jira project by its ID or key.",
       "parameters": [
         {
@@ -1854,7 +1854,7 @@
     {
       "name": "GetSprintIssues",
       "qualifiedName": "Jira.GetSprintIssues",
-      "fullyQualifiedName": "Jira.GetSprintIssues@3.1.4",
+      "fullyQualifiedName": "Jira.GetSprintIssues@3.1.5",
       "description": "Get all issues that are currently assigned to a specific sprint with pagination support.\nReturns issues that are planned for or being worked on in the sprint.",
       "parameters": [
         {
@@ -1955,7 +1955,7 @@
     {
       "name": "GetTransitionById",
       "qualifiedName": "Jira.GetTransitionById",
-      "fullyQualifiedName": "Jira.GetTransitionById@3.1.4",
+      "fullyQualifiedName": "Jira.GetTransitionById@3.1.5",
       "description": "Get a transition by its ID.",
       "parameters": [
         {
@@ -2042,7 +2042,7 @@
     {
       "name": "GetTransitionByStatusName",
       "qualifiedName": "Jira.GetTransitionByStatusName",
-      "fullyQualifiedName": "Jira.GetTransitionByStatusName@3.1.4",
+      "fullyQualifiedName": "Jira.GetTransitionByStatusName@3.1.5",
       "description": "Get a transition available for an issue by the transition name.\n\nThe response will contain screen fields available for the transition, if any.",
       "parameters": [
         {
@@ -2129,7 +2129,7 @@
     {
       "name": "GetTransitionsAvailableForIssue",
       "qualifiedName": "Jira.GetTransitionsAvailableForIssue",
-      "fullyQualifiedName": "Jira.GetTransitionsAvailableForIssue@3.1.4",
+      "fullyQualifiedName": "Jira.GetTransitionsAvailableForIssue@3.1.5",
       "description": "Get the transitions available for an existing Jira issue.",
       "parameters": [
         {
@@ -2203,7 +2203,7 @@
     {
       "name": "GetUserById",
       "qualifiedName": "Jira.GetUserById",
-      "fullyQualifiedName": "Jira.GetUserById@3.1.4",
+      "fullyQualifiedName": "Jira.GetUserById@3.1.5",
       "description": "Get user information by their ID.",
       "parameters": [
         {
@@ -2276,7 +2276,7 @@
     {
       "name": "GetUsersWithoutId",
       "qualifiedName": "Jira.GetUsersWithoutId",
-      "fullyQualifiedName": "Jira.GetUsersWithoutId@3.1.4",
+      "fullyQualifiedName": "Jira.GetUsersWithoutId@3.1.5",
       "description": "Get users without their account ID, searching by display name and email address.\n\nThe Jira user search API will return up to 1,000 (one thousand) users for any given name/email\nquery. If you need to get more users, please use the `Jira.ListAllUsers` tool.",
       "parameters": [
         {
@@ -2388,7 +2388,7 @@
     {
       "name": "ListIssueAttachmentsMetadata",
       "qualifiedName": "Jira.ListIssueAttachmentsMetadata",
-      "fullyQualifiedName": "Jira.ListIssueAttachmentsMetadata@3.1.4",
+      "fullyQualifiedName": "Jira.ListIssueAttachmentsMetadata@3.1.5",
       "description": "Get the metadata about the files attached to an issue.\n\nThis tool does NOT return the actual file contents. To get a file content,\nuse the `Jira.DownloadAttachment` tool.",
       "parameters": [
         {
@@ -2461,7 +2461,7 @@
     {
       "name": "ListIssues",
       "qualifiedName": "Jira.ListIssues",
-      "fullyQualifiedName": "Jira.ListIssues@3.1.4",
+      "fullyQualifiedName": "Jira.ListIssues@3.1.5",
       "description": "Get the issues for a given project.",
       "parameters": [
         {
@@ -2562,7 +2562,7 @@
     {
       "name": "ListIssueTypesByProject",
       "qualifiedName": "Jira.ListIssueTypesByProject",
-      "fullyQualifiedName": "Jira.ListIssueTypesByProject@3.1.4",
+      "fullyQualifiedName": "Jira.ListIssueTypesByProject@3.1.5",
       "description": "Get the list of issue types (e.g. 'Task', 'Epic', etc.) available to a given project.",
       "parameters": [
         {
@@ -2662,7 +2662,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Jira.ListLabels",
-      "fullyQualifiedName": "Jira.ListLabels@3.1.4",
+      "fullyQualifiedName": "Jira.ListLabels@3.1.5",
       "description": "Get the existing labels (tags) in the user's Jira instance.",
       "parameters": [
         {
@@ -2749,7 +2749,7 @@
     {
       "name": "ListPrioritiesAvailableToAnIssue",
       "qualifiedName": "Jira.ListPrioritiesAvailableToAnIssue",
-      "fullyQualifiedName": "Jira.ListPrioritiesAvailableToAnIssue@3.1.4",
+      "fullyQualifiedName": "Jira.ListPrioritiesAvailableToAnIssue@3.1.5",
       "description": "Browse the priorities available to be used in the specified Jira issue.",
       "parameters": [
         {
@@ -2823,7 +2823,7 @@
     {
       "name": "ListPrioritiesAvailableToAProject",
       "qualifiedName": "Jira.ListPrioritiesAvailableToAProject",
-      "fullyQualifiedName": "Jira.ListPrioritiesAvailableToAProject@3.1.4",
+      "fullyQualifiedName": "Jira.ListPrioritiesAvailableToAProject@3.1.5",
       "description": "Browse the priorities available to be used in issues in the specified Jira project.\n\nThis tool may need to loop through several API calls to get all priorities associated with\na specific project. In Jira environments with too many Projects or Priority Schemes,\nthe search may take too long, and the tool call will timeout.",
       "parameters": [
         {
@@ -2897,7 +2897,7 @@
     {
       "name": "ListPrioritiesByScheme",
       "qualifiedName": "Jira.ListPrioritiesByScheme",
-      "fullyQualifiedName": "Jira.ListPrioritiesByScheme@3.1.4",
+      "fullyQualifiedName": "Jira.ListPrioritiesByScheme@3.1.5",
       "description": "Browse the priorities associated with a priority scheme.",
       "parameters": [
         {
@@ -2997,7 +2997,7 @@
     {
       "name": "ListPrioritySchemes",
       "qualifiedName": "Jira.ListPrioritySchemes",
-      "fullyQualifiedName": "Jira.ListPrioritySchemes@3.1.4",
+      "fullyQualifiedName": "Jira.ListPrioritySchemes@3.1.5",
       "description": "Browse the priority schemes available in Jira.",
       "parameters": [
         {
@@ -3113,7 +3113,7 @@
     {
       "name": "ListProjects",
       "qualifiedName": "Jira.ListProjects",
-      "fullyQualifiedName": "Jira.ListProjects@3.1.4",
+      "fullyQualifiedName": "Jira.ListProjects@3.1.5",
       "description": "Browse projects available in Jira.",
       "parameters": [
         {
@@ -3200,7 +3200,7 @@
     {
       "name": "ListProjectsByScheme",
       "qualifiedName": "Jira.ListProjectsByScheme",
-      "fullyQualifiedName": "Jira.ListProjectsByScheme@3.1.4",
+      "fullyQualifiedName": "Jira.ListProjectsByScheme@3.1.5",
       "description": "Browse the projects associated with a priority scheme.",
       "parameters": [
         {
@@ -3313,7 +3313,7 @@
     {
       "name": "ListSprintsForBoards",
       "qualifiedName": "Jira.ListSprintsForBoards",
-      "fullyQualifiedName": "Jira.ListSprintsForBoards@3.1.4",
+      "fullyQualifiedName": "Jira.ListSprintsForBoards@3.1.5",
       "description": "Retrieve sprints from Jira boards with filtering options for planning and tracking purposes.\n\nUse this when you need to view sprints from specific boards or find sprints within specific\ndate ranges. For temporal queries like \"last month\", \"next week\", or \"this quarter\",\nprioritize date parameters over state filtering. Leave board_identifiers_list as None\nto get sprints from all available boards.\n\nDATE FILTERING PRIORITY: When users request sprints by time periods (e.g., \"last month\",\n\"next week\"), use date parameters (start_date, end_date, specific_date) rather than\nstate filtering, as temporal criteria take precedence over sprint status.\n\nReturns sprint data along with a backlog GUI URL link where you can see detailed sprint\ninformation and manage sprint items.\n\nMANDATORY ACTION: ALWAYS when you need to get sprints from multiple boards, you must\ninclude all the board identifiers in a single call rather than making\nmultiple separate tool calls, as this provides much better performance, not doing that will\nbring huge performance penalties.\n\nBOARD LIMIT: Maximum of 25 boards can be processed in a single operation. If you need to\nprocess more boards, split the request into multiple batches of 25 or fewer boards each.\n\nHandles mixed board identifiers (names and IDs) with automatic fallback and deduplication.\nAll boards are processed concurrently for optimal performance.",
       "parameters": [
         {
@@ -3483,7 +3483,7 @@
     {
       "name": "ListUsers",
       "qualifiedName": "Jira.ListUsers",
-      "fullyQualifiedName": "Jira.ListUsers@3.1.4",
+      "fullyQualifiedName": "Jira.ListUsers@3.1.5",
       "description": "Browse users in Jira.",
       "parameters": [
         {
@@ -3582,7 +3582,7 @@
     {
       "name": "MoveIssuesFromSprintToBacklog",
       "qualifiedName": "Jira.MoveIssuesFromSprintToBacklog",
-      "fullyQualifiedName": "Jira.MoveIssuesFromSprintToBacklog@3.1.4",
+      "fullyQualifiedName": "Jira.MoveIssuesFromSprintToBacklog@3.1.5",
       "description": "Move issues from active or future sprints back to the board's backlog.",
       "parameters": [
         {
@@ -3675,7 +3675,7 @@
     {
       "name": "RemoveLabelsFromIssue",
       "qualifiedName": "Jira.RemoveLabelsFromIssue",
-      "fullyQualifiedName": "Jira.RemoveLabelsFromIssue@3.1.4",
+      "fullyQualifiedName": "Jira.RemoveLabelsFromIssue@3.1.5",
       "description": "Remove labels from an existing Jira issue.",
       "parameters": [
         {
@@ -3782,7 +3782,7 @@
     {
       "name": "SearchIssuesWithJql",
       "qualifiedName": "Jira.SearchIssuesWithJql",
-      "fullyQualifiedName": "Jira.SearchIssuesWithJql@3.1.4",
+      "fullyQualifiedName": "Jira.SearchIssuesWithJql@3.1.5",
       "description": "Search for Jira issues using a JQL (Jira Query Language) query.\n\nALWAYS PREFER THE `Jira_SearchIssuesWithoutJql` TOOL OVER THIS ONE, UNLESS IT'S ABSOLUTELY\nNECESSARY TO USE A JQL QUERY TO FILTER IN A WAY THAT IS NOT SUPPORTED BY THE\n`Jira_SearchIssuesWithoutJql` TOOL OR IF THE USER PROVIDES A JQL QUERY THEMSELVES.",
       "parameters": [
         {
@@ -3882,7 +3882,7 @@
     {
       "name": "SearchIssuesWithoutJql",
       "qualifiedName": "Jira.SearchIssuesWithoutJql",
-      "fullyQualifiedName": "Jira.SearchIssuesWithoutJql@3.1.4",
+      "fullyQualifiedName": "Jira.SearchIssuesWithoutJql@3.1.5",
       "description": "Parameterized search for Jira issues (without having to provide a JQL query).\n\nALWAYS PREFER THIS TOOL OVER USING JQL, UNLESS IT'S ABSOLUTELY NECESSARY TO USE A JQL QUERY\nTO FILTER IN A WAY THAT IS NOT SUPPORTED BY THIS TOOL OR IF THE USER PROVIDES A JQL QUERY\nTHEMSELVES.",
       "parameters": [
         {
@@ -4104,7 +4104,7 @@
     {
       "name": "SearchProjects",
       "qualifiedName": "Jira.SearchProjects",
-      "fullyQualifiedName": "Jira.SearchProjects@3.1.4",
+      "fullyQualifiedName": "Jira.SearchProjects@3.1.5",
       "description": "Get the details of all Jira projects.",
       "parameters": [
         {
@@ -4204,7 +4204,7 @@
     {
       "name": "TransitionIssueToNewStatus",
       "qualifiedName": "Jira.TransitionIssueToNewStatus",
-      "fullyQualifiedName": "Jira.TransitionIssueToNewStatus@3.1.4",
+      "fullyQualifiedName": "Jira.TransitionIssueToNewStatus@3.1.5",
       "description": "Transition a Jira issue to a new status.",
       "parameters": [
         {
@@ -4292,7 +4292,7 @@
     {
       "name": "UpdateIssue",
       "qualifiedName": "Jira.UpdateIssue",
-      "fullyQualifiedName": "Jira.UpdateIssue@3.1.4",
+      "fullyQualifiedName": "Jira.UpdateIssue@3.1.5",
       "description": "Update an existing Jira issue.\n\nIf you have a priority name, an assignee name/key/email, or a reporter name/key/email,\nDO NOT CALL OTHER TOOLS only to list available priorities, issue types, or users.\nProvide the name, key, or email and the tool will figure out the ID.",
       "parameters": [
         {
@@ -4516,7 +4516,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Jira.WhoAmI",
-      "fullyQualifiedName": "Jira.WhoAmI@3.1.4",
+      "fullyQualifiedName": "Jira.WhoAmI@3.1.5",
       "description": "CALL THIS TOOL FIRST to establish user profile context.\n\nGet information about the currently logged-in user and their available Jira clouds/clients.",
       "parameters": [],
       "auth": {
@@ -4575,6 +4575,6 @@
       "relativePath": "environment-variables/page.mdx"
     }
   ],
-  "generatedAt": "2026-06-23T12:07:49.216Z",
+  "generatedAt": "2026-07-01T12:07:50.191Z",
   "summary": "The Jira toolkit integrates Arcade with Atlassian Jira, enabling LLMs to manage issues, sprints, boards, users, attachments, and project metadata across Jira Cloud instances.\n\n## Capabilities\n\n- **Issue lifecycle management** — Create, update, transition, search (parameterized or JQL), comment on, label, and attach files to issues; move issues between sprints and backlogs.\n- **Sprint & board operations** — List boards and their sprints (with date-range filtering), retrieve backlog and sprint issues, add/move issues to sprints, and access backlog GUI URLs.\n- **Project & metadata discovery** — Browse projects, issue types, priority schemes, labels, and available transitions; resolve names/keys/emails to IDs automatically without requiring pre-lookup calls.\n- **User & identity management** — Look up users by ID, name, or email; list all users; retrieve the authenticated user's profile and available Atlassian Cloud instances.\n- **Attachment handling** — List attachment metadata, download attachment contents, and upload files (string or base64) to issues.\n\n## OAuth\n\nAuthentication uses OAuth 2.0 via the **Atlassian** provider. See the [Atlassian auth provider docs](https://docs.arcade.dev/en/references/auth-providers/atlassian) for setup details, required scopes, and configuration steps."
 }

--- a/toolkit-docs-generator/data/toolkits/linear.json
+++ b/toolkit-docs-generator/data/toolkits/linear.json
@@ -1,7 +1,7 @@
 {
   "id": "Linear",
   "label": "Linear",
-  "version": "3.6.0",
+  "version": "3.6.2",
   "description": "Arcade tools designed for LLMs to interact with Linear",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "AddComment",
       "qualifiedName": "Linear.AddComment",
-      "fullyQualifiedName": "Linear.AddComment@3.6.0",
+      "fullyQualifiedName": "Linear.AddComment@3.6.2",
       "description": "Add a comment to an issue.",
       "parameters": [
         {
@@ -99,7 +99,7 @@
     {
       "name": "AddProjectComment",
       "qualifiedName": "Linear.AddProjectComment",
-      "fullyQualifiedName": "Linear.AddProjectComment@3.6.0",
+      "fullyQualifiedName": "Linear.AddProjectComment@3.6.2",
       "description": "Add a comment to a project's document content.\n\nIMPORTANT: Due to Linear API limitations, comments created via the API will NOT\nappear visually anchored inline in the document (no yellow highlight on text).\nThe comment will be stored and can be retrieved via list_project_comments, but\nit will appear in the comments panel rather than inline in the document.\n\nFor true inline comments that are visually anchored to text, users should create\nthem directly in the Linear UI by selecting text and adding a comment.\n\nThe quoted_text parameter stores metadata about what text the comment references,\nwhich is useful for context even though the comment won't be visually anchored.",
       "parameters": [
         {
@@ -198,7 +198,7 @@
     {
       "name": "AddProjectToInitiative",
       "qualifiedName": "Linear.AddProjectToInitiative",
-      "fullyQualifiedName": "Linear.AddProjectToInitiative@3.6.0",
+      "fullyQualifiedName": "Linear.AddProjectToInitiative@3.6.2",
       "description": "Link a project to an initiative.\n\nBoth initiative and project can be specified by ID or name.\nIf a name is provided, fuzzy matching is used to resolve it.",
       "parameters": [
         {
@@ -284,7 +284,7 @@
     {
       "name": "ArchiveInitiative",
       "qualifiedName": "Linear.ArchiveInitiative",
-      "fullyQualifiedName": "Linear.ArchiveInitiative@3.6.0",
+      "fullyQualifiedName": "Linear.ArchiveInitiative@3.6.2",
       "description": "Archive an initiative.\n\nArchived initiatives are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -357,7 +357,7 @@
     {
       "name": "ArchiveIssue",
       "qualifiedName": "Linear.ArchiveIssue",
-      "fullyQualifiedName": "Linear.ArchiveIssue@3.6.0",
+      "fullyQualifiedName": "Linear.ArchiveIssue@3.6.2",
       "description": "Archive an issue.\n\nArchived issues are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -417,7 +417,7 @@
     {
       "name": "ArchiveProject",
       "qualifiedName": "Linear.ArchiveProject",
-      "fullyQualifiedName": "Linear.ArchiveProject@3.6.0",
+      "fullyQualifiedName": "Linear.ArchiveProject@3.6.2",
       "description": "Archive a project.\n\nArchived projects are hidden from default views but can be restored.",
       "parameters": [
         {
@@ -490,7 +490,7 @@
     {
       "name": "CreateInitiative",
       "qualifiedName": "Linear.CreateInitiative",
-      "fullyQualifiedName": "Linear.CreateInitiative@3.6.0",
+      "fullyQualifiedName": "Linear.CreateInitiative@3.6.2",
       "description": "Create a new Linear initiative.\n\nInitiatives are high-level strategic goals that group related projects.",
       "parameters": [
         {
@@ -596,7 +596,7 @@
     {
       "name": "CreateIssue",
       "qualifiedName": "Linear.CreateIssue",
-      "fullyQualifiedName": "Linear.CreateIssue@3.6.0",
+      "fullyQualifiedName": "Linear.CreateIssue@3.6.2",
       "description": "Create a new Linear issue with validation.\n\nWhen assignee is None or '@me', the issue is assigned to the authenticated user.\nAll entity references (team, assignee, labels, state, project, cycle, parent)\nare validated before creation. If an entity is not found, suggestions are\nreturned to help correct the input.",
       "parameters": [
         {
@@ -739,6 +739,7 @@
         "providerId": "linear",
         "providerType": "oauth2",
         "scopes": [
+          "read",
           "write"
         ]
       },
@@ -758,12 +759,12 @@
             "required": true
           },
           "title": {
-            "value": "Fix login page redirect bug",
+            "value": "Fix null pointer exception in user authentication flow",
             "type": "string",
             "required": true
           },
           "description": {
-            "value": "## Bug Report\n\nUsers are being redirected to a 404 page after successful login.\n\n**Steps to reproduce:**\n1. Navigate to `/login`\n2. Enter valid credentials\n3. Click 'Sign In'\n\n**Expected:** Redirect to dashboard\n**Actual:** Redirect to `/home` which returns 404",
+            "value": "## Bug Report\n\nA null pointer exception occurs when a user attempts to log in with an unverified email address.\n\n**Steps to Reproduce:**\n1. Register a new account\n2. Skip email verification\n3. Attempt to log in\n\n**Expected:** Friendly error message\n**Actual:** 500 Internal Server Error",
             "type": "string",
             "required": false
           },
@@ -775,13 +776,14 @@
           "labels_to_add": {
             "value": [
               "bug",
-              "high-priority"
+              "high-impact",
+              "backend"
             ],
             "type": "array",
             "required": false
           },
           "priority": {
-            "value": "high",
+            "value": "urgent",
             "type": "string",
             "required": false
           },
@@ -791,7 +793,7 @@
             "required": false
           },
           "project": {
-            "value": "Q3 Platform Improvements",
+            "value": "Q3 Platform Stability",
             "type": "string",
             "required": false
           },
@@ -801,12 +803,12 @@
             "required": false
           },
           "milestone": {
-            "value": "Beta Release",
+            "value": "v2.5 Release",
             "type": "string",
             "required": false
           },
           "parent_issue": {
-            "value": "ENG-101",
+            "value": "ENG-128",
             "type": "string",
             "required": false
           },
@@ -821,12 +823,12 @@
             "required": false
           },
           "attachment_url": {
-            "value": "https://github.com/example-org/repo/issues/88",
+            "value": "https://sentry.io/organizations/example/issues/12345/",
             "type": "string",
             "required": false
           },
           "attachment_title": {
-            "value": "GitHub Issue Reference #88",
+            "value": "Sentry Error Trace - NPE in AuthService",
             "type": "string",
             "required": false
           },
@@ -861,7 +863,7 @@
     {
       "name": "CreateIssueRelation",
       "qualifiedName": "Linear.CreateIssueRelation",
-      "fullyQualifiedName": "Linear.CreateIssueRelation@3.6.0",
+      "fullyQualifiedName": "Linear.CreateIssueRelation@3.6.2",
       "description": "Create a relation between two issues.\n\nRelation types define the relationship from the source issue's perspective:\n- blocks: Source issue blocks the related issue\n- blockedBy: Source issue is blocked by the related issue\n- duplicate: Source issue is a duplicate of the related issue\n- related: Issues are related (bidirectional)",
       "parameters": [
         {
@@ -952,7 +954,7 @@
     {
       "name": "CreateProject",
       "qualifiedName": "Linear.CreateProject",
-      "fullyQualifiedName": "Linear.CreateProject@3.6.0",
+      "fullyQualifiedName": "Linear.CreateProject@3.6.2",
       "description": "Create a new Linear project.\n\nTeam is validated before creation. If team is not found, suggestions are\nreturned to help correct the input. Lead is validated if provided.",
       "parameters": [
         {
@@ -1123,7 +1125,7 @@
     {
       "name": "CreateProjectUpdate",
       "qualifiedName": "Linear.CreateProjectUpdate",
-      "fullyQualifiedName": "Linear.CreateProjectUpdate@3.6.0",
+      "fullyQualifiedName": "Linear.CreateProjectUpdate@3.6.2",
       "description": "Create a project status update.\n\nProject updates are posts that communicate progress, blockers, or status\nchanges to stakeholders. They appear in the project's Updates tab and\ncan include a health status indicator.",
       "parameters": [
         {
@@ -1213,7 +1215,7 @@
     {
       "name": "GetCycle",
       "qualifiedName": "Linear.GetCycle",
-      "fullyQualifiedName": "Linear.GetCycle@3.6.0",
+      "fullyQualifiedName": "Linear.GetCycle@3.6.2",
       "description": "Get detailed information about a specific Linear cycle.",
       "parameters": [
         {
@@ -1273,7 +1275,7 @@
     {
       "name": "GetInitiative",
       "qualifiedName": "Linear.GetInitiative",
-      "fullyQualifiedName": "Linear.GetInitiative@3.6.0",
+      "fullyQualifiedName": "Linear.GetInitiative@3.6.2",
       "description": "Get detailed information about a specific Linear initiative.\n\nSupports lookup by ID or name (with fuzzy matching for name).",
       "parameters": [
         {
@@ -1375,7 +1377,7 @@
     {
       "name": "GetInitiativeDescription",
       "qualifiedName": "Linear.GetInitiativeDescription",
-      "fullyQualifiedName": "Linear.GetInitiativeDescription@3.6.0",
+      "fullyQualifiedName": "Linear.GetInitiativeDescription@3.6.2",
       "description": "Get an initiative's full description with pagination support.\n\nUse this tool when you need the complete description of an initiative that\nwas truncated in the get_initiative response. Supports chunked reading for\nvery large descriptions.",
       "parameters": [
         {
@@ -1461,7 +1463,7 @@
     {
       "name": "GetIssue",
       "qualifiedName": "Linear.GetIssue",
-      "fullyQualifiedName": "Linear.GetIssue@3.6.0",
+      "fullyQualifiedName": "Linear.GetIssue@3.6.2",
       "description": "Get detailed information about a specific Linear issue.\n\nAccepts either the issue UUID or the human-readable identifier (like TOO-123).",
       "parameters": [
         {
@@ -1573,7 +1575,7 @@
     {
       "name": "GetMilestone",
       "qualifiedName": "Linear.GetMilestone",
-      "fullyQualifiedName": "Linear.GetMilestone@3.6.0",
+      "fullyQualifiedName": "Linear.GetMilestone@3.6.2",
       "description": "Get a milestone by ID or name inside a project.",
       "parameters": [
         {
@@ -1659,7 +1661,7 @@
     {
       "name": "GetNotifications",
       "qualifiedName": "Linear.GetNotifications",
-      "fullyQualifiedName": "Linear.GetNotifications@3.6.0",
+      "fullyQualifiedName": "Linear.GetNotifications@3.6.2",
       "description": "Get the authenticated user's notifications.\n\nReturns notifications including issue mentions, comments, assignments,\nand state changes.",
       "parameters": [
         {
@@ -1745,7 +1747,7 @@
     {
       "name": "GetProject",
       "qualifiedName": "Linear.GetProject",
-      "fullyQualifiedName": "Linear.GetProject@3.6.0",
+      "fullyQualifiedName": "Linear.GetProject@3.6.2",
       "description": "Get detailed information about a specific Linear project.\n\nSupports lookup by ID, slug_id, or name (with fuzzy matching for name).",
       "parameters": [
         {
@@ -1861,7 +1863,7 @@
     {
       "name": "GetProjectDescription",
       "qualifiedName": "Linear.GetProjectDescription",
-      "fullyQualifiedName": "Linear.GetProjectDescription@3.6.0",
+      "fullyQualifiedName": "Linear.GetProjectDescription@3.6.2",
       "description": "Get a project's full description with pagination support.\n\nUse this tool when you need the complete description of a project that\nwas truncated in the get_project response. Supports chunked reading for\nvery large descriptions.",
       "parameters": [
         {
@@ -1947,7 +1949,7 @@
     {
       "name": "GetRecentActivity",
       "qualifiedName": "Linear.GetRecentActivity",
-      "fullyQualifiedName": "Linear.GetRecentActivity@3.6.0",
+      "fullyQualifiedName": "Linear.GetRecentActivity@3.6.2",
       "description": "Get the authenticated user's recent issue activity.\n\nReturns issues the user has recently created or been assigned to\nwithin the specified time period.",
       "parameters": [
         {
@@ -2020,7 +2022,7 @@
     {
       "name": "GetTeam",
       "qualifiedName": "Linear.GetTeam",
-      "fullyQualifiedName": "Linear.GetTeam@3.6.0",
+      "fullyQualifiedName": "Linear.GetTeam@3.6.2",
       "description": "Get detailed information about a specific Linear team.\n\nSupports lookup by ID, key (like TOO, ENG), or name (with fuzzy matching).",
       "parameters": [
         {
@@ -2110,7 +2112,7 @@
     {
       "name": "LinkGithubToIssue",
       "qualifiedName": "Linear.LinkGithubToIssue",
-      "fullyQualifiedName": "Linear.LinkGithubToIssue@3.6.0",
+      "fullyQualifiedName": "Linear.LinkGithubToIssue@3.6.2",
       "description": "Link a GitHub PR, commit, or issue to a Linear issue.\n\nAutomatically detects the artifact type from the URL and generates\nan appropriate title if not provided.",
       "parameters": [
         {
@@ -2142,6 +2144,7 @@
         "providerId": "linear",
         "providerType": "oauth2",
         "scopes": [
+          "read",
           "write"
         ]
       },
@@ -2156,17 +2159,17 @@
         "toolName": "Linear.LinkGithubToIssue",
         "parameters": {
           "issue": {
-            "value": "PROJ-123",
+            "value": "ENG-1042",
             "type": "string",
             "required": true
           },
           "github_url": {
-            "value": "https://github.com/example-org/example-repo/pull/78",
+            "value": "https://github.com/myorg/myrepo/pull/318",
             "type": "string",
             "required": true
           },
           "title": {
-            "value": "PR #78: Fix login redirect issue",
+            "value": "Fix authentication bug - PR #318",
             "type": "string",
             "required": false
           }
@@ -2196,7 +2199,7 @@
     {
       "name": "ListComments",
       "qualifiedName": "Linear.ListComments",
-      "fullyQualifiedName": "Linear.ListComments@3.6.0",
+      "fullyQualifiedName": "Linear.ListComments@3.6.2",
       "description": "List comments on an issue.\n\nReturns comments with user info, timestamps, and reply threading info.",
       "parameters": [
         {
@@ -2282,7 +2285,7 @@
     {
       "name": "ListCycles",
       "qualifiedName": "Linear.ListCycles",
-      "fullyQualifiedName": "Linear.ListCycles@3.6.0",
+      "fullyQualifiedName": "Linear.ListCycles@3.6.2",
       "description": "List Linear cycles, optionally filtered by team and status.\n\nCycles are time-boxed iterations (like sprints) for organizing work.",
       "parameters": [
         {
@@ -2394,7 +2397,7 @@
     {
       "name": "ListInitiatives",
       "qualifiedName": "Linear.ListInitiatives",
-      "fullyQualifiedName": "Linear.ListInitiatives@3.6.0",
+      "fullyQualifiedName": "Linear.ListInitiatives@3.6.2",
       "description": "List Linear initiatives, optionally filtered by keywords and other criteria.\n\nReturns all initiatives when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2500,7 +2503,7 @@
     {
       "name": "ListIssues",
       "qualifiedName": "Linear.ListIssues",
-      "fullyQualifiedName": "Linear.ListIssues@3.6.0",
+      "fullyQualifiedName": "Linear.ListIssues@3.6.2",
       "description": "List Linear issues, optionally filtered by keywords and other criteria.\n\nReturns all issues when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -2683,7 +2686,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Linear.ListLabels",
-      "fullyQualifiedName": "Linear.ListLabels@3.6.0",
+      "fullyQualifiedName": "Linear.ListLabels@3.6.2",
       "description": "List available issue labels in the workspace.\n\nReturns labels that can be applied to issues. Use label IDs or names\nwhen creating or updating issues.",
       "parameters": [
         {
@@ -2743,7 +2746,7 @@
     {
       "name": "ListMilestones",
       "qualifiedName": "Linear.ListMilestones",
-      "fullyQualifiedName": "Linear.ListMilestones@3.6.0",
+      "fullyQualifiedName": "Linear.ListMilestones@3.6.2",
       "description": "List milestones in a Linear project.",
       "parameters": [
         {
@@ -2842,7 +2845,7 @@
     {
       "name": "ListProjectComments",
       "qualifiedName": "Linear.ListProjectComments",
-      "fullyQualifiedName": "Linear.ListProjectComments@3.6.0",
+      "fullyQualifiedName": "Linear.ListProjectComments@3.6.2",
       "description": "List comments on a project's document content.\n\nReturns comments with user info, timestamps, quoted text for inline comments,\nand reply threading info. Replies are nested under their parent comments.\n\nUse comment_filter to control which comments are returned:\n- only_quoted (default): Only comments attached to a quote in the text\n- only_unquoted: Only comments not attached to a particular quote\n- all: All comments regardless of being attached to a quote or not",
       "parameters": [
         {
@@ -2971,7 +2974,7 @@
     {
       "name": "ListProjects",
       "qualifiedName": "Linear.ListProjects",
-      "fullyQualifiedName": "Linear.ListProjects@3.6.0",
+      "fullyQualifiedName": "Linear.ListProjects@3.6.2",
       "description": "List Linear projects, optionally filtered by keywords and other criteria.\n\nReturns all projects when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -3096,7 +3099,7 @@
     {
       "name": "ListTeams",
       "qualifiedName": "Linear.ListTeams",
-      "fullyQualifiedName": "Linear.ListTeams@3.6.0",
+      "fullyQualifiedName": "Linear.ListTeams@3.6.2",
       "description": "List Linear teams, optionally filtered by keywords and other criteria.\n\nReturns all teams when no filters provided, or filtered results when\nkeywords or other filters are specified.",
       "parameters": [
         {
@@ -3208,7 +3211,7 @@
     {
       "name": "ListWorkflowStates",
       "qualifiedName": "Linear.ListWorkflowStates",
-      "fullyQualifiedName": "Linear.ListWorkflowStates@3.6.0",
+      "fullyQualifiedName": "Linear.ListWorkflowStates@3.6.2",
       "description": "List available workflow states in the workspace.\n\nReturns workflow states that can be used for issue transitions.\nStates are team-specific and have different types.",
       "parameters": [
         {
@@ -3301,7 +3304,7 @@
     {
       "name": "ManageIssueSubscription",
       "qualifiedName": "Linear.ManageIssueSubscription",
-      "fullyQualifiedName": "Linear.ManageIssueSubscription@3.6.0",
+      "fullyQualifiedName": "Linear.ManageIssueSubscription@3.6.2",
       "description": "Subscribe to or unsubscribe from an issue's notifications.",
       "parameters": [
         {
@@ -3374,7 +3377,7 @@
     {
       "name": "ReplyToComment",
       "qualifiedName": "Linear.ReplyToComment",
-      "fullyQualifiedName": "Linear.ReplyToComment@3.6.0",
+      "fullyQualifiedName": "Linear.ReplyToComment@3.6.2",
       "description": "Reply to an existing comment on an issue.\n\nCreates a threaded reply to the specified parent comment.",
       "parameters": [
         {
@@ -3460,7 +3463,7 @@
     {
       "name": "ReplyToProjectComment",
       "qualifiedName": "Linear.ReplyToProjectComment",
-      "fullyQualifiedName": "Linear.ReplyToProjectComment@3.6.0",
+      "fullyQualifiedName": "Linear.ReplyToProjectComment@3.6.2",
       "description": "Reply to an existing comment on a project document.\n\nCreates a threaded reply to the specified parent comment.",
       "parameters": [
         {
@@ -3559,7 +3562,7 @@
     {
       "name": "TransitionIssueState",
       "qualifiedName": "Linear.TransitionIssueState",
-      "fullyQualifiedName": "Linear.TransitionIssueState@3.6.0",
+      "fullyQualifiedName": "Linear.TransitionIssueState@3.6.2",
       "description": "Transition a Linear issue to a new workflow state.\n\nThe target state is validated against the team's available states.",
       "parameters": [
         {
@@ -3645,7 +3648,7 @@
     {
       "name": "UpdateComment",
       "qualifiedName": "Linear.UpdateComment",
-      "fullyQualifiedName": "Linear.UpdateComment@3.6.0",
+      "fullyQualifiedName": "Linear.UpdateComment@3.6.2",
       "description": "Update an existing comment.",
       "parameters": [
         {
@@ -3718,7 +3721,7 @@
     {
       "name": "UpdateInitiative",
       "qualifiedName": "Linear.UpdateInitiative",
-      "fullyQualifiedName": "Linear.UpdateInitiative@3.6.0",
+      "fullyQualifiedName": "Linear.UpdateInitiative@3.6.2",
       "description": "Update a Linear initiative with partial updates.\n\nOnly fields that are explicitly provided will be updated.",
       "parameters": [
         {
@@ -3837,7 +3840,7 @@
     {
       "name": "UpdateIssue",
       "qualifiedName": "Linear.UpdateIssue",
-      "fullyQualifiedName": "Linear.UpdateIssue@3.6.0",
+      "fullyQualifiedName": "Linear.UpdateIssue@3.6.2",
       "description": "Update a Linear issue with partial updates.\n\nOnly fields that are explicitly provided will be updated. All entity\nreferences are validated before update.",
       "parameters": [
         {
@@ -3989,6 +3992,7 @@
         "providerId": "linear",
         "providerType": "oauth2",
         "scopes": [
+          "read",
           "write"
         ]
       },
@@ -4008,12 +4012,12 @@
             "required": true
           },
           "title": {
-            "value": "Fix login page crash on mobile devices",
+            "value": "Fix authentication timeout bug",
             "type": "string",
             "required": false
           },
           "description": {
-            "value": "## Summary\n\nThe login page crashes when users attempt to sign in on iOS devices running version 16 or later.\n\n## Steps to Reproduce\n1. Open the app on an iOS 16+ device\n2. Enter credentials\n3. Tap 'Sign In'\n\n## Expected Behavior\nUser is authenticated and redirected to dashboard.\n\n## Actual Behavior\nApp crashes immediately.",
+            "value": "## Summary\n\nUsers are experiencing session timeouts after 5 minutes of inactivity.\n\n## Steps to Reproduce\n1. Log in to the app\n2. Wait 5 minutes\n3. Attempt any action\n\n## Expected Behavior\nSession should remain active for 30 minutes.",
             "type": "string",
             "required": false
           },
@@ -4025,7 +4029,6 @@
           "labels_to_add": {
             "value": [
               "bug",
-              "mobile",
               "high-priority"
             ],
             "type": "array",
@@ -4049,7 +4052,7 @@
             "required": false
           },
           "project": {
-            "value": "Mobile App Overhaul",
+            "value": "Q4 Platform Improvements",
             "type": "string",
             "required": false
           },
@@ -4059,7 +4062,7 @@
             "required": false
           },
           "milestone": {
-            "value": "Q3 Release",
+            "value": "v2.5 Release",
             "type": "string",
             "required": false
           },
@@ -4074,17 +4077,17 @@
             "required": false
           },
           "due_date": {
-            "value": "2025-09-15",
+            "value": "2024-12-31",
             "type": "string",
             "required": false
           },
           "attachment_url": {
-            "value": "https://github.com/example-org/repo/issues/456",
+            "value": "https://docs.example.com/issues/auth-timeout-investigation",
             "type": "string",
             "required": false
           },
           "attachment_title": {
-            "value": "Related GitHub Issue #456",
+            "value": "Auth Timeout Investigation Doc",
             "type": "string",
             "required": false
           },
@@ -4119,7 +4122,7 @@
     {
       "name": "UpdateProject",
       "qualifiedName": "Linear.UpdateProject",
-      "fullyQualifiedName": "Linear.UpdateProject@3.6.0",
+      "fullyQualifiedName": "Linear.UpdateProject@3.6.2",
       "description": "Update a Linear project with partial updates.\n\nOnly fields that are explicitly provided will be updated. All entity\nreferences are validated before update.\n\nIMPORTANT: Updating the 'content' field will break any existing inline\ncomment anchoring. The comments will still exist and be retrievable via\nlist_project_comments, but they will no longer appear visually anchored\nto text in the Linear UI. The 'description' field can be safely updated\nwithout affecting inline comments.",
       "parameters": [
         {
@@ -4323,7 +4326,7 @@
     {
       "name": "UpsertMilestone",
       "qualifiedName": "Linear.UpsertMilestone",
-      "fullyQualifiedName": "Linear.UpsertMilestone@3.6.0",
+      "fullyQualifiedName": "Linear.UpsertMilestone@3.6.2",
       "description": "Upsert a project's milestone.",
       "parameters": [
         {
@@ -4449,7 +4452,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Linear.WhoAmI",
-      "fullyQualifiedName": "Linear.WhoAmI@3.6.0",
+      "fullyQualifiedName": "Linear.WhoAmI@3.6.2",
       "description": "Get the authenticated user's profile and team memberships.\n\nReturns the current user's information including their name, email,\norganization, and the teams they belong to.",
       "parameters": [],
       "auth": {
@@ -4503,6 +4506,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-06-29T12:37:19.654Z",
-  "summary": "The **Linear** toolkit connects LLMs to the [Linear](https://linear.app) project management platform, enabling agents to fully manage issues, projects, initiatives, cycles, comments, and team workflows through the Linear API.\n\n## Capabilities\n\n- **Issue lifecycle management** — create, update, archive, transition workflow states, manage relations (blocks/blocked-by/duplicate/related), link GitHub PRs/commits, subscribe to notifications, and retrieve detailed issue data or recent activity.\n- **Projects & milestones** — create, update, archive, and list projects; upsert and retrieve milestones; post and list project status updates; read full paginated project descriptions.\n- **Initiatives** — create, update, archive, and list high-level strategic initiatives; link projects to initiatives; read full paginated initiative descriptions.\n- **Cycles, teams & workflow states** — list time-boxed cycles filtered by team/status; look up teams by ID, key, or fuzzy name; enumerate workspace-wide labels and team-specific workflow states.\n- **Comments & threading** — add, update, list, and reply to threaded comments on both issues and project documents; retrieve project comments filtered by inline-quote anchoring status (note: API-created project comments appear in the comments panel only, not visually anchored to text in the Linear UI).\n- **User & workspace context** — retrieve the authenticated user's profile, team memberships, and notifications.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via the **Linear** provider. Arcade manages token acquisition and refresh automatically. See the [Linear auth provider docs](https://docs.arcade.dev/en/references/auth-providers/linear) for configuration details."
+  "generatedAt": "2026-07-01T12:07:56.201Z",
+  "summary": "# Linear Toolkit\n\nThe Linear toolkit lets LLMs interact with Linear's project management platform via Arcade, covering the full lifecycle of issues, projects, initiatives, cycles, and team workflows.\n\n## Capabilities\n\n- **Issue management** — create, update, archive, transition workflow states, manage labels, link GitHub PRs/commits/issues, subscribe to notifications, and model relationships between issues (blocks, duplicates, related).\n- **Projects & milestones** — create, update, and archive projects; add status updates; upsert and retrieve milestones; fetch full paginated descriptions.\n- **Initiatives** — create, update, archive, and list high-level strategic initiatives; link projects to initiatives; read paginated descriptions.\n- **Comments & threading** — add, update, reply to, and list comments on both issues and project documents; note that API-created project comments appear in the comments panel only (not visually inline-anchored) — true inline anchoring requires the Linear UI.\n- **Cycles, teams & workflow states** — list cycles (sprints) by team/status; inspect team details and workflow states; look up entities by ID, key, or fuzzy name.\n- **User & activity context** — identify the authenticated user (`WhoAmI`), retrieve recent issue activity, and fetch inbox notifications (mentions, assignments, state changes).\n\n## OAuth\n\nThis toolkit authenticates via OAuth 2.0 with **Linear** as the provider. See the [Linear auth provider docs](https://docs.arcade.dev/en/references/auth-providers/linear) for setup details."
 }

--- a/toolkit-docs-generator/data/toolkits/telegram.json
+++ b/toolkit-docs-generator/data/toolkits/telegram.json
@@ -1,7 +1,7 @@
 {
   "id": "Telegram",
   "label": "Telegram",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Arcade.dev LLM tools for Telegram",
   "metadata": {
     "category": "social",
@@ -18,7 +18,7 @@
     {
       "name": "GetChatInfo",
       "qualifiedName": "Telegram.GetChatInfo",
-      "fullyQualifiedName": "Telegram.GetChatInfo@1.0.1",
+      "fullyQualifiedName": "Telegram.GetChatInfo@1.1.0",
       "description": "Get metadata about a Telegram chat, group, or channel.\n\nReturns information including the chat type, title, description, and member count.\nThe bot must be a member of the chat to retrieve its information.",
       "parameters": [
         {
@@ -78,7 +78,7 @@
     {
       "name": "GetMessages",
       "qualifiedName": "Telegram.GetMessages",
-      "fullyQualifiedName": "Telegram.GetMessages@1.0.1",
+      "fullyQualifiedName": "Telegram.GetMessages@1.1.0",
       "description": "Get recent private-chat messages sent to the bot via Telegram's getUpdates API.\n\nReturns messages from private (1:1) chats only. Group and channel messages are\nexcluded for security — any group member could inject content into the response.\nOnly pending (unacknowledged) updates are returned.\n\nThe limit parameter controls how many raw Telegram updates are fetched, not how\nmany messages are returned. After filtering to private-chat messages for the\nrequested chat_id, the result may contain fewer items. has_more indicates whether\nmore updates exist on the server, not whether more messages exist for this chat.\n\nNote: This retrieves updates delivered to the bot, not the full history of a chat.\nPassing a non-zero offset permanently confirms all earlier updates — they cannot be\nretrieved again. Returns newest messages last.",
       "parameters": [
         {
@@ -165,8 +165,8 @@
     {
       "name": "SendMessage",
       "qualifiedName": "Telegram.SendMessage",
-      "fullyQualifiedName": "Telegram.SendMessage@1.0.1",
-      "description": "Send a text message to a Telegram chat, group, or channel.\n\nThe bot must be a member of the target chat or have permission to send messages\nto the specified channel.",
+      "fullyQualifiedName": "Telegram.SendMessage@1.1.0",
+      "description": "Send a text message to a Telegram chat, group, or channel.\n\nThe bot must be a member of the target chat or have permission to send messages to the\nspecified channel.\n\nWhen the message asks the recipient a question, prefer attaching the possible answers as inline\n`buttons` rather than asking in free text. With buttons and wait_for_response (the default),\nthis call waits for the user to tap one and returns it as `selected_option` — the toolkit\ncollapses the keyboard to the choice automatically, so you do not react to the tap yourself. If\nno tap arrives in the wait window, `timed_out` is true and `next_offset` lets you resume waiting\nwithout re-sending. Reserve a plain (button-less) message for statements or genuinely\nopen-ended questions.",
       "parameters": [
         {
           "name": "chat_id",
@@ -203,6 +203,23 @@
           "description": "Send the message silently without a notification sound. Defaults to false.",
           "enum": null,
           "inferrable": true
+        },
+        {
+          "name": "buttons",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "A list of answer options to present as tappable inline buttons below the message (one per row). STRONGLY PREFER this whenever the message asks a question with a known set of answers (confirmations, yes/no, or any multiple-choice) — it turns the reply into a single tap instead of free-form text. Each label must be at most 64 bytes. Leave empty (None) only for a statement or a genuinely open-ended question that needs a free-text answer.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "wait_for_response",
+          "type": "boolean",
+          "required": false,
+          "description": "When the message has buttons, wait for the user to tap one and return the chosen option as selected_option in this same call (the toolkit collapses the keyboard to the choice automatically — you do not react to the tap yourself). Defaults to true. Has no effect when there are no buttons. If no tap arrives within the wait window, the result has timed_out=true with a next_offset cursor to resume waiting from.",
+          "enum": null,
+          "inferrable": true
         }
       ],
       "auth": null,
@@ -229,17 +246,31 @@
             "required": true
           },
           "text": {
-            "value": "Hello! This is a test message sent via the Telegram Bot API.",
+            "value": "Would you like to confirm your appointment for tomorrow at 10:00 AM?",
             "type": "string",
             "required": true
           },
           "parse_mode": {
-            "value": "Markdown",
+            "value": "MARKDOWN",
             "type": "string",
             "required": false
           },
           "disable_notification": {
             "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "buttons": {
+            "value": [
+              "✅ Yes, confirm",
+              "❌ No, cancel",
+              "🔄 Reschedule"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "wait_for_response": {
+            "value": true,
             "type": "boolean",
             "required": false
           }
@@ -255,7 +286,8 @@
         },
         "behavior": {
           "operations": [
-            "create"
+            "create",
+            "update"
           ],
           "readOnly": false,
           "destructive": false,
@@ -268,7 +300,7 @@
     {
       "name": "SendTtsAudio",
       "qualifiedName": "Telegram.SendTtsAudio",
-      "fullyQualifiedName": "Telegram.SendTtsAudio@1.0.1",
+      "fullyQualifiedName": "Telegram.SendTtsAudio@1.1.0",
       "description": "Convert text to speech using OpenAI TTS and send it as an audio message on Telegram.\n\nGenerates an MP3 audio file from the provided text using OpenAI's text-to-speech API,\nthen sends it to the specified Telegram chat.",
       "parameters": [
         {
@@ -406,9 +438,183 @@
       }
     },
     {
+      "name": "WaitForButtonPress",
+      "qualifiedName": "Telegram.WaitForButtonPress",
+      "fullyQualifiedName": "Telegram.WaitForButtonPress@1.1.0",
+      "description": "Resume waiting for an inline-button tap on a message that was already sent with buttons.\n\nUse this only to keep waiting after an earlier attempt's wait window elapsed without a tap — it\ndoes NOT send anything. It is a bounded long-poll on Telegram's getUpdates: it waits a short\nwindow for a tap on the given message, and when one happens the toolkit acknowledges it and\ncollapses the keyboard to the chosen option (no agent round-trip), returning the choice as\nselected_option. If the window elapses with no tap, it returns timed_out=true with a\nnext_offset cursor to resume from again.\n\nCannot be used while the bot has an active webhook, because getUpdates and webhooks are\nmutually exclusive.",
+      "parameters": [
+        {
+          "name": "chat_id",
+          "type": "string",
+          "required": true,
+          "description": "The numeric chat ID where the buttoned message was sent.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "integer",
+          "required": true,
+          "description": "The message_id of the buttoned message to keep watching for a tap (from a prior send_message result).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "Update ID cursor to resume from — pass the next_offset from the prior response. Leave 0 to start a fresh wait. WARNING: advancing the cursor permanently confirms (removes) all updates with a lower update ID across all chats.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "TELEGRAM_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "TELEGRAM_BOT_TOKEN",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Telegram.WaitForButtonPress",
+        "parameters": {
+          "chat_id": {
+            "value": "123456789",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": 42,
+            "type": "integer",
+            "required": true
+          },
+          "offset": {
+            "value": 98765,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read",
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "WaitForNewMessage",
+      "qualifiedName": "Telegram.WaitForNewMessage",
+      "fullyQualifiedName": "Telegram.WaitForNewMessage@1.1.0",
+      "description": "Wait for the next new message in a Telegram private chat, returning as soon as one arrives.\n\nThis is a bounded long-poll built on Telegram's getUpdates: it waits up to timeout_seconds\nfor a new message in the given chat. If one or more arrive, they are returned immediately\nwith timed_out set to false. If the budget elapses with nothing, it returns an empty message\nlist with timed_out set to true and a next_offset cursor, so you can call again with that\nnext_offset to keep waiting.\n\nOn the first call, leave offset at 0: the tool skips any already-pending backlog and waits for\nmessages that arrive after the call begins. To read pending messages without waiting, use\nget_messages instead.\n\nReturns messages from private (1:1) chats only — group and channel messages are excluded for\nsecurity, since any group member could inject content. This tool cannot be used while the bot\nhas an active webhook, because getUpdates and webhooks are mutually exclusive.",
+      "parameters": [
+        {
+          "name": "chat_id",
+          "type": "string",
+          "required": true,
+          "description": "The numeric chat ID to wait for a new message in. Only messages from this private chat are returned.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "timeout_seconds",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of seconds to wait for a new message before returning a timed-out result. Defaults to 20. Maximum is 25.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "Update ID cursor to resume from. Leave 0 on the first call to wait for the next message arriving after this call; the pending backlog is skipped. On a timed-out re-call, pass the next_offset from the previous response to keep waiting without missing messages. WARNING: advancing the cursor permanently confirms (removes) all updates with a lower update ID across all chats.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "TELEGRAM_BOT_TOKEN"
+      ],
+      "secretsInfo": [
+        {
+          "name": "TELEGRAM_BOT_TOKEN",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Telegram.WaitForNewMessage",
+        "parameters": {
+          "chat_id": {
+            "value": "987654321",
+            "type": "string",
+            "required": true
+          },
+          "timeout_seconds": {
+            "value": 15,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "messaging"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read",
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "WhoAmI",
       "qualifiedName": "Telegram.WhoAmI",
-      "fullyQualifiedName": "Telegram.WhoAmI@1.0.1",
+      "fullyQualifiedName": "Telegram.WhoAmI@1.1.0",
       "description": "Get information about the Telegram bot.\n\nReturns the bot's identity including its ID, username, and capabilities.",
       "parameters": [],
       "auth": null,
@@ -454,6 +660,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-04-30T11:39:05.060Z",
-  "summary": "**Telegram toolkit** provides Arcade tools for interacting with Telegram via a bot, enabling LLMs to send messages, retrieve chat data, and deliver AI-generated audio in Telegram chats, groups, and channels.\n\n## Capabilities\n\n- **Bot identity & chat metadata** — Retrieve the bot's own profile and capabilities, and look up metadata (type, title, description, member count) for any chat the bot belongs to.\n- **Message retrieval** — Fetch pending private-chat messages delivered to the bot via Telegram's `getUpdates` API; group/channel messages are excluded by design. Offset handling permanently acknowledges earlier updates.\n- **Messaging** — Send text messages to any chat, group, or channel where the bot has send permissions.\n- **Text-to-speech audio** — Convert text to an MP3 using OpenAI TTS and deliver it as an audio message to a Telegram chat.\n\n## Secrets\n\nThis toolkit requires two secrets:\n\n- **`TELEGRAM_BOT_TOKEN`** — The API token that authenticates your Telegram bot. Create a bot and obtain its token by messaging [@BotFather](https://t.me/BotFather) on Telegram, using the `/newbot` command (or `/token` for an existing bot). BotFather returns a token in the format `123456789:ABC-...`. No special account tier is required. See [Telegram Bot API docs](https://core.telegram.org/bots/tutorial#obtain-your-bot-token) for details.\n\n- **`OPENAI_API_KEY`** — An OpenAI API key used to call the TTS endpoint for `Telegram.SendTtsAudio`. Generate one in the [OpenAI platform dashboard](https://platform.openai.com/api-keys) under **API keys**. The key needs access to the `tts-1` or `tts-1-hd` model; ensure your account has an active billing plan, as TTS is not available on the free tier.\n\nConfigure secrets in Arcade at https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets or via the dashboard at https://api.arcade.dev/dashboard/auth/secrets."
+  "generatedAt": "2026-07-01T12:07:55.509Z",
+  "summary": "# Telegram Toolkit\n\nThe Telegram toolkit lets you build Arcade-powered agents that interact with Telegram bots — sending messages, polling for replies, delivering audio, and inspecting chats — using Telegram's Bot API and OpenAI TTS.\n\n## Capabilities\n\n- **Bot identity & chat metadata**: Retrieve the bot's own profile and inspect any chat, group, or channel the bot belongs to (type, title, description, member count).\n- **Messaging**: Send text messages to any chat, group, or channel the bot has access to; attach inline keyboard buttons and optionally block until a button is tapped, returning the selected option automatically.\n- **Polling for incoming messages**: Long-poll for new private-chat messages or resume a timed-out wait with a `next_offset` cursor; fetch pending unacknowledged updates from private chats via `getUpdates`.\n- **Button-tap resumption**: Continue waiting for an inline-button press on a previously sent message without re-sending it, with automatic keyboard collapse on selection.\n- **Text-to-speech audio**: Convert text to MP3 using OpenAI TTS and deliver it as an audio message to a Telegram chat.\n\n## Secrets\n\n`TELEGRAM_BOT_TOKEN` — The authentication token for your Telegram bot. Create a bot by messaging [@BotFather](https://t.me/BotFather) on Telegram (`/newbot`), then copy the token it returns (format: `123456789:ABCDefgh...`). The bot must be added to any group or channel before it can send or read messages there. Webhooks must **not** be set on the bot when using polling-based tools (`GetMessages`, `WaitForNewMessage`, `WaitForButtonPress`), because Telegram's `getUpdates` and webhooks are mutually exclusive. See [Telegram Bot API docs](https://core.telegram.org/bots#how-do-i-create-a-bot).\n\n`OPENAI_API_KEY` — An OpenAI API key used exclusively by `SendTtsAudio` to call OpenAI's text-to-speech API. Obtain it from the [OpenAI API keys page](https://platform.openai.com/api-keys) in your OpenAI account dashboard. The key must have access to the TTS endpoint (`tts-1` or `tts-1-hd`); a standard paid-tier key is sufficient. No additional organization-level permissions beyond default API access are required.\n\nStore both secrets via the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) or directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
 }


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/28516102869

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are auto-generated documentation metadata only; no runtime code paths in this repo are modified.
> 
> **Overview**
> Scheduled refresh of **generated toolkit JSON** under `toolkit-docs-generator/data/toolkits/` after upstream MCP server releases.
> 
> **Google Calendar (3.5.0)** adds **`RespondToEvent`** so agents can accept or decline invitations on the user’s behalf, bumps all tool qualified names to `@3.5.0`, and updates the toolkit summary to call out RSVP. The catalog index moves Google Calendar from 7 to **8** tools.
> 
> **Telegram (1.1.0)** expands interactive messaging: **`SendMessage`** gains optional inline **`buttons`** and **`wait_for_response`**, plus new **`WaitForButtonPress`** and **`WaitForNewMessage`** long-poll tools. Tool count in the index goes from 5 to **7**; toolkit summary documents polling, button taps, and the webhook vs `getUpdates` constraint.
> 
> **Linear (3.6.2)** and **Jira (3.1.5)** are mostly version and `generatedAt` updates across existing tools. Linear also adds the **`read`** OAuth scope on several write tools’ auth metadata and refreshes code examples and the top-level summary.
> 
> **`index.json`** syncs versions, tool counts, and `generatedAt` for the touched integrations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42c493ccb878f730ed5e80bbfcfdb4f07d4b4101. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->