### PR TITLE
fix: reuse stable branch for toolkit docs auto-PRs

### DIFF
--- a/.github/workflows/generate-toolkit-docs.md
+++ b/.github/workflows/generate-toolkit-docs.md
@@ -7,7 +7,7 @@ This workflow regenerates toolkit JSON and opens a PR with the changes. It can b
 1. Builds the toolkit docs generator.
 2. Generates toolkit JSON in `toolkit-docs-generator/data/toolkits` using the Engine tool metadata and summary endpoints.
 3. Syncs integrations sidebar navigation from the generated JSON.
-4. Creates a PR if any files changed.
+4. Creates or updates a PR on the stable `automation/toolkit-docs` branch if any files changed. Later runs overwrite that open PR with the latest generated docs.
 
 ## Inputs and secrets
 

--- a/.github/workflows/generate-toolkit-docs.yml
+++ b/.github/workflows/generate-toolkit-docs.yml
@@ -110,7 +110,10 @@ jobs:
             - Deploy env: ${{ github.event.client_payload.env || 'unknown' }}
             - Deploy SHA: ${{ github.event.client_payload.deploy_sha || 'unknown' }}
             - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          branch: automation/toolkit-docs-${{ github.run_id }}
+          # Stable branch so later runs update the open auto-PR instead of
+          # opening a new one each time. create-pull-request force-pushes the
+          # latest generated docs onto this branch.
+          branch: automation/toolkit-docs
           delete-branch: true
 
       - name: Request team review

--- a/.github/workflows/generate-toolkit-docs.yml
+++ b/.github/workflows/generate-toolkit-docs.yml
@@ -4,7 +4,7 @@ name: Generate toolkit docs
 # 1) Build the toolkit docs generator
 # 2) Generate toolkit JSON into toolkit-docs-generator/data/toolkits
 # 3) Sync integrations sidebar _meta.tsx from toolkit-docs-generator/data/toolkits
-# 4) Open a PR if changes were produced
+# 4) Create or update a PR if changes were produced
 
 on:
   repository_dispatch:
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: write
   pull-requests: write
+
+concurrency:
+  group: generate-toolkit-docs
+  cancel-in-progress: true
 
 jobs:
   generate:
@@ -84,17 +88,7 @@ jobs:
       - name: Sync toolkit sidebar navigation
         run: pnpm dlx tsx toolkit-docs-generator/scripts/sync-toolkit-sidebar.ts --remove-empty-sections=false --verbose
 
-      - name: Check for changes
-        id: check-changes
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Create pull request
-        if: steps.check-changes.outputs.has_changes == 'true'
         id: cpr
         uses: peter-evans/create-pull-request@v7
         env:
@@ -117,7 +111,7 @@ jobs:
           delete-branch: true
 
       - name: Request team review
-        if: steps.check-changes.outputs.has_changes == 'true' && steps.cpr.outputs.pull-request-number != ''
+        if: steps.cpr.outputs.pull-request-number != ''
         continue-on-error: true
         run: gh pr edit ${{ steps.cpr.outputs.pull-request-number }} --add-reviewer ArcadeAI/engineering-tools-and-dx
         env:


### PR DESCRIPTION
## Summary
- Point `generate-toolkit-docs` at a fixed `automation/toolkit-docs` branch instead of `automation/toolkit-docs-${{ github.run_id }}`.
- Later workflow runs overwrite/update the same open auto-PR with the latest generated toolkit docs (same pattern as design-system and llms.txt automation).
- Document the reuse behavior in the workflow notes.

## Test plan
- [ ] Merge this PR
- [ ] Close or merge any leftover open `[AUTO] Adding MCP Servers docs update` PRs that still use per-run branch names
- [ ] Trigger `Generate toolkit docs` via workflow_dispatch (or wait for the next schedule/Porter deploy)
- [ ] Confirm it opens one PR on `automation/toolkit-docs`
- [ ] Trigger the workflow again with docs changes and confirm it updates that same PR instead of opening another


Made with [Cursor](https://cursor.com)