### PR TITLE
docs: simplify Claude Code MCP setup (PLT-2275)

### DIFF
--- a/app/en/get-started/mcp-clients/claude-code/page.mdx
+++ b/app/en/get-started/mcp-clients/claude-code/page.mdx
@@ -6,23 +6,17 @@ import { SignupLink } from "@/app/_components/analytics";
 <GuideOverview>
 <GuideOverview.Outcomes>
 
-Connect Claude Code to an Arcade MCP Gateway using the Arcade Headers authentication mode.
+Connect Claude Code to an Arcade MCP Gateway.
 
 </GuideOverview.Outcomes>
 
 <GuideOverview.Prerequisites>
 
 1. Create an <SignupLink linkLocation="docs:claude-code-client">Arcade account</SignupLink>
-2. Get an [Arcade API key](/get-started/setup/api-keys)
-3. Create an [Arcade MCP Gateway](/guides/mcp-gateways) and select the tools you want to use
+2. Create an [Arcade MCP Gateway](/guides/mcp-gateways) and select the tools you want to use
 
 </GuideOverview.Prerequisites>
 </GuideOverview>
-
-<Callout type="info">
-  For Claude Code, we recommend setting your gateway auth mode to **Arcade Headers** so you
-  can authenticate via HTTP headers (no browser-based OAuth flow required).
-</Callout>
 
 <Callout type="info">
   **Production end users with their own identities?** If your end users already sign in to Entra ID, Okta, Auth0, Clerk, or another OIDC provider, configure a [User Source](/guides/user-sources) on your gateway. Arcade redirects each end user to your identity provider on sign-in and identifies them by an OIDC subject claim.
@@ -35,9 +29,7 @@ Connect Claude Code to an Arcade MCP Gateway using the Arcade Headers authentica
 Run the following to add your Arcade Gateway as a remote HTTP MCP server in Claude Code:
 
 ```bash
-claude mcp add --transport http arcade "<YOUR_ARCADE_GATEWAY_URL>" \
-  --header "Authorization: Bearer <YOUR_ARCADE_API_KEY>" \
-  --header "Arcade-User-ID: <YOUR_EMAIL>"
+claude mcp add arcade --transport http "<YOUR_ARCADE_GATEWAY_URL>"
 ```
 
 ### Verify the server was added


### PR DESCRIPTION
## Summary

Updates the Claude Code MCP client setup guide (PLT-2275) so users no longer need an Arcade API key or header-based authentication to connect.

### Current Docs [Use Arcade in Claude Code](https://docs.arcade.dev/en/get-started/mcp-clients/claude-code)

<img width="1471" height="1234" alt="Screenshot 2026-07-07 at 1 49 52 PM" src="https://github.com/user-attachments/assets/6da57f39-9633-48fb-8abe-8c7d668e6527" />

### Dashboard setup

<img width="587" height="563" alt="Screenshot 2026-07-07 at 3 40 07 PM" src="https://github.com/user-attachments/assets/1b5b8347-1fa9-415a-b0f9-ed6767f18a91" />

- Removes the **Arcade API key** prerequisite step.
- Removes the `Authorization: Bearer` and `Arcade-User-ID` headers from the `claude mcp add` command.
- Simplifies the command to connect to the gateway URL directly:

  ```bash
  claude mcp add arcade --transport http "<YOUR_ARCADE_GATEWAY_URL>"
  ```

- Drops the "Arcade Headers" auth-mode recommendation callout, which no longer applies.
- Updates the outcome text to "Connect Claude Code to an Arcade MCP Gateway."

The User Source callout for production end-user identities (Entra ID, Okta, Auth0, Clerk, etc.) is retained.



## Test plan

- [x] Pre-commit hooks pass (Vale, lint-staged, Ultracite formatting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)