### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/toolkit-docs-generator/data/toolkits/gmail.json
+++ b/toolkit-docs-generator/data/toolkits/gmail.json
@@ -1,7 +1,7 @@
 {
   "id": "Gmail",
   "label": "Gmail",
-  "version": "7.5.1",
+  "version": "8.0.1",
   "description": "Arcade.dev LLM tools for Gmail",
   "metadata": {
     "category": "productivity",
@@ -30,7 +30,7 @@
     {
       "name": "ChangeEmailLabels",
       "qualifiedName": "Gmail.ChangeEmailLabels",
-      "fullyQualifiedName": "Gmail.ChangeEmailLabels@7.5.1",
+      "fullyQualifiedName": "Gmail.ChangeEmailLabels@8.0.1",
       "description": "Add and remove labels from an email using the Gmail API.",
       "parameters": [
         {
@@ -124,7 +124,7 @@
     {
       "name": "CreateLabel",
       "qualifiedName": "Gmail.CreateLabel",
-      "fullyQualifiedName": "Gmail.CreateLabel@7.5.1",
+      "fullyQualifiedName": "Gmail.CreateLabel@8.0.1",
       "description": "Create a new label in the user's mailbox.",
       "parameters": [
         {
@@ -184,7 +184,7 @@
     {
       "name": "DeleteDraftEmail",
       "qualifiedName": "Gmail.DeleteDraftEmail",
-      "fullyQualifiedName": "Gmail.DeleteDraftEmail@7.5.1",
+      "fullyQualifiedName": "Gmail.DeleteDraftEmail@8.0.1",
       "description": "Delete a draft email using the Gmail API.",
       "parameters": [
         {
@@ -244,7 +244,7 @@
     {
       "name": "GetThread",
       "qualifiedName": "Gmail.GetThread",
-      "fullyQualifiedName": "Gmail.GetThread@7.5.1",
+      "fullyQualifiedName": "Gmail.GetThread@8.0.1",
       "description": "Get the specified thread by ID.",
       "parameters": [
         {
@@ -304,7 +304,7 @@
     {
       "name": "ListDraftEmails",
       "qualifiedName": "Gmail.ListDraftEmails",
-      "fullyQualifiedName": "Gmail.ListDraftEmails@7.5.1",
+      "fullyQualifiedName": "Gmail.ListDraftEmails@8.0.1",
       "description": "Lists draft emails in the user's draft mailbox using the Gmail API.",
       "parameters": [
         {
@@ -312,6 +312,14 @@
           "type": "integer",
           "required": false,
           "description": "Number of draft emails to read (Min 1, Max 100, Default 25)",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "page_token",
+          "type": "string",
+          "required": false,
+          "description": "Page token to retrieve a specific page of results in the list",
           "enum": null,
           "inferrable": true
         }
@@ -336,6 +344,11 @@
           "n_drafts": {
             "value": 10,
             "type": "integer",
+            "required": false
+          },
+          "page_token": {
+            "value": "ABCDEFabcdef1234567890",
+            "type": "string",
             "required": false
           }
         },
@@ -364,7 +377,7 @@
     {
       "name": "ListEmails",
       "qualifiedName": "Gmail.ListEmails",
-      "fullyQualifiedName": "Gmail.ListEmails@7.5.1",
+      "fullyQualifiedName": "Gmail.ListEmails@8.0.1",
       "description": "Read emails from a Gmail account and extract plain text content.\n\nBy default, obvious automated emails are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all emails regardless of source.",
       "parameters": [
         {
@@ -372,6 +385,14 @@
           "type": "integer",
           "required": false,
           "description": "Number of emails to read (Min 1, Max 100, Default 25)",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "page_token",
+          "type": "string",
+          "required": false,
+          "description": "Page token to retrieve a specific page of results in the list",
           "enum": null,
           "inferrable": true
         },
@@ -406,6 +427,11 @@
             "type": "integer",
             "required": false
           },
+          "page_token": {
+            "value": "04852997929874",
+            "type": "string",
+            "required": false
+          },
           "exclude_automated": {
             "value": true,
             "type": "boolean",
@@ -437,38 +463,42 @@
     {
       "name": "ListEmailsByHeader",
       "qualifiedName": "Gmail.ListEmailsByHeader",
-      "fullyQualifiedName": "Gmail.ListEmailsByHeader@7.5.1",
-      "description": "Search for emails by header using the Gmail API.\n\nBy default, obvious automated emails are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all emails regardless of source.",
+      "fullyQualifiedName": "Gmail.ListEmailsByHeader@8.0.1",
+      "description": "Search for emails by header using the Gmail API.",
       "parameters": [
         {
           "name": "sender",
-          "type": "string",
+          "type": "array",
+          "innerType": "string",
           "required": false,
-          "description": "The name or email address of the sender of the email",
+          "description": "Sender names or email addresses to match. A message matches if it is from ANY value in the list (the values are OR-combined). Put each distinct person or address in its own list element; do not split one person's name across elements. A single-word element or an email address matches broadly (a first name can match that person's address); a multi-word element matches as one phrase. Omit or pass an empty list to not filter by sender.",
           "enum": null,
           "inferrable": true
         },
         {
           "name": "recipient",
-          "type": "string",
+          "type": "array",
+          "innerType": "string",
           "required": false,
-          "description": "The name or email address of the recipient",
+          "description": "Recipient names or email addresses to match. A message matches if it was sent to ANY value in the list (OR-combined). Put each distinct person or address in its own element. A single-word element or an email address matches broadly; a multi-word element matches as one phrase. Omit to not filter by recipient.",
           "enum": null,
           "inferrable": true
         },
         {
           "name": "subject",
-          "type": "string",
+          "type": "array",
+          "innerType": "string",
           "required": false,
-          "description": "Words to find in the subject of the email",
+          "description": "Subject search terms. A message matches if its subject contains ANY value in the list (OR-combined). A single-word element matches broadly; a multi-word element matches as one phrase in the subject. Omit to not filter by subject.",
           "enum": null,
           "inferrable": true
         },
         {
           "name": "body",
-          "type": "string",
+          "type": "array",
+          "innerType": "string",
           "required": false,
-          "description": "Words to find in the body of the email",
+          "description": "Body search terms searched anywhere in the message text. A message matches if the body contains ANY value in the list (OR-combined). A single element is treated as free text (all of its words must appear); pass multiple elements to match any of several terms. Omit to not filter by body.",
           "enum": null,
           "inferrable": true
         },
@@ -492,7 +522,7 @@
           "name": "label",
           "type": "string",
           "required": false,
-          "description": "The label name to filter by",
+          "description": "Label name to filter by. When this is a user-created label (not INBOX, SENT, or CATEGORY_*), category-based automated filters are skipped so labeled messages are not hidden by mistake. System labels such as INBOX keep the full automated filter behavior.",
           "enum": null,
           "inferrable": true
         },
@@ -500,7 +530,15 @@
           "name": "max_results",
           "type": "integer",
           "required": false,
-          "description": "The maximum number of emails to return (Min 1, Max 100, Default 25)",
+          "description": "The maximum number of emails to return (Min 1, Max 100, Default 25). Requests above 100 are clamped; the response includes limit_clamped_to_max=True when that happens.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "page_token",
+          "type": "string",
+          "required": false,
+          "description": "Page token to retrieve a specific page of results in the list",
           "enum": null,
           "inferrable": true
         },
@@ -508,7 +546,7 @@
           "name": "exclude_automated",
           "type": "boolean",
           "required": false,
-          "description": "Exclude obvious automated email using no-reply sender patterns and Gmail non-primary categories (promotions, social, updates, forums). Set to False when the user wants automated content like calendar invites, marketing emails, or other filtered categories.",
+          "description": "Exclude obvious automated email using no-reply sender patterns and Gmail non-primary categories (promotions, social, updates, forums). Set to False when the user wants automated content like calendar invites or marketing emails. When label is a user-created label, category exclusions are skipped automatically; noreply sender patterns still apply.",
           "enum": null,
           "inferrable": true
         }
@@ -531,38 +569,55 @@
         "toolName": "Gmail.ListEmailsByHeader",
         "parameters": {
           "sender": {
-            "value": "john.doe@example.com",
-            "type": "string",
+            "value": [
+              "alice@example.com",
+              "Bob Smith"
+            ],
+            "type": "array",
             "required": false
           },
           "recipient": {
-            "value": "jane.smith@example.com",
-            "type": "string",
+            "value": [
+              "carol@example.com",
+              "David Jones"
+            ],
+            "type": "array",
             "required": false
           },
           "subject": {
-            "value": "project update",
-            "type": "string",
+            "value": [
+              "invoice",
+              "project update"
+            ],
+            "type": "array",
             "required": false
           },
           "body": {
-            "value": "quarterly review",
-            "type": "string",
+            "value": [
+              "please find attached",
+              "quarterly report"
+            ],
+            "type": "array",
             "required": false
           },
           "date_range": {
-            "value": "2024-01-01 to 2024-03-31",
+            "value": "2024-01-01 to 2024-06-30",
             "type": "string",
             "required": false
           },
           "label": {
-            "value": "work",
+            "value": "Work",
             "type": "string",
             "required": false
           },
           "max_results": {
             "value": 10,
             "type": "integer",
+            "required": false
+          },
+          "page_token": {
+            "value": "04849884970385",
+            "type": "string",
             "required": false
           },
           "exclude_automated": {
@@ -596,7 +651,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Gmail.ListLabels",
-      "fullyQualifiedName": "Gmail.ListLabels@7.5.1",
+      "fullyQualifiedName": "Gmail.ListLabels@8.0.1",
       "description": "List all the labels in the user's mailbox.",
       "parameters": [],
       "auth": {
@@ -641,7 +696,7 @@
     {
       "name": "ListThreads",
       "qualifiedName": "Gmail.ListThreads",
-      "fullyQualifiedName": "Gmail.ListThreads@7.5.1",
+      "fullyQualifiedName": "Gmail.ListThreads@8.0.1",
       "description": "List threads in the user's mailbox.\n\nBy default, obvious automated threads are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all threads regardless of source.",
       "parameters": [
         {
@@ -740,7 +795,7 @@
     {
       "name": "ReplyToEmail",
       "qualifiedName": "Gmail.ReplyToEmail",
-      "fullyQualifiedName": "Gmail.ReplyToEmail@7.5.1",
+      "fullyQualifiedName": "Gmail.ReplyToEmail@8.0.1",
       "description": "Send a reply to an email message, optionally with one or more file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
@@ -905,8 +960,8 @@
     {
       "name": "SearchThreads",
       "qualifiedName": "Gmail.SearchThreads",
-      "fullyQualifiedName": "Gmail.SearchThreads@7.5.1",
-      "description": "Search for threads in the user's mailbox.\n\nBy default, obvious automated threads are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all threads regardless of source.",
+      "fullyQualifiedName": "Gmail.SearchThreads@8.0.1",
+      "description": "Search for threads in the user's mailbox.",
       "parameters": [
         {
           "name": "page_token",
@@ -920,7 +975,7 @@
           "name": "max_results",
           "type": "integer",
           "required": false,
-          "description": "The maximum number of threads to return (Min 1, Max 100, Default 25)",
+          "description": "The maximum number of threads to return (Min 1, Max 100, Default 25). Requests above 100 are clamped; the response includes limit_clamped_to_max=True when that happens.",
           "enum": null,
           "inferrable": true
         },
@@ -937,39 +992,43 @@
           "type": "array",
           "innerType": "string",
           "required": false,
-          "description": "The IDs of labels to filter by",
+          "description": "Label IDs to filter by. When every ID is a user-created label (not INBOX, SENT, or CATEGORY_*), category-based automated filters are skipped so labeled messages are not hidden by mistake. System label IDs such as INBOX keep the full automated filter behavior.",
           "enum": null,
           "inferrable": true
         },
         {
           "name": "sender",
-          "type": "string",
+          "type": "array",
+          "innerType": "string",
           "required": false,
-          "description": "The name or email address of the sender of the email",
+          "description": "Sender names or email addresses to match. A thread matches if it is from ANY value in the list (the values are OR-combined). Put each distinct person or address in its own list element; do not split one person's name across elements. A single-word element or an email address matches broadly (a first name can match that person's address); a multi-word element matches as one phrase. Omit or pass an empty list to not filter by sender.",
           "enum": null,
           "inferrable": true
         },
         {
           "name": "recipient",
-          "type": "string",
+          "type": "array",
+          "innerType": "string",
           "required": false,
-          "description": "The name or email address of the recipient",
+          "description": "Recipient names or email addresses to match. A thread matches if it was sent to ANY value in the list (OR-combined). Put each distinct person or address in its own element. A single-word element or an email address matches broadly; a multi-word element matches as one phrase. Omit to not filter by recipient.",
           "enum": null,
           "inferrable": true
         },
         {
           "name": "subject",
-          "type": "string",
+          "type": "array",
+          "innerType": "string",
           "required": false,
-          "description": "Words to find in the subject of the email",
+          "description": "Subject search terms. A thread matches if its subject contains ANY value in the list (OR-combined). A single-word element matches broadly; a multi-word element matches as one phrase in the subject. Omit to not filter by subject.",
           "enum": null,
           "inferrable": true
         },
         {
           "name": "body",
-          "type": "string",
+          "type": "array",
+          "innerType": "string",
           "required": false,
-          "description": "Words to find in the body of the email",
+          "description": "Body search terms searched anywhere in the message text. A thread matches if the body contains ANY value in the list (OR-combined). A single element is treated as free text (all of its words must appear); pass multiple elements to match any of several terms. Omit to not filter by body.",
           "enum": null,
           "inferrable": true
         },
@@ -993,7 +1052,7 @@
           "name": "exclude_automated",
           "type": "boolean",
           "required": false,
-          "description": "Exclude obvious automated email using no-reply sender patterns and Gmail non-primary categories (promotions, social, updates, forums). Set to False when the user wants automated content like calendar invites, marketing emails, or other filtered categories.",
+          "description": "Exclude obvious automated email using no-reply sender patterns and Gmail non-primary categories (promotions, social, updates, forums). Set to False when the user wants automated content like calendar invites or marketing emails. When every label_ids entry is a user-created label, category exclusions are skipped automatically; noreply sender patterns still apply.",
           "enum": null,
           "inferrable": true
         }
@@ -1016,7 +1075,7 @@
         "toolName": "Gmail.SearchThreads",
         "parameters": {
           "page_token": {
-            "value": "08534199247523835116:3344178171920213670",
+            "value": "04614780039721854915",
             "type": "string",
             "required": false
           },
@@ -1033,29 +1092,41 @@
           "label_ids": {
             "value": [
               "INBOX",
-              "IMPORTANT"
+              "Label_123456789"
             ],
             "type": "array",
             "required": false
           },
           "sender": {
-            "value": "alice@example.com",
-            "type": "string",
+            "value": [
+              "Alice Johnson",
+              "bob@example.com"
+            ],
+            "type": "array",
             "required": false
           },
           "recipient": {
-            "value": "bob@example.com",
-            "type": "string",
+            "value": [
+              "carol@example.com",
+              "David Smith"
+            ],
+            "type": "array",
             "required": false
           },
           "subject": {
-            "value": "project update",
-            "type": "string",
+            "value": [
+              "Project Update",
+              "meeting agenda"
+            ],
+            "type": "array",
             "required": false
           },
           "body": {
-            "value": "quarterly report",
-            "type": "string",
+            "value": [
+              "please find attached",
+              "deadline"
+            ],
+            "type": "array",
             "required": false
           },
           "date_range": {
@@ -1094,7 +1165,7 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "Gmail.SendDraftEmail",
-      "fullyQualifiedName": "Gmail.SendDraftEmail@7.5.1",
+      "fullyQualifiedName": "Gmail.SendDraftEmail@8.0.1",
       "description": "Send a draft email using the Gmail API.",
       "parameters": [
         {
@@ -1154,7 +1225,7 @@
     {
       "name": "SendEmail",
       "qualifiedName": "Gmail.SendEmail",
-      "fullyQualifiedName": "Gmail.SendEmail@7.5.1",
+      "fullyQualifiedName": "Gmail.SendEmail@8.0.1",
       "description": "Send an email using the Gmail API, optionally with one or more file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
@@ -1315,7 +1386,7 @@
     {
       "name": "TrashEmail",
       "qualifiedName": "Gmail.TrashEmail",
-      "fullyQualifiedName": "Gmail.TrashEmail@7.5.1",
+      "fullyQualifiedName": "Gmail.TrashEmail@8.0.1",
       "description": "Move an email to the trash folder using the Gmail API.",
       "parameters": [
         {
@@ -1375,7 +1446,7 @@
     {
       "name": "UpdateDraftEmail",
       "qualifiedName": "Gmail.UpdateDraftEmail",
-      "fullyQualifiedName": "Gmail.UpdateDraftEmail@7.5.1",
+      "fullyQualifiedName": "Gmail.UpdateDraftEmail@8.0.1",
       "description": "Update an existing email draft using the Gmail API.\n\nSingle-part ``text/plain`` and single-part ``text/html`` drafts both support full\nbody replacement; the rebuild follows the existing draft's content type, so a\nplain draft stays plain and an HTML draft stays HTML. Plain-text input supplied\nagainst an HTML draft is auto-converted to HTML, and HTML input supplied against\na plain draft is stored verbatim as ``text/plain``. Reply drafts preserve their\nreply-quote tail (``> `` lines for plain, ``<blockquote>`` for HTML) when the\nbody is supplied as a top-only update.\n\nMultipart drafts and drafts with attachments still fail when the body changes;\nin those cases the tool succeeds only when the effective body is unchanged\n(metadata-only update preserving the existing MIME tree). Edit those drafts in\nGmail directly.\n\nFor each of subject, body, recipient, cc, and bcc, omitting the parameter or passing\n``None`` leaves that part of the draft unchanged (for cc/bcc, existing headers are kept;\npass an empty list to clear).",
       "parameters": [
         {
@@ -1507,7 +1578,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Gmail.WhoAmI",
-      "fullyQualifiedName": "Gmail.WhoAmI@7.5.1",
+      "fullyQualifiedName": "Gmail.WhoAmI@8.0.1",
       "description": "Get comprehensive user profile and Gmail account information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Gmail account statistics, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1554,7 +1625,7 @@
     {
       "name": "WriteDraftEmail",
       "qualifiedName": "Gmail.WriteDraftEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftEmail@7.5.1",
+      "fullyQualifiedName": "Gmail.WriteDraftEmail@8.0.1",
       "description": "Compose a new email draft using the Gmail API, optionally with file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
@@ -1715,7 +1786,7 @@
     {
       "name": "WriteDraftReplyEmail",
       "qualifiedName": "Gmail.WriteDraftReplyEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@7.5.1",
+      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@8.0.1",
       "description": "Compose a draft reply to an email message, optionally with one or more file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
@@ -1899,6 +1970,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-06-29T12:37:13.647Z",
-  "summary": "# Gmail Toolkit\n\nArcade's Gmail toolkit provides LLM-ready tools for interacting with Gmail via the Gmail API, enabling agents to read, compose, send, organize, and search email on behalf of authenticated users.\n\n## Capabilities\n\n- **Reading & searching:** List and search emails, threads, and drafts with built-in automated-email filtering (no-reply senders, non-primary categories); filtering can be disabled via `exclude_automated=False`. Retrieve threads by ID and search by header.\n- **Composing & drafts:** Create, update, and delete drafts (plain-text or HTML, with smart body-replacement rules); compose draft replies with preserved reply-quote tails.\n- **Sending:** Send new emails or existing drafts; reply to messages directly. All send operations support file attachments via `file://` URIs — file bytes are resolved client-side before the request, never passed through the conversation.\n- **Label management:** List, create, and apply or remove labels on messages; move messages to trash.\n- **Account introspection:** Retrieve the authenticated user's profile, email address, Gmail statistics, and profile picture via `WhoAmI`.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via Google. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details."
+  "generatedAt": "2026-07-08T11:41:33.826Z",
+  "summary": "The Gmail toolkit provides Arcade LLM tools for interacting with Gmail accounts via the Gmail API. It enables agents to read, compose, send, organize, and search email on behalf of authenticated users.\n\n## Capabilities\n\n- **Reading & searching**: List emails, threads, and drafts with built-in filtering to exclude automated/promotional mail by default; search threads and look up messages by header; retrieve full thread context by ID.\n- **Composing & drafting**: Write new draft emails or draft replies, update existing drafts (with smart handling of plain vs. HTML content and reply-quote preservation), and delete drafts.\n- **Sending**: Send new emails, send saved drafts, or reply to existing messages — all with optional file attachments supplied as `file://` URIs (bytes are resolved client-side and never passed through the conversation).\n- **Labels & organization**: List, create, and apply/remove labels on messages; move emails to trash.\n- **Account introspection**: Retrieve the authenticated user's profile, email address, and Gmail account statistics via `WhoAmI`.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 delegated access via Google. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details, required scopes, and configuration."
 }

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-06T12:24:44.168Z",
+  "generatedAt": "2026-07-08T11:41:48.825Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -356,7 +356,7 @@
     {
       "id": "Gmail",
       "label": "Gmail",
-      "version": "7.5.1",
+      "version": "8.0.1",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 18,
@@ -662,10 +662,10 @@
     {
       "id": "MicrosoftExcel",
       "label": "Microsoft Excel",
-      "version": "0.2.0",
+      "version": "1.1.1",
       "category": "productivity",
       "type": "arcade",
-      "toolCount": 9,
+      "toolCount": 10,
       "authType": "oauth2"
     },
     {
@@ -680,7 +680,7 @@
     {
       "id": "MicrosoftOutlookCalendar",
       "label": "Microsoft Outlook Calendar",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 7,
@@ -689,16 +689,16 @@
     {
       "id": "MicrosoftOutlookMail",
       "label": "Microsoft Outlook Mail",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "category": "productivity",
       "type": "arcade",
-      "toolCount": 28,
+      "toolCount": 30,
       "authType": "oauth2"
     },
     {
       "id": "MicrosoftPowerpoint",
       "label": "Microsoft PowerPoint",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 8,
@@ -707,7 +707,7 @@
     {
       "id": "MicrosoftSharepoint",
       "label": "Microsoft SharePoint",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 36,
@@ -716,7 +716,7 @@
     {
       "id": "MicrosoftTeams",
       "label": "Microsoft Teams",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "category": "social",
       "type": "arcade",
       "toolCount": 25,
@@ -725,7 +725,7 @@
     {
       "id": "MicrosoftWord",
       "label": "Microsoft Word",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 4,

--- a/toolkit-docs-generator/data/toolkits/microsoftexcel.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftexcel.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftExcel",
   "label": "Microsoft Excel",
-  "version": "0.2.0",
+  "version": "1.1.1",
   "description": "Arcade.dev LLM tools for Microsoft Excel",
   "metadata": {
     "category": "productivity",
@@ -24,10 +24,10 @@
   },
   "tools": [
     {
-      "name": "AddWorksheet",
-      "qualifiedName": "MicrosoftExcel.AddWorksheet",
-      "fullyQualifiedName": "MicrosoftExcel.AddWorksheet@0.2.0",
-      "description": "Add a new worksheet to the workbook.\n\nNote: The new worksheet name may not be immediately visible to other\ntools due to a brief Graph API propagation delay (up to ~10 s). Pass\nthe returned ``session_id`` to subsequent calls that reference the new\nworksheet to mitigate this.",
+      "name": "AggregateWorksheet",
+      "qualifiedName": "MicrosoftExcel.AggregateWorksheet",
+      "fullyQualifiedName": "MicrosoftExcel.AggregateWorksheet@1.1.1",
+      "description": "Summarize a worksheet by grouping rows and computing per-group aggregates in one call.\n\nUse this instead of reading and paginating raw rows when you need totals, averages, counts,\nor min/max broken down by one or more columns (e.g. revenue by region). Columns can be\nreferenced by letter (group_by) or by header name (group_by_headers) — use whichever is\nmore convenient. Groups are returned in first-seen order and capped by ``limit``.\n\nAlways check each aggregate's ``numeric_count`` field: non-numeric and formula-error cells\nare silently skipped for sum/average/min/max, so a clean-looking total may exclude rows —\nthe ``warnings`` list will name every column and group where this occurred.",
       "parameters": [
         {
           "name": "item_id",
@@ -38,10 +38,77 @@
           "inferrable": true
         },
         {
-          "name": "name",
+          "name": "group_by",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Column letters to group rows by (e.g. ['A'] groups by column A). Omit for a single grand-total group over the whole sheet.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "group_by_headers",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Header names to group rows by (e.g. ['Region']). Alternative to group_by when has_header is true — column letters are resolved automatically from the header row. Can be combined with group_by. Requires has_header=true.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "aggregations",
+          "type": "array",
+          "innerType": "json",
+          "required": false,
+          "description": "Aggregates to compute per group, each a column letter plus a function. Omit to return only each group's row count.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "worksheet",
           "type": "string",
           "required": false,
-          "description": "Name for the new worksheet. If omitted, Excel generates a default name.",
+          "description": "Worksheet name to aggregate. If omitted, uses the first worksheet.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cell_range",
+          "type": "string",
+          "required": false,
+          "description": "Limit aggregation to a bounded A1 range such as 'A3:F20' instead of the full used range. Use this when the sheet has a decorative title row above the data headers (e.g. title in row 1, headers in row 3 → cell_range='A3:F100'). When omitted the full used range is aggregated.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "has_header",
+          "type": "boolean",
+          "required": false,
+          "description": "Treat the first row as a header and exclude it from the data. The header label is returned with each aggregate. Defaults to true.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "filter_column",
+          "type": "string",
+          "required": false,
+          "description": "Column letter to filter rows on before grouping (used with filter_contains). If omitted, no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "filter_contains",
+          "type": "string",
+          "required": false,
+          "description": "Keep only rows whose filter_column cell contains this text (case-insensitive). If omitted, no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of groups to return (1-1000). Defaults to 100. When more groups exist the result is marked truncated.",
           "enum": null,
           "inferrable": true
         },
@@ -66,36 +133,99 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "Files.ReadWrite"
+          "Files.Read"
         ]
       },
       "secrets": [],
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "The created worksheet info."
+        "description": "Per-group aggregates computed over the worksheet's used range."
       },
       "documentationChunks": [],
       "codeExample": {
-        "toolName": "MicrosoftExcel.AddWorksheet",
+        "toolName": "MicrosoftExcel.AggregateWorksheet",
         "parameters": {
           "item_id": {
-            "value": "01T5ABCDEF123456789!123",
+            "value": "01ABCDE1234567890FGHIJ",
             "type": "string",
             "required": true
           },
-          "name": {
-            "value": "Quarterly Report Q2 2026",
+          "group_by": {
+            "value": [
+              "A",
+              "B"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "group_by_headers": {
+            "value": [
+              "Region",
+              "Category"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "aggregations": {
+            "value": [
+              {
+                "column": "C",
+                "function": "sum"
+              },
+              {
+                "column": "D",
+                "function": "average"
+              },
+              {
+                "column": "E",
+                "function": "count"
+              },
+              {
+                "column": "F",
+                "function": "max"
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
+          "worksheet": {
+            "value": "Sales Data",
             "type": "string",
             "required": false
           },
+          "cell_range": {
+            "value": "A3:F200",
+            "type": "string",
+            "required": false
+          },
+          "has_header": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "filter_column": {
+            "value": "B",
+            "type": "string",
+            "required": false
+          },
+          "filter_contains": {
+            "value": "North",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
           "drive_id": {
-            "value": "b!a1B2c3D4e5F6g7H8I9J0",
+            "value": "b!xyz123DriveId456ABC",
             "type": "string",
             "required": false
           },
           "session_id": {
-            "value": "b4f5c6d7-89ab-4cde-0123-456789abcdef",
+            "value": "session-abc123def456",
             "type": "string",
             "required": false
           }
@@ -112,27 +242,52 @@
         },
         "behavior": {
           "operations": [
-            "create"
+            "read"
           ],
-          "readOnly": false,
+          "readOnly": true,
           "destructive": false,
-          "idempotent": false,
+          "idempotent": true,
           "openWorld": true
         },
         "extras": null
       }
     },
     {
-      "name": "CreateWorkbook",
-      "qualifiedName": "MicrosoftExcel.CreateWorkbook",
-      "fullyQualifiedName": "MicrosoftExcel.CreateWorkbook@0.2.0",
-      "description": "Create a new Excel workbook (.xlsx) in OneDrive for Business.\n\nOnly .xlsx files are supported. OneDrive Consumer (personal accounts) is NOT supported.",
+      "name": "CreateOrEditWorkbook",
+      "qualifiedName": "MicrosoftExcel.CreateOrEditWorkbook",
+      "fullyQualifiedName": "MicrosoftExcel.CreateOrEditWorkbook@1.1.1",
+      "description": "Create a new .xlsx workbook or edit an existing one in OneDrive for Business.\n\nOmit `item_id` to create (an empty workbook is created from `filename`, then the\noperations are applied); provide `item_id` to edit. To create a populated workbook, pass\n`filename` plus set_values operations; name the target tab via `worksheet` (or reference\none consistent sheet name in the operations) and the new workbook's initial sheet is\nrenamed to match. For a finished file with formatting/charts intact, upload the bytes\ninstead of rebuilding cell-by-cell.\n\nEach entry in `operations` selects a behavior via its `type`: write/clear cells, format\ncells (font, fill, borders, alignment, wrap, row height), size rows and columns,\nsort, add/restyle tables (style, totals, banding, filter), add/move/restyle charts (anchor\ncell, size, title, legend, axis titles), manage worksheets and named ranges, protect a\nsheet, and recalculate. See the `operations` parameter for the per-type fields.",
       "parameters": [
+        {
+          "name": "operations",
+          "type": "array",
+          "innerType": "json",
+          "required": false,
+          "description": "Ordered edits to apply. Each entry's 'type' selects which fields are read. Operations run in order and the batch is non-atomic, so inspect 'operation_results'.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "item_id",
+          "type": "string",
+          "required": false,
+          "description": "Workbook to edit. Omit to create a new workbook (then 'filename' is used).",
+          "enum": null,
+          "inferrable": true
+        },
         {
           "name": "filename",
           "type": "string",
-          "required": true,
-          "description": "File name for the new workbook. The .xlsx extension is added automatically if not provided.",
+          "required": false,
+          "description": "File name for a new workbook (the .xlsx extension is added if missing). Used only when creating; ignored when editing.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "worksheet",
+          "type": "string",
+          "required": false,
+          "description": "Default worksheet for operations that omit their own 'worksheet'. If omitted, the first worksheet is used. When creating a new workbook, the initial sheet is renamed to this name so operations targeting it succeed in the same call.",
           "enum": null,
           "inferrable": true
         },
@@ -140,93 +295,7 @@
           "name": "parent_folder_id",
           "type": "string",
           "required": false,
-          "description": "Parent folder ID. If omitted, the workbook is created in the root of OneDrive.",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "initial_data",
-          "type": "string",
-          "required": false,
-          "description": "Optional JSON string for initial data in the first worksheet. Format: data[ROW][COL] = VALUE where ROW is a row number as string, COL is a column letter (uppercase), VALUE is string/number/boolean/null. Type: dict[str, dict[str, str | int | float | bool | None]].",
-          "enum": null,
-          "inferrable": true
-        }
-      ],
-      "auth": {
-        "providerId": "microsoft",
-        "providerType": "oauth2",
-        "scopes": [
-          "Files.ReadWrite"
-        ]
-      },
-      "secrets": [],
-      "secretsInfo": [],
-      "output": {
-        "type": "json",
-        "description": "The created Excel workbook metadata with session ID."
-      },
-      "documentationChunks": [],
-      "codeExample": {
-        "toolName": "MicrosoftExcel.CreateWorkbook",
-        "parameters": {
-          "filename": {
-            "value": "Q1_2026_Report",
-            "type": "string",
-            "required": true
-          },
-          "parent_folder_id": {
-            "value": "01ABCDXYZ123!456",
-            "type": "string",
-            "required": false
-          },
-          "initial_data": {
-            "value": "{\"1\":{\"A\":\"Region\",\"B\":\"Sales\",\"C\":\"Growth\"},\"2\":{\"A\":\"North\",\"B\":120000.5,\"C\":0.05},\"3\":{\"A\":\"South\",\"B\":95000,\"C\":-0.02},\"4\":{\"A\":\"Total\",\"B\":215000.5,\"C\":null}}",
-            "type": "string",
-            "required": false
-          }
-        },
-        "requiresAuth": true,
-        "authProvider": "microsoft",
-        "tabLabel": "Call the Tool with User Authorization"
-      },
-      "metadata": {
-        "classification": {
-          "serviceDomains": [
-            "spreadsheets"
-          ]
-        },
-        "behavior": {
-          "operations": [
-            "create"
-          ],
-          "readOnly": false,
-          "destructive": false,
-          "idempotent": false,
-          "openWorld": true
-        },
-        "extras": null
-      }
-    },
-    {
-      "name": "DeleteWorksheet",
-      "qualifiedName": "MicrosoftExcel.DeleteWorksheet",
-      "fullyQualifiedName": "MicrosoftExcel.DeleteWorksheet@0.2.0",
-      "description": "Delete a worksheet from the workbook.\n\nCannot delete the last worksheet in a workbook.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
-      "parameters": [
-        {
-          "name": "item_id",
-          "type": "string",
-          "required": true,
-          "description": "The ID of the Excel workbook.",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "worksheet",
-          "type": "string",
-          "required": true,
-          "description": "Name of the worksheet to delete.",
+          "description": "Parent folder ID for a new workbook. If omitted, it is created in the OneDrive root.",
           "enum": null,
           "inferrable": true
         },
@@ -234,7 +303,7 @@
           "name": "drive_id",
           "type": "string",
           "required": false,
-          "description": "Optional drive ID for shared items. If omitted, uses the user's default OneDrive.",
+          "description": "Drive ID for shared items. If omitted, uses the user's default OneDrive.",
           "enum": null,
           "inferrable": true
         },
@@ -242,7 +311,7 @@
           "name": "session_id",
           "type": "string",
           "required": false,
-          "description": "Optional session ID from a previous operation for better performance.",
+          "description": "Session ID returned by a previous call against the same workbook, for consistency and performance. If omitted, one is created.",
           "enum": null,
           "inferrable": true
         }
@@ -258,29 +327,95 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "Confirmation of the worksheet deletion."
+        "description": "Workbook state and per-operation results."
       },
       "documentationChunks": [],
       "codeExample": {
-        "toolName": "MicrosoftExcel.DeleteWorksheet",
+        "toolName": "MicrosoftExcel.CreateOrEditWorkbook",
         "parameters": {
+          "operations": {
+            "value": [
+              {
+                "type": "set_values",
+                "worksheet": "Sales Data",
+                "range": "A1:C3",
+                "values": [
+                  [
+                    "Region",
+                    "Product",
+                    "Revenue"
+                  ],
+                  [
+                    "North",
+                    "Widget A",
+                    15000
+                  ],
+                  [
+                    "South",
+                    "Widget B",
+                    23000
+                  ]
+                ]
+              },
+              {
+                "type": "format_cells",
+                "worksheet": "Sales Data",
+                "range": "A1:C1",
+                "font": {
+                  "bold": true,
+                  "size": 12
+                },
+                "fill": {
+                  "color": "#4472C4"
+                }
+              },
+              {
+                "type": "add_table",
+                "worksheet": "Sales Data",
+                "range": "A1:C3",
+                "style": "TableStyleMedium9",
+                "totals": true,
+                "banded": true
+              },
+              {
+                "type": "add_chart",
+                "worksheet": "Sales Data",
+                "chart_type": "ColumnClustered",
+                "data_range": "A1:C3",
+                "anchor_cell": "E2",
+                "title": "Regional Revenue"
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
           "item_id": {
-            "value": "01ABCD2EFGHIJKL3456789!101",
+            "value": "01ABCDE3FGH4IJKLMNOP5QRSTUVWXYZ67890",
             "type": "string",
-            "required": true
+            "required": false
+          },
+          "filename": {
+            "value": "Q3_Sales_Report",
+            "type": "string",
+            "required": false
           },
           "worksheet": {
-            "value": "Expenses 2026",
+            "value": "Sales Data",
             "type": "string",
-            "required": true
+            "required": false
+          },
+          "parent_folder_id": {
+            "value": "b!xY1zAbCdEfGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKlMnOpQ",
+            "type": "string",
+            "required": false
           },
           "drive_id": {
-            "value": "b!a1b2c3d4e5f6g7h8i9j0k",
+            "value": "b!AbCdEfGhIjKlMnOpQrStUvWxYz1234567890AbCdEfGhIj",
             "type": "string",
             "required": false
           },
           "session_id": {
-            "value": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "value": "cluster=EX1&session=12345678-abcd-ef01-2345-6789abcdef01%2C0",
             "type": "string",
             "required": false
           }
@@ -297,11 +432,13 @@
         },
         "behavior": {
           "operations": [
+            "create",
+            "update",
             "delete"
           ],
           "readOnly": false,
           "destructive": true,
-          "idempotent": true,
+          "idempotent": false,
           "openWorld": true
         },
         "extras": null
@@ -310,8 +447,8 @@
     {
       "name": "GetWorkbookMetadata",
       "qualifiedName": "MicrosoftExcel.GetWorkbookMetadata",
-      "fullyQualifiedName": "MicrosoftExcel.GetWorkbookMetadata@0.2.0",
-      "description": "Get metadata about an Excel workbook including worksheet list.\n\nReturns workbook name, URL, and all worksheets with their names, positions, and visibility.",
+      "fullyQualifiedName": "MicrosoftExcel.GetWorkbookMetadata@1.1.1",
+      "description": "Get a workbook's structure: worksheets, named ranges, and optionally extents and objects.\n\nCall this first when exploring an unfamiliar workbook: it surfaces hidden worksheets,\nworkbook-scoped named ranges, tables, charts, and (with the flags) used ranges, protection\nstate, and worksheet-local named ranges, so you can target reads precisely and avoid\nmistaking a stale dashboard sheet for the source data. Use `include_used_ranges` to learn\nwhere data lives before reading, and `include_objects` to enumerate tables and charts. Both\nadd a per-worksheet fan-out, so leave them off for a quick worksheet listing.",
       "parameters": [
         {
           "name": "item_id",
@@ -322,10 +459,26 @@
           "inferrable": true
         },
         {
+          "name": "include_used_ranges",
+          "type": "boolean",
+          "required": false,
+          "description": "Also report each worksheet's used range, dimensions, first-row preview, protection state, and worksheet-local named ranges. Adds a per-worksheet fan-out. Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "include_objects",
+          "type": "boolean",
+          "required": false,
+          "description": "Also enumerate tables and charts with their locations. Adds a per-worksheet fan-out. Defaults to false.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
           "name": "drive_id",
           "type": "string",
           "required": false,
-          "description": "Optional drive ID for shared items. If omitted, uses the user's default OneDrive.",
+          "description": "Drive ID for shared items. If omitted, uses the user's default OneDrive.",
           "enum": null,
           "inferrable": true
         },
@@ -333,7 +486,7 @@
           "name": "session_id",
           "type": "string",
           "required": false,
-          "description": "Optional session ID from a previous operation for better performance.",
+          "description": "Session ID from a previous operation for consistency and performance.",
           "enum": null,
           "inferrable": true
         }
@@ -349,24 +502,34 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "Workbook metadata including worksheet list."
+        "description": "Workbook structure overview."
       },
       "documentationChunks": [],
       "codeExample": {
         "toolName": "MicrosoftExcel.GetWorkbookMetadata",
         "parameters": {
           "item_id": {
-            "value": "01A2B3C4D5E6F7G8!123",
+            "value": "01BYE5RZ6QN3ZWBTUFOFD3GSPEY2FEFUOA",
             "type": "string",
             "required": true
           },
+          "include_used_ranges": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "include_objects": {
+            "value": false,
+            "type": "boolean",
+            "required": false
+          },
           "drive_id": {
-            "value": "b!xYzAbCdEfGhIjKlMnOp",
+            "value": "b!eP-qoTqI8EWbj4RNUoRF5B3vMkLpQ1ZDrYw2XhN9cUEaG7mS0kTzR6V3yF4dN8pl",
             "type": "string",
             "required": false
           },
           "session_id": {
-            "value": "session_9f8e7d6c5b4a3",
+            "value": "cluster=EU1&session=sPfqXW7tN2kL1mYvOjRdHgBcA3eIuZs0",
             "type": "string",
             "required": false
           }
@@ -394,10 +557,122 @@
       }
     },
     {
-      "name": "GetWorksheetData",
-      "qualifiedName": "MicrosoftExcel.GetWorksheetData",
-      "fullyQualifiedName": "MicrosoftExcel.GetWorksheetData@0.2.0",
-      "description": "Read cell values from a worksheet.\n\nReturns data in sparse dict format where data[ROW][COL] has userEnteredValue\nand formattedValue for each non-empty cell. Includes pagination hints if more\ndata exists beyond the requested range.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
+      "name": "ListWorkbookComments",
+      "qualifiedName": "MicrosoftExcel.ListWorkbookComments",
+      "fullyQualifiedName": "MicrosoftExcel.ListWorkbookComments@1.1.1",
+      "description": "List a workbook's comments, or the replies on a specific comment thread.\n\nProvide a comment ID to retrieve that thread's replies instead of the top-level comments.",
+      "parameters": [
+        {
+          "name": "item_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the Excel workbook.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "string",
+          "required": false,
+          "description": "When omitted, lists the workbook's comments. When provided, lists the replies on that comment thread in the order they were posted.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-50). Defaults to 50.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "drive_id",
+          "type": "string",
+          "required": false,
+          "description": "Optional drive ID for shared items. If omitted, uses the user's default OneDrive.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "Files.Read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The paginated comments or replies for the workbook."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftExcel.ListWorkbookComments",
+        "parameters": {
+          "item_id": {
+            "value": "01BYE5RZ6QN3ZWBTUFOFD3GSPGOHDJD36K",
+            "type": "string",
+            "required": true
+          },
+          "comment_id": {
+            "value": "1.fLmproph6bMTYsBmGFgIgQAAAAAAAAAA",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          },
+          "drive_id": {
+            "value": "b!dGbmwR7TcU6wYBu4R1YmSabcDEFGHIJKLMNOPQRSTUVWXYZ",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "spreadsheets"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ReadWorksheet",
+      "qualifiedName": "MicrosoftExcel.ReadWorksheet",
+      "fullyQualifiedName": "MicrosoftExcel.ReadWorksheet@1.1.1",
+      "description": "Read a worksheet range with the detail you choose, with guardrails for large sheets.\n\nRequest `annotations` for formulas, cell types, number formats, or the range's\nfill/font/borders; `filter_column` + `filter_contains` to keep matching rows; `columns` to\nproject a subset; `export` for csv/tsv. Reads are bounded to the used range and capped by a\nrow limit and cell budget, paginating via `next_range` rather than returning a whole large\nsheet at once.\n\nSet `row_format=\"records\"` (with `has_header=true`) to get a `record` dict on each data\nrow, keying cell values by the header row (the top row of the worksheet's used range) —\nuseful when agents need to map values to named columns without tracking positional indices.\nThe header is carried across pages, so paginated reads via `next_range` stay correctly\nkeyed. Each row still includes `values`.\n\nTo verify formulas, types, or number patterns in the returned cells, pass `annotations`\n(e.g. `[\"formulas\", \"types\"]`); annotation values land under `annotations` keyed by A1\naddress alongside the displayed values.",
       "parameters": [
         {
           "name": "item_id",
@@ -411,39 +686,368 @@
           "name": "worksheet",
           "type": "string",
           "required": false,
-          "description": "Worksheet name to read from. If omitted, reads from the first worksheet.",
+          "description": "Worksheet to read. If omitted, reads the first worksheet.",
           "enum": null,
           "inferrable": true
         },
         {
-          "name": "start_row",
-          "type": "integer",
-          "required": false,
-          "description": "Starting row number (1-indexed). Defaults to 1.",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "start_col",
+          "name": "cell_range",
           "type": "string",
           "required": false,
-          "description": "Starting column letter. Defaults to A.",
+          "description": "Bounded A1 range to read (e.g. 'A1:D50'). Entire-row/column ranges and an omitted range are bounded to the worksheet's populated extent.",
           "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "annotations",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Extra detail to attach. formulas/types/number_formats are per-cell (under 'annotations'); fill/font/borders report the range's overall formatting (under 'range_format'). If omitted, only displayed values are returned.",
+          "enum": [
+            "formulas",
+            "types",
+            "number_formats",
+            "fill",
+            "font",
+            "borders"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "filter_column",
+          "type": "string",
+          "required": false,
+          "description": "Column letter to filter rows on (used with filter_contains). If omitted, no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "filter_contains",
+          "type": "string",
+          "required": false,
+          "description": "Keep only rows whose filter_column cell contains this text (case-insensitive, matched against the full untruncated value). If omitted, no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "has_header",
+          "type": "boolean",
+          "required": false,
+          "description": "When true and a filter is active, the first row is treated as a column header and always included in the output regardless of the filter value. Defaults to true.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "row_format",
+          "type": "string",
+          "required": false,
+          "description": "Shape of each row in the response. 'array' (default) returns positional cell values under 'values'. 'records' additionally attaches a 'record' dict to each data row, keying values by their column header; requires has_header=true. Blank headers become 'column_<LETTER>' and duplicate headers are disambiguated with a numeric suffix.",
+          "enum": [
+            "array",
+            "records"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "columns",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Column letters to return, in this order. Projecting fewer columns also raises how many rows fit in one page. If omitted, all columns in the range are returned.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "export",
+          "type": "string",
+          "required": false,
+          "description": "Also return the range rendered as delimited text under 'export'. If omitted, no export.",
+          "enum": [
+            "csv",
+            "tsv"
+          ],
           "inferrable": true
         },
         {
           "name": "max_rows",
           "type": "integer",
           "required": false,
-          "description": "Maximum rows to return. Defaults to 1000, maximum allowed is 1000.",
+          "description": "Maximum rows to scan for this page (1-1000). Defaults to 200. This is an upper bound, not a guarantee: a page may return fewer rows than this and set next_range to continue. On wide sheets a per-page cell budget (rows x columns) caps the window below max_rows, so raising max_rows alone may not enlarge the page; project fewer columns to fit more rows. With a filter, a page returns only the matching rows scanned within this bound.",
           "enum": null,
           "inferrable": true
         },
         {
-          "name": "max_cols",
+          "name": "max_length",
           "type": "integer",
           "required": false,
-          "description": "Maximum columns to return. Defaults to 100, maximum allowed is 100.",
+          "description": "Per-cell display length cap; longer values are truncated with an overflow marker. Set to 0 to disable truncation. Defaults to 200.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "drive_id",
+          "type": "string",
+          "required": false,
+          "description": "Drive ID for shared items. If omitted, uses the user's default OneDrive.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "session_id",
+          "type": "string",
+          "required": false,
+          "description": "Session ID from a previous operation for consistency and performance.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "Files.Read"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Worksheet slice with optional annotations and export."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftExcel.ReadWorksheet",
+        "parameters": {
+          "item_id": {
+            "value": "01BYE5RZ5DXKZVZM6ZDBE2LH3QKDB4HZNC",
+            "type": "string",
+            "required": true
+          },
+          "worksheet": {
+            "value": "Sales Data",
+            "type": "string",
+            "required": false
+          },
+          "cell_range": {
+            "value": "A1:F50",
+            "type": "string",
+            "required": false
+          },
+          "annotations": {
+            "value": [
+              "formulas",
+              "types",
+              "number_formats"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "filter_column": {
+            "value": "C",
+            "type": "string",
+            "required": false
+          },
+          "filter_contains": {
+            "value": "North America",
+            "type": "string",
+            "required": false
+          },
+          "has_header": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "row_format": {
+            "value": "records",
+            "type": "string",
+            "required": false
+          },
+          "columns": {
+            "value": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "F"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "export": {
+            "value": "csv",
+            "type": "string",
+            "required": false
+          },
+          "max_rows": {
+            "value": 150,
+            "type": "integer",
+            "required": false
+          },
+          "max_length": {
+            "value": 300,
+            "type": "integer",
+            "required": false
+          },
+          "drive_id": {
+            "value": "b!Qj7vX2mK9UO4dTpW3nRvYA1czHgBfLkPqsZeNwMiOdUTXhbRlCsKF8y2VpJn6E",
+            "type": "string",
+            "required": false
+          },
+          "session_id": {
+            "value": "cluster=EU2&session=7f3a1b2c-4d5e-6f7a-8b9c-0d1e2f3a4b5c",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "spreadsheets"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ReplyToWorkbookComment",
+      "qualifiedName": "MicrosoftExcel.ReplyToWorkbookComment",
+      "fullyQualifiedName": "MicrosoftExcel.ReplyToWorkbookComment@1.1.1",
+      "description": "Post a plain-text reply to an existing comment thread on a workbook.\n\nThe reply is appended to the end of the thread.",
+      "parameters": [
+        {
+          "name": "item_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the Excel workbook.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the comment thread to reply to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "content",
+          "type": "string",
+          "required": true,
+          "description": "The plain-text body of the reply. Cannot be empty.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "drive_id",
+          "type": "string",
+          "required": false,
+          "description": "Optional drive ID for shared items. If omitted, uses the user's default OneDrive.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "Files.ReadWrite"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The newly created reply on the comment thread."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftExcel.ReplyToWorkbookComment",
+        "parameters": {
+          "item_id": {
+            "value": "01BYE5RZ6QN3ZWBTUFOFD3GSPEY2DJDZOQ",
+            "type": "string",
+            "required": true
+          },
+          "comment_id": {
+            "value": "1-ZmI5NWJmMGItNzk4YS00YTg1LTliODctZjUwNjQ4YzFjNGZh",
+            "type": "string",
+            "required": true
+          },
+          "content": {
+            "value": "Thanks for the update! I've reviewed the figures and everything looks correct to me.",
+            "type": "string",
+            "required": true
+          },
+          "drive_id": {
+            "value": "b!t18F8ybVHUqzgQqseB-nYLXyBH38nNVBpVhzlX6Vu8s5tJ8wX9RiQ6gHkJmN1234",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "spreadsheets"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ScanForDataIssues",
+      "qualifiedName": "MicrosoftExcel.ScanForDataIssues",
+      "fullyQualifiedName": "MicrosoftExcel.ScanForDataIssues@1.1.1",
+      "description": "Scan a worksheet (or the whole workbook) for data-quality problems as a structured list.\n\nEach issue carries a ``severity`` field (``\"high\"``, ``\"medium\"``, or ``\"low\"``) and the\nlist is ordered high → low before any truncation cap is applied, so critical findings are\nnever dropped in favour of lower-priority ones.\n\nBy default the scan is sheet-scoped (the named worksheet, or the first sheet when\n``worksheet`` is omitted). Pass ``worksheet='*'`` for a workbook-wide audit: every sheet\nis scanned in one call and each issue carries its own ``worksheet`` field.\n\nDetects formula-error cells (``severity=\"high\"``), type outliers within a column —\na column mostly one type with a few cells of another — (``severity=\"medium\"``),\ninconsistent_column for a column that mixes cell types without a strong majority\n(``severity=\"medium\"``), accidental duplicate values in mostly-unique columns\n(``severity=\"medium\"``), and blank cells inside an otherwise-populated region\n(``severity=\"low\"``). Categorical columns (where repetition is expected) are not flagged\nas duplicates, and the header row is excluded from type-outlier and duplicate checks.\nA clean sheet returns an empty issues list. Detection is deterministic.\nResults are capped; when the cap is reached ``truncated`` is True and a warning is added.\n\nMerged cells are a known limitation: Microsoft Graph reports only the merge anchor as\npopulated and every covered cell as empty, so cells hidden under a merge may be flagged as\nblanks. A worksheet cannot be scanned when its used range exceeds an internal cell limit\n(this tool takes no range argument): a single-sheet scan raises an error asking you to\nreduce the data, while a whole-workbook scan skips the oversized sheet and names it in a\nwarning so the rest of the workbook is still scanned.",
+      "parameters": [
+        {
+          "name": "item_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the Excel workbook.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "worksheet",
+          "type": "string",
+          "required": false,
+          "description": "Worksheet name to scan, or '*' to scan every worksheet in the workbook in one call. If omitted, scans the first worksheet.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "has_header",
+          "type": "boolean",
+          "required": false,
+          "description": "Treat the first row as a header and exclude it from type-outlier and duplicate checks. Defaults to true.",
           "enum": null,
           "inferrable": true
         },
@@ -475,49 +1079,34 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "Worksheet data in sparse dict format with pagination."
+        "description": "Structured list of data-quality issues found in the used range."
       },
       "documentationChunks": [],
       "codeExample": {
-        "toolName": "MicrosoftExcel.GetWorksheetData",
+        "toolName": "MicrosoftExcel.ScanForDataIssues",
         "parameters": {
           "item_id": {
-            "value": "01ABCDabcd2345EF!678",
+            "value": "01BYE5RZ6QN3ZWBZBP2BBJMKQTGIWVXBAS",
             "type": "string",
             "required": true
           },
           "worksheet": {
-            "value": "Sales Q1",
+            "value": "SalesData",
             "type": "string",
             "required": false
           },
-          "start_row": {
-            "value": 2,
-            "type": "integer",
-            "required": false
-          },
-          "start_col": {
-            "value": "B",
-            "type": "string",
-            "required": false
-          },
-          "max_rows": {
-            "value": 250,
-            "type": "integer",
-            "required": false
-          },
-          "max_cols": {
-            "value": 10,
-            "type": "integer",
+          "has_header": {
+            "value": true,
+            "type": "boolean",
             "required": false
           },
           "drive_id": {
-            "value": "b!2aB3cD4EfGhIjK",
+            "value": "b!Xt1mQ3rKvEeZf2LpNjD8aMkOqRsYwBcFlIhUeTnVdPgJuXyHzW",
             "type": "string",
             "required": false
           },
           "session_id": {
-            "value": "3f7a9b2c-4d1e-11ee-8c99-0242ac120002",
+            "value": "cluster=EU&session=7f3a1c2e-9b4d-4f8a-ae12-3d56f0812c47",
             "type": "string",
             "required": false
           }
@@ -545,160 +1134,40 @@
       }
     },
     {
-      "name": "RenameWorksheet",
-      "qualifiedName": "MicrosoftExcel.RenameWorksheet",
-      "fullyQualifiedName": "MicrosoftExcel.RenameWorksheet@0.2.0",
-      "description": "Rename an existing worksheet in the workbook.\n\nNote: The new name may not be immediately visible to other tools due\nto a brief Graph API propagation delay (up to ~10 s). Pass the returned\n``session_id`` to subsequent calls that reference the renamed worksheet\nto mitigate this. If referencing a recently added worksheet as the source,\nthe same delay applies; retry with the ``session_id`` if a\nWorksheetNotFoundError occurs.",
+      "name": "SearchWorkbooks",
+      "qualifiedName": "MicrosoftExcel.SearchWorkbooks",
+      "fullyQualifiedName": "MicrosoftExcel.SearchWorkbooks@1.1.1",
+      "description": "Find Excel workbooks in OneDrive by keyword or folder, returning their item_ids.\n\nProvide `query` to search the whole drive by name/content, or leave it empty and pass\n`parent_folder_id` to list one folder; only .xlsx files are returned. Use a returned\n`item_id` to read, edit, scan, or comment on a workbook you did not create this session.",
       "parameters": [
         {
-          "name": "item_id",
-          "type": "string",
-          "required": true,
-          "description": "The ID of the Excel workbook.",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "worksheet",
-          "type": "string",
-          "required": true,
-          "description": "Current name of the worksheet to rename.",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "new_name",
-          "type": "string",
-          "required": true,
-          "description": "New name for the worksheet.",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "drive_id",
+          "name": "query",
           "type": "string",
           "required": false,
-          "description": "Optional drive ID for shared items. If omitted, uses the user's default OneDrive.",
+          "description": "Keyword to match against the workbook name or contents across the whole drive. Leave empty to list workbooks in a folder instead. Defaults to empty.",
           "enum": null,
           "inferrable": true
         },
         {
-          "name": "session_id",
+          "name": "parent_folder_id",
           "type": "string",
           "required": false,
-          "description": "Optional session ID from a previous operation for better performance.",
-          "enum": null,
-          "inferrable": true
-        }
-      ],
-      "auth": {
-        "providerId": "microsoft",
-        "providerType": "oauth2",
-        "scopes": [
-          "Files.ReadWrite"
-        ]
-      },
-      "secrets": [],
-      "secretsInfo": [],
-      "output": {
-        "type": "json",
-        "description": "The renamed worksheet info."
-      },
-      "documentationChunks": [],
-      "codeExample": {
-        "toolName": "MicrosoftExcel.RenameWorksheet",
-        "parameters": {
-          "item_id": {
-            "value": "01234567-89ab-cdef-0123-456789abcdef",
-            "type": "string",
-            "required": true
-          },
-          "worksheet": {
-            "value": "Sheet1",
-            "type": "string",
-            "required": true
-          },
-          "new_name": {
-            "value": "Summary Q1 2026",
-            "type": "string",
-            "required": true
-          },
-          "drive_id": {
-            "value": "b!A1B2C3D4E5F6G7H8I9J0K",
-            "type": "string",
-            "required": false
-          },
-          "session_id": {
-            "value": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-            "type": "string",
-            "required": false
-          }
-        },
-        "requiresAuth": true,
-        "authProvider": "microsoft",
-        "tabLabel": "Call the Tool with User Authorization"
-      },
-      "metadata": {
-        "classification": {
-          "serviceDomains": [
-            "spreadsheets"
-          ]
-        },
-        "behavior": {
-          "operations": [
-            "update"
-          ],
-          "readOnly": false,
-          "destructive": false,
-          "idempotent": true,
-          "openWorld": true
-        },
-        "extras": null
-      }
-    },
-    {
-      "name": "UpdateCell",
-      "qualifiedName": "MicrosoftExcel.UpdateCell",
-      "fullyQualifiedName": "MicrosoftExcel.UpdateCell@0.2.0",
-      "description": "Update a single cell value in an Excel workbook.\n\nSupports strings, numbers, booleans, and formulas (values starting with '=').\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
-      "parameters": [
-        {
-          "name": "item_id",
-          "type": "string",
-          "required": true,
-          "description": "The ID of the Excel workbook.",
+          "description": "Folder to list workbooks from when no query is given. If omitted, the OneDrive root is listed.",
           "enum": null,
           "inferrable": true
         },
         {
-          "name": "column",
-          "type": "string",
-          "required": true,
-          "description": "Column letter or letters (e.g., 'A', 'BC').",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "row",
+          "name": "limit",
           "type": "integer",
-          "required": true,
-          "description": "Row number (1-indexed).",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "value",
-          "type": "string",
-          "required": true,
-          "description": "The value to set. Supports strings, numbers, booleans, and formulas (e.g., '=SUM(A1:A10)').",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "worksheet",
-          "type": "string",
           "required": false,
-          "description": "Worksheet name to update. If omitted, updates the first worksheet.",
+          "description": "Maximum workbooks to return (1-50). Defaults to 25.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed position of the first workbook to return. Defaults to 0.",
           "enum": null,
           "inferrable": true
         },
@@ -706,15 +1175,7 @@
           "name": "drive_id",
           "type": "string",
           "required": false,
-          "description": "Optional drive ID for shared items. If omitted, uses the user's default OneDrive.",
-          "enum": null,
-          "inferrable": true
-        },
-        {
-          "name": "session_id",
-          "type": "string",
-          "required": false,
-          "description": "Optional session ID from a previous operation for better performance.",
+          "description": "Drive ID for shared items. If omitted, uses the user's default OneDrive.",
           "enum": null,
           "inferrable": true
         }
@@ -723,51 +1184,41 @@
         "providerId": "microsoft",
         "providerType": "oauth2",
         "scopes": [
-          "Files.ReadWrite"
+          "Files.Read"
         ]
       },
       "secrets": [],
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "Confirmation of the cell update."
+        "description": "Matching .xlsx workbooks with their item_ids."
       },
       "documentationChunks": [],
       "codeExample": {
-        "toolName": "MicrosoftExcel.UpdateCell",
+        "toolName": "MicrosoftExcel.SearchWorkbooks",
         "parameters": {
-          "item_id": {
-            "value": "01234567-89ab-cdef-0123-456789abcdef",
+          "query": {
+            "value": "Q3 Sales Report",
             "type": "string",
-            "required": true
+            "required": false
           },
-          "column": {
-            "value": "C",
+          "parent_folder_id": {
+            "value": "01BYE5RZ56Y2GOVW7725BZO354PWSELRRZ",
             "type": "string",
-            "required": true
+            "required": false
           },
-          "row": {
-            "value": 5,
+          "limit": {
+            "value": 10,
             "type": "integer",
-            "required": true
+            "required": false
           },
-          "value": {
-            "value": "=SUM(C1:C10)",
-            "type": "string",
-            "required": true
-          },
-          "worksheet": {
-            "value": "Quarterly Budget",
-            "type": "string",
+          "offset": {
+            "value": 0,
+            "type": "integer",
             "required": false
           },
           "drive_id": {
-            "value": "b!a1B2c3D4e5F6g7H8",
-            "type": "string",
-            "required": false
-          },
-          "session_id": {
-            "value": "session-123e4567-e89b-12d3-a456-426614174000",
+            "value": "b!dGVzdERyaXZlSWQxMjM0NTY3ODkwMTIz",
             "type": "string",
             "required": false
           }
@@ -784,9 +1235,9 @@
         },
         "behavior": {
           "operations": [
-            "update"
+            "read"
           ],
-          "readOnly": false,
+          "readOnly": true,
           "destructive": false,
           "idempotent": true,
           "openWorld": true
@@ -795,32 +1246,32 @@
       }
     },
     {
-      "name": "UpdateRange",
-      "qualifiedName": "MicrosoftExcel.UpdateRange",
-      "fullyQualifiedName": "MicrosoftExcel.UpdateRange@0.2.0",
-      "description": "Update multiple cells in a worksheet using sparse dict format.\n\nOnly specified cells are updated; unspecified cells remain unchanged.\nThe data format is the same as Google Sheets update_cells.\n\nInternally, a single PATCH request is sent covering the bounding box\nof all specified cells.  Cells within the box that are not in the\ninput are sent as ``null``, which the Graph API treats as \"skip\".\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
+      "name": "UploadWorkbook",
+      "qualifiedName": "MicrosoftExcel.UploadWorkbook",
+      "fullyQualifiedName": "MicrosoftExcel.UploadWorkbook@1.1.1",
+      "description": "Upload a complete .xlsx file into OneDrive for Business, preserving it byte-for-byte.\n\nUse this instead of rebuilding a finished file cell-by-cell. Large files are uploaded\nvia a resumable upload session automatically.",
       "parameters": [
         {
-          "name": "item_id",
+          "name": "filename",
           "type": "string",
           "required": true,
-          "description": "The ID of the Excel workbook.",
+          "description": "Destination file name (the .xlsx extension is added if missing).",
           "enum": null,
           "inferrable": true
         },
         {
-          "name": "data",
+          "name": "file_content_base64",
           "type": "string",
           "required": true,
-          "description": "JSON string where data[ROW][COL] = VALUE. ROW is a row number as string, COL is a column letter (uppercase), VALUE is string/number/boolean/null. Type: dict[str, dict[str, str | int | float | bool | None]].",
+          "description": "The complete .xlsx file contents, base64-encoded. Uploaded intact so formatting, formulas, charts, and tables are preserved.",
           "enum": null,
           "inferrable": true
         },
         {
-          "name": "worksheet",
+          "name": "parent_folder_id",
           "type": "string",
           "required": false,
-          "description": "Worksheet name to update. If omitted, updates the first worksheet.",
+          "description": "Parent folder ID. If omitted, the file is uploaded to the OneDrive root.",
           "enum": null,
           "inferrable": true
         },
@@ -828,15 +1279,15 @@
           "name": "drive_id",
           "type": "string",
           "required": false,
-          "description": "Optional drive ID for shared items. If omitted, uses the user's default OneDrive.",
+          "description": "Drive ID for shared items (e.g. a SharePoint library). If omitted, uses the user's default OneDrive.",
           "enum": null,
           "inferrable": true
         },
         {
-          "name": "session_id",
-          "type": "string",
+          "name": "overwrite",
+          "type": "boolean",
           "required": false,
-          "description": "Optional session ID from a previous operation for better performance.",
+          "description": "If true, replace an existing file with the same name; if false, reject the upload when the name already exists. Defaults to false.",
           "enum": null,
           "inferrable": true
         }
@@ -852,35 +1303,35 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "Confirmation of the range update with cell count."
+        "description": "The stored workbook and its worksheets."
       },
       "documentationChunks": [],
       "codeExample": {
-        "toolName": "MicrosoftExcel.UpdateRange",
+        "toolName": "MicrosoftExcel.UploadWorkbook",
         "parameters": {
-          "item_id": {
-            "value": "01234567-89ab-cdef-0123-456789abcdef",
+          "filename": {
+            "value": "Q3_Sales_Report",
             "type": "string",
             "required": true
           },
-          "data": {
-            "value": "{\"1\":{\"A\":\"Name\",\"B\":\"Amount\"},\"2\":{\"A\":\"Alice\",\"B\":1234.56,\"C\":true},\"3\":{\"A\":\"Bob\",\"B\":null,\"C\":false},\"10\":{\"D\":\"Note\"}}",
+          "file_content_base64": {
+            "value": "UEsDBBQABgAIAAAAIQDfpNJsWgEAACAFAAATAAgCW0NvbnRlbnRfVHlwZXNdLnhtbCCiBAIooAAC",
             "type": "string",
             "required": true
           },
-          "worksheet": {
-            "value": "Expenses",
+          "parent_folder_id": {
+            "value": "01BYE5C474RRTF7KXNBZDZUQ7G3SVNZN5T",
             "type": "string",
             "required": false
           },
           "drive_id": {
-            "value": "b!aBcD_ExampleDriveId123",
+            "value": "b!abc123XyZ456defGHI789jklMNO012pqrSTU345vwxYZ678",
             "type": "string",
             "required": false
           },
-          "session_id": {
-            "value": "session_01ab23",
-            "type": "string",
+          "overwrite": {
+            "value": true,
+            "type": "boolean",
             "required": false
           }
         },
@@ -896,11 +1347,12 @@
         },
         "behavior": {
           "operations": [
+            "create",
             "update"
           ],
           "readOnly": false,
-          "destructive": false,
-          "idempotent": true,
+          "destructive": true,
+          "idempotent": false,
           "openWorld": true
         },
         "extras": null
@@ -909,7 +1361,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftExcel.WhoAmI",
-      "fullyQualifiedName": "MicrosoftExcel.WhoAmI@0.2.0",
+      "fullyQualifiedName": "MicrosoftExcel.WhoAmI@1.1.1",
       "description": "Get information about the current user and their Microsoft Excel environment.",
       "parameters": [],
       "auth": {
@@ -955,6 +1407,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-02-26T20:45:10.414Z",
-  "summary": "Microsoft Excel toolkit for Arcade.dev lets LLMs operate on Excel workbooks stored in OneDrive for Business via the Microsoft Graph API. It enables creating workbooks, managing worksheets, reading workbook and worksheet metadata, and reading/updating cells and ranges using sparse formats and pagination.\n\n**Capabilities**\n- Manage workbook and worksheet lifecycle (create, add, rename, delete) with session_id support to mitigate Graph propagation delays.\n- Inspect workbook metadata and worksheet lists including visibility and positions.\n- Read sparse cell data with pagination hints and update single cells or sparse ranges (strings, numbers, booleans, formulas).\n- Handle consistency and retry patterns around short propagation windows.\n\n**OAuth**\nProvider: microsoft\nScopes: Files.Read, Files.ReadWrite, User.Read"
+  "generatedAt": "2026-07-08T11:41:38.268Z",
+  "summary": "Microsoft Excel toolkit for Arcade lets LLMs read, write, audit, and comment on Excel workbooks stored in OneDrive for Business via the Microsoft Graph API.\n\n## Capabilities\n\n- **Workbook discovery & metadata** — search OneDrive by keyword or folder to locate `.xlsx` files; inspect workbook structure (worksheets, named ranges, tables, charts, protection state, used ranges) before operating on data.\n- **Reading & querying data** — read worksheet ranges with pagination, column projection, row filtering, and optional annotations (formulas, types, number formats, borders/fills); aggregate rows into grouped summaries (sum, average, count, min/max) without fetching raw data.\n- **Writing & formatting** — create new workbooks or edit existing ones with a rich operation set: write/clear cells, apply font/fill/border/alignment formatting, size rows and columns, sort, manage tables and charts, handle worksheets and named ranges, protect sheets, and recalculate.\n- **Upload & export** — upload a finished `.xlsx` file byte-for-byte (resumable for large files) instead of rebuilding it cell-by-cell; export worksheet data as CSV or TSV.\n- **Data quality auditing** — scan a sheet or entire workbook for formula errors, type outliers, inconsistent columns, accidental duplicates, and blank cells, with severity-ordered results and workbook-wide support.\n- **Commenting** — list comment threads (or replies on a specific thread) and post plain-text replies to existing threads.\n\n## OAuth\n\nThis toolkit authenticates via OAuth 2.0 with **Microsoft** as the identity provider. See the [Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration details."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftoutlookcalendar.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftoutlookcalendar.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftOutlookCalendar",
   "label": "Microsoft Outlook Calendar",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Arcade.dev LLM tools for Outlook Calendar",
   "metadata": {
     "category": "productivity",
@@ -28,7 +28,7 @@
     {
       "name": "CreateEvent",
       "qualifiedName": "MicrosoftOutlookCalendar.CreateEvent",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.CreateEvent@0.3.0",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.CreateEvent@0.3.1",
       "description": "Create an event in the authenticated user's default calendar.\n\nIgnores timezone offsets provided in the start_date_time and end_date_time parameters.\nInstead, uses the user's default calendar timezone to filter events.\nIf the user has not set a timezone for their calendar, then the timezone will be UTC.",
       "parameters": [
         {
@@ -185,7 +185,7 @@
     {
       "name": "GetEvent",
       "qualifiedName": "MicrosoftOutlookCalendar.GetEvent",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.GetEvent@0.3.0",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.GetEvent@0.3.1",
       "description": "Get an event by its ID from the user's calendar.",
       "parameters": [
         {
@@ -246,7 +246,7 @@
     {
       "name": "ListCalendars",
       "qualifiedName": "MicrosoftOutlookCalendar.ListCalendars",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListCalendars@0.3.0",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListCalendars@0.3.1",
       "description": "List all calendars the user has access to.\n\nReturns the user's own calendars plus any shared or delegated calendars.\nEach calendar includes its ID, name, owner, and permissions.\n\nUse a calendar_id from the results to target a specific calendar\nin other calendar tools.",
       "parameters": [
         {
@@ -319,7 +319,7 @@
     {
       "name": "ListEventAttachments",
       "qualifiedName": "MicrosoftOutlookCalendar.ListEventAttachments",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListEventAttachments@0.3.0",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListEventAttachments@0.3.1",
       "description": "List attachment metadata for a calendar event.\n\nReturns metadata only (name, size, type, etc.). Attachment content is not included.\nUse this tool when the user wants to know what files are attached to a calendar event\nor meeting.\n\nPass a calendar_id to list attachments on events in shared or delegated calendars.",
       "parameters": [
         {
@@ -419,7 +419,7 @@
     {
       "name": "ListEventsInTimeRange",
       "qualifiedName": "MicrosoftOutlookCalendar.ListEventsInTimeRange",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListEventsInTimeRange@0.3.0",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListEventsInTimeRange@0.3.1",
       "description": "List events in the user's calendar in a specific time range.\n\nIgnores timezone offsets provided in the start_date_time and end_date_time parameters.\nInstead, uses the user's default calendar timezone to filter events.\nIf the user has not set a timezone for their calendar, then the timezone will be UTC.",
       "parameters": [
         {
@@ -506,7 +506,7 @@
     {
       "name": "SearchEvents",
       "qualifiedName": "MicrosoftOutlookCalendar.SearchEvents",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.SearchEvents@0.3.0",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.SearchEvents@0.3.1",
       "description": "Search calendar events within a time range with optional filters.\n\nResults are in chronological order.\n\nEvent bodies are truncated to 200 characters for efficient skimming.\nUse the event_id from the results to retrieve full event details.",
       "parameters": [
         {
@@ -718,7 +718,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftOutlookCalendar.WhoAmI",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.WhoAmI@0.3.0",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.WhoAmI@0.3.1",
       "description": "Get information about the current user and their Outlook Calendar environment.",
       "parameters": [],
       "auth": {
@@ -766,6 +766,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-05-13T11:50:27.729Z",
+  "generatedAt": "2026-07-08T11:41:30.265Z",
   "summary": "## Microsoft Outlook Calendar Toolkit\n\nThe Microsoft Outlook Calendar toolkit lets Arcade-powered LLMs interact with a user's Outlook Calendar via the Microsoft Graph API, enabling calendar reads, writes, and queries on behalf of authenticated users.\n\n## Capabilities\n\n- **Calendar discovery & context:** List all calendars the user owns, shares, or has delegated access to; retrieve current user identity and calendar environment details.\n- **Event creation:** Create events in the user's default calendar; timezone handling defers to the calendar's configured timezone (falls back to UTC if unset).\n- **Event retrieval & listing:** Fetch a specific event by ID, or list all events within a defined time range using the calendar's native timezone.\n- **Search & filtering:** Search events across a time range with optional filters; results are chronologically ordered with body content truncated to 200 characters for efficiency — use the returned event ID to fetch full details.\n- **Attachment inspection:** List attachment metadata (name, size, type) for any calendar event, including events on shared or delegated calendars; attachment content is not returned.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 delegated auth via **Microsoft**. Arcade handles the OAuth flow automatically. See the [Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration details."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftoutlookmail.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftoutlookmail.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftOutlookMail",
   "label": "Microsoft Outlook Mail",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Arcade.dev LLM tools for Outlook Mail",
   "metadata": {
     "category": "productivity",
@@ -31,7 +31,7 @@
     {
       "name": "CreateAndSendEmail",
       "qualifiedName": "MicrosoftOutlookMail.CreateAndSendEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.CreateAndSendEmail@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.CreateAndSendEmail@0.5.0",
       "description": "Create and immediately send a new email in Outlook to the specified recipients.\n\nReturns the sent message's ``message_id`` and ``conversation_id`` so callers\ncan immediately chain follow-ups (e.g. reply to what they just sent) without\nhaving to search Sent Items.",
       "parameters": [
         {
@@ -170,7 +170,7 @@
     {
       "name": "CreateDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.CreateDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.CreateDraftEmail@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.CreateDraftEmail@0.5.0",
       "description": "Compose a new draft email in Outlook",
       "parameters": [
         {
@@ -307,9 +307,99 @@
       }
     },
     {
+      "name": "CreateDraftReply",
+      "qualifiedName": "MicrosoftOutlookMail.CreateDraftReply",
+      "fullyQualifiedName": "MicrosoftOutlookMail.CreateDraftReply@0.5.0",
+      "description": "Create a reply or reply-all draft for an existing Outlook email without sending it.\n\nThe draft is threaded to the original message and saved to the Drafts folder,\nso it can be reviewed, edited, and sent later. For a reply-all, the original\nrecipients (excluding the mailbox owner) are populated automatically. This\ntool never sends the email.",
+      "parameters": [
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the email to create a reply draft for",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "required": true,
+          "description": "The body of the reply draft",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "reply_type",
+          "type": "string",
+          "required": false,
+          "description": "Specify ReplyType.REPLY to draft a reply to only the sender, or ReplyType.REPLY_ALL to draft a reply to all recipients. Defaults to ReplyType.REPLY.",
+          "enum": [
+            "reply",
+            "reply_all"
+          ],
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "MailboxSettings.Read",
+          "Mail.ReadWrite"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "A dictionary containing the created reply draft details"
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.CreateDraftReply",
+        "parameters": {
+          "message_id": {
+            "value": "AAMkAGI2TG93AAA=",
+            "type": "string",
+            "required": true
+          },
+          "body": {
+            "value": "Thank you for reaching out! I will review the details and get back to you by end of the week.",
+            "type": "string",
+            "required": true
+          },
+          "reply_type": {
+            "value": "ReplyType.REPLY_ALL",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "GetEmail",
       "qualifiedName": "MicrosoftOutlookMail.GetEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.GetEmail@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.GetEmail@0.5.0",
       "description": "Retrieve a single email message by its ID.\n\nReturns email metadata and body content. By default, the body is returned\nas plain text (HTML tags stripped) and capped at 5000 characters. Set\nbody_format to HTML to get the original markup. Use body_offset to\ncontinue reading long emails, or set max_body_characters to None for the\nfull body.\n\nUse this tool to read the full content of an email after finding it via\nsearch_emails or any listing tool.",
       "parameters": [
         {
@@ -412,7 +502,7 @@
     {
       "name": "ListEmailAttachments",
       "qualifiedName": "MicrosoftOutlookMail.ListEmailAttachments",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailAttachments@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailAttachments@0.5.0",
       "description": "List attachment metadata for an email message.\n\nReturns metadata only (name, size, type, etc.). Attachment content is not included.\nUse this tool when the user wants to know what files are attached to an email.",
       "parameters": [
         {
@@ -499,7 +589,7 @@
     {
       "name": "ListEmails",
       "qualifiedName": "MicrosoftOutlookMail.ListEmails",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmails@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmails@0.5.0",
       "description": "List emails in the user's mailbox across all folders.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).\n\nSince this tool lists email across all folders, it may return sent items,\ndrafts, and other items that are not in the inbox.",
       "parameters": [
         {
@@ -607,7 +697,7 @@
     {
       "name": "ListEmailsByProperty",
       "qualifiedName": "MicrosoftOutlookMail.ListEmailsByProperty",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsByProperty@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsByProperty@0.5.0",
       "description": "List emails in the user's mailbox across all folders filtering by a property.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).\n\nSorting by RECEIVED_DATE_TIME works with any filter property. Sorting by\na different property (SUBJECT, SENDER, IMPORTANCE) while filtering by an\nunrelated property may fail due to a Microsoft Graph API restriction. If\nthis happens, either sort by RECEIVED_DATE_TIME, or use list_emails (no\nfilter) with the desired sort_by.",
       "parameters": [
         {
@@ -773,7 +863,7 @@
     {
       "name": "ListEmailsInFolder",
       "qualifiedName": "MicrosoftOutlookMail.ListEmailsInFolder",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsInFolder@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsInFolder@0.5.0",
       "description": "List the user's emails in the specified folder.\n\nExactly one of `well_known_folder_name` or `folder_id` MUST be provided.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
       "parameters": [
         {
@@ -915,7 +1005,7 @@
     {
       "name": "ListMailFolders",
       "qualifiedName": "MicrosoftOutlookMail.ListMailFolders",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListMailFolders@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListMailFolders@0.5.0",
       "description": "List mail folders in the user's mailbox.\n\nReturns folder names, IDs, unread counts, and total item counts.\nUse the folder ID in follow-up calls to list_emails_in_folder.\nOmit parent_folder_id to list top-level folders, or provide a folder ID\nto list its child folders.",
       "parameters": [
         {
@@ -1014,7 +1104,7 @@
     {
       "name": "MoveEmailToFolder",
       "qualifiedName": "MicrosoftOutlookMail.MoveEmailToFolder",
-      "fullyQualifiedName": "MicrosoftOutlookMail.MoveEmailToFolder@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.MoveEmailToFolder@0.5.0",
       "description": "Move an email message to a different folder in Outlook.\n\nExactly one of `destination_well_known_folder_name` or\n`destination_folder_id` MUST be provided. Use `list_mail_folders` to\ndiscover custom folder IDs.",
       "parameters": [
         {
@@ -1109,7 +1199,7 @@
     {
       "name": "ReplyToEmail",
       "qualifiedName": "MicrosoftOutlookMail.ReplyToEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ReplyToEmail@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ReplyToEmail@0.5.0",
       "description": "Reply to an existing email in Outlook.\n\nUse this tool to reply to the sender or all recipients of the email.\nSpecify the reply_type to determine the scope of the reply.",
       "parameters": [
         {
@@ -1199,7 +1289,7 @@
     {
       "name": "SearchEmails",
       "qualifiedName": "MicrosoftOutlookMail.SearchEmails",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SearchEmails@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SearchEmails@0.5.0",
       "description": "Search emails across the user's entire mailbox.\n\nCombines full-text keyword search with structured filters for sender,\nread status, attachments, importance, and more. All provided parameters\nare combined with AND. Results are ordered by date sent (most recent first).\n\nEmail bodies are truncated to 255 characters for efficient skimming.\nUse get_email with the message_id to retrieve the full email content.\n\nUse this tool when the user wants to find emails by content, topic, sender,\nor a combination of criteria. For exact property filtering (e.g., by\nconversationId or flag status), use list_emails_by_property instead.\n\n.. note::\n   Microsoft Graph's ``$search`` on messages is backed by the Microsoft\n   Search index, which returns message IDs in the legacy REST-ID format\n   even when the client opts into Immutable IDs (which other tools in\n   this toolkit do by default). Do not directly compare a ``message_id``\n   from ``search_emails`` against one from ``list_emails`` /\n   ``get_email`` — the ID shapes differ. To chain from a search hit,\n   pass the returned ID straight back into ``get_email`` (which accepts\n   either format), and use ``conversation_id`` as the deduplication\n   key across result sets.",
       "parameters": [
         {
@@ -1423,7 +1513,7 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.SendDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SendDraftEmail@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SendDraftEmail@0.5.0",
       "description": "Send an existing draft email in Outlook.\n\nSends any un-sent message — draft, reply-draft, reply-all draft, or\nforward draft — and returns the message's ``message_id`` and\n``conversation_id`` so callers can chain follow-ups (e.g. reply to\nthe message they just sent) without searching Sent Items.",
       "parameters": [
         {
@@ -1484,7 +1574,7 @@
     {
       "name": "SharedMailboxCheckCapabilities",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxCheckCapabilities",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCheckCapabilities@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCheckCapabilities@0.5.0",
       "description": "Check which provided mailboxes are reachable via shared mailbox APIs.\n\nThis is a capability checker, not an Exchange permission inventory. It\nverifies whether each provided mailbox can be reached through a cheap,\nread-only Graph call. When checking multiple mailboxes, pass them together\nin one ``owner_emails`` list so results can be deduplicated and rate-limited\nconsistently. Microsoft Graph does not expose exact ``Send As`` vs ``Send\non behalf`` permissions, so the response names that limitation explicitly\ninstead of guessing.",
       "parameters": [
         {
@@ -1549,7 +1639,7 @@
     {
       "name": "SharedMailboxCreateAndSendEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateAndSendEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateAndSendEmail@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateAndSendEmail@0.5.0",
       "description": "Create and immediately send an email from a shared or delegated mailbox.\n\nUse this when the user wants the email to be sent from a team inbox (like\nsales@ or support@) or from an executive's mailbox they have been\ndelegated access to, rather than from their own address.",
       "parameters": [
         {
@@ -1701,7 +1791,7 @@
     {
       "name": "SharedMailboxCreateDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateDraftEmail@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateDraftEmail@0.5.0",
       "description": "Compose a new draft email in a shared or delegated mailbox.",
       "parameters": [
         {
@@ -1851,9 +1941,112 @@
       }
     },
     {
+      "name": "SharedMailboxCreateDraftReply",
+      "qualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateDraftReply",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateDraftReply@0.5.0",
+      "description": "Create a reply or reply-all draft in a shared or delegated mailbox without sending it.\n\nThe draft is threaded to the original message and saved to the mailbox's\nDrafts folder, so it can be reviewed, edited, and sent later. For a\nreply-all, the original recipients (excluding the mailbox owner) are\npopulated automatically. This tool never sends the email.",
+      "parameters": [
+        {
+          "name": "owner_email",
+          "type": "string",
+          "required": true,
+          "description": "The mailbox address to create the reply draft in. Can be a team or shared mailbox, or a specific person's mailbox you have delegate access to. Provide as a Microsoft Graph UPN (local-part@verified-domain).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "message_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the email to create a reply draft for",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "required": true,
+          "description": "The body of the reply draft",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "reply_type",
+          "type": "string",
+          "required": false,
+          "description": "Specify ReplyType.REPLY to draft a reply to only the sender, or ReplyType.REPLY_ALL to draft a reply to all recipients. Defaults to ReplyType.REPLY.",
+          "enum": [
+            "reply",
+            "reply_all"
+          ],
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft",
+        "providerType": "oauth2",
+        "scopes": [
+          "MailboxSettings.Read",
+          "Mail.ReadWrite.Shared"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "No description provided."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftOutlookMail.SharedMailboxCreateDraftReply",
+        "parameters": {
+          "owner_email": {
+            "value": "support-team@contoso.com",
+            "type": "string",
+            "required": true
+          },
+          "message_id": {
+            "value": "AAMkAGI2TG93AAA=",
+            "type": "string",
+            "required": true
+          },
+          "body": {
+            "value": "Thank you for reaching out. We have reviewed your request and will get back to you with a detailed response by end of business today.",
+            "type": "string",
+            "required": true
+          },
+          "reply_type": {
+            "value": "ReplyType.REPLY_ALL",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "SharedMailboxGetEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxGetEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxGetEmail@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxGetEmail@0.5.0",
       "description": "Retrieve a single email from a shared or delegated mailbox by message ID.\n\nReturns email metadata and body content. By default, the body is returned\nas plain text (HTML tags stripped) and capped at 5000 characters. Use\nbody_offset to continue reading long emails, or set max_body_characters\nto None for the full body.",
       "parameters": [
         {
@@ -1969,7 +2162,7 @@
     {
       "name": "SharedMailboxListEmailAttachments",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailAttachments",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailAttachments@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailAttachments@0.5.0",
       "description": "List attachment metadata for an email in a shared or delegated mailbox.",
       "parameters": [
         {
@@ -2069,7 +2262,7 @@
     {
       "name": "SharedMailboxListEmails",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmails",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmails@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmails@0.5.0",
       "description": "List emails in a shared or delegated mailbox, across all folders.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
       "parameters": [
         {
@@ -2190,7 +2383,7 @@
     {
       "name": "SharedMailboxListEmailsByProperty",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsByProperty",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsByProperty@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsByProperty@0.5.0",
       "description": "List emails in a shared or delegated mailbox filtered by a property.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
       "parameters": [
         {
@@ -2369,7 +2562,7 @@
     {
       "name": "SharedMailboxListEmailsInFolder",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsInFolder",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsInFolder@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsInFolder@0.5.0",
       "description": "List emails in a specific folder of a shared or delegated mailbox.\n\nExactly one of `well_known_folder_name` or `folder_id` MUST be provided.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
       "parameters": [
         {
@@ -2524,7 +2717,7 @@
     {
       "name": "SharedMailboxListMailFolders",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListMailFolders",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListMailFolders@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListMailFolders@0.5.0",
       "description": "List mail folders in a shared or delegated mailbox.\n\nReturns folder names, IDs, unread counts, and total item counts.\nUse the folder ID when listing emails in a specific folder.",
       "parameters": [
         {
@@ -2636,7 +2829,7 @@
     {
       "name": "SharedMailboxMoveEmailToFolder",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxMoveEmailToFolder",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxMoveEmailToFolder@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxMoveEmailToFolder@0.5.0",
       "description": "Move an email message to a different folder in a shared or delegated mailbox.\n\nExactly one of `destination_well_known_folder_name` or\n`destination_folder_id` MUST be provided. Use\n`shared_mailbox_list_mail_folders` (with the same `owner_email`) to\ndiscover custom folder IDs; folder IDs are specific to the target\nmailbox.",
       "parameters": [
         {
@@ -2744,7 +2937,7 @@
     {
       "name": "SharedMailboxReplyToEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxReplyToEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxReplyToEmail@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxReplyToEmail@0.5.0",
       "description": "Reply to an email in a shared or delegated mailbox.\n\nThe reply is sent from the shared mailbox address, not the signed-in\nuser's personal address. Specify reply_type to reply only to the sender\nor to all recipients.",
       "parameters": [
         {
@@ -2847,7 +3040,7 @@
     {
       "name": "SharedMailboxSearchEmails",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxSearchEmails",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxSearchEmails@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxSearchEmails@0.5.0",
       "description": "Search emails in a shared or delegated mailbox.\n\nCombines full-text keyword search with structured filters for sender,\nread status, attachments, importance, and more. All provided parameters\nare combined with AND. Results are ordered by date sent (most recent first).\n\nEmail bodies are truncated to 255 characters. Retrieve a message by its\nmessage ID when the full content is needed.\n\n.. note::\n   Search results may use a different Graph ID shape than list/get\n   results. Use returned message IDs directly for message retrieval and\n   ``conversation_id`` for deduplication across result sets.",
       "parameters": [
         {
@@ -3083,7 +3276,7 @@
     {
       "name": "SharedMailboxSendDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxSendDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxSendDraftEmail@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxSendDraftEmail@0.5.0",
       "description": "Send an existing draft email from a shared or delegated mailbox.\n\nThis tool can send any un-sent email in the shared mailbox:\n    - draft\n    - reply-draft\n    - reply-all draft\n    - forward draft\n\nReturns the message's ``message_id`` and ``conversation_id`` so callers\ncan chain follow-ups (e.g. reply to the message they just sent) without\nsearching Sent Items.",
       "parameters": [
         {
@@ -3157,7 +3350,7 @@
     {
       "name": "SharedMailboxUpdateDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxUpdateDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxUpdateDraftEmail@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxUpdateDraftEmail@0.5.0",
       "description": "Update an existing draft email in a shared or delegated mailbox.\n\nOverwrites the subject and body of a draft (if provided) and modifies its\nrecipient lists by selectively adding or removing email addresses.",
       "parameters": [
         {
@@ -3354,7 +3547,7 @@
     {
       "name": "UpdateDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.UpdateDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.UpdateDraftEmail@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.UpdateDraftEmail@0.5.0",
       "description": "Update an existing draft email in Outlook.\n\nThis tool overwrites the subject and body of a draft email (if provided),\nand modifies its recipient lists by selectively adding or removing email addresses.\n\nThis tool can update any un-sent email:\n    - draft\n    - reply-draft\n    - reply-all draft\n    - forward draft",
       "parameters": [
         {
@@ -3538,7 +3731,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftOutlookMail.WhoAmI",
-      "fullyQualifiedName": "MicrosoftOutlookMail.WhoAmI@0.4.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.WhoAmI@0.5.0",
       "description": "Get comprehensive user profile and Outlook Mail environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, mailbox settings, automatic replies configuration, and other\nimportant profile details from Outlook Mail services.",
       "parameters": [],
       "auth": {
@@ -3585,6 +3778,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-06-04T12:06:49.152Z",
-  "summary": "The Microsoft Outlook Mail toolkit connects Arcade to the Microsoft Graph Mail API, enabling LLMs to read, compose, send, search, organize, and manage email in both personal and shared/delegated Outlook mailboxes.\n\n## Capabilities\n\n- **Read & search mail** — retrieve individual messages (with pagination and HTML/plain-text control), list emails across all folders or within a specific folder, filter by structured properties (sender, flag, importance, conversation, etc.), and run full-text keyword searches with combined AND filters across an entire mailbox.\n- **Compose & send** — create and immediately send emails, compose drafts, update draft recipients/subject/body, send existing drafts (including reply, reply-all, and forward drafts), and reply to messages (sender-only or reply-all).\n- **Folder & organization management** — list top-level and nested mail folders with unread/total counts, discover custom folder IDs, and move messages between folders using well-known folder names or folder IDs.\n- **Attachments** — list attachment metadata (name, size, type) for any message without downloading content.\n- **Shared & delegated mailboxes** — a full parallel set of tools (prefixed `SharedMailbox`) covers all read, compose, send, search, folder, and attachment operations against team inboxes (e.g., `sales@`, `support@`) or executive mailboxes the user has delegate access to; includes a capability checker to verify mailbox reachability before acting.\n- **Identity & mailbox settings** — retrieve the authenticated user's profile, mailbox settings, and automatic-replies configuration via `WhoAmI`.\n\n## OAuth\n\nThis toolkit authenticates via **Microsoft** OAuth 2.0. Arcade manages token acquisition and refresh automatically.\n\nSee the [Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration details."
+  "generatedAt": "2026-07-08T11:41:33.033Z",
+  "summary": "The **Microsoft Outlook Mail** toolkit connects Arcade to the Microsoft Graph Mail API, enabling LLMs to read, compose, send, search, organize, and manage email in both personal and shared/delegated Outlook mailboxes.\n\n## Capabilities\n\n- **Compose & Send** — Create and immediately send emails, compose drafts (new, reply, reply-all, forward), update draft recipients/subject/body, and send existing drafts; returns `message_id` and `conversation_id` for chaining follow-ups without searching Sent Items.\n- **Read & Retrieve** — Fetch full email content by ID (plain text or HTML, with offset pagination for long bodies), list attachment metadata, and retrieve the authenticated user's profile and mailbox settings.\n- **Search & Filter** — Full-text search across the entire mailbox with structured AND-combined filters (sender, read status, attachments, importance, date); property-based listing for exact field matching (conversation ID, flag status, etc.); results include truncated previews with pointers to retrieve full content.\n- **Folder & Organization** — List mail folders (top-level or nested) with unread/total counts, list emails per folder or across all folders with configurable sort, and move messages between folders using well-known names or folder IDs.\n- **Shared & Delegated Mailboxes** — Full feature parity (compose, send, draft, reply, search, list, move, update) for shared or delegated mailboxes (e.g., `sales@`, `support@`); includes a capability checker to verify mailbox reachability before acting.\n\n## OAuth\n\nAuthentication uses **Microsoft** OAuth 2.0. See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for setup details, required permissions, and configuration."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftpowerpoint.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftpowerpoint.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftPowerpoint",
   "label": "Microsoft PowerPoint",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Arcade.dev LLM tools for Microsoft PowerPoint",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "CreatePresentation",
       "qualifiedName": "MicrosoftPowerpoint.CreatePresentation",
-      "fullyQualifiedName": "MicrosoftPowerpoint.CreatePresentation@0.3.0",
+      "fullyQualifiedName": "MicrosoftPowerpoint.CreatePresentation@0.3.1",
       "description": "Create a new PowerPoint presentation in OneDrive.\n\nThe presentation will be created with a title slide containing the specified title.",
       "parameters": [
         {
@@ -99,7 +99,7 @@
     {
       "name": "CreateSlide",
       "qualifiedName": "MicrosoftPowerpoint.CreateSlide",
-      "fullyQualifiedName": "MicrosoftPowerpoint.CreateSlide@0.3.0",
+      "fullyQualifiedName": "MicrosoftPowerpoint.CreateSlide@0.3.1",
       "description": "Append a new slide to the end of an existing PowerPoint presentation in OneDrive.\n\nThe slide will be added at the end of the presentation. Both title and body\nare optional to support layouts like BLANK or TITLE_ONLY.\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -208,7 +208,7 @@
     {
       "name": "CreateTwoContentSlide",
       "qualifiedName": "MicrosoftPowerpoint.CreateTwoContentSlide",
-      "fullyQualifiedName": "MicrosoftPowerpoint.CreateTwoContentSlide@0.3.0",
+      "fullyQualifiedName": "MicrosoftPowerpoint.CreateTwoContentSlide@0.3.1",
       "description": "Append a TWO_CONTENT slide with side-by-side content areas to a PowerPoint presentation.\n\nThis layout is useful for comparisons, pros/cons lists, or any content that\nbenefits from a two-column layout.\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -307,7 +307,7 @@
     {
       "name": "GetAllSlideNotes",
       "qualifiedName": "MicrosoftPowerpoint.GetAllSlideNotes",
-      "fullyQualifiedName": "MicrosoftPowerpoint.GetAllSlideNotes@0.3.0",
+      "fullyQualifiedName": "MicrosoftPowerpoint.GetAllSlideNotes@0.3.1",
       "description": "Get all speaker notes from every slide in a PowerPoint presentation.\n\nReturns notes for all slides in one call, which is more efficient than\ncalling get_slide_notes for each slide individually. Notes are returned\nin markdown format.",
       "parameters": [
         {
@@ -367,7 +367,7 @@
     {
       "name": "GetPresentationAsMarkdown",
       "qualifiedName": "MicrosoftPowerpoint.GetPresentationAsMarkdown",
-      "fullyQualifiedName": "MicrosoftPowerpoint.GetPresentationAsMarkdown@0.3.0",
+      "fullyQualifiedName": "MicrosoftPowerpoint.GetPresentationAsMarkdown@0.3.1",
       "description": "Get the content of a PowerPoint presentation as markdown.\n\nThis tool downloads the presentation and converts it to a markdown representation,\npreserving text content, tables, and chart data. Images and other media are\nrepresented as placeholders.",
       "parameters": [
         {
@@ -427,7 +427,7 @@
     {
       "name": "GetSlideNotes",
       "qualifiedName": "MicrosoftPowerpoint.GetSlideNotes",
-      "fullyQualifiedName": "MicrosoftPowerpoint.GetSlideNotes@0.3.0",
+      "fullyQualifiedName": "MicrosoftPowerpoint.GetSlideNotes@0.3.1",
       "description": "Get the speaker notes from a specific slide in a PowerPoint presentation.\n\nSpeaker notes are returned in markdown format, preserving basic formatting\nlike bold, italic, and bullet points.",
       "parameters": [
         {
@@ -500,7 +500,7 @@
     {
       "name": "SetSlideNotes",
       "qualifiedName": "MicrosoftPowerpoint.SetSlideNotes",
-      "fullyQualifiedName": "MicrosoftPowerpoint.SetSlideNotes@0.3.0",
+      "fullyQualifiedName": "MicrosoftPowerpoint.SetSlideNotes@0.3.1",
       "description": "Set or update the speaker notes on a specific slide in a PowerPoint presentation.\n\nNotes can be formatted using markdown:\n- **bold** for bold text\n- *italic* for italic text\n- __underline__ for underlined text\n- Lines starting with - or * become bullet points\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.\n- Indent with spaces for nested bullets",
       "parameters": [
         {
@@ -586,7 +586,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftPowerpoint.WhoAmI",
-      "fullyQualifiedName": "MicrosoftPowerpoint.WhoAmI@0.3.0",
+      "fullyQualifiedName": "MicrosoftPowerpoint.WhoAmI@0.3.1",
       "description": "Get information about the current user and their PowerPoint environment.",
       "parameters": [],
       "auth": {
@@ -632,6 +632,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-06-04T12:06:45.030Z",
+  "generatedAt": "2026-07-08T11:41:30.265Z",
   "summary": "## Microsoft PowerPoint Toolkit\n\nThe Microsoft PowerPoint toolkit provides Arcade LLM tools for creating and managing PowerPoint presentations stored in OneDrive via the Microsoft Graph API.\n\n## Capabilities\n\n- **Presentation creation**: Create new presentations in OneDrive with a title slide; supports both small and large files (>4 MB via resumable upload sessions).\n- **Slide authoring**: Append slides with standard or two-column (`TWO_CONTENT`) layouts; titles and body content are optional to support blank or title-only layouts.\n- **Speaker notes management**: Read notes from a single slide or all slides at once; write/update notes with Markdown formatting (bold, italic, underline, bullets with nesting support).\n- **Content reading**: Export a full presentation to Markdown, preserving text, tables, and chart data; images and media are represented as placeholders.\n- **User context**: Retrieve information about the authenticated user and their PowerPoint environment.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via the **Microsoft** provider. See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration details."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftsharepoint.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftsharepoint.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftSharepoint",
   "label": "Microsoft SharePoint",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Arcade.dev LLM tools for Microsoft SharePoint",
   "metadata": {
     "category": "productivity",
@@ -27,7 +27,7 @@
     {
       "name": "AddWorksheet",
       "qualifiedName": "MicrosoftSharepoint.AddWorksheet",
-      "fullyQualifiedName": "MicrosoftSharepoint.AddWorksheet@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.AddWorksheet@0.2.1",
       "description": "Add a new worksheet to a SharePoint Excel workbook.\n\nNote: The new worksheet name may not be immediately visible to other\ntools due to a brief Graph API propagation delay (up to ~10 s). Pass\nthe returned ``session_id`` to subsequent calls that reference the new\nworksheet to mitigate this.",
       "parameters": [
         {
@@ -128,7 +128,7 @@
     {
       "name": "CopyItem",
       "qualifiedName": "MicrosoftSharepoint.CopyItem",
-      "fullyQualifiedName": "MicrosoftSharepoint.CopyItem@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.CopyItem@0.2.1",
       "description": "Copy a file or folder. Returns a completed item or an operation id.",
       "parameters": [
         {
@@ -228,7 +228,7 @@
     {
       "name": "CreateFolder",
       "qualifiedName": "MicrosoftSharepoint.CreateFolder",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateFolder@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateFolder@0.2.1",
       "description": "Create a new folder in a SharePoint drive.",
       "parameters": [
         {
@@ -315,7 +315,7 @@
     {
       "name": "CreatePresentation",
       "qualifiedName": "MicrosoftSharepoint.CreatePresentation",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreatePresentation@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreatePresentation@0.2.1",
       "description": "Create a new PowerPoint presentation in a SharePoint drive.\n\nThe presentation will be created with a title slide containing the specified title.",
       "parameters": [
         {
@@ -402,7 +402,7 @@
     {
       "name": "CreateShareLink",
       "qualifiedName": "MicrosoftSharepoint.CreateShareLink",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateShareLink@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateShareLink@0.2.1",
       "description": "Create a share link for a SharePoint drive item.",
       "parameters": [
         {
@@ -476,7 +476,7 @@
     {
       "name": "CreateSlide",
       "qualifiedName": "MicrosoftSharepoint.CreateSlide",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateSlide@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateSlide@0.2.1",
       "description": "Append a new slide to the end of an existing PowerPoint presentation in a SharePoint drive.\n\nThe slide will be added at the end of the presentation. Both title and body\nare optional to support layouts like BLANK or TITLE_ONLY.\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -599,7 +599,7 @@
     {
       "name": "CreateTwoContentSlide",
       "qualifiedName": "MicrosoftSharepoint.CreateTwoContentSlide",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateTwoContentSlide@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateTwoContentSlide@0.2.1",
       "description": "Append a TWO_CONTENT slide with side-by-side content areas to a SharePoint PowerPoint.\n\nThis layout is useful for comparisons, pros/cons lists, or any content that\nbenefits from a two-column layout.\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -712,7 +712,7 @@
     {
       "name": "CreateWordDocument",
       "qualifiedName": "MicrosoftSharepoint.CreateWordDocument",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateWordDocument@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateWordDocument@0.2.1",
       "description": "Create a new Word document in a SharePoint drive.\n\n4MB upload limit. Optionally include text content.",
       "parameters": [
         {
@@ -825,7 +825,7 @@
     {
       "name": "CreateWorkbook",
       "qualifiedName": "MicrosoftSharepoint.CreateWorkbook",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateWorkbook@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateWorkbook@0.2.1",
       "description": "Create a new Excel workbook (.xlsx) in a SharePoint drive.\n\nOnly .xlsx files are supported.",
       "parameters": [
         {
@@ -926,7 +926,7 @@
     {
       "name": "DeleteItem",
       "qualifiedName": "MicrosoftSharepoint.DeleteItem",
-      "fullyQualifiedName": "MicrosoftSharepoint.DeleteItem@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.DeleteItem@0.2.1",
       "description": "Delete a file or folder from a SharePoint drive.",
       "parameters": [
         {
@@ -1000,7 +1000,7 @@
     {
       "name": "DeleteWorksheet",
       "qualifiedName": "MicrosoftSharepoint.DeleteWorksheet",
-      "fullyQualifiedName": "MicrosoftSharepoint.DeleteWorksheet@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.DeleteWorksheet@0.2.1",
       "description": "Delete a worksheet from a SharePoint Excel workbook.\n\nCannot delete the last worksheet in a workbook.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -1101,7 +1101,7 @@
     {
       "name": "GetAllSlideNotes",
       "qualifiedName": "MicrosoftSharepoint.GetAllSlideNotes",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetAllSlideNotes@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetAllSlideNotes@0.2.1",
       "description": "Get all speaker notes from every slide in a SharePoint PowerPoint presentation.\n\nReturns notes for all slides in one call, which is more efficient than\ncalling get_slide_notes for each slide individually. Notes are returned\nin markdown format.",
       "parameters": [
         {
@@ -1175,7 +1175,7 @@
     {
       "name": "GetCopyStatus",
       "qualifiedName": "MicrosoftSharepoint.GetCopyStatus",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetCopyStatus@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetCopyStatus@0.2.1",
       "description": "Check status of an async copy operation using the token returned by copy_item.",
       "parameters": [
         {
@@ -1249,7 +1249,7 @@
     {
       "name": "GetDrivesFromSite",
       "qualifiedName": "MicrosoftSharepoint.GetDrivesFromSite",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetDrivesFromSite@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetDrivesFromSite@0.2.1",
       "description": "Retrieve drives / document libraries from a SharePoint site.\n\nIf you have a site name, it is not necessary to call Sharepoint.SearchSites first.\nYou can simply call this tool with the site name / keywords.",
       "parameters": [
         {
@@ -1310,7 +1310,7 @@
     {
       "name": "GetItemsFromList",
       "qualifiedName": "MicrosoftSharepoint.GetItemsFromList",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetItemsFromList@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetItemsFromList@0.2.1",
       "description": "Retrieve items from a list in a SharePoint site.\n\nNote: The Microsoft Graph API does not offer endpoints to retrieve list item attachments.\nBecause of that, the only information we can get is whether the item has attachments or not.",
       "parameters": [
         {
@@ -1384,7 +1384,7 @@
     {
       "name": "GetListsFromSite",
       "qualifiedName": "MicrosoftSharepoint.GetListsFromSite",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetListsFromSite@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetListsFromSite@0.2.1",
       "description": "Retrieve lists from a SharePoint site.",
       "parameters": [
         {
@@ -1445,7 +1445,7 @@
     {
       "name": "GetPage",
       "qualifiedName": "MicrosoftSharepoint.GetPage",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetPage@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetPage@0.2.1",
       "description": "Retrieve metadata and the contents of a page in a SharePoint site.\n\nPage content is a list of Microsoft Sharepoint web part objects, such as text, images, banners,\nbuttons, etc.\n\nIf `include_page_content` is set to False, the tool will return only the page metadata.",
       "parameters": [
         {
@@ -1532,7 +1532,7 @@
     {
       "name": "GetPresentationAsMarkdown",
       "qualifiedName": "MicrosoftSharepoint.GetPresentationAsMarkdown",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetPresentationAsMarkdown@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetPresentationAsMarkdown@0.2.1",
       "description": "Get the content of a PowerPoint presentation stored in a SharePoint drive as markdown.\n\nThis tool downloads the presentation and converts it to a markdown representation,\npreserving text content, tables, and chart data. Images and other media are\nrepresented as placeholders.",
       "parameters": [
         {
@@ -1606,7 +1606,7 @@
     {
       "name": "GetSite",
       "qualifiedName": "MicrosoftSharepoint.GetSite",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetSite@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetSite@0.2.1",
       "description": "Retrieve information about a specific SharePoint site by its ID, URL, or name.",
       "parameters": [
         {
@@ -1667,7 +1667,7 @@
     {
       "name": "GetSlideNotes",
       "qualifiedName": "MicrosoftSharepoint.GetSlideNotes",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetSlideNotes@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetSlideNotes@0.2.1",
       "description": "Get the speaker notes from a specific slide in a SharePoint PowerPoint presentation.\n\nSpeaker notes are returned in markdown format, preserving basic formatting\nlike bold, italic, and bullet points.",
       "parameters": [
         {
@@ -1754,7 +1754,7 @@
     {
       "name": "GetWordDocument",
       "qualifiedName": "MicrosoftSharepoint.GetWordDocument",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetWordDocument@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetWordDocument@0.2.1",
       "description": "Get a Word document's metadata and content from a SharePoint drive. Supports only `.docx`.\n\nReturns the document content as Markdown by default.\nReturns only metadata when metadata_only is True.",
       "parameters": [
         {
@@ -1841,7 +1841,7 @@
     {
       "name": "GetWorkbookMetadata",
       "qualifiedName": "MicrosoftSharepoint.GetWorkbookMetadata",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetWorkbookMetadata@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetWorkbookMetadata@0.2.1",
       "description": "Get metadata about an Excel workbook in a SharePoint drive, including worksheet list.",
       "parameters": [
         {
@@ -1929,7 +1929,7 @@
     {
       "name": "GetWorksheetData",
       "qualifiedName": "MicrosoftSharepoint.GetWorksheetData",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetWorksheetData@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetWorksheetData@0.2.1",
       "description": "Read cell values from a worksheet in a SharePoint Excel workbook.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -2082,7 +2082,7 @@
     {
       "name": "InsertTextAtEndOfWordDocument",
       "qualifiedName": "MicrosoftSharepoint.InsertTextAtEndOfWordDocument",
-      "fullyQualifiedName": "MicrosoftSharepoint.InsertTextAtEndOfWordDocument@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.InsertTextAtEndOfWordDocument@0.2.1",
       "description": "Append text to the end of an existing Word document.\n\nThis tool only supports files with the `.docx` extension and enforces the 4MB limit.",
       "parameters": [
         {
@@ -2169,7 +2169,7 @@
     {
       "name": "ListItemsInFolder",
       "qualifiedName": "MicrosoftSharepoint.ListItemsInFolder",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListItemsInFolder@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListItemsInFolder@0.2.1",
       "description": "Retrieve items from a folder in a drive in a SharePoint site.\n\nNote: The Microsoft Graph API requires retrieving all items,\nincluding those skipped by offset.\nExecution time increases with higher offset values.",
       "parameters": [
         {
@@ -2269,7 +2269,7 @@
     {
       "name": "ListPages",
       "qualifiedName": "MicrosoftSharepoint.ListPages",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListPages@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListPages@0.2.1",
       "description": "Retrieve pages from a SharePoint site.\n\nThe Microsoft Graph API does not support pagination on this endpoint.",
       "parameters": [
         {
@@ -2343,7 +2343,7 @@
     {
       "name": "ListRootItemsInDrive",
       "qualifiedName": "MicrosoftSharepoint.ListRootItemsInDrive",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListRootItemsInDrive@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListRootItemsInDrive@0.2.1",
       "description": "Retrieve items from the root of a drive in a SharePoint site.\n\nNote: The Microsoft Graph API requires retrieving all items,\nincluding those skipped by offset.\nExecution time increases with higher offset values.",
       "parameters": [
         {
@@ -2430,7 +2430,7 @@
     {
       "name": "ListSites",
       "qualifiedName": "MicrosoftSharepoint.ListSites",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListSites@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListSites@0.2.1",
       "description": "List all SharePoint sites accessible to the current user.",
       "parameters": [
         {
@@ -2504,7 +2504,7 @@
     {
       "name": "MoveItem",
       "qualifiedName": "MicrosoftSharepoint.MoveItem",
-      "fullyQualifiedName": "MicrosoftSharepoint.MoveItem@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.MoveItem@0.2.1",
       "description": "Move a file or folder to a new location in a SharePoint drive.",
       "parameters": [
         {
@@ -2591,7 +2591,7 @@
     {
       "name": "RenameWorksheet",
       "qualifiedName": "MicrosoftSharepoint.RenameWorksheet",
-      "fullyQualifiedName": "MicrosoftSharepoint.RenameWorksheet@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.RenameWorksheet@0.2.1",
       "description": "Rename an existing worksheet in a SharePoint Excel workbook.\n\nNote: The new name may not be immediately visible to other tools due\nto a brief Graph API propagation delay (up to ~10 s). Pass the returned\n``session_id`` to subsequent calls that reference the renamed worksheet\nto mitigate this. If referencing a recently added worksheet as the source,\nthe same delay applies; retry with the ``session_id`` if a\nWorksheetNotFoundError occurs.",
       "parameters": [
         {
@@ -2705,7 +2705,7 @@
     {
       "name": "SearchDriveItems",
       "qualifiedName": "MicrosoftSharepoint.SearchDriveItems",
-      "fullyQualifiedName": "MicrosoftSharepoint.SearchDriveItems@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.SearchDriveItems@0.2.1",
       "description": "Search for items in one or more Sharepoint drives.\n\nNote: When searching a single Drive and/or Folder,\nthe API must retrieve all items including those skipped by offset.\nExecution time increases with higher offset values.",
       "parameters": [
         {
@@ -2818,7 +2818,7 @@
     {
       "name": "SearchSites",
       "qualifiedName": "MicrosoftSharepoint.SearchSites",
-      "fullyQualifiedName": "MicrosoftSharepoint.SearchSites@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.SearchSites@0.2.1",
       "description": "Search for SharePoint sites by name or description.\n\nIn case you need to retrieve a specific site by its name, ID or SharePoint URL, use the\n`Sharepoint.GetSite` tool instead, passing the ID, name or SharePoint URL to it.",
       "parameters": [
         {
@@ -2905,7 +2905,7 @@
     {
       "name": "SetSlideNotes",
       "qualifiedName": "MicrosoftSharepoint.SetSlideNotes",
-      "fullyQualifiedName": "MicrosoftSharepoint.SetSlideNotes@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.SetSlideNotes@0.2.1",
       "description": "Set or update the speaker notes on a specific slide in a SharePoint PowerPoint.\n\nNotes can be formatted using markdown:\n- **bold** for bold text\n- *italic* for italic text\n- __underline__ for underlined text\n- Lines starting with - or * become bullet points\n- Indent with spaces for nested bullets\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -3005,7 +3005,7 @@
     {
       "name": "UpdateCell",
       "qualifiedName": "MicrosoftSharepoint.UpdateCell",
-      "fullyQualifiedName": "MicrosoftSharepoint.UpdateCell@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.UpdateCell@0.2.1",
       "description": "Update a single cell value in a SharePoint Excel workbook.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -3145,7 +3145,7 @@
     {
       "name": "UpdateRange",
       "qualifiedName": "MicrosoftSharepoint.UpdateRange",
-      "fullyQualifiedName": "MicrosoftSharepoint.UpdateRange@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.UpdateRange@0.2.1",
       "description": "Update multiple cells in a SharePoint Excel worksheet using sparse dict format.\n\nOnly specified cells are updated; unspecified cells remain unchanged.\n\nInternally, a single PATCH request is sent covering the bounding box\nof all specified cells.  Cells within the box that are not in the\ninput are sent as ``null``, which the Graph API treats as \"skip\".\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -3259,7 +3259,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftSharepoint.WhoAmI",
-      "fullyQualifiedName": "MicrosoftSharepoint.WhoAmI@0.2.0",
+      "fullyQualifiedName": "MicrosoftSharepoint.WhoAmI@0.2.1",
       "description": "Get information about the current user and their SharePoint environment.",
       "parameters": [],
       "auth": {
@@ -3306,6 +3306,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-06-04T12:06:45.042Z",
+  "generatedAt": "2026-07-08T11:41:30.284Z",
   "summary": "The Microsoft SharePoint toolkit integrates Arcade with Microsoft SharePoint via the Microsoft Graph API, enabling LLMs to read, write, and manage SharePoint content programmatically.\n\n## Capabilities\n\n- **Site & drive navigation** — list, search, and retrieve sites, drives/document libraries, lists, list items, folders, and root drive contents; look up the current user's SharePoint environment.\n- **File & folder management** — create folders, copy, move, rename, and delete files or folders; check async copy operation status; generate share links for drive items.\n- **Excel workbook editing** — create workbooks, add/rename/delete worksheets, read cell ranges, update individual cells or sparse multi-cell ranges, and retrieve workbook metadata. Propagation-delay mitigations via `session_id` are built in.\n- **PowerPoint authoring** — create presentations with a title slide, append standard or two-column-layout slides, get/set/update speaker notes per slide or across all slides, and export presentations to Markdown (preserving text, tables, and chart data).\n- **Word document handling** — create `.docx` files with optional initial content, retrieve document content as Markdown or metadata-only, and append text to existing documents (4 MB limit).\n- **SharePoint pages & lists** — list and retrieve site pages (with full web-part content or metadata-only), and read items from SharePoint lists.\n\n## OAuth\n\nThis toolkit authenticates via **Microsoft** OAuth 2.0. See the [Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration details, required permissions, and setup steps."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftteams.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftteams.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftTeams",
   "label": "Microsoft Teams",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Arcade.dev LLM tools for Microsoft Teams",
   "metadata": {
     "category": "social",
@@ -37,7 +37,7 @@
     {
       "name": "CreateChat",
       "qualifiedName": "MicrosoftTeams.CreateChat",
-      "fullyQualifiedName": "MicrosoftTeams.CreateChat@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.CreateChat@0.6.2",
       "description": "Creates a Microsoft Teams chat.\n\nIf the chat already exists with the specified members, the MS Graph API will return the\nexisting chat.\n\nProvide any combination of user_ids and/or user_names. When available, prefer providing\nuser_ids for optimal performance.",
       "parameters": [
         {
@@ -121,7 +121,7 @@
     {
       "name": "GetChannelMessageReplies",
       "qualifiedName": "MicrosoftTeams.GetChannelMessageReplies",
-      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessageReplies@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessageReplies@0.6.2",
       "description": "Retrieves the replies to a Microsoft Teams channel message.",
       "parameters": [
         {
@@ -209,7 +209,7 @@
     {
       "name": "GetChannelMessages",
       "qualifiedName": "MicrosoftTeams.GetChannelMessages",
-      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessages@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessages@0.6.2",
       "description": "Retrieves the messages in a Microsoft Teams channel.\n\nThe Microsoft Graph API does not support pagination for this endpoint.",
       "parameters": [
         {
@@ -310,7 +310,7 @@
     {
       "name": "GetChannelMetadata",
       "qualifiedName": "MicrosoftTeams.GetChannelMetadata",
-      "fullyQualifiedName": "MicrosoftTeams.GetChannelMetadata@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.GetChannelMetadata@0.6.2",
       "description": "Retrieves metadata about a Microsoft Teams channel and its members.\n\nProvide either a channel_id or channel_name, not both. When available, prefer providing a\nchannel_id for optimal performance.\n\nThe Microsoft Graph API returns only up to the first 999 members in the channel.\n\nThis tool does not return messages exchanged in the channel. To retrieve channel messages,\nuse the `Teams.GetChannelMessages` tool.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use.",
       "parameters": [
         {
@@ -398,7 +398,7 @@
     {
       "name": "GetChatMessageById",
       "qualifiedName": "MicrosoftTeams.GetChatMessageById",
-      "fullyQualifiedName": "MicrosoftTeams.GetChatMessageById@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.GetChatMessageById@0.6.2",
       "description": "Retrieves a Microsoft Teams chat message.",
       "parameters": [
         {
@@ -508,7 +508,7 @@
     {
       "name": "GetChatMessages",
       "qualifiedName": "MicrosoftTeams.GetChatMessages",
-      "fullyQualifiedName": "MicrosoftTeams.GetChatMessages@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.GetChatMessages@0.6.2",
       "description": "Retrieves messages from a Microsoft Teams chat (individual or group).\n\nProvide one of chat_id OR any combination of user_ids and/or user_names. When available, prefer\nproviding a chat_id or user_ids for optimal performance.\n\nIf the user provides user name(s), DO NOT CALL THE `Teams.SearchUsers` or `Teams.SearchPeople`\ntools first. Instead, provide the user name(s) directly to this tool through the `user_names`\nargument. It is not necessary to provide the currently signed in user's name/id, so do not call\n`Teams.GetSignedInUser` before calling this tool.\n\nMessages will be sorted in descending order by the messages' `created_datetime` field.\n\nThe Microsoft Teams API does not support pagination for this tool.",
       "parameters": [
         {
@@ -645,7 +645,7 @@
     {
       "name": "GetChatMetadata",
       "qualifiedName": "MicrosoftTeams.GetChatMetadata",
-      "fullyQualifiedName": "MicrosoftTeams.GetChatMetadata@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.GetChatMetadata@0.6.2",
       "description": "Retrieves metadata about a Microsoft Teams chat.\n\nProvide exactly one of chat_id or user_ids/user_names. When available, prefer providing a\nchat_id or user_ids for optimal performance.\n\nIf multiple roup chats exist with those exact members, returns the most recently updated one.\n\nMax 20 DIFFERENT users can be provided in user_ids/user_names.\n\nThis tool DOES NOT return messages in a chat. Use the `Teams.GetChatMessages` tool to get\nchat messages.",
       "parameters": [
         {
@@ -744,7 +744,7 @@
     {
       "name": "GetSignedInUser",
       "qualifiedName": "MicrosoftTeams.GetSignedInUser",
-      "fullyQualifiedName": "MicrosoftTeams.GetSignedInUser@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.GetSignedInUser@0.6.2",
       "description": "Get the user currently signed in Microsoft Teams.\n\nThis tool is not necessary to call before calling other tools.",
       "parameters": [],
       "auth": {
@@ -789,7 +789,7 @@
     {
       "name": "GetTeam",
       "qualifiedName": "MicrosoftTeams.GetTeam",
-      "fullyQualifiedName": "MicrosoftTeams.GetTeam@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.GetTeam@0.6.2",
       "description": "Retrieves metadata about a team in Microsoft Teams.\n\nProvide one of team_id OR team_name, never both. When available, prefer providing a team_id for\noptimal performance.\n\nIf team_id nor team_name are provided: 1) if the user has a single team, the tool will retrieve\nit; 2) if the user has multiple teams, an error will be returned with a list of all teams to\npick from.",
       "parameters": [
         {
@@ -862,7 +862,7 @@
     {
       "name": "ListChannels",
       "qualifiedName": "MicrosoftTeams.ListChannels",
-      "fullyQualifiedName": "MicrosoftTeams.ListChannels@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.ListChannels@0.6.2",
       "description": "Lists channels in Microsoft Teams (including shared incoming channels).\n\nThis tool does not return messages nor members in the channels. To retrieve channel messages,\nuse the `Teams.GetChannelMessages` tool. To retrieve channel members, use the\n`Teams.ListChannelMembers` tool.",
       "parameters": [
         {
@@ -949,7 +949,7 @@
     {
       "name": "ListChats",
       "qualifiedName": "MicrosoftTeams.ListChats",
-      "fullyQualifiedName": "MicrosoftTeams.ListChats@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.ListChats@0.6.2",
       "description": "List the Microsoft Teams chats to which the current user is a member of.",
       "parameters": [
         {
@@ -1022,7 +1022,7 @@
     {
       "name": "ListTeamMembers",
       "qualifiedName": "MicrosoftTeams.ListTeamMembers",
-      "fullyQualifiedName": "MicrosoftTeams.ListTeamMembers@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.ListTeamMembers@0.6.2",
       "description": "Lists the members of a team in Microsoft Teams.\n\nProvide one of team_id OR team_name, never both. When available, prefer providing a team_id for\noptimal performance.\n\nIf team_id nor team_name are provided: 1) if the user has a single team, the tool will use it;\n2) if the user has multiple teams, an error will be returned with a list of all teams to pick\nfrom.\n\nThe Microsoft Graph API returns only up to the first 999 members.",
       "parameters": [
         {
@@ -1122,7 +1122,7 @@
     {
       "name": "ListTeams",
       "qualifiedName": "MicrosoftTeams.ListTeams",
-      "fullyQualifiedName": "MicrosoftTeams.ListTeams@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.ListTeams@0.6.2",
       "description": "Lists the teams the current user is associated with in Microsoft Teams.",
       "parameters": [
         {
@@ -1185,7 +1185,7 @@
     {
       "name": "ListUsers",
       "qualifiedName": "MicrosoftTeams.ListUsers",
-      "fullyQualifiedName": "MicrosoftTeams.ListUsers@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.ListUsers@0.6.2",
       "description": "Lists the users in the Microsoft Teams tenant.\n\nThe Microsoft Graph API returns only up to the first 999 users.",
       "parameters": [
         {
@@ -1259,7 +1259,7 @@
     {
       "name": "ReplyToChannelMessage",
       "qualifiedName": "MicrosoftTeams.ReplyToChannelMessage",
-      "fullyQualifiedName": "MicrosoftTeams.ReplyToChannelMessage@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.ReplyToChannelMessage@0.6.2",
       "description": "Sends a reply to a Microsoft Teams channel message.\n\nWhen available, prefer providing a channel_id for optimal performance.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use.",
       "parameters": [
         {
@@ -1360,7 +1360,7 @@
     {
       "name": "ReplyToChatMessage",
       "qualifiedName": "MicrosoftTeams.ReplyToChatMessage",
-      "fullyQualifiedName": "MicrosoftTeams.ReplyToChatMessage@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.ReplyToChatMessage@0.6.2",
       "description": "Sends a reply to a Microsoft Teams chat message.\n\nProvide exactly one of chat_id or user_ids/user_names. When available, prefer providing a\nchat_id or user_ids for optimal performance.\n\nIf the user provides user name(s), DO NOT CALL THE `Teams.SearchUsers` or `Teams.SearchPeople`\ntools first. Instead, provide the user name(s) directly to this tool through the `user_names`\nargument. It is not necessary to provide the currently signed in user's name/id, so do not call\n`Teams.GetSignedInUser` before calling this tool either.",
       "parameters": [
         {
@@ -1485,7 +1485,7 @@
     {
       "name": "SearchChannels",
       "qualifiedName": "MicrosoftTeams.SearchChannels",
-      "fullyQualifiedName": "MicrosoftTeams.SearchChannels@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.SearchChannels@0.6.2",
       "description": "Searches for channels in a given Microsoft Teams team.",
       "parameters": [
         {
@@ -1606,7 +1606,7 @@
     {
       "name": "SearchMessages",
       "qualifiedName": "MicrosoftTeams.SearchMessages",
-      "fullyQualifiedName": "MicrosoftTeams.SearchMessages@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.SearchMessages@0.6.2",
       "description": "Searches for messages across Microsoft Teams chats and channels.\n\nNote: the Microsoft Graph API search is not strongly consistent. Recent messages may not be\nincluded in search results.",
       "parameters": [
         {
@@ -1694,7 +1694,7 @@
     {
       "name": "SearchPeople",
       "qualifiedName": "MicrosoftTeams.SearchPeople",
-      "fullyQualifiedName": "MicrosoftTeams.SearchPeople@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.SearchPeople@0.6.2",
       "description": "Searches for people the user has interacted with in Microsoft Teams and other 365 products.\n\nThis tool only returns users that the currently signed in user has interacted with. It may also\ninclude people that are part of external tenants/organizations. If you need to retrieve users\nthat may not have interacted with the current user and/or that are exclusively part of the same\ntenant, use the `Teams.SearchUsers` tool instead.",
       "parameters": [
         {
@@ -1801,7 +1801,7 @@
     {
       "name": "SearchTeamMembers",
       "qualifiedName": "MicrosoftTeams.SearchTeamMembers",
-      "fullyQualifiedName": "MicrosoftTeams.SearchTeamMembers@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.SearchTeamMembers@0.6.2",
       "description": "Searches for members of a team in Microsoft Teams.\n\nProvide one of team_id OR team_name, never both. When available, prefer providing a team_id for\noptimal performance.\n\nIf team_id nor team_name are provided: 1) if the user has a single team, the tool will use it;\n2) if the user has multiple teams, an error will be raised with a list of available teams to\npick from.\n\nThe Microsoft Graph API returns only up to the first 999 members of a team.",
       "parameters": [
         {
@@ -1914,7 +1914,7 @@
     {
       "name": "SearchTeams",
       "qualifiedName": "MicrosoftTeams.SearchTeams",
-      "fullyQualifiedName": "MicrosoftTeams.SearchTeams@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.SearchTeams@0.6.2",
       "description": "Searches for teams available to the current user in Microsoft Teams.",
       "parameters": [
         {
@@ -2000,7 +2000,7 @@
     {
       "name": "SearchUsers",
       "qualifiedName": "MicrosoftTeams.SearchUsers",
-      "fullyQualifiedName": "MicrosoftTeams.SearchUsers@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.SearchUsers@0.6.2",
       "description": "Searches for users in the Microsoft Teams tenant.\n\nThis tool only return users that are directly linked to the tenant the current signed in user\nis a member of. If you need to retrieve users that have interacted with the current user but\nare from external tenants/organizations, use `Teams.SearchPeople`, instead.\n\nThe Microsoft Graph API returns only up to the first 999 users.",
       "parameters": [
         {
@@ -2108,7 +2108,7 @@
     {
       "name": "SendMessageToChannel",
       "qualifiedName": "MicrosoftTeams.SendMessageToChannel",
-      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChannel@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChannel@0.6.2",
       "description": "Sends a message to a Microsoft Teams channel.\n\nWhen available, prefer providing a channel_id for optimal performance.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use.",
       "parameters": [
         {
@@ -2196,7 +2196,7 @@
     {
       "name": "SendMessageToChat",
       "qualifiedName": "MicrosoftTeams.SendMessageToChat",
-      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChat@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChat@0.6.2",
       "description": "Sends a message to a Microsoft Teams chat.\n\nProvide exactly one of chat_id or user_ids/user_names. When available, prefer providing a\nchat_id or user_ids for optimal performance.\n\nIf the user provides user name(s), DO NOT CALL THE `Teams.SearchUsers` or `Teams.SearchPeople`\ntools first. Instead, provide the user name(s) directly to this tool through the `user_names`\nargument. It is not necessary to provide the currently signed in user's name/id, so do not call\n`Teams.GetSignedInUser` before calling this tool either.",
       "parameters": [
         {
@@ -2307,7 +2307,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftTeams.WhoAmI",
-      "fullyQualifiedName": "MicrosoftTeams.WhoAmI@0.6.1",
+      "fullyQualifiedName": "MicrosoftTeams.WhoAmI@0.6.2",
       "description": "Get information about the current user and their Microsoft Teams environment.",
       "parameters": [],
       "auth": {
@@ -2360,6 +2360,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-05-28T12:15:52.129Z",
+  "generatedAt": "2026-07-08T11:41:30.269Z",
   "summary": "## Microsoft Teams Toolkit\n\nThe Microsoft Teams toolkit provides Arcade LLM tools for interacting with Microsoft Teams via the Microsoft Graph API, enabling agents to read and send messages, manage chats and channels, and look up users and teams.\n\n## Capabilities\n\n- **Messaging — chats:** Create chats, retrieve chat metadata and messages, send messages, and reply to messages in one-on-one or group chats; addressable by chat ID or user names/IDs.\n- **Messaging — channels:** Retrieve channel messages and their replies, send messages to channels, and reply to channel messages; addressable by channel ID or name.\n- **Chat & channel discovery:** List all chats the current user belongs to, list channels within a team (including shared incoming channels), and search for channels by name.\n- **Team & member management:** List teams the user belongs to, retrieve team metadata, list or search team members (up to 999 per Graph API limit), and list all tenant users.\n- **User & people search:** Search users within the signed-in user's tenant (`SearchUsers`), search people the user has previously interacted with across Microsoft 365 — including external tenants (`SearchPeople`), and retrieve the currently signed-in user's profile.\n- **Cross-scope search:** Search messages across chats and channels tenant-wide (note: Graph API search is not strongly consistent; very recent messages may be absent).\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via Microsoft (Entra ID / Azure AD). See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for setup details, required permissions, and configuration."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftword.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftword.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftWord",
   "label": "Microsoft Word",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Arcade.dev LLM tools for Microsoft Word",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "CreateDocument",
       "qualifiedName": "MicrosoftWord.CreateDocument",
-      "fullyQualifiedName": "MicrosoftWord.CreateDocument@0.2.1",
+      "fullyQualifiedName": "MicrosoftWord.CreateDocument@0.2.2",
       "description": "Create a new Word document in OneDrive (4MB upload limit).\n\nOptionally include text content.",
       "parameters": [
         {
@@ -125,7 +125,7 @@
     {
       "name": "GetDocument",
       "qualifiedName": "MicrosoftWord.GetDocument",
-      "fullyQualifiedName": "MicrosoftWord.GetDocument@0.2.1",
+      "fullyQualifiedName": "MicrosoftWord.GetDocument@0.2.2",
       "description": "Get a Word document's metadata and content (`.docx` only).\n\nReturns the document content as Markdown by default.\nReturns only metadata when metadata_only is True.",
       "parameters": [
         {
@@ -211,7 +211,7 @@
     {
       "name": "InsertTextAtEnd",
       "qualifiedName": "MicrosoftWord.InsertTextAtEnd",
-      "fullyQualifiedName": "MicrosoftWord.InsertTextAtEnd@0.2.1",
+      "fullyQualifiedName": "MicrosoftWord.InsertTextAtEnd@0.2.2",
       "description": "Append text to the end of a Word document (supports only `.docx`, 4MB limit).",
       "parameters": [
         {
@@ -297,7 +297,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftWord.WhoAmI",
-      "fullyQualifiedName": "MicrosoftWord.WhoAmI@0.2.1",
+      "fullyQualifiedName": "MicrosoftWord.WhoAmI@0.2.2",
       "description": "Get information about the current user and their Microsoft Word environment.",
       "parameters": [],
       "auth": {
@@ -343,6 +343,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-04-27T11:41:15.672Z",
+  "generatedAt": "2026-07-08T11:41:30.265Z",
   "summary": "Arcade's Microsoft Word toolkit lets developers create, read, and update Word documents stored in OneDrive through Microsoft Graph.\n\n**Capabilities**\n- Create `.docx` documents with optional initial text, automatic `.docx` extension handling, folder targeting, and configurable filename conflict behavior: fail, rename, or replace.\n- Retrieve Word document metadata and Markdown content, or request metadata only.\n- Append text to existing `.docx` documents within the 4 MB upload limit.\n- Fetch authenticated user profile and Microsoft Word environment information.\n\n**OAuth**\n- **Provider**: Microsoft\n- **Scopes**: Files.Read, Files.ReadWrite, User.Read\n\n**Secrets**\n- No secret types required for toolkit operation."
 }


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/28939612845

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Gmail 8.x and Excel 1.x are breaking contract changes for anyone pinning tool names or parameter shapes from docs; risk is mitigated because this PR only updates generated docs, not runtime code.
> 
> **Overview**
> Regenerates `toolkit-docs-generator/data/toolkits/*.json` and `index.json` after a scheduled Porter deploy, bumping toolkit versions and tool metadata that the docs site consumes.
> 
> **Gmail (7.5.1 → 8.0.1)** adds optional `page_token` on list tools and changes `ListEmailsByHeader` / `SearchThreads` so `sender`, `recipient`, `subject`, and `body` are **string arrays** (OR semantics) instead of single strings. Parameter docs now describe label-aware automated filtering, `max_results` clamping, and updated code examples.
> 
> **Microsoft Excel (0.2.0 → 1.1.1)** replaces the old granular write API (`AddWorksheet`, `CreateWorkbook`, `GetWorksheetData`, `UpdateCell`, etc.) with a new set: `AggregateWorksheet`, `CreateOrEditWorkbook`, `ReadWorksheet`, `UploadWorkbook`, `SearchWorkbooks`, `ScanForDataIssues`, comment tools, and related summaries—**10 tools** in the index (was 9).
> 
> **Microsoft Outlook Mail (0.4.0 → 0.5.0)** documents new **`CreateDraftReply`** and **`SharedMailboxCreateDraftReply`**; other Microsoft toolkits get patch version bumps with refreshed `fullyQualifiedName` / `generatedAt` only.
> 
> The toolkit index `generatedAt` and per-toolkit versions/counts are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8496f4a996cb165fd87b301b983bd7c622c506d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->