### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/app/en/resources/integrations/productivity/_meta.tsx
+++ b/app/en/resources/integrations/productivity/_meta.tsx
@@ -29,6 +29,10 @@ const meta: MetaRecord = {
     title: "Figma",
     href: "/en/resources/integrations/productivity/figma",
   },
+  fireflies: {
+    title: "Fireflies",
+    href: "/en/resources/integrations/productivity/fireflies",
+  },
   forkable: {
     title: "Forkable",
     href: "/en/resources/integrations/productivity/forkable",

--- a/app/en/resources/integrations/sales/_meta.tsx
+++ b/app/en/resources/integrations/sales/_meta.tsx
@@ -17,6 +17,10 @@ const meta: MetaRecord = {
     title: "HubSpot",
     href: "/en/resources/integrations/sales/hubspot",
   },
+  insightly: {
+    title: "Insightly",
+    href: "/en/resources/integrations/sales/insightly",
+  },
   salesforce: {
     title: "Salesforce",
     href: "/en/resources/integrations/sales/salesforce",

--- a/toolkit-docs-generator/data/toolkits/fireflies.json
+++ b/toolkit-docs-generator/data/toolkits/fireflies.json
@@ -1,0 +1,1586 @@
+{
+  "id": "Fireflies",
+  "label": "Fireflies",
+  "version": "0.3.0",
+  "description": "Arcade.dev tools for interacting with Fireflies",
+  "metadata": {
+    "category": "productivity",
+    "iconUrl": "https://design-system.arcade.dev/icons/fireflies.svg",
+    "isBYOC": true,
+    "isPro": false,
+    "type": "arcade",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/productivity/fireflies",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": null,
+  "tools": [
+    {
+      "name": "AddNotetakerToLiveMeeting",
+      "qualifiedName": "Fireflies.AddNotetakerToLiveMeeting",
+      "fullyQualifiedName": "Fireflies.AddNotetakerToLiveMeeting@0.3.0",
+      "description": "Send the Fireflies notetaker into a live meeting to capture it.\n\nThe bot can take up to a minute to join after a successful dispatch.",
+      "parameters": [
+        {
+          "name": "meeting_link",
+          "type": "string",
+          "required": true,
+          "description": "The live meeting URL for the notetaker to join.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "description": "Title for the meeting. Leave empty to let Fireflies infer one.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "duration",
+          "type": "integer",
+          "required": false,
+          "description": "Minutes the notetaker should stay (15-120). Defaults to 60.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "language",
+          "type": "string",
+          "required": false,
+          "description": "Spoken-language code (e.g. 'en'). Leave empty for auto-detection.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.AddNotetakerToLiveMeeting",
+        "parameters": {
+          "meeting_link": {
+            "value": "https://zoom.us/j/92345678901?pwd=aB3cDeFgHiJkLmNoPqRsTuVw",
+            "type": "string",
+            "required": true
+          },
+          "title": {
+            "value": "Q3 Product Roadmap Sync",
+            "type": "string",
+            "required": false
+          },
+          "duration": {
+            "value": 45,
+            "type": "integer",
+            "required": false
+          },
+          "language": {
+            "value": "en",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "AnalyzeTeamMeetings",
+      "qualifiedName": "Fireflies.AnalyzeTeamMeetings",
+      "fullyQualifiedName": "Fireflies.AnalyzeTeamMeetings@0.3.0",
+      "description": "Aggregate team conversation metrics and a per-speaker breakdown over a date range.\n\nUse this to spot team-level trends across meetings in a window no wider than 30 days.\nAggregates are rolled up from each meeting's own analytics, so the sentiment and\ntalk-time reflect every call in the window (not just the calls of mapped team users).\nThe most recent 50 meetings in the range are aggregated; when more fall in the range the\nresult's ``truncated`` flag is set so partial aggregates are not read as complete.",
+      "parameters": [
+        {
+          "name": "from_date",
+          "type": "string",
+          "required": true,
+          "description": "Start of the range to aggregate over (ISO 8601 UTC, YYYY-MM-DD or full date-time). The range from_date..to_date may span at most 30 days.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "to_date",
+          "type": "string",
+          "required": true,
+          "description": "End of the range to aggregate over (ISO 8601 UTC, YYYY-MM-DD or full date-time). Must be on or after from_date, and the window may span at most 30 days. A date-only value includes the whole named day (meetings through end of that day), which counts toward the 30-day span.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.AnalyzeTeamMeetings",
+        "parameters": {
+          "from_date": {
+            "value": "2024-06-01",
+            "type": "string",
+            "required": true
+          },
+          "to_date": {
+            "value": "2024-06-28",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "AskAboutMeeting",
+      "qualifiedName": "Fireflies.AskAboutMeeting",
+      "fullyQualifiedName": "Fireflies.AskAboutMeeting@0.3.0",
+      "description": "Ask a grounded question about a meeting and get an AI answer with suggested follow-ups.\n\nPrefer this over reading the full transcript when the user has a specific question.\nPass the returned thread id back as thread_id to continue the same conversation.",
+      "parameters": [
+        {
+          "name": "question",
+          "type": "string",
+          "required": true,
+          "description": "The plain-language question to answer from the meeting.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "transcript_id",
+          "type": "string",
+          "required": false,
+          "description": "The meeting to ask about. Required when starting a new conversation; leave empty when continuing an existing thread.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "thread_id",
+          "type": "string",
+          "required": false,
+          "description": "Continue a prior conversation by passing the thread id from an earlier answer. Leave empty to start a new conversation about the meeting.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.AskAboutMeeting",
+        "parameters": {
+          "question": {
+            "value": "What action items were assigned to the engineering team during the meeting?",
+            "type": "string",
+            "required": true
+          },
+          "transcript_id": {
+            "value": "txr_a1b2c3d4e5f67890",
+            "type": "string",
+            "required": false
+          },
+          "thread_id": {
+            "value": "thrd_z9y8x7w6v5u43210",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CreateSoundbite",
+      "qualifiedName": "Fireflies.CreateSoundbite",
+      "fullyQualifiedName": "Fireflies.CreateSoundbite@0.3.0",
+      "description": "Clip a soundbite from a time range within a recorded meeting.\n\nThe new clip processes asynchronously; the result reports its initial processing\nstate. Use the soundbite read tools to retrieve it once ready.",
+      "parameters": [
+        {
+          "name": "transcript_id",
+          "type": "string",
+          "required": true,
+          "description": "The meeting's transcript id to clip from.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "start_time",
+          "type": "number",
+          "required": true,
+          "description": "Clip start, in seconds from the start of the recording.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "end_time",
+          "type": "number",
+          "required": true,
+          "description": "Clip end, in seconds from the start of the recording.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Name for the soundbite. Leave empty to let Fireflies pick one.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "media_type",
+          "type": "string",
+          "required": false,
+          "description": "Format of the clip. Defaults to video. A video clip requested from an audio-only recording is automatically created as audio instead (the result detail notes the switch), so the clip never silently fails to process.",
+          "enum": [
+            "audio",
+            "video"
+          ],
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.CreateSoundbite",
+        "parameters": {
+          "transcript_id": {
+            "value": "txr_a1b2c3d4e5f6",
+            "type": "string",
+            "required": true
+          },
+          "start_time": {
+            "value": 142.5,
+            "type": "integer",
+            "required": true
+          },
+          "end_time": {
+            "value": 198,
+            "type": "integer",
+            "required": true
+          },
+          "name": {
+            "value": "Product Launch Key Highlight",
+            "type": "string",
+            "required": false
+          },
+          "media_type": {
+            "value": "video",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetMeetingAnalytics",
+      "qualifiedName": "Fireflies.GetMeetingAnalytics",
+      "fullyQualifiedName": "Fireflies.GetMeetingAnalytics@0.3.0",
+      "description": "Get per-speaker talk-time and pace plus the sentiment breakdown for one meeting.\n\nUse this to gauge how a call went -- who dominated, speaking pace, and overall\nsentiment. Analytics may be sparse or empty for very short calls.",
+      "parameters": [
+        {
+          "name": "transcript_id",
+          "type": "string",
+          "required": true,
+          "description": "The meeting's transcript id.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.GetMeetingAnalytics",
+        "parameters": {
+          "transcript_id": {
+            "value": "tr_a1b2c3d4e5f67890",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetMeetingSummary",
+      "qualifiedName": "Fireflies.GetMeetingSummary",
+      "fullyQualifiedName": "Fireflies.GetMeetingSummary@0.3.0",
+      "description": "Get Fireflies' AI-generated notes for a meeting: overview, action items, keywords, outline.\n\nUse this single call to answer \"what were the takeaways / action items from this\ncall?\"; it is far cheaper and more reliable than reading the verbatim transcript.",
+      "parameters": [
+        {
+          "name": "transcript_id",
+          "type": "string",
+          "required": true,
+          "description": "The meeting's transcript id.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.GetMeetingSummary",
+        "parameters": {
+          "transcript_id": {
+            "value": "abc123xyz456",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetMeetingTranscript",
+      "qualifiedName": "Fireflies.GetMeetingTranscript",
+      "fullyQualifiedName": "Fireflies.GetMeetingTranscript@0.3.0",
+      "description": "Get the verbatim spoken lines of a meeting, in chronological order with speaker attribution.\n\nFireflies serves a meeting's lines only as a whole, so each call retrieves the full\ntranscript; limit, offset, and the from_time/to_time window then bound what is returned\nto keep the response small (they do not reduce what is fetched upstream). Transcripts can\nrun to thousands of lines, so request a narrow window. To quote a moment found via the AI\nquestion or notes tools (which report timestamps in seconds), pass from_time and/or to_time;\noffset and limit then apply within that window. For takeaways or action items, prefer the AI\nmeeting-notes tool over reading raw lines.",
+      "parameters": [
+        {
+          "name": "transcript_id",
+          "type": "string",
+          "required": true,
+          "description": "The meeting's transcript id.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum lines to return, starting from the beginning of the recording (1-500). Defaults to 200.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "Number of lines to skip from the start (0-indexed). Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "from_time",
+          "type": "number",
+          "required": false,
+          "description": "Only return lines spoken at or after this many seconds into the recording. Leave unset for no lower bound.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "to_time",
+          "type": "number",
+          "required": false,
+          "description": "Only return lines spoken at or before this many seconds into the recording. Leave unset for no upper bound.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.GetMeetingTranscript",
+        "parameters": {
+          "transcript_id": {
+            "value": "abc123xyz789",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          },
+          "from_time": {
+            "value": 120.5,
+            "type": "integer",
+            "required": false
+          },
+          "to_time": {
+            "value": 480,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetSoundbite",
+      "qualifiedName": "Fireflies.GetSoundbite",
+      "fullyQualifiedName": "Fireflies.GetSoundbite@0.3.0",
+      "description": "Get a single soundbite by id.\n\nReturns a graceful not-found result instead of raising for an unknown or\ninaccessible id, so lookups compose like the list/search tools.",
+      "parameters": [
+        {
+          "name": "bite_id",
+          "type": "string",
+          "required": true,
+          "description": "The soundbite's id.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.GetSoundbite",
+        "parameters": {
+          "bite_id": {
+            "value": "sb_a1b2c3d4e5f67890",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListActionItems",
+      "qualifiedName": "Fireflies.ListActionItems",
+      "fullyQualifiedName": "Fireflies.ListActionItems@0.3.0",
+      "description": "Gather follow-ups from recent meetings into one flat list to answer \"what do I owe?\".\n\nEach meeting's AI action-items notes are flattened into individual, owner-attributed\nitems so the caller's outstanding follow-ups across many calls surface in one request\nrather than by opening each meeting. Prefer this over reading each call's notes\nseparately when triaging open commitments; set assigned_to_me to narrow to the caller's\nown follow-ups, or assignee_email to narrow to a specific teammate's.",
+      "parameters": [
+        {
+          "name": "from_date",
+          "type": "string",
+          "required": false,
+          "description": "Only include meetings on or after this UTC date-time (ISO 8601). Leave empty for no lower bound.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "to_date",
+          "type": "string",
+          "required": false,
+          "description": "Only include meetings on or before this UTC date-time (ISO 8601). A date-only value (YYYY-MM-DD) includes the whole named day. Leave empty for no upper bound.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "assigned_to_me",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, return only follow-ups attributed to the caller. Defaults to false (every meeting's follow-ups, each flagged with whether it is the caller's).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "assignee_email",
+          "type": "string",
+          "required": false,
+          "description": "Only include follow-ups attributed to this person, matched by their email handle and name (so 'shawnee@acme.com' matches items owned by 'Shawnee'). Use this to triage what a specific teammate owes. Leave empty for no assignee filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum recent meetings to scan for follow-ups (1-50). Defaults to 25.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "Number of recent meetings to skip before scanning (0-indexed). Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.ListActionItems",
+        "parameters": {
+          "from_date": {
+            "value": "2024-10-01T00:00:00Z",
+            "type": "string",
+            "required": false
+          },
+          "to_date": {
+            "value": "2024-10-31",
+            "type": "string",
+            "required": false
+          },
+          "assigned_to_me": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "assignee_email": {
+            "value": "shawnee@acme.com",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListChannels",
+      "qualifiedName": "Fireflies.ListChannels",
+      "fullyQualifiedName": "Fireflies.ListChannels@0.3.0",
+      "description": "List the channels meetings are filed into.\n\nA channel's id can be passed to a meeting search to narrow results to that channel, so\nthis is the lookup behind that filter as well as a view of how the account organizes\nits calls.",
+      "parameters": [
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum channels to return (1-50). Defaults to 25.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "Number of channels to skip from the start (0-indexed). Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.ListChannels",
+        "parameters": {
+          "limit": {
+            "value": 10,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListContacts",
+      "qualifiedName": "Fireflies.ListContacts",
+      "fullyQualifiedName": "Fireflies.ListContacts@0.3.0",
+      "description": "List the people the caller has met with, most recent first.",
+      "parameters": [
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum contacts to return (1-50). Defaults to 25.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "Number of contacts to skip from the start (0-indexed). Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.ListContacts",
+        "parameters": {
+          "limit": {
+            "value": 10,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListSoundbites",
+      "qualifiedName": "Fireflies.ListSoundbites",
+      "fullyQualifiedName": "Fireflies.ListSoundbites@0.3.0",
+      "description": "List soundbites, optionally scoped to your own, your team's, or a single meeting's.",
+      "parameters": [
+        {
+          "name": "mine",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, return only soundbites the caller created. Defaults to true.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "my_team",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, include soundbites shared across the caller's team. Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "transcript_id",
+          "type": "string",
+          "required": false,
+          "description": "Keep only soundbites clipped from this meeting, applied to each fetched page. Leave empty to not filter by meeting.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum soundbites to return (1-50). Defaults to 25.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position; number of soundbites to skip. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.ListSoundbites",
+        "parameters": {
+          "mine": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "my_team": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "transcript_id": {
+            "value": "tr_abc123xyz456",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 10,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "RevokeMeetingAccess",
+      "qualifiedName": "Fireflies.RevokeMeetingAccess",
+      "fullyQualifiedName": "Fireflies.RevokeMeetingAccess@0.3.0",
+      "description": "Remove a previously granted teammate's access to a meeting.\n\nYou can only manage sharing on a meeting you own or manage. Revoking an email that\ndoes not currently have access is not a silent no-op: Fireflies may return a\n``failed`` status, so treat a failed result as \"no change was made\" rather than a hard\nerror.",
+      "parameters": [
+        {
+          "name": "transcript_id",
+          "type": "string",
+          "required": true,
+          "description": "The meeting's transcript id to revoke access to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "required": true,
+          "description": "The email address whose access should be removed.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.RevokeMeetingAccess",
+        "parameters": {
+          "transcript_id": {
+            "value": "abc123xyz789",
+            "type": "string",
+            "required": true
+          },
+          "email": {
+            "value": "teammate@example.com",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchMeetings",
+      "qualifiedName": "Fireflies.SearchMeetings",
+      "fullyQualifiedName": "Fireflies.SearchMeetings@0.3.0",
+      "description": "Find a recorded meeting by its title, the people on it, when it happened, or its topic.\n\nUse this single call to locate a past call; results are newest first. By default the\nkeyword matches the meeting title only; switch match to content to find a call by its\nspoken topics -- that scans each recent meeting's AI notes (gist, summary, keywords,\ntopics, action items) and keeps the ones whose notes or title contain the keyword.\nEach result carries a one-line AI gist for triage; set include_notes to also pull each\ncall's short summary and action items in the same request (the standup-prep digest).",
+      "parameters": [
+        {
+          "name": "keyword",
+          "type": "string",
+          "required": false,
+          "description": "Text to match. Matched against the meeting title, or against what was discussed (the AI notes) when content matching is selected. Leave empty for no keyword filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "from_date",
+          "type": "string",
+          "required": false,
+          "description": "Only include meetings on or after this UTC date-time (ISO 8601). Leave empty for no lower bound.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "to_date",
+          "type": "string",
+          "required": false,
+          "description": "Only include meetings on or before this UTC date-time (ISO 8601). A date-only value (YYYY-MM-DD) includes the whole named day. Leave empty for no upper bound.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "host_email",
+          "type": "string",
+          "required": false,
+          "description": "Only include meetings hosted by this email. Leave empty to not filter by host.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "organizer_email",
+          "type": "string",
+          "required": false,
+          "description": "Only include meetings organized by this email. Leave empty to not filter by organizer.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "participant_email",
+          "type": "string",
+          "required": false,
+          "description": "Only include meetings this email participated in. Leave empty to not filter by participant.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "channel_id",
+          "type": "string",
+          "required": false,
+          "description": "Only include meetings filed under this channel id. Leave empty to not filter by channel.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "mine",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, restrict to the caller's own meetings. Defaults to false (all accessible).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "match",
+          "type": "string",
+          "required": false,
+          "description": "How the keyword is matched. Defaults to matching the meeting title (fast, exact, across all history). Switch to content matching to find a call by what was discussed when the title is generic or unknown; content matching scans the AI notes of the most recent meetings in the requested window.",
+          "enum": [
+            "title",
+            "content"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "include_notes",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, also return each meeting's short summary and action items so a 'catch me up since <date>' digest can be built in one call. Defaults to false (only the one-line gist).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum meetings to return (1-50). Defaults to 25.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "Number of matching meetings to skip (0-indexed). Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.SearchMeetings",
+        "parameters": {
+          "keyword": {
+            "value": "product roadmap",
+            "type": "string",
+            "required": false
+          },
+          "from_date": {
+            "value": "2024-10-01T00:00:00Z",
+            "type": "string",
+            "required": false
+          },
+          "to_date": {
+            "value": "2024-11-15",
+            "type": "string",
+            "required": false
+          },
+          "host_email": {
+            "value": "alice.johnson@example.com",
+            "type": "string",
+            "required": false
+          },
+          "organizer_email": {
+            "value": "bob.smith@example.com",
+            "type": "string",
+            "required": false
+          },
+          "participant_email": {
+            "value": "carol.white@example.com",
+            "type": "string",
+            "required": false
+          },
+          "channel_id": {
+            "value": "ch_a1b2c3d4e5f6",
+            "type": "string",
+            "required": false
+          },
+          "mine": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "match": {
+            "value": "content",
+            "type": "string",
+            "required": false
+          },
+          "include_notes": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "limit": {
+            "value": 10,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ShareMeeting",
+      "qualifiedName": "Fireflies.ShareMeeting",
+      "fullyQualifiedName": "Fireflies.ShareMeeting@0.3.0",
+      "description": "Grant one or more teammates access to a meeting's notes and recording.\n\nYou can only share a meeting you own or manage. Re-sharing an email that already has\naccess is not a silent no-op: Fireflies may return a ``failed`` status, so treat a\nfailed result as \"no change was made\" rather than relying on this call to idempotently\nensure access.",
+      "parameters": [
+        {
+          "name": "transcript_id",
+          "type": "string",
+          "required": true,
+          "description": "The meeting's transcript id to share.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "emails",
+          "type": "array",
+          "innerType": "string",
+          "required": true,
+          "description": "Email addresses to grant access to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "expiry_days",
+          "type": "integer",
+          "required": false,
+          "description": "Days until the granted access expires. Use 0 for access that never expires; a negative value is rejected. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.ShareMeeting",
+        "parameters": {
+          "transcript_id": {
+            "value": "trans_4a7f2c91b3e845d6",
+            "type": "string",
+            "required": true
+          },
+          "emails": {
+            "value": [
+              "alice@example.com",
+              "bob@example.com",
+              "carol@example.com"
+            ],
+            "type": "array",
+            "required": true
+          },
+          "expiry_days": {
+            "value": 30,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "UploadRecording",
+      "qualifiedName": "Fireflies.UploadRecording",
+      "fullyQualifiedName": "Fireflies.UploadRecording@0.3.0",
+      "description": "Queue an already-recorded audio or video file for Fireflies transcription.\n\nUse this for a recording that exists elsewhere; use the live-notetaker tool to\ncapture a meeting happening now. Transcription runs asynchronously after queuing.",
+      "parameters": [
+        {
+          "name": "url",
+          "type": "string",
+          "required": true,
+          "description": "Publicly accessible https URL of the audio or video recording to transcribe.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "description": "Title for the recording. Leave empty to let Fireflies infer one.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "language",
+          "type": "string",
+          "required": false,
+          "description": "Spoken-language code (e.g. 'en'). Leave empty for auto-detection.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "save_video",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, retain the source video alongside the transcript. Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.UploadRecording",
+        "parameters": {
+          "url": {
+            "value": "https://storage.example.com/recordings/team-standup-2024-06-15.mp4",
+            "type": "string",
+            "required": true
+          },
+          "title": {
+            "value": "Team Standup Meeting - June 15 2024",
+            "type": "string",
+            "required": false
+          },
+          "language": {
+            "value": "en",
+            "type": "string",
+            "required": false
+          },
+          "save_video": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "WhoAmI",
+      "qualifiedName": "Fireflies.WhoAmI",
+      "fullyQualifiedName": "Fireflies.WhoAmI@0.3.0",
+      "description": "Get the caller's own Fireflies identity and usage summary.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "FIREFLIES_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "FIREFLIES_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Fireflies.WhoAmI",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "documents"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-07-05T11:37:43.788Z",
+  "summary": "Fireflies is an AI meeting assistant platform; this toolkit lets Arcade agents interact with Fireflies to capture, search, analyze, and share meeting recordings and transcripts.\n\n## Capabilities\n\n- **Meeting capture & ingestion**: Dispatch the Fireflies notetaker bot into a live meeting or upload an existing audio/video file for async transcription.\n- **Search & retrieval**: Find past meetings by title, participants, date, or spoken content; list channels, contacts, and soundbites with flexible scoping filters.\n- **Summaries, transcripts & Q&A**: Fetch AI-generated notes (overview, action items, keywords), retrieve verbatim transcripts with time-windowing, or ask grounded natural-language questions with conversational follow-up.\n- **Analytics**: Get per-speaker talk-time, speaking pace, and sentiment for individual meetings, or aggregate those metrics across a team's calls over a rolling 30-day window.\n- **Collaboration**: Share or revoke meeting access with teammates; clip soundbites from recordings for sharing or reference.\n- **Account introspection**: Retrieve the caller's own Fireflies identity and usage summary.\n\n## Secrets\n\n`FIREFLIES_API_KEY` — A personal API key issued by Fireflies that authenticates every GraphQL request made on behalf of your account. To obtain one: log in to [Fireflies](https://app.fireflies.ai), open **Integrations → API Access** (or navigate directly to `https://app.fireflies.ai/api-integrations`), and generate or copy your API key. The key is tied to your user account and carries full access to your meetings and team data, so treat it as a credential. See the [Fireflies API docs](https://docs.fireflies.ai/getting-started/authentication) for details.\n\nStore the key as an Arcade secret. See the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) and the [Arcade secrets dashboard](https://api.arcade.dev/dashboard/auth/secrets)."
+}

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-01T12:08:11.358Z",
+  "generatedAt": "2026-07-05T11:38:04.267Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -279,6 +279,15 @@
       "category": "development",
       "type": "arcade",
       "toolCount": 6,
+      "authType": "none"
+    },
+    {
+      "id": "Fireflies",
+      "label": "Fireflies",
+      "version": "0.3.0",
+      "category": "productivity",
+      "type": "arcade",
+      "toolCount": 17,
       "authType": "none"
     },
     {
@@ -576,6 +585,15 @@
       "category": "entertainment",
       "type": "arcade",
       "toolCount": 3,
+      "authType": "none"
+    },
+    {
+      "id": "Insightly",
+      "label": "Insightly",
+      "version": "0.1.0",
+      "category": "sales",
+      "type": "arcade",
+      "toolCount": 29,
       "authType": "none"
     },
     {

--- a/toolkit-docs-generator/data/toolkits/insightly.json
+++ b/toolkit-docs-generator/data/toolkits/insightly.json
@@ -1,0 +1,3580 @@
+{
+  "id": "Insightly",
+  "label": "Insightly",
+  "version": "0.1.0",
+  "description": "Arcade.dev tools for interacting with Insightly",
+  "metadata": {
+    "category": "sales",
+    "iconUrl": "https://design-system.arcade.dev/icons/insightly.svg",
+    "isBYOC": false,
+    "isPro": false,
+    "type": "arcade",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/sales/insightly",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": null,
+  "tools": [
+    {
+      "name": "ConvertLead",
+      "qualifiedName": "Insightly.ConvertLead",
+      "fullyQualifiedName": "Insightly.ConvertLead@0.1.0",
+      "description": "Convert a qualified lead into a contact (when the lead names a person), an organization\n(when the lead names one), and optionally an opportunity, then mark the lead converted.\n\nThe lead's name, email, phone, and title carry onto the contact, and its name/phone/website\nonto the organization. A lead with only a last name becomes a contact under that name, since\nInsightly stores a single-name person in the contact's first-name field. Insightly leaves the\nlead's notes on the lead, so by default they are copied onto the new contact (or organization).\n\nFails if the lead has already been converted. Conversion is several creates followed by the\nfinal lead update; it is not idempotent, so if a later step fails the lead stays unconverted\nand any records already created remain. Check the lead in Insightly before retrying a failed\nconversion so a retry does not duplicate records.",
+      "parameters": [
+        {
+          "name": "lead_id",
+          "type": "string",
+          "required": true,
+          "description": "The unique identifier of the lead to convert.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "create_opportunity",
+          "type": "boolean",
+          "required": false,
+          "description": "Also create an opportunity (true) or only a contact and org (false). Default false.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "opportunity_name",
+          "type": "string",
+          "required": false,
+          "description": "Name for the created opportunity. Used only when create_opportunity is true.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "pipeline_id",
+          "type": "string",
+          "required": false,
+          "description": "Pipeline id for the created opportunity. Used only when create_opportunity is true.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "stage_id",
+          "type": "string",
+          "required": false,
+          "description": "Stage id for the created opportunity. Used only when create_opportunity is true.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "value",
+          "type": "number",
+          "required": false,
+          "description": "Monetary value to size the created opportunity. Used only when create_opportunity is true; omit to leave the value unset.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "forecast_close_date",
+          "type": "string",
+          "required": false,
+          "description": "Forecast close date (YYYY-MM-DD) for the created opportunity. Used only when create_opportunity is true; empty to leave it unset.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "responsible_user_id",
+          "type": "integer",
+          "required": false,
+          "description": "User id to own the created opportunity. Used only when create_opportunity is true; omit to leave it unset.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "copy_notes",
+          "type": "boolean",
+          "required": false,
+          "description": "Carry the lead's notes onto the new record (true) so the converted contact keeps the context that lived on the lead, or leave them on the lead only (false). Defaults to true.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.ConvertLead",
+        "parameters": {
+          "lead_id": {
+            "value": "1042837",
+            "type": "string",
+            "required": true
+          },
+          "create_opportunity": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "opportunity_name": {
+            "value": "Acme Corp - Enterprise License Deal",
+            "type": "string",
+            "required": false
+          },
+          "pipeline_id": {
+            "value": "pipeline_00891",
+            "type": "string",
+            "required": false
+          },
+          "stage_id": {
+            "value": "stage_00342",
+            "type": "string",
+            "required": false
+          },
+          "value": {
+            "value": 48500,
+            "type": "integer",
+            "required": false
+          },
+          "forecast_close_date": {
+            "value": "2025-09-30",
+            "type": "string",
+            "required": false
+          },
+          "responsible_user_id": {
+            "value": 7214,
+            "type": "integer",
+            "required": false
+          },
+          "copy_notes": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CreateNote",
+      "qualifiedName": "Insightly.CreateNote",
+      "fullyQualifiedName": "Insightly.CreateNote@0.1.0",
+      "description": "Log a note against one CRM record. Provide exactly one record id to attach it to.",
+      "parameters": [
+        {
+          "name": "body",
+          "type": "string",
+          "required": true,
+          "description": "The note text, such as a call summary or meeting recap.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "description": "Short subject line for the note. Empty derives it from the body's first line.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "contact_id",
+          "type": "string",
+          "required": false,
+          "description": "Attach the note to this contact. Empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "opportunity_id",
+          "type": "string",
+          "required": false,
+          "description": "Attach the note to this opportunity. Empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "organization_id",
+          "type": "string",
+          "required": false,
+          "description": "Attach the note to this organization. Empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "project_id",
+          "type": "string",
+          "required": false,
+          "description": "Attach the note to this project. Empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "lead_id",
+          "type": "string",
+          "required": false,
+          "description": "Attach the note to this lead. Empty for none.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.CreateNote",
+        "parameters": {
+          "body": {
+            "value": "Called John to discuss the Q3 renewal proposal. He expressed interest in upgrading to the Enterprise tier and requested a follow-up demo next Tuesday at 2 PM. Action item: send updated pricing deck by EOD Friday.",
+            "type": "string",
+            "required": true
+          },
+          "title": {
+            "value": "Q3 Renewal Call Summary",
+            "type": "string",
+            "required": false
+          },
+          "contact_id": {
+            "value": "CON-00482",
+            "type": "string",
+            "required": false
+          },
+          "opportunity_id": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "organization_id": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "project_id": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "lead_id": {
+            "value": "",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetContact",
+      "qualifiedName": "Insightly.GetContact",
+      "fullyQualifiedName": "Insightly.GetContact@0.1.0",
+      "description": "Retrieve a single contact by its identifier.",
+      "parameters": [
+        {
+          "name": "contact_id",
+          "type": "string",
+          "required": true,
+          "description": "The unique identifier of the contact.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.GetContact",
+        "parameters": {
+          "contact_id": {
+            "value": "123456789",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetCurrentUser",
+      "qualifiedName": "Insightly.GetCurrentUser",
+      "fullyQualifiedName": "Insightly.GetCurrentUser@0.1.0",
+      "description": "Return the identity of the authenticated Insightly user (the \"who am I\" for this account).\n\nCall this first to confirm who actions will be attributed to.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.GetCurrentUser",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetLead",
+      "qualifiedName": "Insightly.GetLead",
+      "fullyQualifiedName": "Insightly.GetLead@0.1.0",
+      "description": "Retrieve a single lead by its identifier.",
+      "parameters": [
+        {
+          "name": "lead_id",
+          "type": "string",
+          "required": true,
+          "description": "The unique identifier of the lead.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.GetLead",
+        "parameters": {
+          "lead_id": {
+            "value": "123456",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetMyOpenWork",
+      "qualifiedName": "Insightly.GetMyOpenWork",
+      "fullyQualifiedName": "Insightly.GetMyOpenWork@0.1.0",
+      "description": "Roll up one user's open deals and open tasks in a single call.\n\nDefaults to the caller (the authenticated user), so \"what's on my plate\" is one read instead\nof a separate pipeline summary and task search. The summed open-deal value covers every\nmatched deal, not just the returned window.",
+      "parameters": [
+        {
+          "name": "responsible_user_id",
+          "type": "integer",
+          "required": false,
+          "description": "Roll up the open work owned by this user id. 0 (the default) resolves the caller's own id, giving a 'what's on my plate' view.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "opportunity_limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum open opportunities to include, soonest forecast close first (1-100). Defaults to 10.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "task_limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum open tasks to include, soonest due first (1-100). Defaults to 10.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.GetMyOpenWork",
+        "parameters": {
+          "responsible_user_id": {
+            "value": 847263,
+            "type": "integer",
+            "required": false
+          },
+          "opportunity_limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "task_limit": {
+            "value": 15,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetOpportunity",
+      "qualifiedName": "Insightly.GetOpportunity",
+      "fullyQualifiedName": "Insightly.GetOpportunity@0.1.0",
+      "description": "Retrieve a single opportunity by its identifier.",
+      "parameters": [
+        {
+          "name": "opportunity_id",
+          "type": "string",
+          "required": true,
+          "description": "The unique identifier of the opportunity.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.GetOpportunity",
+        "parameters": {
+          "opportunity_id": {
+            "value": "987654321",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetOrganization",
+      "qualifiedName": "Insightly.GetOrganization",
+      "fullyQualifiedName": "Insightly.GetOrganization@0.1.0",
+      "description": "Retrieve a single organization by its identifier.",
+      "parameters": [
+        {
+          "name": "organization_id",
+          "type": "string",
+          "required": true,
+          "description": "The unique identifier of the organization.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.GetOrganization",
+        "parameters": {
+          "organization_id": {
+            "value": "123456789",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetProject",
+      "qualifiedName": "Insightly.GetProject",
+      "fullyQualifiedName": "Insightly.GetProject@0.1.0",
+      "description": "Retrieve a single project by its identifier.",
+      "parameters": [
+        {
+          "name": "project_id",
+          "type": "string",
+          "required": true,
+          "description": "The unique identifier of the project.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.GetProject",
+        "parameters": {
+          "project_id": {
+            "value": "987654",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetRecordActivity",
+      "qualifiedName": "Insightly.GetRecordActivity",
+      "fullyQualifiedName": "Insightly.GetRecordActivity@0.1.0",
+      "description": "Gather one record's recent notes and open tasks in one call, plus the deal stage.\n\nProvide exactly one record id. Use this single call to prepare for a call or recap an\naccount instead of running separate note and task searches. When the record is an\nopportunity, the response also carries that deal's current stage, state, and value; when\nit is a project, it carries the project's parent opportunity and that deal's organization\nso a delivery kickoff brief is one read; when it is a contact or organization, the response\nalso carries the opportunities and delivery projects that touch the account.",
+      "parameters": [
+        {
+          "name": "contact_id",
+          "type": "string",
+          "required": false,
+          "description": "Gather activity for this contact. Empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "opportunity_id",
+          "type": "string",
+          "required": false,
+          "description": "Gather activity for this opportunity. Empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "organization_id",
+          "type": "string",
+          "required": false,
+          "description": "Gather activity for this organization. Empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "project_id",
+          "type": "string",
+          "required": false,
+          "description": "Gather activity for this project. Empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "lead_id",
+          "type": "string",
+          "required": false,
+          "description": "Gather activity for this lead. Empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "exclude_system_notes",
+          "type": "boolean",
+          "required": false,
+          "description": "Exclude Insightly's auto-generated stage/state/status-change notes so the brief shows only human-logged notes. Defaults to true.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "note_limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum notes to include, most recent first (1-100). Defaults to 10. The response's note_count is the full match total; when it exceeds the notes returned, raise this to include more.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "task_limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum open tasks to include, soonest due first (1-100). Defaults to 10. The response's open_task_count is the full match total; when it exceeds the tasks returned, raise this to include more.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "linked_limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum linked opportunities and projects to include for a contact or organization, most recently updated first (1-100). Defaults to 10. The response's linked_opportunity_count / linked_project_count are the full match totals; when either exceeds the items returned, raise this to include more.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.GetRecordActivity",
+        "parameters": {
+          "contact_id": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "opportunity_id": {
+            "value": "OPP-00482",
+            "type": "string",
+            "required": false
+          },
+          "organization_id": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "project_id": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "lead_id": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "exclude_system_notes": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "note_limit": {
+            "value": 15,
+            "type": "integer",
+            "required": false
+          },
+          "task_limit": {
+            "value": 10,
+            "type": "integer",
+            "required": false
+          },
+          "linked_limit": {
+            "value": 20,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetTask",
+      "qualifiedName": "Insightly.GetTask",
+      "fullyQualifiedName": "Insightly.GetTask@0.1.0",
+      "description": "Retrieve a single task by its identifier.",
+      "parameters": [
+        {
+          "name": "task_id",
+          "type": "string",
+          "required": true,
+          "description": "The unique identifier of the task.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.GetTask",
+        "parameters": {
+          "task_id": {
+            "value": "1234567",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListLeadFieldOptions",
+      "qualifiedName": "Insightly.ListLeadFieldOptions",
+      "fullyQualifiedName": "Insightly.ListLeadFieldOptions@0.1.0",
+      "description": "List the account's configured lead statuses and lead sources so a natural-language\nstatus or source name maps to the id that save_lead expects.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.ListLeadFieldOptions",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListPipelines",
+      "qualifiedName": "Insightly.ListPipelines",
+      "fullyQualifiedName": "Insightly.ListPipelines@0.1.0",
+      "description": "List the configured pipelines, optionally filtered to opportunity or project pipelines.",
+      "parameters": [
+        {
+          "name": "for_opportunities",
+          "type": "boolean",
+          "required": false,
+          "description": "Filter to opportunity pipelines (true) or non-opportunity (false). Omit for all.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "for_projects",
+          "type": "boolean",
+          "required": false,
+          "description": "Filter to project pipelines (true) or non-project (false). Omit for all.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.ListPipelines",
+        "parameters": {
+          "for_opportunities": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "for_projects": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListPipelineStages",
+      "qualifiedName": "Insightly.ListPipelineStages",
+      "fullyQualifiedName": "Insightly.ListPipelineStages@0.1.0",
+      "description": "List a pipeline's stages in their defined order, so stage moves target real stages.",
+      "parameters": [
+        {
+          "name": "pipeline_id",
+          "type": "string",
+          "required": true,
+          "description": "The pipeline id whose stages to list.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.ListPipelineStages",
+        "parameters": {
+          "pipeline_id": {
+            "value": "pipeline_78432",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListUsers",
+      "qualifiedName": "Insightly.ListUsers",
+      "fullyQualifiedName": "Insightly.ListUsers@0.1.0",
+      "description": "List the users in the account, for attributing and assigning records.",
+      "parameters": [
+        {
+          "name": "email",
+          "type": "string",
+          "required": false,
+          "description": "Only return users whose email contains this text (case-insensitive). Empty matches all.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum users to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.ListUsers",
+        "parameters": {
+          "email": {
+            "value": "john.doe@example.com",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SaveContact",
+      "qualifiedName": "Insightly.SaveContact",
+      "fullyQualifiedName": "Insightly.SaveContact@0.1.0",
+      "description": "Create or update a contact. Omit contact_id to create (a first or last name is required).",
+      "parameters": [
+        {
+          "name": "contact_id",
+          "type": "string",
+          "required": false,
+          "description": "Omit to create a new contact; provide an existing id to update that contact.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "first_name",
+          "type": "string",
+          "required": false,
+          "description": "First name. Sets the value when creating; changes it when updating, or leave omitted.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "last_name",
+          "type": "string",
+          "required": false,
+          "description": "Last name. Sets the value when creating; changes it when updating, or leave omitted.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "required": false,
+          "description": "Email address. Provide to set or change it; empty string clears it; omit to leave it.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "phone",
+          "type": "string",
+          "required": false,
+          "description": "Phone number. Provide to set or change it; empty string clears it; omit to leave it.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "description": "Job title. Omit to leave unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "organization_id",
+          "type": "string",
+          "required": false,
+          "description": "Organization id to link the contact to. Omit to leave unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "background",
+          "type": "string",
+          "required": false,
+          "description": "Freeform background notes. Omit to leave unchanged.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.SaveContact",
+        "parameters": {
+          "contact_id": {
+            "value": "1234567",
+            "type": "string",
+            "required": false
+          },
+          "first_name": {
+            "value": "Jane",
+            "type": "string",
+            "required": false
+          },
+          "last_name": {
+            "value": "Doe",
+            "type": "string",
+            "required": false
+          },
+          "email": {
+            "value": "jane.doe@example.com",
+            "type": "string",
+            "required": false
+          },
+          "phone": {
+            "value": "+1-555-867-5309",
+            "type": "string",
+            "required": false
+          },
+          "title": {
+            "value": "Senior Product Manager",
+            "type": "string",
+            "required": false
+          },
+          "organization_id": {
+            "value": "9876543",
+            "type": "string",
+            "required": false
+          },
+          "background": {
+            "value": "Met at the 2024 SaaS conference. Interested in enterprise plan.",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SaveLead",
+      "qualifiedName": "Insightly.SaveLead",
+      "fullyQualifiedName": "Insightly.SaveLead@0.1.0",
+      "description": "Create or update a lead. Omit lead_id to create a new lead (supply a last name, an\norganization name, or both).",
+      "parameters": [
+        {
+          "name": "lead_id",
+          "type": "string",
+          "required": false,
+          "description": "Omit to create a new lead; provide an existing id to update that lead.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "last_name",
+          "type": "string",
+          "required": false,
+          "description": "Last name. When creating, supply this or an organization name (a company-only lead needs no person); when updating, omit to leave it unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "first_name",
+          "type": "string",
+          "required": false,
+          "description": "First name. Omit to leave unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "required": false,
+          "description": "Email address. Provide to set or change it; empty string clears it; omit to leave it.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "phone",
+          "type": "string",
+          "required": false,
+          "description": "Phone number. Provide to set or change it; empty string clears it; omit to leave it.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "organization_name",
+          "type": "string",
+          "required": false,
+          "description": "The lead's organization name. Omit to leave unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "description": "Job title. Omit to leave unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "lead_status_id",
+          "type": "integer",
+          "required": false,
+          "description": "Lead status id. Omit to leave unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "lead_source_id",
+          "type": "integer",
+          "required": false,
+          "description": "Lead source id. Omit to leave unchanged.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.SaveLead",
+        "parameters": {
+          "lead_id": {
+            "value": "987654",
+            "type": "string",
+            "required": false
+          },
+          "last_name": {
+            "value": "Thompson",
+            "type": "string",
+            "required": false
+          },
+          "first_name": {
+            "value": "Sarah",
+            "type": "string",
+            "required": false
+          },
+          "email": {
+            "value": "sarah.thompson@example.com",
+            "type": "string",
+            "required": false
+          },
+          "phone": {
+            "value": "+1-555-867-5309",
+            "type": "string",
+            "required": false
+          },
+          "organization_name": {
+            "value": "Acme Solutions Ltd.",
+            "type": "string",
+            "required": false
+          },
+          "title": {
+            "value": "VP of Marketing",
+            "type": "string",
+            "required": false
+          },
+          "lead_status_id": {
+            "value": 3,
+            "type": "integer",
+            "required": false
+          },
+          "lead_source_id": {
+            "value": 7,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SaveOpportunity",
+      "qualifiedName": "Insightly.SaveOpportunity",
+      "fullyQualifiedName": "Insightly.SaveOpportunity@0.1.0",
+      "description": "Create or update an opportunity, including advancing its stage and recording won/lost.\n\nOmit opportunity_id to create (a name is required). A new opportunity created without a\npipeline_id and stage_id is left unplaced: it still rolls up in the forecast under the\n\"(no stage)\" bucket but cannot advance through a stage-based pipeline, so set pipeline_id\nand stage_id together when you know the deal's pipeline and stage.",
+      "parameters": [
+        {
+          "name": "opportunity_id",
+          "type": "string",
+          "required": false,
+          "description": "Omit to create a new opportunity; provide an existing id to update it.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Opportunity name. Sets it when creating; changes it when updating, or leave omitted.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "organization_id",
+          "type": "string",
+          "required": false,
+          "description": "Organization id to link the opportunity to. Omit to leave unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "pipeline_id",
+          "type": "string",
+          "required": false,
+          "description": "Place the opportunity on this pipeline id. Combine with stage_id to also set the stage.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "stage_id",
+          "type": "string",
+          "required": false,
+          "description": "Move the opportunity to this stage id (advance the deal). Omit to leave the stage as is.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "value",
+          "type": "number",
+          "required": false,
+          "description": "Monetary value of the deal. Omit to leave unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "state",
+          "type": "string",
+          "required": false,
+          "description": "Record this lifecycle state (for example mark won or lost). Omit to leave unchanged.",
+          "enum": [
+            "OPEN",
+            "WON",
+            "LOST",
+            "ABANDONED",
+            "SUSPENDED"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "forecast_close_date",
+          "type": "string",
+          "required": false,
+          "description": "Forecast close date (YYYY-MM-DD). Omit to leave unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "responsible_user_id",
+          "type": "integer",
+          "required": false,
+          "description": "User id responsible for the opportunity. Omit to leave unchanged.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.SaveOpportunity",
+        "parameters": {
+          "opportunity_id": {
+            "value": "987654321",
+            "type": "string",
+            "required": false
+          },
+          "name": {
+            "value": "Acme Corp Enterprise License Deal",
+            "type": "string",
+            "required": false
+          },
+          "organization_id": {
+            "value": "112233445",
+            "type": "string",
+            "required": false
+          },
+          "pipeline_id": {
+            "value": "56789",
+            "type": "string",
+            "required": false
+          },
+          "stage_id": {
+            "value": "34512",
+            "type": "string",
+            "required": false
+          },
+          "value": {
+            "value": 75000,
+            "type": "integer",
+            "required": false
+          },
+          "state": {
+            "value": "WON",
+            "type": "string",
+            "required": false
+          },
+          "forecast_close_date": {
+            "value": "2024-09-30",
+            "type": "string",
+            "required": false
+          },
+          "responsible_user_id": {
+            "value": 100423,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SaveOrganization",
+      "qualifiedName": "Insightly.SaveOrganization",
+      "fullyQualifiedName": "Insightly.SaveOrganization@0.1.0",
+      "description": "Create or update an organization. Omit organization_id to create (a name is required).",
+      "parameters": [
+        {
+          "name": "organization_id",
+          "type": "string",
+          "required": false,
+          "description": "Omit to create a new organization; provide an existing id to update it.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Organization name. Sets it when creating; changes it when updating, or leave omitted.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "phone",
+          "type": "string",
+          "required": false,
+          "description": "Phone number. Provide to set or change it; empty string clears it; omit to leave it.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "website",
+          "type": "string",
+          "required": false,
+          "description": "Website URL. Provide to set or change it; empty string clears it; omit to leave it.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "background",
+          "type": "string",
+          "required": false,
+          "description": "Freeform background notes. Omit to leave unchanged.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.SaveOrganization",
+        "parameters": {
+          "organization_id": {
+            "value": "987654",
+            "type": "string",
+            "required": false
+          },
+          "name": {
+            "value": "Acme Corporation",
+            "type": "string",
+            "required": false
+          },
+          "phone": {
+            "value": "+1-555-867-5309",
+            "type": "string",
+            "required": false
+          },
+          "website": {
+            "value": "https://www.acmecorp.com",
+            "type": "string",
+            "required": false
+          },
+          "background": {
+            "value": "Key enterprise client based in New York. Primary contact is the CTO. Interested in annual subscription plans.",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SaveProject",
+      "qualifiedName": "Insightly.SaveProject",
+      "fullyQualifiedName": "Insightly.SaveProject@0.1.0",
+      "description": "Create or update a delivery project, including advancing its stage.\n\nOmit project_id to create (a name is required).",
+      "parameters": [
+        {
+          "name": "project_id",
+          "type": "string",
+          "required": false,
+          "description": "Omit to create a new project; provide an existing id to update it.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Project name. Sets it when creating; changes it when updating, or leave omitted.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "required": false,
+          "description": "Project status (for example mark completed). When creating, defaults to NOT_STARTED; when updating, omit to leave unchanged.",
+          "enum": [
+            "not_started",
+            "in_progress",
+            "completed",
+            "deferred",
+            "abandoned"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "pipeline_id",
+          "type": "string",
+          "required": false,
+          "description": "Place the project on this pipeline id. Combine with stage_id to also set the stage.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "stage_id",
+          "type": "string",
+          "required": false,
+          "description": "Move the project to this stage id (advance it). Omit to leave the stage as is.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "opportunity_id",
+          "type": "string",
+          "required": false,
+          "description": "Opportunity id to link the project to. Omit to leave unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "responsible_user_id",
+          "type": "integer",
+          "required": false,
+          "description": "User id responsible for the project. Omit to leave unchanged.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.SaveProject",
+        "parameters": {
+          "project_id": {
+            "value": "987654",
+            "type": "string",
+            "required": false
+          },
+          "name": {
+            "value": "Website Redesign Launch",
+            "type": "string",
+            "required": false
+          },
+          "status": {
+            "value": "IN_PROGRESS",
+            "type": "string",
+            "required": false
+          },
+          "pipeline_id": {
+            "value": "112233",
+            "type": "string",
+            "required": false
+          },
+          "stage_id": {
+            "value": "445566",
+            "type": "string",
+            "required": false
+          },
+          "opportunity_id": {
+            "value": "778899",
+            "type": "string",
+            "required": false
+          },
+          "responsible_user_id": {
+            "value": 42,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SaveTask",
+      "qualifiedName": "Insightly.SaveTask",
+      "fullyQualifiedName": "Insightly.SaveTask@0.1.0",
+      "description": "Create or update a task, optionally linked to a deal, project, contact, or org.\n\nOmit task_id to create (a title is required).",
+      "parameters": [
+        {
+          "name": "task_id",
+          "type": "string",
+          "required": false,
+          "description": "Omit to create a new task; provide an existing id to update it.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "description": "Task title. Sets it when creating; changes it when updating, or leave omitted.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "required": false,
+          "description": "Task status; set it to COMPLETED to complete the task or a non-completed value to reopen it. Omit to leave unchanged.",
+          "enum": [
+            "not_started",
+            "in_progress",
+            "waiting",
+            "completed",
+            "deferred"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "due_date",
+          "type": "string",
+          "required": false,
+          "description": "When the task is due (YYYY-MM-DD). Empty string clears it; omit to leave it.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "priority",
+          "type": "string",
+          "required": false,
+          "description": "Task priority. Omit to leave unchanged (defaults to NORMAL on create).",
+          "enum": [
+            "LOW",
+            "NORMAL",
+            "HIGH"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "responsible_user_id",
+          "type": "integer",
+          "required": false,
+          "description": "User id responsible for the task. Omit to leave unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "project_id",
+          "type": "string",
+          "required": false,
+          "description": "Link the task to this project id. Omit to skip.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "opportunity_id",
+          "type": "string",
+          "required": false,
+          "description": "Link the task to this opportunity id. Omit to skip.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "contact_id",
+          "type": "string",
+          "required": false,
+          "description": "Link the task to this contact id. Omit to skip.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "organization_id",
+          "type": "string",
+          "required": false,
+          "description": "Link the task to this organization id. Omit to skip.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.SaveTask",
+        "parameters": {
+          "task_id": {
+            "value": "987654",
+            "type": "string",
+            "required": false
+          },
+          "title": {
+            "value": "Follow up with client regarding proposal",
+            "type": "string",
+            "required": false
+          },
+          "status": {
+            "value": "IN_PROGRESS",
+            "type": "string",
+            "required": false
+          },
+          "due_date": {
+            "value": "2024-08-15",
+            "type": "string",
+            "required": false
+          },
+          "priority": {
+            "value": "HIGH",
+            "type": "string",
+            "required": false
+          },
+          "responsible_user_id": {
+            "value": 102,
+            "type": "integer",
+            "required": false
+          },
+          "project_id": {
+            "value": "proj_4421",
+            "type": "string",
+            "required": false
+          },
+          "opportunity_id": {
+            "value": "opp_7893",
+            "type": "string",
+            "required": false
+          },
+          "contact_id": {
+            "value": "con_3310",
+            "type": "string",
+            "required": false
+          },
+          "organization_id": {
+            "value": "org_5567",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchContacts",
+      "qualifiedName": "Insightly.SearchContacts",
+      "fullyQualifiedName": "Insightly.SearchContacts@0.1.0",
+      "description": "Find contacts by name, email, or organization. Returns the account's default order.",
+      "parameters": [
+        {
+          "name": "query",
+          "type": "string",
+          "required": false,
+          "description": "Match against contact name or email (case-insensitive substring). Empty matches all.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "required": false,
+          "description": "Only return contacts whose email contains this text. Empty for no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "organization_id",
+          "type": "string",
+          "required": false,
+          "description": "Only return contacts linked to this organization id. Empty for no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "updated_after",
+          "type": "string",
+          "required": false,
+          "description": "Contacts updated on/after this UTC date (YYYY-MM-DD). Empty = no lower bound.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.SearchContacts",
+        "parameters": {
+          "query": {
+            "value": "john",
+            "type": "string",
+            "required": false
+          },
+          "email": {
+            "value": "gmail.com",
+            "type": "string",
+            "required": false
+          },
+          "organization_id": {
+            "value": "478291",
+            "type": "string",
+            "required": false
+          },
+          "updated_after": {
+            "value": "2024-01-15",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchLeads",
+      "qualifiedName": "Insightly.SearchLeads",
+      "fullyQualifiedName": "Insightly.SearchLeads@0.1.0",
+      "description": "Find leads by name, email, conversion state, or status. Returns the account's default\norder.",
+      "parameters": [
+        {
+          "name": "query",
+          "type": "string",
+          "required": false,
+          "description": "Match against lead name, organization, or email (substring). Empty matches all.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "required": false,
+          "description": "Only return leads whose email contains this text. Empty for no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "converted",
+          "type": "boolean",
+          "required": false,
+          "description": "true for converted leads only, false for unconverted only. Omit for both.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "lead_status_id",
+          "type": "integer",
+          "required": false,
+          "description": "Only return leads in this status (its id). 0 for no status filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "updated_after",
+          "type": "string",
+          "required": false,
+          "description": "Leads updated on/after this UTC date (YYYY-MM-DD). Empty = no lower bound.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.SearchLeads",
+        "parameters": {
+          "query": {
+            "value": "Johnson",
+            "type": "string",
+            "required": false
+          },
+          "email": {
+            "value": "@gmail.com",
+            "type": "string",
+            "required": false
+          },
+          "converted": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "lead_status_id": {
+            "value": 3,
+            "type": "integer",
+            "required": false
+          },
+          "updated_after": {
+            "value": "2024-01-15",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchNotes",
+      "qualifiedName": "Insightly.SearchNotes",
+      "fullyQualifiedName": "Insightly.SearchNotes@0.1.0",
+      "description": "Read notes most recently created first within the scanned window, account-wide or for one\nrecord.\n\nOmit every record id for an account-wide activity feed (combine owner_user_id and the\ncreated_after / created_before window for a standup-style recap), or provide exactly one\nrecord id to read the notes on that single record. Date bounds are inclusive.\n\nNotes are gathered by scanning the collection up to a ceiling and ordering that scanned set\nmost-recently-created first; when scan_truncated is true the scan stopped before reaching the\nwhole collection, so the newest notes may lie beyond the scanned window. Narrow with a record\nid, owner, or a created_after / created_before window to bring the result within that window.",
+      "parameters": [
+        {
+          "name": "contact_id",
+          "type": "string",
+          "required": false,
+          "description": "Read notes attached to this contact. Empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "opportunity_id",
+          "type": "string",
+          "required": false,
+          "description": "Read notes attached to this opportunity. Empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "organization_id",
+          "type": "string",
+          "required": false,
+          "description": "Read notes attached to this organization. Empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "project_id",
+          "type": "string",
+          "required": false,
+          "description": "Read notes attached to this project. Empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "lead_id",
+          "type": "string",
+          "required": false,
+          "description": "Read notes attached to this lead. Empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "record_types",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Only return notes attached to a record of one of these kinds (for example to exclude auto-logged opportunity stage-change chatter from a recap). Omit for any kind.",
+          "enum": [
+            "CONTACT",
+            "OPPORTUNITY",
+            "ORGANISATION",
+            "PROJECT",
+            "LEAD"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "exclude_system_notes",
+          "type": "boolean",
+          "required": false,
+          "description": "Exclude Insightly's auto-generated stage/state/status-change notes (across opportunities, projects, and tasks) so a recap shows only human-logged notes. Defaults to false (every note is returned).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "query",
+          "type": "string",
+          "required": false,
+          "description": "Match this text against the note title or body (case-insensitive substring). Empty matches all notes in scope.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "owner_user_id",
+          "type": "integer",
+          "required": false,
+          "description": "Only return notes authored by this user id. 0 for no owner filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "created_after",
+          "type": "string",
+          "required": false,
+          "description": "Only return notes created on or after this UTC date (YYYY-MM-DD). Empty for no lower bound.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "created_before",
+          "type": "string",
+          "required": false,
+          "description": "Only return notes created on or before this UTC date (YYYY-MM-DD). Empty for no upper bound.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.SearchNotes",
+        "parameters": {
+          "contact_id": {
+            "value": "123456",
+            "type": "string",
+            "required": false
+          },
+          "opportunity_id": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "organization_id": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "project_id": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "lead_id": {
+            "value": "",
+            "type": "string",
+            "required": false
+          },
+          "record_types": {
+            "value": [
+              "contact",
+              "opportunity"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "exclude_system_notes": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "query": {
+            "value": "follow-up",
+            "type": "string",
+            "required": false
+          },
+          "owner_user_id": {
+            "value": 78910,
+            "type": "integer",
+            "required": false
+          },
+          "created_after": {
+            "value": "2024-01-01",
+            "type": "string",
+            "required": false
+          },
+          "created_before": {
+            "value": "2024-06-30",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchOpportunities",
+      "qualifiedName": "Insightly.SearchOpportunities",
+      "fullyQualifiedName": "Insightly.SearchOpportunities@0.1.0",
+      "description": "Find opportunities by name, state, pipeline, or organization. Returns the default order.",
+      "parameters": [
+        {
+          "name": "query",
+          "type": "string",
+          "required": false,
+          "description": "Match against the opportunity name (case-insensitive substring). Empty matches all.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "state",
+          "type": "string",
+          "required": false,
+          "description": "Only return opportunities in this state. Omit for any state.",
+          "enum": [
+            "OPEN",
+            "WON",
+            "LOST",
+            "ABANDONED",
+            "SUSPENDED"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "pipeline_id",
+          "type": "string",
+          "required": false,
+          "description": "Only return opportunities on this pipeline id. Empty for no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "organization_id",
+          "type": "string",
+          "required": false,
+          "description": "Only return opportunities linked to this organization id. Empty for no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "updated_after",
+          "type": "string",
+          "required": false,
+          "description": "Opportunities updated on/after this UTC date (YYYY-MM-DD). Empty = no lower bound.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.SearchOpportunities",
+        "parameters": {
+          "query": {
+            "value": "enterprise",
+            "type": "string",
+            "required": false
+          },
+          "state": {
+            "value": "Open",
+            "type": "string",
+            "required": false
+          },
+          "pipeline_id": {
+            "value": "pipeline_4821",
+            "type": "string",
+            "required": false
+          },
+          "organization_id": {
+            "value": "org_30957",
+            "type": "string",
+            "required": false
+          },
+          "updated_after": {
+            "value": "2024-01-15",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchOrganizations",
+      "qualifiedName": "Insightly.SearchOrganizations",
+      "fullyQualifiedName": "Insightly.SearchOrganizations@0.1.0",
+      "description": "Find organizations by name or domain. Returns records in the account's default order.",
+      "parameters": [
+        {
+          "name": "query",
+          "type": "string",
+          "required": false,
+          "description": "Match against the organization name (case-insensitive substring). Empty matches all.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "required": false,
+          "description": "Only return orgs whose website contains this domain. Empty for no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "updated_after",
+          "type": "string",
+          "required": false,
+          "description": "Organizations updated on/after this UTC date (YYYY-MM-DD). Empty = no lower bound.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.SearchOrganizations",
+        "parameters": {
+          "query": {
+            "value": "Acme",
+            "type": "string",
+            "required": false
+          },
+          "domain": {
+            "value": "acmecorp.com",
+            "type": "string",
+            "required": false
+          },
+          "updated_after": {
+            "value": "2024-01-15",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchProjects",
+      "qualifiedName": "Insightly.SearchProjects",
+      "fullyQualifiedName": "Insightly.SearchProjects@0.1.0",
+      "description": "Find projects by name, status, or pipeline. Returns the account's default order.",
+      "parameters": [
+        {
+          "name": "query",
+          "type": "string",
+          "required": false,
+          "description": "Match against the project name (case-insensitive substring). Empty matches all.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "required": false,
+          "description": "Only return projects in this status. Omit for any status.",
+          "enum": [
+            "not_started",
+            "in_progress",
+            "completed",
+            "deferred",
+            "abandoned"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "pipeline_id",
+          "type": "string",
+          "required": false,
+          "description": "Only return projects on this pipeline id. Empty for no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "updated_after",
+          "type": "string",
+          "required": false,
+          "description": "Projects updated on/after this UTC date (YYYY-MM-DD). Empty = no lower bound.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.SearchProjects",
+        "parameters": {
+          "query": {
+            "value": "website redesign",
+            "type": "string",
+            "required": false
+          },
+          "status": {
+            "value": "In Progress",
+            "type": "string",
+            "required": false
+          },
+          "pipeline_id": {
+            "value": "482931",
+            "type": "string",
+            "required": false
+          },
+          "updated_after": {
+            "value": "2024-01-15",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SearchTasks",
+      "qualifiedName": "Insightly.SearchTasks",
+      "fullyQualifiedName": "Insightly.SearchTasks@0.1.0",
+      "description": "Find tasks by title, status, completion, due date, owner, or link. Due bounds inclusive.",
+      "parameters": [
+        {
+          "name": "query",
+          "type": "string",
+          "required": false,
+          "description": "Match this text against the task title (case-insensitive substring). Empty matches all.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "required": false,
+          "description": "Only return tasks in this status. Omit for any status.",
+          "enum": [
+            "not_started",
+            "in_progress",
+            "waiting",
+            "completed",
+            "deferred"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "completed",
+          "type": "boolean",
+          "required": false,
+          "description": "Filter by completion: false for open tasks, true for completed. Omit for both.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "due_before",
+          "type": "string",
+          "required": false,
+          "description": "Only return tasks due on or before this date (YYYY-MM-DD). Empty for no upper bound.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "due_after",
+          "type": "string",
+          "required": false,
+          "description": "Only return tasks due on or after this date (YYYY-MM-DD). Empty for no lower bound.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "responsible_user_id",
+          "type": "integer",
+          "required": false,
+          "description": "Only return tasks assigned to this user id. 0 for no owner filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "project_id",
+          "type": "string",
+          "required": false,
+          "description": "Only return tasks linked to this project id. Empty for no project filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "opportunity_id",
+          "type": "string",
+          "required": false,
+          "description": "Only return tasks linked to this opportunity id. Empty for no opportunity filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "contact_id",
+          "type": "string",
+          "required": false,
+          "description": "Only return tasks linked to this contact id. Empty for no contact filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "organization_id",
+          "type": "string",
+          "required": false,
+          "description": "Only return tasks linked to this organization id. Empty for no organization filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.SearchTasks",
+        "parameters": {
+          "query": {
+            "value": "follow up",
+            "type": "string",
+            "required": false
+          },
+          "status": {
+            "value": "IN PROGRESS",
+            "type": "string",
+            "required": false
+          },
+          "completed": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
+          "due_before": {
+            "value": "2024-06-30",
+            "type": "string",
+            "required": false
+          },
+          "due_after": {
+            "value": "2024-01-01",
+            "type": "string",
+            "required": false
+          },
+          "responsible_user_id": {
+            "value": 142857,
+            "type": "integer",
+            "required": false
+          },
+          "project_id": {
+            "value": "PRJ-00123",
+            "type": "string",
+            "required": false
+          },
+          "opportunity_id": {
+            "value": "OPP-00456",
+            "type": "string",
+            "required": false
+          },
+          "contact_id": {
+            "value": "CON-00789",
+            "type": "string",
+            "required": false
+          },
+          "organization_id": {
+            "value": "ORG-00321",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SummarizePipeline",
+      "qualifiedName": "Insightly.SummarizePipeline",
+      "fullyQualifiedName": "Insightly.SummarizePipeline@0.1.0",
+      "description": "Roll up opportunities by pipeline stage with a count and summed value per stage.\n\nA forecast view for closing out the week: groups are ordered by the stage's defined order.",
+      "parameters": [
+        {
+          "name": "state",
+          "type": "string",
+          "required": false,
+          "description": "Roll up only opportunities in this state. Defaults to OPEN (the live forecast); pass null to include every state.",
+          "enum": [
+            "OPEN",
+            "WON",
+            "LOST",
+            "ABANDONED",
+            "SUSPENDED"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "pipeline_id",
+          "type": "string",
+          "required": false,
+          "description": "Roll up only opportunities on this pipeline id. Empty for all pipelines.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "organization_id",
+          "type": "string",
+          "required": false,
+          "description": "Roll up only opportunities linked to this organization id. Empty for no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "responsible_user_id",
+          "type": "integer",
+          "required": false,
+          "description": "Roll up only opportunities owned by this user id (the caller's own id gives a 'my pipeline' view). 0 for every owner.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "include_empty_stages",
+          "type": "boolean",
+          "required": false,
+          "description": "Also list configured stages that hold no opportunities in scope, with a count and value of 0, so the forecast covers every stage rather than only the populated ones. Scoped to pipeline_id when set, otherwise every pipeline's stages. Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "INSIGHTLY_API_KEY",
+        "INSIGHTLY_API_URL"
+      ],
+      "secretsInfo": [
+        {
+          "name": "INSIGHTLY_API_KEY",
+          "type": "api_key"
+        },
+        {
+          "name": "INSIGHTLY_API_URL",
+          "type": "unknown"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Insightly.SummarizePipeline",
+        "parameters": {
+          "state": {
+            "value": "OPEN",
+            "type": "string",
+            "required": false
+          },
+          "pipeline_id": {
+            "value": "pipe_4821",
+            "type": "string",
+            "required": false
+          },
+          "organization_id": {
+            "value": "org_30947",
+            "type": "string",
+            "required": false
+          },
+          "responsible_user_id": {
+            "value": 102,
+            "type": "integer",
+            "required": false
+          },
+          "include_empty_stages": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "crm"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-07-05T11:37:45.816Z",
+  "summary": "Arcade tools for [Insightly](https://www.insightly.com/), a CRM platform. This toolkit enables reading, creating, updating, and querying Insightly records—contacts, leads, organizations, opportunities, projects, tasks, notes, and pipelines—via Arcade-hosted tools.\n\n## Capabilities\n\n- **Record CRUD** — Create and update the core CRM objects: contacts, leads, organizations, opportunities, projects, and tasks. Each save tool doubles as a create (omit the ID) or update (supply the ID).\n- **Search and lookup** — Search any object type by name, email, status, pipeline, domain, due date, or related record; retrieve single records by ID for any object type.\n- **Activity and context gathering** — Fetch a record's recent notes, open tasks, deal stage, and linked account/project in a single call to prepare for calls or account briefings without chaining multiple queries.\n- **Pipeline and forecast views** — List pipelines, list stages in defined order, and roll up opportunities by stage with counts and summed values for pipeline forecasting.\n- **Lead conversion** — Convert a qualified lead into a contact, organization, and optional opportunity in one operation, carrying over all relevant fields.\n- **Account and user metadata** — Identify the authenticated user, list all account users, and look up configured lead statuses, sources, and pipeline definitions for mapping natural-language values to IDs.\n\n## Secrets\n\n`INSIGHTLY_API_KEY`\nYour Insightly REST API key, used to authenticate every request. Retrieve it from the Insightly web app: go to **User Menu → User Settings → API Key** (the key is shown at the bottom of the page). All Insightly plans include API access; no special tier is required. See [Insightly API authentication docs](https://api.insightly.com/v3.1/Help#!/Overview/Introduction) for details.\n\n`INSIGHTLY_API_URL`\nThe base URL for your Insightly API endpoint (e.g., `https://api.insightly.com/v3.1`). Insightly uses a single global endpoint for most accounts, but verify the correct URL in your Insightly plan or API documentation if you are on a regional or private instance. This lets the toolkit route requests to the right host without hardcoding.\n\nStore both secrets in Arcade using the [secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets), or manage them directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
+}


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/28739367246

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only generated JSON and nav metadata; no application or auth logic changes.
> 
> **Overview**
> Adds **Fireflies** (productivity, 17 tools) and **Insightly** (sales, 29 tools) to the integration docs catalog via regenerated toolkit metadata.
> 
> New entries in `toolkit-docs-generator/data/toolkits/` (`fireflies.json`, `insightly.json`) and an updated `index.json` timestamp. Integration sidebars gain nav links under productivity and sales `_meta.tsx` so the new pages appear in the docs site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bbcddae0265b3cacfb49f405eca711af4338ce6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->