### PR TITLE
[AUTO] Adding MCP Servers docs update

### DIFF
--- a/app/en/resources/integrations/development/_meta.tsx
+++ b/app/en/resources/integrations/development/_meta.tsx
@@ -49,6 +49,10 @@ const meta: MetaRecord = {
     title: "PostHog",
     href: "/en/resources/integrations/development/posthog",
   },
+  postman: {
+    title: "Postman",
+    href: "/en/resources/integrations/development/postman",
+  },
   vercel: {
     title: "Vercel",
     href: "/en/resources/integrations/development/vercel",

--- a/app/en/resources/integrations/productivity/_meta.tsx
+++ b/app/en/resources/integrations/productivity/_meta.tsx
@@ -93,6 +93,10 @@ const meta: MetaRecord = {
     title: "Microsoft Outlook Mail",
     href: "/en/resources/integrations/productivity/microsoft-outlook-mail",
   },
+  "microsoft-power-bi": {
+    title: "Microsoft Power BI",
+    href: "/en/resources/integrations/productivity/microsoft-power-bi",
+  },
   "microsoft-powerpoint": {
     title: "Microsoft PowerPoint",
     href: "/en/resources/integrations/productivity/microsoft-powerpoint",

--- a/toolkit-docs-generator/data/toolkits/gmail.json
+++ b/toolkit-docs-generator/data/toolkits/gmail.json
@@ -1,7 +1,7 @@
 {
   "id": "Gmail",
   "label": "Gmail",
-  "version": "8.0.1",
+  "version": "8.0.3",
   "description": "Arcade.dev LLM tools for Gmail",
   "metadata": {
     "category": "productivity",
@@ -30,8 +30,8 @@
     {
       "name": "ChangeEmailLabels",
       "qualifiedName": "Gmail.ChangeEmailLabels",
-      "fullyQualifiedName": "Gmail.ChangeEmailLabels@8.0.1",
-      "description": "Add and remove labels from an email using the Gmail API.",
+      "fullyQualifiedName": "Gmail.ChangeEmailLabels@8.0.3",
+      "description": "Add and remove labels from an email using the Gmail API.\n\nLabel names match case-insensitively when there is no exact match, so\n\"important\" resolves to the \"Important\" label. The confirmation reflects the\nlabels actually present on the message after the change, not the requested\ninput.",
       "parameters": [
         {
           "name": "email_id",
@@ -46,7 +46,7 @@
           "type": "array",
           "innerType": "string",
           "required": true,
-          "description": "List of label names to add",
+          "description": "Label names to add. Pass an empty list to only remove labels.",
           "enum": null,
           "inferrable": true
         },
@@ -55,7 +55,7 @@
           "type": "array",
           "innerType": "string",
           "required": true,
-          "description": "List of label names to remove",
+          "description": "Label names to remove. Pass an empty list to only add labels.",
           "enum": null,
           "inferrable": true
         }
@@ -71,7 +71,7 @@
       "secretsInfo": [],
       "output": {
         "type": "json",
-        "description": "Confirmation with labels that were added and removed"
+        "description": "Confirmation with the labels that were actually applied"
       },
       "documentationChunks": [],
       "codeExample": {
@@ -122,9 +122,103 @@
       }
     },
     {
+      "name": "ChangeThreadLabels",
+      "qualifiedName": "Gmail.ChangeThreadLabels",
+      "fullyQualifiedName": "Gmail.ChangeThreadLabels@8.0.3",
+      "description": "Add and remove labels on every message in a thread using the Gmail API.\n\nUse this to change a whole conversation at once (for example, marking a\nthread read by removing \"UNREAD\") instead of modifying each message.\nLabel names match case-insensitively when there is no exact match. The\nconfirmation reflects the labels actually present across the thread after\nthe change, not the requested input.",
+      "parameters": [
+        {
+          "name": "thread_id",
+          "type": "string",
+          "required": true,
+          "description": "The ID of the thread to modify labels for",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "labels_to_add",
+          "type": "array",
+          "innerType": "string",
+          "required": true,
+          "description": "Label names to add to every message. Pass an empty list to only remove labels.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "labels_to_remove",
+          "type": "array",
+          "innerType": "string",
+          "required": true,
+          "description": "Label names to remove from every message. Pass an empty list to only add labels.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "google",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://www.googleapis.com/auth/gmail.modify"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Confirmation with the labels that were actually applied"
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Gmail.ChangeThreadLabels",
+        "parameters": {
+          "thread_id": {
+            "value": "17a3f2c9e4b12d08",
+            "type": "string",
+            "required": true
+          },
+          "labels_to_add": {
+            "value": [
+              "STARRED",
+              "IMPORTANT"
+            ],
+            "type": "array",
+            "required": true
+          },
+          "labels_to_remove": {
+            "value": [
+              "UNREAD",
+              "INBOX"
+            ],
+            "type": "array",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "google",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "email"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
       "name": "CreateLabel",
       "qualifiedName": "Gmail.CreateLabel",
-      "fullyQualifiedName": "Gmail.CreateLabel@8.0.1",
+      "fullyQualifiedName": "Gmail.CreateLabel@8.0.3",
       "description": "Create a new label in the user's mailbox.",
       "parameters": [
         {
@@ -184,7 +278,7 @@
     {
       "name": "DeleteDraftEmail",
       "qualifiedName": "Gmail.DeleteDraftEmail",
-      "fullyQualifiedName": "Gmail.DeleteDraftEmail@8.0.1",
+      "fullyQualifiedName": "Gmail.DeleteDraftEmail@8.0.3",
       "description": "Delete a draft email using the Gmail API.",
       "parameters": [
         {
@@ -244,7 +338,7 @@
     {
       "name": "GetThread",
       "qualifiedName": "Gmail.GetThread",
-      "fullyQualifiedName": "Gmail.GetThread@8.0.1",
+      "fullyQualifiedName": "Gmail.GetThread@8.0.3",
       "description": "Get the specified thread by ID.",
       "parameters": [
         {
@@ -304,7 +398,7 @@
     {
       "name": "ListDraftEmails",
       "qualifiedName": "Gmail.ListDraftEmails",
-      "fullyQualifiedName": "Gmail.ListDraftEmails@8.0.1",
+      "fullyQualifiedName": "Gmail.ListDraftEmails@8.0.3",
       "description": "Lists draft emails in the user's draft mailbox using the Gmail API.",
       "parameters": [
         {
@@ -377,7 +471,7 @@
     {
       "name": "ListEmails",
       "qualifiedName": "Gmail.ListEmails",
-      "fullyQualifiedName": "Gmail.ListEmails@8.0.1",
+      "fullyQualifiedName": "Gmail.ListEmails@8.0.3",
       "description": "Read emails from a Gmail account and extract plain text content.\n\nBy default, obvious automated emails are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all emails regardless of source.",
       "parameters": [
         {
@@ -463,7 +557,7 @@
     {
       "name": "ListEmailsByHeader",
       "qualifiedName": "Gmail.ListEmailsByHeader",
-      "fullyQualifiedName": "Gmail.ListEmailsByHeader@8.0.1",
+      "fullyQualifiedName": "Gmail.ListEmailsByHeader@8.0.3",
       "description": "Search for emails by header using the Gmail API.",
       "parameters": [
         {
@@ -651,7 +745,7 @@
     {
       "name": "ListLabels",
       "qualifiedName": "Gmail.ListLabels",
-      "fullyQualifiedName": "Gmail.ListLabels@8.0.1",
+      "fullyQualifiedName": "Gmail.ListLabels@8.0.3",
       "description": "List all the labels in the user's mailbox.",
       "parameters": [],
       "auth": {
@@ -696,7 +790,7 @@
     {
       "name": "ListThreads",
       "qualifiedName": "Gmail.ListThreads",
-      "fullyQualifiedName": "Gmail.ListThreads@8.0.1",
+      "fullyQualifiedName": "Gmail.ListThreads@8.0.3",
       "description": "List threads in the user's mailbox.\n\nBy default, obvious automated threads are excluded from results using\nno-reply sender patterns and Gmail's non-primary category filters\n(promotions, social, updates, forums). Set exclude_automated=False to\ninclude all threads regardless of source.",
       "parameters": [
         {
@@ -795,7 +889,7 @@
     {
       "name": "ReplyToEmail",
       "qualifiedName": "Gmail.ReplyToEmail",
-      "fullyQualifiedName": "Gmail.ReplyToEmail@8.0.1",
+      "fullyQualifiedName": "Gmail.ReplyToEmail@8.0.3",
       "description": "Send a reply to an email message, optionally with one or more file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
@@ -960,7 +1054,7 @@
     {
       "name": "SearchThreads",
       "qualifiedName": "Gmail.SearchThreads",
-      "fullyQualifiedName": "Gmail.SearchThreads@8.0.1",
+      "fullyQualifiedName": "Gmail.SearchThreads@8.0.3",
       "description": "Search for threads in the user's mailbox.",
       "parameters": [
         {
@@ -1165,7 +1259,7 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "Gmail.SendDraftEmail",
-      "fullyQualifiedName": "Gmail.SendDraftEmail@8.0.1",
+      "fullyQualifiedName": "Gmail.SendDraftEmail@8.0.3",
       "description": "Send a draft email using the Gmail API.",
       "parameters": [
         {
@@ -1225,7 +1319,7 @@
     {
       "name": "SendEmail",
       "qualifiedName": "Gmail.SendEmail",
-      "fullyQualifiedName": "Gmail.SendEmail@8.0.1",
+      "fullyQualifiedName": "Gmail.SendEmail@8.0.3",
       "description": "Send an email using the Gmail API, optionally with one or more file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
@@ -1386,7 +1480,7 @@
     {
       "name": "TrashEmail",
       "qualifiedName": "Gmail.TrashEmail",
-      "fullyQualifiedName": "Gmail.TrashEmail@8.0.1",
+      "fullyQualifiedName": "Gmail.TrashEmail@8.0.3",
       "description": "Move an email to the trash folder using the Gmail API.",
       "parameters": [
         {
@@ -1446,7 +1540,7 @@
     {
       "name": "UpdateDraftEmail",
       "qualifiedName": "Gmail.UpdateDraftEmail",
-      "fullyQualifiedName": "Gmail.UpdateDraftEmail@8.0.1",
+      "fullyQualifiedName": "Gmail.UpdateDraftEmail@8.0.3",
       "description": "Update an existing email draft using the Gmail API.\n\nSingle-part ``text/plain`` and single-part ``text/html`` drafts both support full\nbody replacement; the rebuild follows the existing draft's content type, so a\nplain draft stays plain and an HTML draft stays HTML. Plain-text input supplied\nagainst an HTML draft is auto-converted to HTML, and HTML input supplied against\na plain draft is stored verbatim as ``text/plain``. Reply drafts preserve their\nreply-quote tail (``> `` lines for plain, ``<blockquote>`` for HTML) when the\nbody is supplied as a top-only update.\n\nMultipart drafts and drafts with attachments still fail when the body changes;\nin those cases the tool succeeds only when the effective body is unchanged\n(metadata-only update preserving the existing MIME tree). Edit those drafts in\nGmail directly.\n\nFor each of subject, body, recipient, cc, and bcc, omitting the parameter or passing\n``None`` leaves that part of the draft unchanged (for cc/bcc, existing headers are kept;\npass an empty list to clear).",
       "parameters": [
         {
@@ -1578,7 +1672,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "Gmail.WhoAmI",
-      "fullyQualifiedName": "Gmail.WhoAmI@8.0.1",
+      "fullyQualifiedName": "Gmail.WhoAmI@8.0.3",
       "description": "Get comprehensive user profile and Gmail account information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, profile picture, Gmail account statistics, and other\nimportant profile details from Google services.",
       "parameters": [],
       "auth": {
@@ -1625,7 +1719,7 @@
     {
       "name": "WriteDraftEmail",
       "qualifiedName": "Gmail.WriteDraftEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftEmail@8.0.1",
+      "fullyQualifiedName": "Gmail.WriteDraftEmail@8.0.3",
       "description": "Compose a new email draft using the Gmail API, optionally with file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
@@ -1786,7 +1880,7 @@
     {
       "name": "WriteDraftReplyEmail",
       "qualifiedName": "Gmail.WriteDraftReplyEmail",
-      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@8.0.1",
+      "fullyQualifiedName": "Gmail.WriteDraftReplyEmail@8.0.3",
       "description": "Compose a draft reply to an email message, optionally with one or more file attachments.\n\nTo attach files, pass ``attachments`` and give each file's local path as a\n``file://`` URI in ``source`` (formatted ``file:///absolute/path/to/file``). The\nfile's bytes are read and substituted on the client before the request is sent, so\nthe contents never pass through this conversation. Do not read, encode, or inline\nthe bytes yourself.",
       "parameters": [
         {
@@ -1970,6 +2064,6 @@
     "import ScopePicker from \"@/app/_components/scope-picker\";"
   ],
   "subPages": [],
-  "generatedAt": "2026-07-10T12:06:06.482Z",
-  "summary": "The Gmail toolkit provides Arcade LLM tools for interacting with Gmail via the Google Gmail API. It enables agents to read, compose, send, organize, and manage email on behalf of authenticated users.\n\n## Capabilities\n\n- **Reading & searching mail:** List emails, threads, and drafts with built-in automated-mail filtering (no-reply patterns, non-primary categories); search or query threads; retrieve individual threads by ID; look up emails by header.\n- **Composing & drafting:** Create new drafts or draft replies; update existing drafts (subject, body, recipients, cc/bcc) with smart MIME-type preservation; attach local files via `file://` URIs (bytes are resolved client-side and never passed through the conversation).\n- **Sending mail:** Send emails or draft replies directly, or promote an existing draft to sent; all send operations support file attachments using the same `file://` URI pattern.\n- **Label & organization management:** List, create, and apply or remove labels; trash individual emails.\n- **Account introspection:** Retrieve the authenticated user's profile, email address, account statistics, and avatar via `WhoAmI`.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 delegated access via **Google**. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup instructions, required consent screen configuration, and available permission scopes."
+  "generatedAt": "2026-07-15T11:37:32.007Z",
+  "summary": "The Gmail toolkit provides Arcade LLM tools for interacting with a user's Gmail account via the Gmail API. It enables agents to read, compose, send, organize, and manage email messages, threads, drafts, and labels.\n\n## Capabilities\n\n- **Reading & searching:** List and retrieve emails, threads, and drafts; filter by headers; smart exclusion of automated/promotional mail by default (togglable); search threads with Gmail query syntax.\n- **Composing & sending:** Send new emails or draft replies immediately, with support for file attachments passed as `file://` URIs (bytes resolved client-side, never in-conversation).\n- **Draft management:** Create, update, list, send, and delete drafts; update drafts support partial edits (subject, body, recipients, cc, bcc independently); reply-draft quotes are preserved.\n- **Labels & organization:** List, create, and apply/remove labels on individual messages or entire threads; label matching is case-insensitive.\n- **Trash:** Move individual messages to trash.\n- **Account info:** Retrieve authenticated user profile, email address, Gmail statistics, and account details.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via **Google**. See the [Arcade Google auth provider docs](https://docs.arcade.dev/en/references/auth-providers/google) for setup details."
 }

--- a/toolkit-docs-generator/data/toolkits/index.json
+++ b/toolkit-docs-generator/data/toolkits/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-10T12:06:21.796Z",
+  "generatedAt": "2026-07-15T11:37:49.016Z",
   "version": "1.0.0",
   "toolkits": [
     {
@@ -356,10 +356,10 @@
     {
       "id": "Gmail",
       "label": "Gmail",
-      "version": "8.0.1",
+      "version": "8.0.3",
       "category": "productivity",
       "type": "arcade",
-      "toolCount": 18,
+      "toolCount": 19,
       "authType": "oauth2"
     },
     {
@@ -662,7 +662,7 @@
     {
       "id": "MicrosoftExcel",
       "label": "Microsoft Excel",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 10,
@@ -671,7 +671,7 @@
     {
       "id": "MicrosoftOnedrive",
       "label": "Microsoft OneDrive",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 16,
@@ -680,7 +680,7 @@
     {
       "id": "MicrosoftOutlookCalendar",
       "label": "Microsoft Outlook Calendar",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 7,
@@ -689,16 +689,25 @@
     {
       "id": "MicrosoftOutlookMail",
       "label": "Microsoft Outlook Mail",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 30,
       "authType": "oauth2"
     },
     {
+      "id": "MicrosoftPowerbi",
+      "label": "Microsoft Power BI",
+      "version": "0.3.0",
+      "category": "productivity",
+      "type": "arcade",
+      "toolCount": 15,
+      "authType": "oauth2"
+    },
+    {
       "id": "MicrosoftPowerpoint",
       "label": "Microsoft PowerPoint",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 8,
@@ -707,7 +716,7 @@
     {
       "id": "MicrosoftSharepoint",
       "label": "Microsoft SharePoint",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 36,
@@ -716,7 +725,7 @@
     {
       "id": "MicrosoftTeams",
       "label": "Microsoft Teams",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "category": "social",
       "type": "arcade",
       "toolCount": 25,
@@ -725,7 +734,7 @@
     {
       "id": "MicrosoftWord",
       "label": "Microsoft Word",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "category": "productivity",
       "type": "arcade",
       "toolCount": 4,
@@ -801,6 +810,15 @@
       "category": "development",
       "type": "arcade_starter",
       "toolCount": 766,
+      "authType": "none"
+    },
+    {
+      "id": "Postman",
+      "label": "Postman",
+      "version": "0.1.0",
+      "category": "development",
+      "type": "arcade",
+      "toolCount": 30,
       "authType": "none"
     },
     {

--- a/toolkit-docs-generator/data/toolkits/microsoftexcel.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftexcel.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftExcel",
   "label": "Microsoft Excel",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Arcade.dev LLM tools for Microsoft Excel",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "AggregateWorksheet",
       "qualifiedName": "MicrosoftExcel.AggregateWorksheet",
-      "fullyQualifiedName": "MicrosoftExcel.AggregateWorksheet@1.1.1",
+      "fullyQualifiedName": "MicrosoftExcel.AggregateWorksheet@1.1.2",
       "description": "Summarize a worksheet by grouping rows and computing per-group aggregates in one call.\n\nUse this instead of reading and paginating raw rows when you need totals, averages, counts,\nor min/max broken down by one or more columns (e.g. revenue by region). Columns can be\nreferenced by letter (group_by) or by header name (group_by_headers) — use whichever is\nmore convenient. Groups are returned in first-seen order and capped by ``limit``.\n\nAlways check each aggregate's ``numeric_count`` field: non-numeric and formula-error cells\nare silently skipped for sum/average/min/max, so a clean-looking total may exclude rows —\nthe ``warnings`` list will name every column and group where this occurred.",
       "parameters": [
         {
@@ -259,7 +259,7 @@
     {
       "name": "CreateOrEditWorkbook",
       "qualifiedName": "MicrosoftExcel.CreateOrEditWorkbook",
-      "fullyQualifiedName": "MicrosoftExcel.CreateOrEditWorkbook@1.1.1",
+      "fullyQualifiedName": "MicrosoftExcel.CreateOrEditWorkbook@1.1.2",
       "description": "Create a new .xlsx workbook or edit an existing one in OneDrive for Business.\n\nOmit `item_id` to create (an empty workbook is created from `filename`, then the\noperations are applied); provide `item_id` to edit. To create a populated workbook, pass\n`filename` plus set_values operations; name the target tab via `worksheet` (or reference\none consistent sheet name in the operations) and the new workbook's initial sheet is\nrenamed to match. For a finished file with formatting/charts intact, upload the bytes\ninstead of rebuilding cell-by-cell.\n\nEach entry in `operations` selects a behavior via its `type`: write/clear cells, format\ncells (font, fill, borders, alignment, wrap, row height), size rows and columns,\nsort, add/restyle tables (style, totals, banding, filter), add/move/restyle charts (anchor\ncell, size, title, legend, axis titles), manage worksheets and named ranges, protect a\nsheet, and recalculate. See the `operations` parameter for the per-type fields.",
       "parameters": [
         {
@@ -443,8 +443,8 @@
     {
       "name": "GetWorkbookMetadata",
       "qualifiedName": "MicrosoftExcel.GetWorkbookMetadata",
-      "fullyQualifiedName": "MicrosoftExcel.GetWorkbookMetadata@1.1.1",
-      "description": "Get a workbook's structure: worksheets, named ranges, and optionally extents and objects.\n\nCall this first when exploring an unfamiliar workbook: it surfaces hidden worksheets,\nworkbook-scoped named ranges, tables, charts, and (with the flags) used ranges, protection\nstate, and worksheet-local named ranges, so you can target reads precisely and avoid\nmistaking a stale dashboard sheet for the source data. Use `include_used_ranges` to learn\nwhere data lives before reading, and `include_objects` to enumerate tables and charts. Both\nadd a per-worksheet fan-out, so leave them off for a quick worksheet listing.",
+      "fullyQualifiedName": "MicrosoftExcel.GetWorkbookMetadata@1.1.2",
+      "description": "Get a workbook's structure: worksheets, named ranges, and optionally extents and objects.\n\nCall this first when exploring an unfamiliar workbook: it surfaces hidden worksheets and\nworkbook-scoped named ranges. Use `include_used_ranges` to also learn where data lives\n(used ranges, protection state, and worksheet-local named ranges) before reading, and\n`include_objects` to enumerate tables and charts. Both add a per-worksheet fan-out, so leave\nthem off for a quick worksheet listing.",
       "parameters": [
         {
           "name": "item_id",
@@ -555,7 +555,7 @@
     {
       "name": "ListWorkbookComments",
       "qualifiedName": "MicrosoftExcel.ListWorkbookComments",
-      "fullyQualifiedName": "MicrosoftExcel.ListWorkbookComments@1.1.1",
+      "fullyQualifiedName": "MicrosoftExcel.ListWorkbookComments@1.1.2",
       "description": "List a workbook's comments, or the replies on a specific comment thread.\n\nProvide a comment ID to retrieve that thread's replies instead of the top-level comments.",
       "parameters": [
         {
@@ -667,7 +667,7 @@
     {
       "name": "ReadWorksheet",
       "qualifiedName": "MicrosoftExcel.ReadWorksheet",
-      "fullyQualifiedName": "MicrosoftExcel.ReadWorksheet@1.1.1",
+      "fullyQualifiedName": "MicrosoftExcel.ReadWorksheet@1.1.2",
       "description": "Read a worksheet range with the detail you choose, with guardrails for large sheets.\n\nRequest `annotations` for formulas, cell types, number formats, or the range's\nfill/font/borders; `filter_column` + `filter_contains` to keep matching rows; `columns` to\nproject a subset; `export` for csv/tsv. Reads are bounded to the used range and capped by a\nrow limit and cell budget, paginating via `next_range` rather than returning a whole large\nsheet at once.\n\nSet `row_format=\"records\"` (with `has_header=true`) to get a `record` dict on each data\nrow, keying cell values by the header row (the top row of the worksheet's used range) —\nuseful when agents need to map values to named columns without tracking positional indices.\nThe header is carried across pages, so paginated reads via `next_range` stay correctly\nkeyed. Each row still includes `values`.\n\nTo verify formulas, types, or number patterns in the returned cells, pass `annotations`\n(e.g. `[\"formulas\", \"types\"]`); annotation values land under `annotations` keyed by A1\naddress alongside the displayed values.",
       "parameters": [
         {
@@ -921,7 +921,7 @@
     {
       "name": "ReplyToWorkbookComment",
       "qualifiedName": "MicrosoftExcel.ReplyToWorkbookComment",
-      "fullyQualifiedName": "MicrosoftExcel.ReplyToWorkbookComment@1.1.1",
+      "fullyQualifiedName": "MicrosoftExcel.ReplyToWorkbookComment@1.1.2",
       "description": "Post a plain-text reply to an existing comment thread on a workbook.\n\nThe reply is appended to the end of the thread.",
       "parameters": [
         {
@@ -1020,7 +1020,7 @@
     {
       "name": "ScanForDataIssues",
       "qualifiedName": "MicrosoftExcel.ScanForDataIssues",
-      "fullyQualifiedName": "MicrosoftExcel.ScanForDataIssues@1.1.1",
+      "fullyQualifiedName": "MicrosoftExcel.ScanForDataIssues@1.1.2",
       "description": "Scan a worksheet (or the whole workbook) for data-quality problems as a structured list.\n\nEach issue carries a ``severity`` field (``\"high\"``, ``\"medium\"``, or ``\"low\"``) and the\nlist is ordered high → low before any truncation cap is applied, so critical findings are\nnever dropped in favour of lower-priority ones.\n\nBy default the scan is sheet-scoped (the named worksheet, or the first sheet when\n``worksheet`` is omitted). Pass ``worksheet='*'`` for a workbook-wide audit: every sheet\nis scanned in one call and each issue carries its own ``worksheet`` field.\n\nDetects formula-error cells (``severity=\"high\"``), type outliers within a column —\na column mostly one type with a few cells of another — (``severity=\"medium\"``),\ninconsistent_column for a column that mixes cell types without a strong majority\n(``severity=\"medium\"``), accidental duplicate values in mostly-unique columns\n(``severity=\"medium\"``), and blank cells inside an otherwise-populated region\n(``severity=\"low\"``). Categorical columns (where repetition is expected) are not flagged\nas duplicates, and the header row is excluded from type-outlier and duplicate checks.\nA clean sheet returns an empty issues list. Detection is deterministic.\nResults are capped; when the cap is reached ``truncated`` is True and a warning is added.\n\nMerged cells are a known limitation: Microsoft Graph reports only the merge anchor as\npopulated and every covered cell as empty, so cells hidden under a merge may be flagged as\nblanks. A worksheet cannot be scanned when its used range exceeds an internal cell limit\n(this tool takes no range argument): a single-sheet scan raises an error asking you to\nreduce the data, while a whole-workbook scan skips the oversized sheet and names it in a\nwarning so the rest of the workbook is still scanned.",
       "parameters": [
         {
@@ -1132,7 +1132,7 @@
     {
       "name": "SearchWorkbooks",
       "qualifiedName": "MicrosoftExcel.SearchWorkbooks",
-      "fullyQualifiedName": "MicrosoftExcel.SearchWorkbooks@1.1.1",
+      "fullyQualifiedName": "MicrosoftExcel.SearchWorkbooks@1.1.2",
       "description": "Find Excel workbooks in OneDrive by keyword or folder, returning their item_ids.\n\nProvide `query` to search the whole drive by name/content, or leave it empty and pass\n`parent_folder_id` to list one folder; only .xlsx files are returned. Use a returned\n`item_id` to read, edit, scan, or comment on a workbook you did not create this session.",
       "parameters": [
         {
@@ -1244,7 +1244,7 @@
     {
       "name": "UploadWorkbook",
       "qualifiedName": "MicrosoftExcel.UploadWorkbook",
-      "fullyQualifiedName": "MicrosoftExcel.UploadWorkbook@1.1.1",
+      "fullyQualifiedName": "MicrosoftExcel.UploadWorkbook@1.1.2",
       "description": "Upload a complete .xlsx file into OneDrive for Business, preserving it byte-for-byte.\n\nUse this instead of rebuilding a finished file cell-by-cell. Large files are uploaded\nvia a resumable upload session automatically.",
       "parameters": [
         {
@@ -1357,7 +1357,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftExcel.WhoAmI",
-      "fullyQualifiedName": "MicrosoftExcel.WhoAmI@1.1.1",
+      "fullyQualifiedName": "MicrosoftExcel.WhoAmI@1.1.2",
       "description": "Get information about the current user and their Microsoft Excel environment.",
       "parameters": [],
       "auth": {
@@ -1403,6 +1403,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-07-10T12:06:11.185Z",
-  "summary": "**Microsoft Excel toolkit** connects Arcade to Microsoft Excel via the Microsoft Graph API, enabling agents to read, write, audit, and collaborate on `.xlsx` workbooks stored in OneDrive for Business.\n\n## Capabilities\n\n- **Workbook discovery & metadata** — search OneDrive for workbooks by keyword or folder, retrieve full workbook structure (worksheets, named ranges, tables, charts, protection state, used-range extents), and identify the current user's environment.\n- **Reading & analysis** — read worksheet ranges with pagination, column projection, row filtering, CSV/TSV export, and per-cell annotations (formulas, types, number formats, fill/font/borders); aggregate data by grouping rows with sum, average, count, min, or max.\n- **Writing & editing** — create new workbooks or edit existing ones with a rich operation set: write/clear cells, format cells, resize rows/columns, sort, manage tables and charts, rename/add/protect worksheets, manage named ranges, and recalculate.\n- **Data quality** — scan a single worksheet or an entire workbook for formula errors, type outliers, inconsistent columns, accidental duplicates, and blank cells, with severity-ordered results.\n- **File upload** — upload a complete `.xlsx` file byte-for-byte into OneDrive (resumable for large files), avoiding the need to rebuild complex files cell-by-cell.\n- **Comments & collaboration** — list comment threads (or replies on a specific thread) and post plain-text replies to existing comment threads.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 delegated authorization via **Microsoft**. Arcade handles the OAuth flow automatically. See the [Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for setup details."
+  "generatedAt": "2026-07-15T11:37:29.796Z",
+  "summary": "The Microsoft Excel toolkit for Arcade provides LLM-ready tools for reading, writing, auditing, and managing Excel workbooks stored in OneDrive for Business via the Microsoft Graph API.\n\n## Capabilities\n\n- **Discovery & navigation**: Search OneDrive for workbooks by keyword or folder, retrieve workbook metadata (worksheets, named ranges, tables, charts, extents, protection state), and identify the current user's environment.\n- **Reading & analysis**: Read worksheet ranges with filtering, column projection, pagination, and optional annotations (formulas, types, number formats, styles); aggregate data by group with sum/average/count/min/max in a single call.\n- **Writing & editing**: Create new `.xlsx` workbooks or edit existing ones with a rich operation set — write/clear cells, apply formatting, resize rows/columns, sort, manage tables and charts, handle worksheets and named ranges, protect sheets, and recalculate.\n- **File-level upload**: Upload a complete `.xlsx` file byte-for-byte (with automatic resumable upload for large files), bypassing cell-by-cell reconstruction.\n- **Data quality scanning**: Audit a worksheet or entire workbook for formula errors, type outliers, inconsistent columns, accidental duplicates, and blank cells — results are severity-ordered so critical issues are never truncated first.\n- **Comments & collaboration**: List comment threads (or replies on a specific thread) and post plain-text replies to existing threads.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via Microsoft. Arcade manages the OAuth flow; see the [Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for setup details."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftonedrive.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftonedrive.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftOnedrive",
   "label": "Microsoft OneDrive",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Arcade.dev LLM tools for Microsoft OneDrive",
   "metadata": {
     "category": "productivity",
@@ -25,7 +25,7 @@
     {
       "name": "CopyItem",
       "qualifiedName": "MicrosoftOnedrive.CopyItem",
-      "fullyQualifiedName": "MicrosoftOnedrive.CopyItem@1.0.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.CopyItem@1.0.1",
       "description": "Copy a file or folder and wait for the copy to finish, returning the new item.\n\nMicrosoft Graph performs copies asynchronously; this tool polls the operation to\ncompletion within a bounded budget so the caller receives the finished item directly.\nA stale or mistyped source id returns a structured not_found envelope (status\n\"not_found\", retryable false) rather than a fatal error, so the caller can branch on\nthe field.",
       "parameters": [
         {
@@ -129,7 +129,7 @@
     {
       "name": "CreateFolder",
       "qualifiedName": "MicrosoftOnedrive.CreateFolder",
-      "fullyQualifiedName": "MicrosoftOnedrive.CreateFolder@1.0.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.CreateFolder@1.0.1",
       "description": "Create a new folder in OneDrive.",
       "parameters": [
         {
@@ -202,7 +202,7 @@
     {
       "name": "CreateShareLink",
       "qualifiedName": "MicrosoftOnedrive.CreateShareLink",
-      "fullyQualifiedName": "MicrosoftOnedrive.CreateShareLink@1.0.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.CreateShareLink@1.0.1",
       "description": "Create a share link for a OneDrive item.\n\nSet link_type to EDIT to let recipients change the item; use scope ORGANIZATION to keep\nthe link inside the tenant instead of anyone-with-the-link.",
       "parameters": [
         {
@@ -320,7 +320,7 @@
     {
       "name": "DeleteItem",
       "qualifiedName": "MicrosoftOnedrive.DeleteItem",
-      "fullyQualifiedName": "MicrosoftOnedrive.DeleteItem@1.0.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.DeleteItem@1.0.1",
       "description": "Delete one or more files or folders from OneDrive in a single call.\n\nAn item open for editing elsewhere is reported as locked and retryable rather than\nfailing the whole batch; every requested id is attempted.",
       "parameters": [
         {
@@ -385,7 +385,7 @@
     {
       "name": "DownloadFile",
       "qualifiedName": "MicrosoftOnedrive.DownloadFile",
-      "fullyQualifiedName": "MicrosoftOnedrive.DownloadFile@1.0.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.DownloadFile@1.0.1",
       "description": "Download a OneDrive file's content as base64, paging large files by byte offset.\n\nFiles at or under the per-call cap return fully in one call; for larger files, re-call\nwith offset set to the returned next_offset until is_final is true. A stale or mistyped\nid returns a structured not_found envelope (status \"not_found\", retryable false) rather\nthan a fatal error, so the caller can branch on the field.",
       "parameters": [
         {
@@ -484,7 +484,7 @@
     {
       "name": "FindDuplicateFiles",
       "qualifiedName": "MicrosoftOnedrive.FindDuplicateFiles",
-      "fullyQualifiedName": "MicrosoftOnedrive.FindDuplicateFiles@1.0.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.FindDuplicateFiles@1.0.1",
       "description": "Find files that are byte-identical copies of each other across folders in one call.\n\nGroups examined files by content fingerprint and returns only the fingerprints with two\nor more copies, each group flagging the copy to keep and the rest as deletion candidates,\nso a de-dup cleanup can act without listing and grouping by hash manually.\nThe scan walks the drive directly rather than the search index, so a file copied moments\nago is seen immediately. Supply folder_id to scope the scan to a subtree (much more likely to\nbe complete, though still bounded by limit and an internal walk cap); keywords further\nrestrict to files whose name contains the term.\nWhen truncated is true, truncated_warning explains what was missed and how to refocus.",
       "parameters": [
         {
@@ -583,7 +583,7 @@
     {
       "name": "GetCopyStatus",
       "qualifiedName": "MicrosoftOnedrive.GetCopyStatus",
-      "fullyQualifiedName": "MicrosoftOnedrive.GetCopyStatus@1.0.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.GetCopyStatus@1.0.1",
       "description": "Check status of an async copy operation using the token returned by copy_item.",
       "parameters": [
         {
@@ -643,7 +643,7 @@
     {
       "name": "GetItem",
       "qualifiedName": "MicrosoftOnedrive.GetItem",
-      "fullyQualifiedName": "MicrosoftOnedrive.GetItem@1.0.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.GetItem@1.0.1",
       "description": "Resolve a single OneDrive file or folder's metadata directly from its id.\n\nA stale or mistyped id returns a structured not_found envelope (status \"not_found\",\nretryable false) rather than a fatal error, so the caller can branch on the field.",
       "parameters": [
         {
@@ -703,7 +703,7 @@
     {
       "name": "GetMyDrive",
       "qualifiedName": "MicrosoftOnedrive.GetMyDrive",
-      "fullyQualifiedName": "MicrosoftOnedrive.GetMyDrive@1.0.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.GetMyDrive@1.0.1",
       "description": "Get metadata about the user's OneDrive (id, name, quota, owner).",
       "parameters": [],
       "auth": {
@@ -748,7 +748,7 @@
     {
       "name": "GetSharedWithMe",
       "qualifiedName": "MicrosoftOnedrive.GetSharedWithMe",
-      "fullyQualifiedName": "MicrosoftOnedrive.GetSharedWithMe@1.0.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.GetSharedWithMe@1.0.1",
       "description": "List files shared with the current user.",
       "parameters": [
         {
@@ -821,7 +821,7 @@
     {
       "name": "ListFolderItems",
       "qualifiedName": "MicrosoftOnedrive.ListFolderItems",
-      "fullyQualifiedName": "MicrosoftOnedrive.ListFolderItems@1.0.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.ListFolderItems@1.0.1",
       "description": "List files and folders in a OneDrive folder. Lists root if folder_id is omitted.",
       "parameters": [
         {
@@ -907,7 +907,7 @@
     {
       "name": "ListItemPermissions",
       "qualifiedName": "MicrosoftOnedrive.ListItemPermissions",
-      "fullyQualifiedName": "MicrosoftOnedrive.ListItemPermissions@1.0.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.ListItemPermissions@1.0.1",
       "description": "List who can currently access a OneDrive item: every share link and direct grant on it.\n\nUse this to answer \"who can see this?\" and to find the permission_id needed to revoke a\ngrant. A stale or mistyped id returns a structured not_found envelope (status \"not_found\",\nretryable false) rather than a fatal error, so the caller can branch on the field. When\nhas_more is true, pass next_token back unchanged to fetch the remaining grants.",
       "parameters": [
         {
@@ -980,7 +980,7 @@
     {
       "name": "MoveItem",
       "qualifiedName": "MicrosoftOnedrive.MoveItem",
-      "fullyQualifiedName": "MicrosoftOnedrive.MoveItem@1.0.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.MoveItem@1.0.1",
       "description": "Move and/or rename one or more files or folders in OneDrive in a single call.\n\nProvide new_parent_id to relocate items, new_name (single item only) to rename in place,\nor both. At least one must be supplied. An item open for editing elsewhere is reported as\nlocked and retryable rather than failing the whole batch.",
       "parameters": [
         {
@@ -1070,7 +1070,7 @@
     {
       "name": "RevokeItemPermission",
       "qualifiedName": "MicrosoftOnedrive.RevokeItemPermission",
-      "fullyQualifiedName": "MicrosoftOnedrive.RevokeItemPermission@1.0.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.RevokeItemPermission@1.0.1",
       "description": "Revoke one or all anonymous sharing grants on a OneDrive item.\n\nSingle-grant mode (revoke_all_anonymous=false): removes the grant identified by\npermission_id. An unknown item or permission id returns a structured not_found envelope\nrather than a fatal error. To revoke an inherited grant, target the parent folder instead.\n\nBulk mode (revoke_all_anonymous=true): removes every anonymous (anyone-with-the-link) grant\non the item in one call. revoked_count reports how many were removed; 0 means none existed.",
       "parameters": [
         {
@@ -1156,7 +1156,7 @@
     {
       "name": "SearchItems",
       "qualifiedName": "MicrosoftOnedrive.SearchItems",
-      "fullyQualifiedName": "MicrosoftOnedrive.SearchItems@1.0.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.SearchItems@1.0.1",
       "description": "Search for files and folders in the user's OneDrive.\n\nIt may take a few seconds to minutes for the search index to update with newly created items.",
       "parameters": [
         {
@@ -1242,7 +1242,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftOnedrive.WhoAmI",
-      "fullyQualifiedName": "MicrosoftOnedrive.WhoAmI@1.0.0",
+      "fullyQualifiedName": "MicrosoftOnedrive.WhoAmI@1.0.1",
       "description": "Identify the current user and confirm OneDrive access for orientation.",
       "parameters": [],
       "auth": {
@@ -1288,6 +1288,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-06-29T12:37:18.560Z",
+  "generatedAt": "2026-07-15T11:37:29.801Z",
   "summary": "Microsoft OneDrive toolkit for Arcade provides LLM-ready tools for managing files, folders, permissions, and sharing in a user's OneDrive via Microsoft Graph.\n\n## Capabilities\n\n- **File & folder operations:** Create folders, copy (with async polling to completion), move/rename (single or batch), delete (single or batch), and download files (with byte-offset paging for large files).\n- **Browse & search:** List folder contents, list files shared with the current user, search the drive index, and retrieve metadata for a single item or the drive itself.\n- **Permissions & sharing:** Create share links (view/edit, user/organization scope), list all grants on an item (links and direct grants), and revoke a single grant or all anonymous links in bulk.\n- **Duplicate detection:** Scan a drive or subtree for byte-identical files, grouped by content fingerprint, with deletion candidates flagged — no manual hashing required.\n- **Resilient error handling:** Stale or missing item IDs return structured `not_found` envelopes (with a `retryable` flag) instead of fatal errors; locked items in batch operations are reported individually without aborting the batch.\n- **Identity & orientation:** Confirm the authenticated user's identity and validate OneDrive access before performing operations.\n\n## OAuth\n\nThis toolkit authenticates via OAuth 2.0 using **Microsoft** as the provider. See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for setup details."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftoutlookcalendar.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftoutlookcalendar.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftOutlookCalendar",
   "label": "Microsoft Outlook Calendar",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Arcade.dev LLM tools for Outlook Calendar",
   "metadata": {
     "category": "productivity",
@@ -28,7 +28,7 @@
     {
       "name": "CreateEvent",
       "qualifiedName": "MicrosoftOutlookCalendar.CreateEvent",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.CreateEvent@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.CreateEvent@0.3.2",
       "description": "Create an event in the authenticated user's default calendar.\n\nIgnores timezone offsets provided in the start_date_time and end_date_time parameters.\nInstead, uses the user's default calendar timezone to filter events.\nIf the user has not set a timezone for their calendar, then the timezone will be UTC.",
       "parameters": [
         {
@@ -185,7 +185,7 @@
     {
       "name": "GetEvent",
       "qualifiedName": "MicrosoftOutlookCalendar.GetEvent",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.GetEvent@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.GetEvent@0.3.2",
       "description": "Get an event by its ID from the user's calendar.",
       "parameters": [
         {
@@ -246,7 +246,7 @@
     {
       "name": "ListCalendars",
       "qualifiedName": "MicrosoftOutlookCalendar.ListCalendars",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListCalendars@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListCalendars@0.3.2",
       "description": "List all calendars the user has access to.\n\nReturns the user's own calendars plus any shared or delegated calendars.\nEach calendar includes its ID, name, owner, and permissions.\n\nUse a calendar_id from the results to target a specific calendar\nin other calendar tools.",
       "parameters": [
         {
@@ -319,7 +319,7 @@
     {
       "name": "ListEventAttachments",
       "qualifiedName": "MicrosoftOutlookCalendar.ListEventAttachments",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListEventAttachments@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListEventAttachments@0.3.2",
       "description": "List attachment metadata for a calendar event.\n\nReturns metadata only (name, size, type, etc.). Attachment content is not included.\nUse this tool when the user wants to know what files are attached to a calendar event\nor meeting.\n\nPass a calendar_id to list attachments on events in shared or delegated calendars.",
       "parameters": [
         {
@@ -419,7 +419,7 @@
     {
       "name": "ListEventsInTimeRange",
       "qualifiedName": "MicrosoftOutlookCalendar.ListEventsInTimeRange",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListEventsInTimeRange@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.ListEventsInTimeRange@0.3.2",
       "description": "List events in the user's calendar in a specific time range.\n\nIgnores timezone offsets provided in the start_date_time and end_date_time parameters.\nInstead, uses the user's default calendar timezone to filter events.\nIf the user has not set a timezone for their calendar, then the timezone will be UTC.",
       "parameters": [
         {
@@ -506,7 +506,7 @@
     {
       "name": "SearchEvents",
       "qualifiedName": "MicrosoftOutlookCalendar.SearchEvents",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.SearchEvents@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.SearchEvents@0.3.2",
       "description": "Search calendar events within a time range with optional filters.\n\nResults are in chronological order.\n\nEvent bodies are truncated to 200 characters for efficient skimming.\nUse the event_id from the results to retrieve full event details.",
       "parameters": [
         {
@@ -718,7 +718,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftOutlookCalendar.WhoAmI",
-      "fullyQualifiedName": "MicrosoftOutlookCalendar.WhoAmI@0.3.1",
+      "fullyQualifiedName": "MicrosoftOutlookCalendar.WhoAmI@0.3.2",
       "description": "Get information about the current user and their Outlook Calendar environment.",
       "parameters": [],
       "auth": {
@@ -766,6 +766,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-07-10T12:06:03.049Z",
+  "generatedAt": "2026-07-15T11:37:29.796Z",
   "summary": "## Microsoft Outlook Calendar Toolkit\n\nThe Microsoft Outlook Calendar toolkit lets Arcade-powered LLMs interact with a user's Outlook Calendar via the Microsoft Graph API, enabling calendar reads, writes, and queries on behalf of authenticated users.\n\n## Capabilities\n\n- **Calendar discovery & context:** List all calendars the user owns, shares, or has delegated access to; retrieve current user identity and calendar environment details.\n- **Event creation:** Create events in the user's default calendar; timezone handling defers to the calendar's configured timezone (falls back to UTC if unset).\n- **Event retrieval & listing:** Fetch a specific event by ID, or list all events within a defined time range using the calendar's native timezone.\n- **Search & filtering:** Search events across a time range with optional filters; results are chronologically ordered with body content truncated to 200 characters for efficiency — use the returned event ID to fetch full details.\n- **Attachment inspection:** List attachment metadata (name, size, type) for any calendar event, including events on shared or delegated calendars; attachment content is not returned.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 delegated auth via **Microsoft**. Arcade handles the OAuth flow automatically. See the [Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration details."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftoutlookmail.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftoutlookmail.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftOutlookMail",
   "label": "Microsoft Outlook Mail",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Arcade.dev LLM tools for Outlook Mail",
   "metadata": {
     "category": "productivity",
@@ -31,7 +31,7 @@
     {
       "name": "CreateAndSendEmail",
       "qualifiedName": "MicrosoftOutlookMail.CreateAndSendEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.CreateAndSendEmail@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.CreateAndSendEmail@0.5.1",
       "description": "Create and immediately send a new email in Outlook to the specified recipients.\n\nReturns the sent message's ``message_id`` and ``conversation_id`` so callers\ncan immediately chain follow-ups (e.g. reply to what they just sent) without\nhaving to search Sent Items.",
       "parameters": [
         {
@@ -170,7 +170,7 @@
     {
       "name": "CreateDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.CreateDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.CreateDraftEmail@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.CreateDraftEmail@0.5.1",
       "description": "Compose a new draft email in Outlook",
       "parameters": [
         {
@@ -309,7 +309,7 @@
     {
       "name": "CreateDraftReply",
       "qualifiedName": "MicrosoftOutlookMail.CreateDraftReply",
-      "fullyQualifiedName": "MicrosoftOutlookMail.CreateDraftReply@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.CreateDraftReply@0.5.1",
       "description": "Create a reply or reply-all draft for an existing Outlook email without sending it.\n\nThe draft is threaded to the original message and saved to the Drafts folder,\nso it can be reviewed, edited, and sent later. For a reply-all, the original\nrecipients (excluding the mailbox owner) are populated automatically. This\ntool never sends the email.",
       "parameters": [
         {
@@ -399,7 +399,7 @@
     {
       "name": "GetEmail",
       "qualifiedName": "MicrosoftOutlookMail.GetEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.GetEmail@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.GetEmail@0.5.1",
       "description": "Retrieve a single email message by its ID.\n\nReturns email metadata and body content. By default, the body is returned\nas plain text (HTML tags stripped) and capped at 5000 characters. Set\nbody_format to HTML to get the original markup. Use body_offset to\ncontinue reading long emails, or set max_body_characters to None for the\nfull body.\n\nUse this tool to read the full content of an email after finding it via\nsearch_emails or any listing tool.",
       "parameters": [
         {
@@ -502,7 +502,7 @@
     {
       "name": "ListEmailAttachments",
       "qualifiedName": "MicrosoftOutlookMail.ListEmailAttachments",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailAttachments@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailAttachments@0.5.1",
       "description": "List attachment metadata for an email message.\n\nReturns metadata only (name, size, type, etc.). Attachment content is not included.\nUse this tool when the user wants to know what files are attached to an email.",
       "parameters": [
         {
@@ -589,7 +589,7 @@
     {
       "name": "ListEmails",
       "qualifiedName": "MicrosoftOutlookMail.ListEmails",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmails@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmails@0.5.1",
       "description": "List emails in the user's mailbox across all folders.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).\n\nSince this tool lists email across all folders, it may return sent items,\ndrafts, and other items that are not in the inbox.",
       "parameters": [
         {
@@ -697,7 +697,7 @@
     {
       "name": "ListEmailsByProperty",
       "qualifiedName": "MicrosoftOutlookMail.ListEmailsByProperty",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsByProperty@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsByProperty@0.5.1",
       "description": "List emails in the user's mailbox across all folders filtering by a property.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).\n\nSorting by RECEIVED_DATE_TIME works with any filter property. Sorting by\na different property (SUBJECT, SENDER, IMPORTANCE) while filtering by an\nunrelated property may fail due to a Microsoft Graph API restriction. If\nthis happens, either sort by RECEIVED_DATE_TIME, or use list_emails (no\nfilter) with the desired sort_by.",
       "parameters": [
         {
@@ -863,7 +863,7 @@
     {
       "name": "ListEmailsInFolder",
       "qualifiedName": "MicrosoftOutlookMail.ListEmailsInFolder",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsInFolder@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListEmailsInFolder@0.5.1",
       "description": "List the user's emails in the specified folder.\n\nExactly one of `well_known_folder_name` or `folder_id` MUST be provided.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
       "parameters": [
         {
@@ -1005,7 +1005,7 @@
     {
       "name": "ListMailFolders",
       "qualifiedName": "MicrosoftOutlookMail.ListMailFolders",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ListMailFolders@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ListMailFolders@0.5.1",
       "description": "List mail folders in the user's mailbox.\n\nReturns folder names, IDs, unread counts, and total item counts.\nUse the folder ID in follow-up calls to list_emails_in_folder.\nOmit parent_folder_id to list top-level folders, or provide a folder ID\nto list its child folders.",
       "parameters": [
         {
@@ -1104,7 +1104,7 @@
     {
       "name": "MoveEmailToFolder",
       "qualifiedName": "MicrosoftOutlookMail.MoveEmailToFolder",
-      "fullyQualifiedName": "MicrosoftOutlookMail.MoveEmailToFolder@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.MoveEmailToFolder@0.5.1",
       "description": "Move an email message to a different folder in Outlook.\n\nExactly one of `destination_well_known_folder_name` or\n`destination_folder_id` MUST be provided. Use `list_mail_folders` to\ndiscover custom folder IDs.",
       "parameters": [
         {
@@ -1199,7 +1199,7 @@
     {
       "name": "ReplyToEmail",
       "qualifiedName": "MicrosoftOutlookMail.ReplyToEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.ReplyToEmail@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.ReplyToEmail@0.5.1",
       "description": "Reply to an existing email in Outlook.\n\nUse this tool to reply to the sender or all recipients of the email.\nSpecify the reply_type to determine the scope of the reply.",
       "parameters": [
         {
@@ -1289,7 +1289,7 @@
     {
       "name": "SearchEmails",
       "qualifiedName": "MicrosoftOutlookMail.SearchEmails",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SearchEmails@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SearchEmails@0.5.1",
       "description": "Search emails across the user's entire mailbox.\n\nCombines full-text keyword search with structured filters for sender,\nread status, attachments, importance, and more. All provided parameters\nare combined with AND. Results are ordered by date sent (most recent first).\n\nEmail bodies are truncated to 255 characters for efficient skimming.\nUse get_email with the message_id to retrieve the full email content.\n\nUse this tool when the user wants to find emails by content, topic, sender,\nor a combination of criteria. For exact property filtering (e.g., by\nconversationId or flag status), use list_emails_by_property instead.\n\n.. note::\n   Microsoft Graph's ``$search`` on messages is backed by the Microsoft\n   Search index, which returns message IDs in the legacy REST-ID format\n   even when the client opts into Immutable IDs (which other tools in\n   this toolkit do by default). Do not directly compare a ``message_id``\n   from ``search_emails`` against one from ``list_emails`` /\n   ``get_email`` — the ID shapes differ. To chain from a search hit,\n   pass the returned ID straight back into ``get_email`` (which accepts\n   either format), and use ``conversation_id`` as the deduplication\n   key across result sets.",
       "parameters": [
         {
@@ -1513,7 +1513,7 @@
     {
       "name": "SendDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.SendDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SendDraftEmail@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SendDraftEmail@0.5.1",
       "description": "Send an existing draft email in Outlook.\n\nSends any un-sent message — draft, reply-draft, reply-all draft, or\nforward draft — and returns the message's ``message_id`` and\n``conversation_id`` so callers can chain follow-ups (e.g. reply to\nthe message they just sent) without searching Sent Items.",
       "parameters": [
         {
@@ -1574,7 +1574,7 @@
     {
       "name": "SharedMailboxCheckCapabilities",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxCheckCapabilities",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCheckCapabilities@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCheckCapabilities@0.5.1",
       "description": "Check which provided mailboxes are reachable via shared mailbox APIs.\n\nThis is a capability checker, not an Exchange permission inventory. It\nverifies whether each provided mailbox can be reached through a cheap,\nread-only Graph call. When checking multiple mailboxes, pass them together\nin one ``owner_emails`` list so results can be deduplicated and rate-limited\nconsistently. Microsoft Graph does not expose exact ``Send As`` vs ``Send\non behalf`` permissions, so the response names that limitation explicitly\ninstead of guessing.",
       "parameters": [
         {
@@ -1639,7 +1639,7 @@
     {
       "name": "SharedMailboxCreateAndSendEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateAndSendEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateAndSendEmail@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateAndSendEmail@0.5.1",
       "description": "Create and immediately send an email from a shared or delegated mailbox.\n\nUse this when the user wants the email to be sent from a team inbox (like\nsales@ or support@) or from an executive's mailbox they have been\ndelegated access to, rather than from their own address.",
       "parameters": [
         {
@@ -1791,7 +1791,7 @@
     {
       "name": "SharedMailboxCreateDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateDraftEmail@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateDraftEmail@0.5.1",
       "description": "Compose a new draft email in a shared or delegated mailbox.",
       "parameters": [
         {
@@ -1943,7 +1943,7 @@
     {
       "name": "SharedMailboxCreateDraftReply",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateDraftReply",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateDraftReply@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxCreateDraftReply@0.5.1",
       "description": "Create a reply or reply-all draft in a shared or delegated mailbox without sending it.\n\nThe draft is threaded to the original message and saved to the mailbox's\nDrafts folder, so it can be reviewed, edited, and sent later. For a\nreply-all, the original recipients (excluding the mailbox owner) are\npopulated automatically. This tool never sends the email.",
       "parameters": [
         {
@@ -2046,7 +2046,7 @@
     {
       "name": "SharedMailboxGetEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxGetEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxGetEmail@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxGetEmail@0.5.1",
       "description": "Retrieve a single email from a shared or delegated mailbox by message ID.\n\nReturns email metadata and body content. By default, the body is returned\nas plain text (HTML tags stripped) and capped at 5000 characters. Use\nbody_offset to continue reading long emails, or set max_body_characters\nto None for the full body.",
       "parameters": [
         {
@@ -2162,7 +2162,7 @@
     {
       "name": "SharedMailboxListEmailAttachments",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailAttachments",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailAttachments@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailAttachments@0.5.1",
       "description": "List attachment metadata for an email in a shared or delegated mailbox.",
       "parameters": [
         {
@@ -2262,7 +2262,7 @@
     {
       "name": "SharedMailboxListEmails",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmails",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmails@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmails@0.5.1",
       "description": "List emails in a shared or delegated mailbox, across all folders.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
       "parameters": [
         {
@@ -2383,7 +2383,7 @@
     {
       "name": "SharedMailboxListEmailsByProperty",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsByProperty",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsByProperty@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsByProperty@0.5.1",
       "description": "List emails in a shared or delegated mailbox filtered by a property.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
       "parameters": [
         {
@@ -2562,7 +2562,7 @@
     {
       "name": "SharedMailboxListEmailsInFolder",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsInFolder",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsInFolder@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListEmailsInFolder@0.5.1",
       "description": "List emails in a specific folder of a shared or delegated mailbox.\n\nExactly one of `well_known_folder_name` or `folder_id` MUST be provided.\n\nResults are sorted by sort_by in the sort_order direction.\nDefaults to newest first (receivedDateTime descending).",
       "parameters": [
         {
@@ -2717,7 +2717,7 @@
     {
       "name": "SharedMailboxListMailFolders",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxListMailFolders",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListMailFolders@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxListMailFolders@0.5.1",
       "description": "List mail folders in a shared or delegated mailbox.\n\nReturns folder names, IDs, unread counts, and total item counts.\nUse the folder ID when listing emails in a specific folder.",
       "parameters": [
         {
@@ -2829,7 +2829,7 @@
     {
       "name": "SharedMailboxMoveEmailToFolder",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxMoveEmailToFolder",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxMoveEmailToFolder@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxMoveEmailToFolder@0.5.1",
       "description": "Move an email message to a different folder in a shared or delegated mailbox.\n\nExactly one of `destination_well_known_folder_name` or\n`destination_folder_id` MUST be provided. Use\n`shared_mailbox_list_mail_folders` (with the same `owner_email`) to\ndiscover custom folder IDs; folder IDs are specific to the target\nmailbox.",
       "parameters": [
         {
@@ -2937,7 +2937,7 @@
     {
       "name": "SharedMailboxReplyToEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxReplyToEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxReplyToEmail@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxReplyToEmail@0.5.1",
       "description": "Reply to an email in a shared or delegated mailbox.\n\nThe reply is sent from the shared mailbox address, not the signed-in\nuser's personal address. Specify reply_type to reply only to the sender\nor to all recipients.",
       "parameters": [
         {
@@ -3040,7 +3040,7 @@
     {
       "name": "SharedMailboxSearchEmails",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxSearchEmails",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxSearchEmails@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxSearchEmails@0.5.1",
       "description": "Search emails in a shared or delegated mailbox.\n\nCombines full-text keyword search with structured filters for sender,\nread status, attachments, importance, and more. All provided parameters\nare combined with AND. Results are ordered by date sent (most recent first).\n\nEmail bodies are truncated to 255 characters. Retrieve a message by its\nmessage ID when the full content is needed.\n\n.. note::\n   Search results may use a different Graph ID shape than list/get\n   results. Use returned message IDs directly for message retrieval and\n   ``conversation_id`` for deduplication across result sets.",
       "parameters": [
         {
@@ -3276,7 +3276,7 @@
     {
       "name": "SharedMailboxSendDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxSendDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxSendDraftEmail@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxSendDraftEmail@0.5.1",
       "description": "Send an existing draft email from a shared or delegated mailbox.\n\nThis tool can send any un-sent email in the shared mailbox:\n    - draft\n    - reply-draft\n    - reply-all draft\n    - forward draft\n\nReturns the message's ``message_id`` and ``conversation_id`` so callers\ncan chain follow-ups (e.g. reply to the message they just sent) without\nsearching Sent Items.",
       "parameters": [
         {
@@ -3350,7 +3350,7 @@
     {
       "name": "SharedMailboxUpdateDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.SharedMailboxUpdateDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxUpdateDraftEmail@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.SharedMailboxUpdateDraftEmail@0.5.1",
       "description": "Update an existing draft email in a shared or delegated mailbox.\n\nOverwrites the subject and body of a draft (if provided) and modifies its\nrecipient lists by selectively adding or removing email addresses.",
       "parameters": [
         {
@@ -3547,7 +3547,7 @@
     {
       "name": "UpdateDraftEmail",
       "qualifiedName": "MicrosoftOutlookMail.UpdateDraftEmail",
-      "fullyQualifiedName": "MicrosoftOutlookMail.UpdateDraftEmail@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.UpdateDraftEmail@0.5.1",
       "description": "Update an existing draft email in Outlook.\n\nThis tool overwrites the subject and body of a draft email (if provided),\nand modifies its recipient lists by selectively adding or removing email addresses.\n\nThis tool can update any un-sent email:\n    - draft\n    - reply-draft\n    - reply-all draft\n    - forward draft",
       "parameters": [
         {
@@ -3731,7 +3731,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftOutlookMail.WhoAmI",
-      "fullyQualifiedName": "MicrosoftOutlookMail.WhoAmI@0.5.0",
+      "fullyQualifiedName": "MicrosoftOutlookMail.WhoAmI@0.5.1",
       "description": "Get comprehensive user profile and Outlook Mail environment information.\n\nThis tool provides detailed information about the authenticated user including\ntheir name, email, mailbox settings, automatic replies configuration, and other\nimportant profile details from Outlook Mail services.",
       "parameters": [],
       "auth": {
@@ -3778,6 +3778,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-07-10T12:06:05.994Z",
+  "generatedAt": "2026-07-15T11:37:29.801Z",
   "summary": "The **Microsoft Outlook Mail** toolkit connects Arcade to the Microsoft Graph Mail API, enabling LLMs to read, compose, send, search, and organize emails in both personal and shared/delegated Outlook mailboxes.\n\n## Capabilities\n\n- **Compose & send** — Create and immediately send emails, compose drafts (new, reply, or reply-all), update draft recipients/subject/body, and send any existing draft; returns `message_id` and `conversation_id` for immediate chaining.\n- **Read & retrieve** — Fetch a single email by ID with configurable body format (plain text or HTML), body length cap, and offset for long messages; list attachment metadata for any message.\n- **List & filter** — Browse emails across all folders or a specific folder, filter by structured properties (sender, flag, conversation ID, importance, read status), and sort by received date, subject, sender, or importance.\n- **Search** — Full-text keyword search combined with structured filters across the entire mailbox; results include 255-character body previews with `get_email` used to retrieve full content.\n- **Folder management** — List top-level and child mail folders (with unread/total counts), move messages between folders using well-known folder names or folder IDs.\n- **Shared & delegated mailboxes** — Full parallel surface (compose, send, draft, reply, search, list, move, folder management, capability check) for team inboxes and delegated executive mailboxes, sending from the shared address rather than the authenticated user's address.\n\n## OAuth\n\nAuthentication uses **Microsoft** OAuth 2.0. See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for setup details, required permissions, and configuration."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftpowerbi.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftpowerbi.json
@@ -1,0 +1,1260 @@
+{
+  "id": "MicrosoftPowerbi",
+  "label": "Microsoft Power BI",
+  "version": "0.3.0",
+  "description": "Arcade MCP toolkit for Microsoft Power BI",
+  "metadata": {
+    "category": "productivity",
+    "iconUrl": "https://design-system.arcade.dev/icons/microsoft-power-bi.svg",
+    "isBYOC": false,
+    "isPro": false,
+    "type": "arcade",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/productivity/microsoft-power-bi",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": {
+    "type": "oauth2",
+    "providerId": "microsoft-powerbi",
+    "allScopes": [
+      "https://analysis.windows.net/powerbi/api/Dataset.Read.All",
+      "https://analysis.windows.net/powerbi/api/Dataset.ReadWrite.All",
+      "https://analysis.windows.net/powerbi/api/Report.Read.All",
+      "https://analysis.windows.net/powerbi/api/Workspace.Read.All"
+    ]
+  },
+  "tools": [
+    {
+      "name": "DatasetGatewayHealth",
+      "qualifiedName": "MicrosoftPowerbi.DatasetGatewayHealth",
+      "fullyQualifiedName": "MicrosoftPowerbi.DatasetGatewayHealth@0.3.0",
+      "description": "Report whether each of a dataset's gateway-bound data sources is currently\nreachable.\n\nPoint this at a dataset whose refresh failed to tell whether the gateway path is\nhealthy before escalating. Stored credentials are never returned.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": true,
+          "description": "The workspace id (or a pasted app.powerbi.com link) of the dataset to check.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "dataset_id",
+          "type": "string",
+          "required": true,
+          "description": "A dataset id (or pasted link) whose gateway-bound data sources should be probed for connectivity.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft-powerbi",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://analysis.windows.net/powerbi/api/Dataset.ReadWrite.All"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The connectivity status of the dataset's gateway-bound data sources."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftPowerbi.DatasetGatewayHealth",
+        "parameters": {
+          "workspace_id": {
+            "value": "f4b8c2d1-3e7a-4f09-bc12-9a6d5e081234",
+            "type": "string",
+            "required": true
+          },
+          "dataset_id": {
+            "value": "a1d3f592-7b4e-4c08-ae21-3f6b8d902e47",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft-powerbi",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "business_intelligence"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetDatasetRefreshHistory",
+      "qualifiedName": "MicrosoftPowerbi.GetDatasetRefreshHistory",
+      "fullyQualifiedName": "MicrosoftPowerbi.GetDatasetRefreshHistory@0.3.0",
+      "description": "Get the most recent refresh runs of a semantic model, with status and timing.\n\nReturns each run newest first with its status, type, start/end time, and any error.\nPower BI reports a run's status as 'Unknown' while it is still in progress or its\noutcome is not yet known, so each run also carries `is_terminal`: false while the run\nis still running (status 'Unknown'), true once it has settled ('Completed', 'Failed',\nor 'Disabled'). Re-poll this tool while the newest run is not terminal to obtain its\nfinal status.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": true,
+          "description": "The workspace id containing the semantic model.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "dataset_id",
+          "type": "string",
+          "required": true,
+          "description": "The semantic model (dataset) id.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "How many recent refresh runs to return (default 20, max 50).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft-powerbi",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://analysis.windows.net/powerbi/api/Dataset.Read.All"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Recent refresh runs for the semantic model."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftPowerbi.GetDatasetRefreshHistory",
+        "parameters": {
+          "workspace_id": {
+            "value": "3d9b93c6-7b6d-4801-a491-1738910904fd",
+            "type": "string",
+            "required": true
+          },
+          "dataset_id": {
+            "value": "cfafbeb1-8037-4d0c-896e-a46fb27ff229",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 10,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft-powerbi",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "business_intelligence"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetReport",
+      "qualifiedName": "MicrosoftPowerbi.GetReport",
+      "fullyQualifiedName": "MicrosoftPowerbi.GetReport@0.3.0",
+      "description": "Get a single Power BI report's detail, including the semantic model (dataset) it is built on.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": true,
+          "description": "The workspace (group) id containing the report.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "report_id",
+          "type": "string",
+          "required": true,
+          "description": "The report id to read.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft-powerbi",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://analysis.windows.net/powerbi/api/Report.Read.All"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The report's detail, including its dataset id and embed URL."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftPowerbi.GetReport",
+        "parameters": {
+          "workspace_id": {
+            "value": "3d9b93c6-7b6d-4801-a491-1738910904fd",
+            "type": "string",
+            "required": true
+          },
+          "report_id": {
+            "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft-powerbi",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "business_intelligence"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetSchema",
+      "qualifiedName": "MicrosoftPowerbi.GetSchema",
+      "fullyQualifiedName": "MicrosoftPowerbi.GetSchema@0.3.0",
+      "description": "Get the full structure of a Power BI semantic model.\n\nReturns each table with its columns and measures and the relationships between tables,\nso a caller can compose valid DAX that references real table and column names. Each\nmeasure carries its DAX expression when the model exposes it; a read-only caller may\nnot receive measure formulas, in which case expression_available is false.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": true,
+          "description": "The workspace id containing the semantic model.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "dataset_id",
+          "type": "string",
+          "required": true,
+          "description": "The semantic model (dataset) id to inspect.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft-powerbi",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://analysis.windows.net/powerbi/api/Dataset.Read.All"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The model's tables, columns, measures, and relationships."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftPowerbi.GetSchema",
+        "parameters": {
+          "workspace_id": {
+            "value": "a3f1b2c4-d5e6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": true
+          },
+          "dataset_id": {
+            "value": "b7e2d3f5-a1c4-4e8b-9f0d-123456789abc",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft-powerbi",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "business_intelligence"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "InspectDataset",
+      "qualifiedName": "MicrosoftPowerbi.InspectDataset",
+      "fullyQualifiedName": "MicrosoftPowerbi.InspectDataset@0.3.0",
+      "description": "Inspect one dataset in a single call: where it pulls data from, what parameters\ndrive it, when it refreshes, and its core detail (owner, storage mode, refreshable).\n\nUse this to diagnose a dataset that \"looks wrong\" without three separate calls.\nStored credentials are never returned for any data source.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": true,
+          "description": "The workspace id (or a pasted app.powerbi.com link) containing the dataset.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "dataset_id",
+          "type": "string",
+          "required": true,
+          "description": "The dataset (semantic model) id, or a pasted app.powerbi.com link to it.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft-powerbi",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://analysis.windows.net/powerbi/api/Dataset.Read.All"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The dataset's core detail, data sources, parameters, and schedule."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftPowerbi.InspectDataset",
+        "parameters": {
+          "workspace_id": {
+            "value": "f4b8c2d1-3a7e-4f92-b6d5-8e1c0a9f2b34",
+            "type": "string",
+            "required": true
+          },
+          "dataset_id": {
+            "value": "a1d3e5f7-2c4b-4890-9e6d-7b0f1a2c3d45",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft-powerbi",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "business_intelligence"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListDatasets",
+      "qualifiedName": "MicrosoftPowerbi.ListDatasets",
+      "fullyQualifiedName": "MicrosoftPowerbi.ListDatasets@0.3.0",
+      "description": "List the Power BI semantic models (datasets) in a workspace.\n\nResults are paginated: when next_cursor is non-empty, pass it back verbatim to fetch\nthe next page.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": true,
+          "description": "The workspace (group) id to list datasets in.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum datasets to return (default 20, max 50).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Opaque pagination token from a prior call's next_cursor; omit for the first page.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft-powerbi",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://analysis.windows.net/powerbi/api/Dataset.Read.All"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The Power BI semantic models (datasets) in the workspace."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftPowerbi.ListDatasets",
+        "parameters": {
+          "workspace_id": {
+            "value": "f089354e-8366-4e18-aea3-4cb4a3a50b48",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "cursor": {
+            "value": "eyJza2lwIjoyNSwidG9rZW4iOiJhYmNkZWYxMjM0NTY3ODkwIn0=",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft-powerbi",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "business_intelligence"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListGateways",
+      "qualifiedName": "MicrosoftPowerbi.ListGateways",
+      "fullyQualifiedName": "MicrosoftPowerbi.ListGateways@0.3.0",
+      "description": "List the data gateways the caller administers, with the id needed to reference\neach one.",
+      "parameters": [],
+      "auth": {
+        "providerId": "microsoft-powerbi",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://analysis.windows.net/powerbi/api/Dataset.Read.All"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The data gateways the caller administers."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftPowerbi.ListGateways",
+        "parameters": {},
+        "requiresAuth": true,
+        "authProvider": "microsoft-powerbi",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "business_intelligence"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListReports",
+      "qualifiedName": "MicrosoftPowerbi.ListReports",
+      "fullyQualifiedName": "MicrosoftPowerbi.ListReports@0.3.0",
+      "description": "List the Power BI reports in a workspace, each with the semantic model (dataset) it is built on.\n\nResults are paginated: when next_cursor is non-empty, pass it back verbatim to fetch\nthe next page.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": true,
+          "description": "The workspace (group) id to list reports in.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum reports to return (default 20, max 50).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Opaque pagination token from a prior call's next_cursor; omit for the first page.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft-powerbi",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://analysis.windows.net/powerbi/api/Report.Read.All"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The Power BI reports in the workspace, each with its dataset id."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftPowerbi.ListReports",
+        "parameters": {
+          "workspace_id": {
+            "value": "3d9b93c6-7b6d-4801-a491-1738910904fd",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "cursor": {
+            "value": "eyJza2lwIjoyNSwidG9rZW4iOiJhYmNkZWYxMjM0NTYifQ==",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft-powerbi",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "business_intelligence"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListWorkspaceMembers",
+      "qualifiedName": "MicrosoftPowerbi.ListWorkspaceMembers",
+      "fullyQualifiedName": "MicrosoftPowerbi.ListWorkspaceMembers@0.3.0",
+      "description": "List who can access a workspace and the role each principal holds, for an\naccess review.\n\nA single call returns one consistent snapshot of the page it serves, in a stable\nsorted order (by principal identifier) so pages are deterministic. The default limit\nis the maximum (50), so a definitive access review should fit in one page; when\nnext_cursor is non-empty the listing was truncated and multi-page reads are best-effort\n(membership changes between pages can skip or duplicate principals) -- the warning field\nflags this. Only what the Power BI portal itself shows for a member is returned; no\nsecrets.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": true,
+          "description": "The workspace id, or a pasted app.powerbi.com link to the workspace.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum members to return (default 50, max 50). The default is the maximum so a typical access review fits in one page.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Opaque pagination token from a prior call's next_cursor; omit for the first page.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft-powerbi",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://analysis.windows.net/powerbi/api/Workspace.Read.All"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The workspace's members and the role each holds."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftPowerbi.ListWorkspaceMembers",
+        "parameters": {
+          "workspace_id": {
+            "value": "3d9b93c6-7b6d-4801-a491-1738910904fd",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "cursor": {
+            "value": "eyJza2lwIjoyNX0=",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft-powerbi",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "business_intelligence"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListWorkspaces",
+      "qualifiedName": "MicrosoftPowerbi.ListWorkspaces",
+      "fullyQualifiedName": "MicrosoftPowerbi.ListWorkspaces@0.3.0",
+      "description": "List the Power BI workspaces (groups) the calling user can access.\n\nReturns each workspace's id and name. Results are paginated: when next_cursor is\nnon-empty, pass it back verbatim to fetch the next page.",
+      "parameters": [
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum workspaces to return (default 20, max 50).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Opaque pagination token from a prior call's next_cursor; omit for the first page.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft-powerbi",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://analysis.windows.net/powerbi/api/Workspace.Read.All"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The Power BI workspaces the calling user can access."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftPowerbi.ListWorkspaces",
+        "parameters": {
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "cursor": {
+            "value": "eyJza2lwIjoyMCwidG9rZW4iOiJhYmMxMjMifQ==",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft-powerbi",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "business_intelligence"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "RunDax",
+      "qualifiedName": "MicrosoftPowerbi.RunDax",
+      "fullyQualifiedName": "MicrosoftPowerbi.RunDax@0.3.0",
+      "description": "Run a DAX query against a semantic model and return the rows as structured data.\n\nThe query must be a DAX EVALUATE statement, for example:\n  EVALUATE TOPN(100, 'Sales')\n  EVALUATE SUMMARIZECOLUMNS('Date'[Year], \"Revenue\", SUM('Sales'[Amount]))\n  EVALUATE FILTER('Product', 'Product'[Category] = \"Bikes\")\nResults are capped at max_rows and a size budget; when capped, truncated is true,\nso narrow the query rather than assume the rows are complete. columns lists the full\nprojection the query returned even when a wide row is size-trimmed, so a column may\nappear in columns without a matching key in every returned row. Invalid DAX is\nreported as a clear error.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": true,
+          "description": "The workspace id containing the semantic model.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "dataset_id",
+          "type": "string",
+          "required": true,
+          "description": "The semantic model (dataset) id to query.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "dax_query",
+          "type": "string",
+          "required": true,
+          "description": "A DAX query beginning with EVALUATE.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "max_rows",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum rows to return (default 100, capped at 100).",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft-powerbi",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://analysis.windows.net/powerbi/api/Dataset.Read.All"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The query's rows, with truncation flagged."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftPowerbi.RunDax",
+        "parameters": {
+          "workspace_id": {
+            "value": "a3f1d2e4-7b89-4c23-9d56-1e2f3a4b5c6d",
+            "type": "string",
+            "required": true
+          },
+          "dataset_id": {
+            "value": "b7c8e9f0-1a2b-3c4d-5e6f-7a8b9c0d1e2f",
+            "type": "string",
+            "required": true
+          },
+          "dax_query": {
+            "value": "EVALUATE SUMMARIZECOLUMNS('Date'[Year], 'Product'[Category], \"TotalRevenue\", SUM('Sales'[Amount]), \"UnitsSold\", SUM('Sales'[Quantity]))",
+            "type": "string",
+            "required": true
+          },
+          "max_rows": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft-powerbi",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "business_intelligence"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "TriggerDatasetRefresh",
+      "qualifiedName": "MicrosoftPowerbi.TriggerDatasetRefresh",
+      "fullyQualifiedName": "MicrosoftPowerbi.TriggerDatasetRefresh@0.3.0",
+      "description": "Start an on-demand refresh of a semantic model.\n\nA refresh can take a long time (minutes or more for a large model), so this\nreturns as soon as the refresh is accepted rather than waiting for it to finish.\nThe run's progress and final success or failure are recorded in the model's\nrefresh history.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": true,
+          "description": "The workspace id containing the semantic model.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "dataset_id",
+          "type": "string",
+          "required": true,
+          "description": "The semantic model (dataset) id to refresh.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft-powerbi",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://analysis.windows.net/powerbi/api/Dataset.ReadWrite.All"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The accepted refresh job handle."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftPowerbi.TriggerDatasetRefresh",
+        "parameters": {
+          "workspace_id": {
+            "value": "3d9b93c6-7b6d-4801-a491-1738910904fd",
+            "type": "string",
+            "required": true
+          },
+          "dataset_id": {
+            "value": "cfafbeb1-8037-4d0c-896e-a46fb27ff229",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft-powerbi",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "business_intelligence"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "UpdateDatasetSettings",
+      "qualifiedName": "MicrosoftPowerbi.UpdateDatasetSettings",
+      "fullyQualifiedName": "MicrosoftPowerbi.UpdateDatasetSettings@0.3.0",
+      "description": "Repoint a dataset's parameters and/or change its refresh timing in one request.\n\nUpsert/patch semantics: only the fields supplied are applied; everything else is\nleft untouched. Setting a parameter the dataset does not define is refused with the\nlist of parameter names it actually exposes, rather than reported as a false success.\nPower BI ignores day/time edits while scheduled refresh is disabled, so set\nrefresh_enabled=true in the same call when you want new times to take effect.\nEach applied parameter is returned with the previous_value observed just before the\nwrite, so the change is auditable and the prior value can be restored. A committed\nparameter change only updates the model definition -- run trigger_dataset_refresh\nafterwards so query and report results reflect the new values.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": true,
+          "description": "The workspace id (or a pasted app.powerbi.com link) containing the dataset.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "dataset_id",
+          "type": "string",
+          "required": true,
+          "description": "The dataset (semantic model) id, or a pasted app.powerbi.com link to it.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "parameters",
+          "type": "array",
+          "innerType": "json",
+          "required": false,
+          "description": "Parameter values to set. Only the listed parameters change; the rest are left untouched. Omit to change no parameters.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "refresh_days",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Days the refresh runs on. Provide to replace the scheduled days; omit to leave the days unchanged.",
+          "enum": [
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Saturday",
+            "Sunday"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "refresh_times",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Times the refresh runs at, each as HH:MM on the hour or half-hour (e.g. 08:00, 08:30). Provide to replace the scheduled times; omit to leave them unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "refresh_enabled",
+          "type": "boolean",
+          "required": false,
+          "description": "Whether scheduled refresh is on. Provide to toggle it; omit to leave it unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "refresh_local_time_zone_id",
+          "type": "string",
+          "required": false,
+          "description": "The schedule's time zone id (e.g. 'UTC', 'Pacific Standard Time'). Provide to change it; omit to leave it unchanged.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft-powerbi",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://analysis.windows.net/powerbi/api/Dataset.ReadWrite.All"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Which parameters were set and whether the schedule changed."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftPowerbi.UpdateDatasetSettings",
+        "parameters": {
+          "workspace_id": {
+            "value": "d4e5f6a7-b8c9-4d0e-a1f2-3b4c5d6e7f8a",
+            "type": "string",
+            "required": true
+          },
+          "dataset_id": {
+            "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": true
+          },
+          "parameters": {
+            "value": [
+              {
+                "name": "ServerName",
+                "newValue": "prod-sql-server.database.windows.net"
+              },
+              {
+                "name": "DatabaseName",
+                "newValue": "SalesDataWarehouse"
+              },
+              {
+                "name": "SchemaName",
+                "newValue": "dbo"
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
+          "refresh_days": {
+            "value": [
+              "Monday",
+              "Wednesday",
+              "Friday"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "refresh_times": {
+            "value": [
+              "06:00",
+              "12:00",
+              "18:30"
+            ],
+            "type": "array",
+            "required": false
+          },
+          "refresh_enabled": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          },
+          "refresh_local_time_zone_id": {
+            "value": "Eastern Standard Time",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft-powerbi",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "business_intelligence"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ValidateDax",
+      "qualifiedName": "MicrosoftPowerbi.ValidateDax",
+      "fullyQualifiedName": "MicrosoftPowerbi.ValidateDax@0.3.0",
+      "description": "Check whether a DAX query is valid for a semantic model without returning its rows.\n\nReturns valid=true when the query is accepted, or valid=false with a short error\nwhen it is not. Transient, auth, and server errors are raised (not reported as\ninvalid) so the caller retries rather than rewriting valid DAX.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": true,
+          "description": "The workspace id containing the semantic model.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "dataset_id",
+          "type": "string",
+          "required": true,
+          "description": "The semantic model (dataset) id to validate against.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "dax_query",
+          "type": "string",
+          "required": true,
+          "description": "The DAX query to validate, beginning with EVALUATE.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": {
+        "providerId": "microsoft-powerbi",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://analysis.windows.net/powerbi/api/Dataset.Read.All"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "Whether the DAX is valid, with any errors found."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftPowerbi.ValidateDax",
+        "parameters": {
+          "workspace_id": {
+            "value": "d4e5f6a7-b8c9-4d2e-a1f3-789012345678",
+            "type": "string",
+            "required": true
+          },
+          "dataset_id": {
+            "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": true
+          },
+          "dax_query": {
+            "value": "EVALUATE SUMMARIZECOLUMNS(Sales[Region], \"Total Sales\", SUM(Sales[Amount]))",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": true,
+        "authProvider": "microsoft-powerbi",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "business_intelligence"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "WhoAmI",
+      "qualifiedName": "MicrosoftPowerbi.WhoAmI",
+      "fullyQualifiedName": "MicrosoftPowerbi.WhoAmI@0.3.0",
+      "description": "Report the Microsoft account the toolkit is acting as: id, name, UPN, and tenant.\n\nUse this to confirm which user the current connection authenticates as before\nreading or changing anything. Identity is read from the signed-in user's own Power\nBI access token (Power BI has no current-user endpoint); it is for display and\nconfirmation only, not an authorization decision, and the fields are best-effort.\nBecause identity is derived from the token's claims, it is unavailable when Microsoft\nissues an opaque or encrypted (non-JWT) access token -- Microsoft is rolling out\nencrypted access tokens for Microsoft-owned APIs -- in which case this tool fails with\na clear error while every other Power BI tool keeps working.",
+      "parameters": [],
+      "auth": {
+        "providerId": "microsoft-powerbi",
+        "providerType": "oauth2",
+        "scopes": [
+          "https://analysis.windows.net/powerbi/api/Workspace.Read.All"
+        ]
+      },
+      "secrets": [],
+      "secretsInfo": [],
+      "output": {
+        "type": "json",
+        "description": "The signed-in Microsoft user's identity."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "MicrosoftPowerbi.WhoAmI",
+        "parameters": {},
+        "requiresAuth": true,
+        "authProvider": "microsoft-powerbi",
+        "tabLabel": "Call the Tool with User Authorization"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": [
+            "business_intelligence"
+          ]
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-07-15T11:37:33.875Z",
+  "summary": "Arcade toolkit for Microsoft Power BI, enabling programmatic access to workspaces, semantic models, reports, gateways, and DAX execution via the Power BI REST API.\n\n## Capabilities\n\n- **Discovery & navigation:** List and inspect workspaces, reports, datasets (semantic models), and gateways; enumerate workspace members for access reviews; identify the authenticated user.\n- **Schema & data access:** Retrieve the full structure of a semantic model (tables, columns, measures, relationships) and run or validate arbitrary DAX `EVALUATE` queries against it.\n- **Dataset diagnostics:** Inspect a dataset in one call (data sources, parameters, refresh schedule, ownership); check gateway/data-source reachability; retrieve paginated refresh history with terminal/in-progress status.\n- **Dataset management:** Trigger on-demand refreshes; update dataset parameters and scheduled-refresh settings with patch semantics and auditable before/after values.\n\n## OAuth\n\nThis toolkit authenticates via OAuth 2.0 using the **Microsoft Power BI** provider. See the [Microsoft Power BI auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft-powerbi) for setup details, required permissions, and token configuration."
+}

--- a/toolkit-docs-generator/data/toolkits/microsoftpowerpoint.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftpowerpoint.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftPowerpoint",
   "label": "Microsoft PowerPoint",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Arcade.dev LLM tools for Microsoft PowerPoint",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "CreatePresentation",
       "qualifiedName": "MicrosoftPowerpoint.CreatePresentation",
-      "fullyQualifiedName": "MicrosoftPowerpoint.CreatePresentation@0.3.1",
+      "fullyQualifiedName": "MicrosoftPowerpoint.CreatePresentation@0.3.2",
       "description": "Create a new PowerPoint presentation in OneDrive.\n\nThe presentation will be created with a title slide containing the specified title.",
       "parameters": [
         {
@@ -99,7 +99,7 @@
     {
       "name": "CreateSlide",
       "qualifiedName": "MicrosoftPowerpoint.CreateSlide",
-      "fullyQualifiedName": "MicrosoftPowerpoint.CreateSlide@0.3.1",
+      "fullyQualifiedName": "MicrosoftPowerpoint.CreateSlide@0.3.2",
       "description": "Append a new slide to the end of an existing PowerPoint presentation in OneDrive.\n\nThe slide will be added at the end of the presentation. Both title and body\nare optional to support layouts like BLANK or TITLE_ONLY.\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -208,7 +208,7 @@
     {
       "name": "CreateTwoContentSlide",
       "qualifiedName": "MicrosoftPowerpoint.CreateTwoContentSlide",
-      "fullyQualifiedName": "MicrosoftPowerpoint.CreateTwoContentSlide@0.3.1",
+      "fullyQualifiedName": "MicrosoftPowerpoint.CreateTwoContentSlide@0.3.2",
       "description": "Append a TWO_CONTENT slide with side-by-side content areas to a PowerPoint presentation.\n\nThis layout is useful for comparisons, pros/cons lists, or any content that\nbenefits from a two-column layout.\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -307,7 +307,7 @@
     {
       "name": "GetAllSlideNotes",
       "qualifiedName": "MicrosoftPowerpoint.GetAllSlideNotes",
-      "fullyQualifiedName": "MicrosoftPowerpoint.GetAllSlideNotes@0.3.1",
+      "fullyQualifiedName": "MicrosoftPowerpoint.GetAllSlideNotes@0.3.2",
       "description": "Get all speaker notes from every slide in a PowerPoint presentation.\n\nReturns notes for all slides in one call, which is more efficient than\ncalling get_slide_notes for each slide individually. Notes are returned\nin markdown format.",
       "parameters": [
         {
@@ -367,7 +367,7 @@
     {
       "name": "GetPresentationAsMarkdown",
       "qualifiedName": "MicrosoftPowerpoint.GetPresentationAsMarkdown",
-      "fullyQualifiedName": "MicrosoftPowerpoint.GetPresentationAsMarkdown@0.3.1",
+      "fullyQualifiedName": "MicrosoftPowerpoint.GetPresentationAsMarkdown@0.3.2",
       "description": "Get the content of a PowerPoint presentation as markdown.\n\nThis tool downloads the presentation and converts it to a markdown representation,\npreserving text content, tables, and chart data. Images and other media are\nrepresented as placeholders.",
       "parameters": [
         {
@@ -427,7 +427,7 @@
     {
       "name": "GetSlideNotes",
       "qualifiedName": "MicrosoftPowerpoint.GetSlideNotes",
-      "fullyQualifiedName": "MicrosoftPowerpoint.GetSlideNotes@0.3.1",
+      "fullyQualifiedName": "MicrosoftPowerpoint.GetSlideNotes@0.3.2",
       "description": "Get the speaker notes from a specific slide in a PowerPoint presentation.\n\nSpeaker notes are returned in markdown format, preserving basic formatting\nlike bold, italic, and bullet points.",
       "parameters": [
         {
@@ -500,7 +500,7 @@
     {
       "name": "SetSlideNotes",
       "qualifiedName": "MicrosoftPowerpoint.SetSlideNotes",
-      "fullyQualifiedName": "MicrosoftPowerpoint.SetSlideNotes@0.3.1",
+      "fullyQualifiedName": "MicrosoftPowerpoint.SetSlideNotes@0.3.2",
       "description": "Set or update the speaker notes on a specific slide in a PowerPoint presentation.\n\nNotes can be formatted using markdown:\n- **bold** for bold text\n- *italic* for italic text\n- __underline__ for underlined text\n- Lines starting with - or * become bullet points\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.\n- Indent with spaces for nested bullets",
       "parameters": [
         {
@@ -586,7 +586,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftPowerpoint.WhoAmI",
-      "fullyQualifiedName": "MicrosoftPowerpoint.WhoAmI@0.3.1",
+      "fullyQualifiedName": "MicrosoftPowerpoint.WhoAmI@0.3.2",
       "description": "Get information about the current user and their PowerPoint environment.",
       "parameters": [],
       "auth": {
@@ -632,6 +632,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-07-10T12:06:03.050Z",
+  "generatedAt": "2026-07-15T11:37:29.796Z",
   "summary": "## Microsoft PowerPoint Toolkit\n\nThe Microsoft PowerPoint toolkit provides Arcade LLM tools for creating and managing PowerPoint presentations stored in OneDrive via the Microsoft Graph API.\n\n## Capabilities\n\n- **Presentation creation**: Create new presentations in OneDrive with a title slide; supports both small and large files (>4 MB via resumable upload sessions).\n- **Slide authoring**: Append slides with standard or two-column (`TWO_CONTENT`) layouts; titles and body content are optional to support blank or title-only layouts.\n- **Speaker notes management**: Read notes from a single slide or all slides at once; write/update notes with Markdown formatting (bold, italic, underline, bullets with nesting support).\n- **Content reading**: Export a full presentation to Markdown, preserving text, tables, and chart data; images and media are represented as placeholders.\n- **User context**: Retrieve information about the authenticated user and their PowerPoint environment.\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via the **Microsoft** provider. See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration details."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftsharepoint.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftsharepoint.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftSharepoint",
   "label": "Microsoft SharePoint",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Arcade.dev LLM tools for Microsoft SharePoint",
   "metadata": {
     "category": "productivity",
@@ -27,7 +27,7 @@
     {
       "name": "AddWorksheet",
       "qualifiedName": "MicrosoftSharepoint.AddWorksheet",
-      "fullyQualifiedName": "MicrosoftSharepoint.AddWorksheet@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.AddWorksheet@0.2.2",
       "description": "Add a new worksheet to a SharePoint Excel workbook.\n\nNote: The new worksheet name may not be immediately visible to other\ntools due to a brief Graph API propagation delay (up to ~10 s). Pass\nthe returned ``session_id`` to subsequent calls that reference the new\nworksheet to mitigate this.",
       "parameters": [
         {
@@ -128,7 +128,7 @@
     {
       "name": "CopyItem",
       "qualifiedName": "MicrosoftSharepoint.CopyItem",
-      "fullyQualifiedName": "MicrosoftSharepoint.CopyItem@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.CopyItem@0.2.2",
       "description": "Copy a file or folder. Returns a completed item or an operation id.",
       "parameters": [
         {
@@ -228,7 +228,7 @@
     {
       "name": "CreateFolder",
       "qualifiedName": "MicrosoftSharepoint.CreateFolder",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateFolder@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateFolder@0.2.2",
       "description": "Create a new folder in a SharePoint drive.",
       "parameters": [
         {
@@ -315,7 +315,7 @@
     {
       "name": "CreatePresentation",
       "qualifiedName": "MicrosoftSharepoint.CreatePresentation",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreatePresentation@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreatePresentation@0.2.2",
       "description": "Create a new PowerPoint presentation in a SharePoint drive.\n\nThe presentation will be created with a title slide containing the specified title.",
       "parameters": [
         {
@@ -402,7 +402,7 @@
     {
       "name": "CreateShareLink",
       "qualifiedName": "MicrosoftSharepoint.CreateShareLink",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateShareLink@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateShareLink@0.2.2",
       "description": "Create a share link for a SharePoint drive item.",
       "parameters": [
         {
@@ -476,7 +476,7 @@
     {
       "name": "CreateSlide",
       "qualifiedName": "MicrosoftSharepoint.CreateSlide",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateSlide@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateSlide@0.2.2",
       "description": "Append a new slide to the end of an existing PowerPoint presentation in a SharePoint drive.\n\nThe slide will be added at the end of the presentation. Both title and body\nare optional to support layouts like BLANK or TITLE_ONLY.\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -599,7 +599,7 @@
     {
       "name": "CreateTwoContentSlide",
       "qualifiedName": "MicrosoftSharepoint.CreateTwoContentSlide",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateTwoContentSlide@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateTwoContentSlide@0.2.2",
       "description": "Append a TWO_CONTENT slide with side-by-side content areas to a SharePoint PowerPoint.\n\nThis layout is useful for comparisons, pros/cons lists, or any content that\nbenefits from a two-column layout.\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -712,7 +712,7 @@
     {
       "name": "CreateWordDocument",
       "qualifiedName": "MicrosoftSharepoint.CreateWordDocument",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateWordDocument@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateWordDocument@0.2.2",
       "description": "Create a new Word document in a SharePoint drive.\n\n4MB upload limit. Optionally include text content.",
       "parameters": [
         {
@@ -825,7 +825,7 @@
     {
       "name": "CreateWorkbook",
       "qualifiedName": "MicrosoftSharepoint.CreateWorkbook",
-      "fullyQualifiedName": "MicrosoftSharepoint.CreateWorkbook@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.CreateWorkbook@0.2.2",
       "description": "Create a new Excel workbook (.xlsx) in a SharePoint drive.\n\nOnly .xlsx files are supported.",
       "parameters": [
         {
@@ -926,7 +926,7 @@
     {
       "name": "DeleteItem",
       "qualifiedName": "MicrosoftSharepoint.DeleteItem",
-      "fullyQualifiedName": "MicrosoftSharepoint.DeleteItem@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.DeleteItem@0.2.2",
       "description": "Delete a file or folder from a SharePoint drive.",
       "parameters": [
         {
@@ -1000,7 +1000,7 @@
     {
       "name": "DeleteWorksheet",
       "qualifiedName": "MicrosoftSharepoint.DeleteWorksheet",
-      "fullyQualifiedName": "MicrosoftSharepoint.DeleteWorksheet@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.DeleteWorksheet@0.2.2",
       "description": "Delete a worksheet from a SharePoint Excel workbook.\n\nCannot delete the last worksheet in a workbook.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -1101,7 +1101,7 @@
     {
       "name": "GetAllSlideNotes",
       "qualifiedName": "MicrosoftSharepoint.GetAllSlideNotes",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetAllSlideNotes@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetAllSlideNotes@0.2.2",
       "description": "Get all speaker notes from every slide in a SharePoint PowerPoint presentation.\n\nReturns notes for all slides in one call, which is more efficient than\ncalling get_slide_notes for each slide individually. Notes are returned\nin markdown format.",
       "parameters": [
         {
@@ -1175,7 +1175,7 @@
     {
       "name": "GetCopyStatus",
       "qualifiedName": "MicrosoftSharepoint.GetCopyStatus",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetCopyStatus@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetCopyStatus@0.2.2",
       "description": "Check status of an async copy operation using the token returned by copy_item.",
       "parameters": [
         {
@@ -1249,7 +1249,7 @@
     {
       "name": "GetDrivesFromSite",
       "qualifiedName": "MicrosoftSharepoint.GetDrivesFromSite",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetDrivesFromSite@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetDrivesFromSite@0.2.2",
       "description": "Retrieve drives / document libraries from a SharePoint site.\n\nIf you have a site name, it is not necessary to call Sharepoint.SearchSites first.\nYou can simply call this tool with the site name / keywords.",
       "parameters": [
         {
@@ -1310,7 +1310,7 @@
     {
       "name": "GetItemsFromList",
       "qualifiedName": "MicrosoftSharepoint.GetItemsFromList",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetItemsFromList@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetItemsFromList@0.2.2",
       "description": "Retrieve items from a list in a SharePoint site.\n\nNote: The Microsoft Graph API does not offer endpoints to retrieve list item attachments.\nBecause of that, the only information we can get is whether the item has attachments or not.",
       "parameters": [
         {
@@ -1384,7 +1384,7 @@
     {
       "name": "GetListsFromSite",
       "qualifiedName": "MicrosoftSharepoint.GetListsFromSite",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetListsFromSite@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetListsFromSite@0.2.2",
       "description": "Retrieve lists from a SharePoint site.",
       "parameters": [
         {
@@ -1445,7 +1445,7 @@
     {
       "name": "GetPage",
       "qualifiedName": "MicrosoftSharepoint.GetPage",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetPage@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetPage@0.2.2",
       "description": "Retrieve metadata and the contents of a page in a SharePoint site.\n\nPage content is a list of Microsoft Sharepoint web part objects, such as text, images, banners,\nbuttons, etc.\n\nIf `include_page_content` is set to False, the tool will return only the page metadata.",
       "parameters": [
         {
@@ -1532,7 +1532,7 @@
     {
       "name": "GetPresentationAsMarkdown",
       "qualifiedName": "MicrosoftSharepoint.GetPresentationAsMarkdown",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetPresentationAsMarkdown@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetPresentationAsMarkdown@0.2.2",
       "description": "Get the content of a PowerPoint presentation stored in a SharePoint drive as markdown.\n\nThis tool downloads the presentation and converts it to a markdown representation,\npreserving text content, tables, and chart data. Images and other media are\nrepresented as placeholders.",
       "parameters": [
         {
@@ -1606,7 +1606,7 @@
     {
       "name": "GetSite",
       "qualifiedName": "MicrosoftSharepoint.GetSite",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetSite@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetSite@0.2.2",
       "description": "Retrieve information about a specific SharePoint site by its ID, URL, or name.",
       "parameters": [
         {
@@ -1667,7 +1667,7 @@
     {
       "name": "GetSlideNotes",
       "qualifiedName": "MicrosoftSharepoint.GetSlideNotes",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetSlideNotes@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetSlideNotes@0.2.2",
       "description": "Get the speaker notes from a specific slide in a SharePoint PowerPoint presentation.\n\nSpeaker notes are returned in markdown format, preserving basic formatting\nlike bold, italic, and bullet points.",
       "parameters": [
         {
@@ -1754,7 +1754,7 @@
     {
       "name": "GetWordDocument",
       "qualifiedName": "MicrosoftSharepoint.GetWordDocument",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetWordDocument@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetWordDocument@0.2.2",
       "description": "Get a Word document's metadata and content from a SharePoint drive. Supports only `.docx`.\n\nReturns the document content as Markdown by default.\nReturns only metadata when metadata_only is True.",
       "parameters": [
         {
@@ -1841,7 +1841,7 @@
     {
       "name": "GetWorkbookMetadata",
       "qualifiedName": "MicrosoftSharepoint.GetWorkbookMetadata",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetWorkbookMetadata@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetWorkbookMetadata@0.2.2",
       "description": "Get metadata about an Excel workbook in a SharePoint drive, including worksheet list.",
       "parameters": [
         {
@@ -1929,7 +1929,7 @@
     {
       "name": "GetWorksheetData",
       "qualifiedName": "MicrosoftSharepoint.GetWorksheetData",
-      "fullyQualifiedName": "MicrosoftSharepoint.GetWorksheetData@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.GetWorksheetData@0.2.2",
       "description": "Read cell values from a worksheet in a SharePoint Excel workbook.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -2082,7 +2082,7 @@
     {
       "name": "InsertTextAtEndOfWordDocument",
       "qualifiedName": "MicrosoftSharepoint.InsertTextAtEndOfWordDocument",
-      "fullyQualifiedName": "MicrosoftSharepoint.InsertTextAtEndOfWordDocument@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.InsertTextAtEndOfWordDocument@0.2.2",
       "description": "Append text to the end of an existing Word document.\n\nThis tool only supports files with the `.docx` extension and enforces the 4MB limit.",
       "parameters": [
         {
@@ -2169,7 +2169,7 @@
     {
       "name": "ListItemsInFolder",
       "qualifiedName": "MicrosoftSharepoint.ListItemsInFolder",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListItemsInFolder@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListItemsInFolder@0.2.2",
       "description": "Retrieve items from a folder in a drive in a SharePoint site.\n\nNote: The Microsoft Graph API requires retrieving all items,\nincluding those skipped by offset.\nExecution time increases with higher offset values.",
       "parameters": [
         {
@@ -2269,7 +2269,7 @@
     {
       "name": "ListPages",
       "qualifiedName": "MicrosoftSharepoint.ListPages",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListPages@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListPages@0.2.2",
       "description": "Retrieve pages from a SharePoint site.\n\nThe Microsoft Graph API does not support pagination on this endpoint.",
       "parameters": [
         {
@@ -2343,7 +2343,7 @@
     {
       "name": "ListRootItemsInDrive",
       "qualifiedName": "MicrosoftSharepoint.ListRootItemsInDrive",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListRootItemsInDrive@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListRootItemsInDrive@0.2.2",
       "description": "Retrieve items from the root of a drive in a SharePoint site.\n\nNote: The Microsoft Graph API requires retrieving all items,\nincluding those skipped by offset.\nExecution time increases with higher offset values.",
       "parameters": [
         {
@@ -2430,7 +2430,7 @@
     {
       "name": "ListSites",
       "qualifiedName": "MicrosoftSharepoint.ListSites",
-      "fullyQualifiedName": "MicrosoftSharepoint.ListSites@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.ListSites@0.2.2",
       "description": "List all SharePoint sites accessible to the current user.",
       "parameters": [
         {
@@ -2504,7 +2504,7 @@
     {
       "name": "MoveItem",
       "qualifiedName": "MicrosoftSharepoint.MoveItem",
-      "fullyQualifiedName": "MicrosoftSharepoint.MoveItem@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.MoveItem@0.2.2",
       "description": "Move a file or folder to a new location in a SharePoint drive.",
       "parameters": [
         {
@@ -2591,7 +2591,7 @@
     {
       "name": "RenameWorksheet",
       "qualifiedName": "MicrosoftSharepoint.RenameWorksheet",
-      "fullyQualifiedName": "MicrosoftSharepoint.RenameWorksheet@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.RenameWorksheet@0.2.2",
       "description": "Rename an existing worksheet in a SharePoint Excel workbook.\n\nNote: The new name may not be immediately visible to other tools due\nto a brief Graph API propagation delay (up to ~10 s). Pass the returned\n``session_id`` to subsequent calls that reference the renamed worksheet\nto mitigate this. If referencing a recently added worksheet as the source,\nthe same delay applies; retry with the ``session_id`` if a\nWorksheetNotFoundError occurs.",
       "parameters": [
         {
@@ -2705,7 +2705,7 @@
     {
       "name": "SearchDriveItems",
       "qualifiedName": "MicrosoftSharepoint.SearchDriveItems",
-      "fullyQualifiedName": "MicrosoftSharepoint.SearchDriveItems@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.SearchDriveItems@0.2.2",
       "description": "Search for items in one or more Sharepoint drives.\n\nNote: When searching a single Drive and/or Folder,\nthe API must retrieve all items including those skipped by offset.\nExecution time increases with higher offset values.",
       "parameters": [
         {
@@ -2818,7 +2818,7 @@
     {
       "name": "SearchSites",
       "qualifiedName": "MicrosoftSharepoint.SearchSites",
-      "fullyQualifiedName": "MicrosoftSharepoint.SearchSites@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.SearchSites@0.2.2",
       "description": "Search for SharePoint sites by name or description.\n\nIn case you need to retrieve a specific site by its name, ID or SharePoint URL, use the\n`Sharepoint.GetSite` tool instead, passing the ID, name or SharePoint URL to it.",
       "parameters": [
         {
@@ -2905,7 +2905,7 @@
     {
       "name": "SetSlideNotes",
       "qualifiedName": "MicrosoftSharepoint.SetSlideNotes",
-      "fullyQualifiedName": "MicrosoftSharepoint.SetSlideNotes@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.SetSlideNotes@0.2.2",
       "description": "Set or update the speaker notes on a specific slide in a SharePoint PowerPoint.\n\nNotes can be formatted using markdown:\n- **bold** for bold text\n- *italic* for italic text\n- __underline__ for underlined text\n- Lines starting with - or * become bullet points\n- Indent with spaces for nested bullets\n\nFor presentations larger than 4 MB, the upload uses a resumable session.\nConcurrency protection (etag check) is best-effort in that case, since\nMicrosoft Graph upload sessions do not support If-Match headers.",
       "parameters": [
         {
@@ -3005,7 +3005,7 @@
     {
       "name": "UpdateCell",
       "qualifiedName": "MicrosoftSharepoint.UpdateCell",
-      "fullyQualifiedName": "MicrosoftSharepoint.UpdateCell@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.UpdateCell@0.2.2",
       "description": "Update a single cell value in a SharePoint Excel workbook.\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -3145,7 +3145,7 @@
     {
       "name": "UpdateRange",
       "qualifiedName": "MicrosoftSharepoint.UpdateRange",
-      "fullyQualifiedName": "MicrosoftSharepoint.UpdateRange@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.UpdateRange@0.2.2",
       "description": "Update multiple cells in a SharePoint Excel worksheet using sparse dict format.\n\nOnly specified cells are updated; unspecified cells remain unchanged.\n\nInternally, a single PATCH request is sent covering the bounding box\nof all specified cells.  Cells within the box that are not in the\ninput are sent as ``null``, which the Graph API treats as \"skip\".\n\nNote: If referencing a recently added or renamed worksheet, pass the\n``session_id`` from that operation. A brief Graph API propagation delay\n(up to ~10 s) may cause a WorksheetNotFoundError; retry with the\n``session_id`` if this occurs.",
       "parameters": [
         {
@@ -3259,7 +3259,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftSharepoint.WhoAmI",
-      "fullyQualifiedName": "MicrosoftSharepoint.WhoAmI@0.2.1",
+      "fullyQualifiedName": "MicrosoftSharepoint.WhoAmI@0.2.2",
       "description": "Get information about the current user and their SharePoint environment.",
       "parameters": [],
       "auth": {
@@ -3306,6 +3306,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-07-10T12:06:03.068Z",
+  "generatedAt": "2026-07-15T11:37:29.822Z",
   "summary": "The Microsoft SharePoint toolkit integrates Arcade with Microsoft SharePoint via the Microsoft Graph API, enabling LLMs to read, write, and manage SharePoint content programmatically.\n\n## Capabilities\n\n- **Site & drive navigation** — list, search, and retrieve sites, drives/document libraries, lists, list items, folders, and root drive contents; look up the current user's SharePoint environment.\n- **File & folder management** — create folders, copy, move, rename, and delete files or folders; check async copy operation status; generate share links for drive items.\n- **Excel workbook editing** — create workbooks, add/rename/delete worksheets, read cell ranges, update individual cells or sparse multi-cell ranges, and retrieve workbook metadata. Propagation-delay mitigations via `session_id` are built in.\n- **PowerPoint authoring** — create presentations with a title slide, append standard or two-column-layout slides, get/set/update speaker notes per slide or across all slides, and export presentations to Markdown (preserving text, tables, and chart data).\n- **Word document handling** — create `.docx` files with optional initial content, retrieve document content as Markdown or metadata-only, and append text to existing documents (4 MB limit).\n- **SharePoint pages & lists** — list and retrieve site pages (with full web-part content or metadata-only), and read items from SharePoint lists.\n\n## OAuth\n\nThis toolkit authenticates via **Microsoft** OAuth 2.0. See the [Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for configuration details, required permissions, and setup steps."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftteams.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftteams.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftTeams",
   "label": "Microsoft Teams",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Arcade.dev LLM tools for Microsoft Teams",
   "metadata": {
     "category": "social",
@@ -37,7 +37,7 @@
     {
       "name": "CreateChat",
       "qualifiedName": "MicrosoftTeams.CreateChat",
-      "fullyQualifiedName": "MicrosoftTeams.CreateChat@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.CreateChat@0.6.3",
       "description": "Creates a Microsoft Teams chat.\n\nIf the chat already exists with the specified members, the MS Graph API will return the\nexisting chat.\n\nProvide any combination of user_ids and/or user_names. When available, prefer providing\nuser_ids for optimal performance.",
       "parameters": [
         {
@@ -121,7 +121,7 @@
     {
       "name": "GetChannelMessageReplies",
       "qualifiedName": "MicrosoftTeams.GetChannelMessageReplies",
-      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessageReplies@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessageReplies@0.6.3",
       "description": "Retrieves the replies to a Microsoft Teams channel message.",
       "parameters": [
         {
@@ -209,7 +209,7 @@
     {
       "name": "GetChannelMessages",
       "qualifiedName": "MicrosoftTeams.GetChannelMessages",
-      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessages@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.GetChannelMessages@0.6.3",
       "description": "Retrieves the messages in a Microsoft Teams channel.\n\nThe Microsoft Graph API does not support pagination for this endpoint.",
       "parameters": [
         {
@@ -310,7 +310,7 @@
     {
       "name": "GetChannelMetadata",
       "qualifiedName": "MicrosoftTeams.GetChannelMetadata",
-      "fullyQualifiedName": "MicrosoftTeams.GetChannelMetadata@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.GetChannelMetadata@0.6.3",
       "description": "Retrieves metadata about a Microsoft Teams channel and its members.\n\nProvide either a channel_id or channel_name, not both. When available, prefer providing a\nchannel_id for optimal performance.\n\nThe Microsoft Graph API returns only up to the first 999 members in the channel.\n\nThis tool does not return messages exchanged in the channel. To retrieve channel messages,\nuse the `Teams.GetChannelMessages` tool.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use.",
       "parameters": [
         {
@@ -398,7 +398,7 @@
     {
       "name": "GetChatMessageById",
       "qualifiedName": "MicrosoftTeams.GetChatMessageById",
-      "fullyQualifiedName": "MicrosoftTeams.GetChatMessageById@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.GetChatMessageById@0.6.3",
       "description": "Retrieves a Microsoft Teams chat message.",
       "parameters": [
         {
@@ -508,7 +508,7 @@
     {
       "name": "GetChatMessages",
       "qualifiedName": "MicrosoftTeams.GetChatMessages",
-      "fullyQualifiedName": "MicrosoftTeams.GetChatMessages@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.GetChatMessages@0.6.3",
       "description": "Retrieves messages from a Microsoft Teams chat (individual or group).\n\nProvide one of chat_id OR any combination of user_ids and/or user_names. When available, prefer\nproviding a chat_id or user_ids for optimal performance.\n\nIf the user provides user name(s), DO NOT CALL THE `Teams.SearchUsers` or `Teams.SearchPeople`\ntools first. Instead, provide the user name(s) directly to this tool through the `user_names`\nargument. It is not necessary to provide the currently signed in user's name/id, so do not call\n`Teams.GetSignedInUser` before calling this tool.\n\nMessages will be sorted in descending order by the messages' `created_datetime` field.\n\nThe Microsoft Teams API does not support pagination for this tool.",
       "parameters": [
         {
@@ -645,7 +645,7 @@
     {
       "name": "GetChatMetadata",
       "qualifiedName": "MicrosoftTeams.GetChatMetadata",
-      "fullyQualifiedName": "MicrosoftTeams.GetChatMetadata@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.GetChatMetadata@0.6.3",
       "description": "Retrieves metadata about a Microsoft Teams chat.\n\nProvide exactly one of chat_id or user_ids/user_names. When available, prefer providing a\nchat_id or user_ids for optimal performance.\n\nIf multiple roup chats exist with those exact members, returns the most recently updated one.\n\nMax 20 DIFFERENT users can be provided in user_ids/user_names.\n\nThis tool DOES NOT return messages in a chat. Use the `Teams.GetChatMessages` tool to get\nchat messages.",
       "parameters": [
         {
@@ -744,7 +744,7 @@
     {
       "name": "GetSignedInUser",
       "qualifiedName": "MicrosoftTeams.GetSignedInUser",
-      "fullyQualifiedName": "MicrosoftTeams.GetSignedInUser@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.GetSignedInUser@0.6.3",
       "description": "Get the user currently signed in Microsoft Teams.\n\nThis tool is not necessary to call before calling other tools.",
       "parameters": [],
       "auth": {
@@ -789,7 +789,7 @@
     {
       "name": "GetTeam",
       "qualifiedName": "MicrosoftTeams.GetTeam",
-      "fullyQualifiedName": "MicrosoftTeams.GetTeam@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.GetTeam@0.6.3",
       "description": "Retrieves metadata about a team in Microsoft Teams.\n\nProvide one of team_id OR team_name, never both. When available, prefer providing a team_id for\noptimal performance.\n\nIf team_id nor team_name are provided: 1) if the user has a single team, the tool will retrieve\nit; 2) if the user has multiple teams, an error will be returned with a list of all teams to\npick from.",
       "parameters": [
         {
@@ -862,7 +862,7 @@
     {
       "name": "ListChannels",
       "qualifiedName": "MicrosoftTeams.ListChannels",
-      "fullyQualifiedName": "MicrosoftTeams.ListChannels@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.ListChannels@0.6.3",
       "description": "Lists channels in Microsoft Teams (including shared incoming channels).\n\nThis tool does not return messages nor members in the channels. To retrieve channel messages,\nuse the `Teams.GetChannelMessages` tool. To retrieve channel members, use the\n`Teams.ListChannelMembers` tool.",
       "parameters": [
         {
@@ -949,7 +949,7 @@
     {
       "name": "ListChats",
       "qualifiedName": "MicrosoftTeams.ListChats",
-      "fullyQualifiedName": "MicrosoftTeams.ListChats@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.ListChats@0.6.3",
       "description": "List the Microsoft Teams chats to which the current user is a member of.",
       "parameters": [
         {
@@ -1022,7 +1022,7 @@
     {
       "name": "ListTeamMembers",
       "qualifiedName": "MicrosoftTeams.ListTeamMembers",
-      "fullyQualifiedName": "MicrosoftTeams.ListTeamMembers@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.ListTeamMembers@0.6.3",
       "description": "Lists the members of a team in Microsoft Teams.\n\nProvide one of team_id OR team_name, never both. When available, prefer providing a team_id for\noptimal performance.\n\nIf team_id nor team_name are provided: 1) if the user has a single team, the tool will use it;\n2) if the user has multiple teams, an error will be returned with a list of all teams to pick\nfrom.\n\nThe Microsoft Graph API returns only up to the first 999 members.",
       "parameters": [
         {
@@ -1122,7 +1122,7 @@
     {
       "name": "ListTeams",
       "qualifiedName": "MicrosoftTeams.ListTeams",
-      "fullyQualifiedName": "MicrosoftTeams.ListTeams@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.ListTeams@0.6.3",
       "description": "Lists the teams the current user is associated with in Microsoft Teams.",
       "parameters": [
         {
@@ -1185,7 +1185,7 @@
     {
       "name": "ListUsers",
       "qualifiedName": "MicrosoftTeams.ListUsers",
-      "fullyQualifiedName": "MicrosoftTeams.ListUsers@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.ListUsers@0.6.3",
       "description": "Lists the users in the Microsoft Teams tenant.\n\nThe Microsoft Graph API returns only up to the first 999 users.",
       "parameters": [
         {
@@ -1259,7 +1259,7 @@
     {
       "name": "ReplyToChannelMessage",
       "qualifiedName": "MicrosoftTeams.ReplyToChannelMessage",
-      "fullyQualifiedName": "MicrosoftTeams.ReplyToChannelMessage@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.ReplyToChannelMessage@0.6.3",
       "description": "Sends a reply to a Microsoft Teams channel message.\n\nWhen available, prefer providing a channel_id for optimal performance.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use.",
       "parameters": [
         {
@@ -1360,7 +1360,7 @@
     {
       "name": "ReplyToChatMessage",
       "qualifiedName": "MicrosoftTeams.ReplyToChatMessage",
-      "fullyQualifiedName": "MicrosoftTeams.ReplyToChatMessage@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.ReplyToChatMessage@0.6.3",
       "description": "Sends a reply to a Microsoft Teams chat message.\n\nProvide exactly one of chat_id or user_ids/user_names. When available, prefer providing a\nchat_id or user_ids for optimal performance.\n\nIf the user provides user name(s), DO NOT CALL THE `Teams.SearchUsers` or `Teams.SearchPeople`\ntools first. Instead, provide the user name(s) directly to this tool through the `user_names`\nargument. It is not necessary to provide the currently signed in user's name/id, so do not call\n`Teams.GetSignedInUser` before calling this tool either.",
       "parameters": [
         {
@@ -1485,7 +1485,7 @@
     {
       "name": "SearchChannels",
       "qualifiedName": "MicrosoftTeams.SearchChannels",
-      "fullyQualifiedName": "MicrosoftTeams.SearchChannels@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.SearchChannels@0.6.3",
       "description": "Searches for channels in a given Microsoft Teams team.",
       "parameters": [
         {
@@ -1606,7 +1606,7 @@
     {
       "name": "SearchMessages",
       "qualifiedName": "MicrosoftTeams.SearchMessages",
-      "fullyQualifiedName": "MicrosoftTeams.SearchMessages@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.SearchMessages@0.6.3",
       "description": "Searches for messages across Microsoft Teams chats and channels.\n\nNote: the Microsoft Graph API search is not strongly consistent. Recent messages may not be\nincluded in search results.",
       "parameters": [
         {
@@ -1694,7 +1694,7 @@
     {
       "name": "SearchPeople",
       "qualifiedName": "MicrosoftTeams.SearchPeople",
-      "fullyQualifiedName": "MicrosoftTeams.SearchPeople@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.SearchPeople@0.6.3",
       "description": "Searches for people the user has interacted with in Microsoft Teams and other 365 products.\n\nThis tool only returns users that the currently signed in user has interacted with. It may also\ninclude people that are part of external tenants/organizations. If you need to retrieve users\nthat may not have interacted with the current user and/or that are exclusively part of the same\ntenant, use the `Teams.SearchUsers` tool instead.",
       "parameters": [
         {
@@ -1801,7 +1801,7 @@
     {
       "name": "SearchTeamMembers",
       "qualifiedName": "MicrosoftTeams.SearchTeamMembers",
-      "fullyQualifiedName": "MicrosoftTeams.SearchTeamMembers@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.SearchTeamMembers@0.6.3",
       "description": "Searches for members of a team in Microsoft Teams.\n\nProvide one of team_id OR team_name, never both. When available, prefer providing a team_id for\noptimal performance.\n\nIf team_id nor team_name are provided: 1) if the user has a single team, the tool will use it;\n2) if the user has multiple teams, an error will be raised with a list of available teams to\npick from.\n\nThe Microsoft Graph API returns only up to the first 999 members of a team.",
       "parameters": [
         {
@@ -1914,7 +1914,7 @@
     {
       "name": "SearchTeams",
       "qualifiedName": "MicrosoftTeams.SearchTeams",
-      "fullyQualifiedName": "MicrosoftTeams.SearchTeams@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.SearchTeams@0.6.3",
       "description": "Searches for teams available to the current user in Microsoft Teams.",
       "parameters": [
         {
@@ -2000,7 +2000,7 @@
     {
       "name": "SearchUsers",
       "qualifiedName": "MicrosoftTeams.SearchUsers",
-      "fullyQualifiedName": "MicrosoftTeams.SearchUsers@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.SearchUsers@0.6.3",
       "description": "Searches for users in the Microsoft Teams tenant.\n\nThis tool only return users that are directly linked to the tenant the current signed in user\nis a member of. If you need to retrieve users that have interacted with the current user but\nare from external tenants/organizations, use `Teams.SearchPeople`, instead.\n\nThe Microsoft Graph API returns only up to the first 999 users.",
       "parameters": [
         {
@@ -2108,7 +2108,7 @@
     {
       "name": "SendMessageToChannel",
       "qualifiedName": "MicrosoftTeams.SendMessageToChannel",
-      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChannel@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChannel@0.6.3",
       "description": "Sends a message to a Microsoft Teams channel.\n\nWhen available, prefer providing a channel_id for optimal performance.\n\nIt is not necessary to call `Teams.ListTeams` before calling this tool. If the user does not\nprovide a team_id_or_name, the tool will try to find a unique team to use.",
       "parameters": [
         {
@@ -2196,7 +2196,7 @@
     {
       "name": "SendMessageToChat",
       "qualifiedName": "MicrosoftTeams.SendMessageToChat",
-      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChat@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.SendMessageToChat@0.6.3",
       "description": "Sends a message to a Microsoft Teams chat.\n\nProvide exactly one of chat_id or user_ids/user_names. When available, prefer providing a\nchat_id or user_ids for optimal performance.\n\nIf the user provides user name(s), DO NOT CALL THE `Teams.SearchUsers` or `Teams.SearchPeople`\ntools first. Instead, provide the user name(s) directly to this tool through the `user_names`\nargument. It is not necessary to provide the currently signed in user's name/id, so do not call\n`Teams.GetSignedInUser` before calling this tool either.",
       "parameters": [
         {
@@ -2307,7 +2307,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftTeams.WhoAmI",
-      "fullyQualifiedName": "MicrosoftTeams.WhoAmI@0.6.2",
+      "fullyQualifiedName": "MicrosoftTeams.WhoAmI@0.6.3",
       "description": "Get information about the current user and their Microsoft Teams environment.",
       "parameters": [],
       "auth": {
@@ -2360,6 +2360,6 @@
   ],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-07-10T12:06:03.054Z",
+  "generatedAt": "2026-07-15T11:37:29.828Z",
   "summary": "## Microsoft Teams Toolkit\n\nThe Microsoft Teams toolkit provides Arcade LLM tools for interacting with Microsoft Teams via the Microsoft Graph API, enabling agents to read and send messages, manage chats and channels, and look up users and teams.\n\n## Capabilities\n\n- **Messaging — chats:** Create chats, retrieve chat metadata and messages, send messages, and reply to messages in one-on-one or group chats; addressable by chat ID or user names/IDs.\n- **Messaging — channels:** Retrieve channel messages and their replies, send messages to channels, and reply to channel messages; addressable by channel ID or name.\n- **Chat & channel discovery:** List all chats the current user belongs to, list channels within a team (including shared incoming channels), and search for channels by name.\n- **Team & member management:** List teams the user belongs to, retrieve team metadata, list or search team members (up to 999 per Graph API limit), and list all tenant users.\n- **User & people search:** Search users within the signed-in user's tenant (`SearchUsers`), search people the user has previously interacted with across Microsoft 365 — including external tenants (`SearchPeople`), and retrieve the currently signed-in user's profile.\n- **Cross-scope search:** Search messages across chats and channels tenant-wide (note: Graph API search is not strongly consistent; very recent messages may be absent).\n\n## OAuth\n\nThis toolkit uses OAuth 2.0 via Microsoft (Entra ID / Azure AD). See the [Arcade Microsoft auth provider docs](https://docs.arcade.dev/en/references/auth-providers/microsoft) for setup details, required permissions, and configuration."
 }

--- a/toolkit-docs-generator/data/toolkits/microsoftword.json
+++ b/toolkit-docs-generator/data/toolkits/microsoftword.json
@@ -1,7 +1,7 @@
 {
   "id": "MicrosoftWord",
   "label": "Microsoft Word",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Arcade.dev LLM tools for Microsoft Word",
   "metadata": {
     "category": "productivity",
@@ -26,7 +26,7 @@
     {
       "name": "CreateDocument",
       "qualifiedName": "MicrosoftWord.CreateDocument",
-      "fullyQualifiedName": "MicrosoftWord.CreateDocument@0.2.2",
+      "fullyQualifiedName": "MicrosoftWord.CreateDocument@0.2.3",
       "description": "Create a new Word document in OneDrive (4MB upload limit).\n\nOptionally include text content.",
       "parameters": [
         {
@@ -125,7 +125,7 @@
     {
       "name": "GetDocument",
       "qualifiedName": "MicrosoftWord.GetDocument",
-      "fullyQualifiedName": "MicrosoftWord.GetDocument@0.2.2",
+      "fullyQualifiedName": "MicrosoftWord.GetDocument@0.2.3",
       "description": "Get a Word document's metadata and content (`.docx` only).\n\nReturns the document content as Markdown by default.\nReturns only metadata when metadata_only is True.",
       "parameters": [
         {
@@ -211,7 +211,7 @@
     {
       "name": "InsertTextAtEnd",
       "qualifiedName": "MicrosoftWord.InsertTextAtEnd",
-      "fullyQualifiedName": "MicrosoftWord.InsertTextAtEnd@0.2.2",
+      "fullyQualifiedName": "MicrosoftWord.InsertTextAtEnd@0.2.3",
       "description": "Append text to the end of a Word document (supports only `.docx`, 4MB limit).",
       "parameters": [
         {
@@ -297,7 +297,7 @@
     {
       "name": "WhoAmI",
       "qualifiedName": "MicrosoftWord.WhoAmI",
-      "fullyQualifiedName": "MicrosoftWord.WhoAmI@0.2.2",
+      "fullyQualifiedName": "MicrosoftWord.WhoAmI@0.2.3",
       "description": "Get information about the current user and their Microsoft Word environment.",
       "parameters": [],
       "auth": {
@@ -343,6 +343,6 @@
   "documentationChunks": [],
   "customImports": [],
   "subPages": [],
-  "generatedAt": "2026-07-10T12:06:03.050Z",
+  "generatedAt": "2026-07-15T11:37:29.827Z",
   "summary": "Arcade's Microsoft Word toolkit lets developers create, read, and update Word documents stored in OneDrive through Microsoft Graph.\n\n**Capabilities**\n- Create `.docx` documents with optional initial text, automatic `.docx` extension handling, folder targeting, and configurable filename conflict behavior: fail, rename, or replace.\n- Retrieve Word document metadata and Markdown content, or request metadata only.\n- Append text to existing `.docx` documents within the 4 MB upload limit.\n- Fetch authenticated user profile and Microsoft Word environment information.\n\n**OAuth**\n- **Provider**: Microsoft\n- **Scopes**: Files.Read, Files.ReadWrite, User.Read\n\n**Secrets**\n- No secret types required for toolkit operation."
 }

--- a/toolkit-docs-generator/data/toolkits/postman.json
+++ b/toolkit-docs-generator/data/toolkits/postman.json
@@ -1,0 +1,2475 @@
+{
+  "id": "Postman",
+  "label": "Postman",
+  "version": "0.1.0",
+  "description": "Arcade.dev tools for interacting with Postman",
+  "metadata": {
+    "category": "development",
+    "iconUrl": "https://design-system.arcade.dev/icons/postman.svg",
+    "isBYOC": false,
+    "isPro": false,
+    "type": "arcade",
+    "docsLink": "https://docs.arcade.dev/en/resources/integrations/development/postman",
+    "isComingSoon": false,
+    "isHidden": false
+  },
+  "auth": null,
+  "tools": [
+    {
+      "name": "CreateCollectionFolder",
+      "qualifiedName": "Postman.CreateCollectionFolder",
+      "fullyQualifiedName": "Postman.CreateCollectionFolder@0.1.0",
+      "description": "Add a folder to a collection, optionally nested inside an existing folder.",
+      "parameters": [
+        {
+          "name": "collection_id",
+          "type": "string",
+          "required": true,
+          "description": "The collection id or uid to add the folder to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "Name for the new folder.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "required": false,
+          "description": "Description for the folder. Leave empty to omit.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "parent_folder_id",
+          "type": "string",
+          "required": false,
+          "description": "Id of a folder to nest this folder inside. Leave empty to add at the top level.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The newly created folder."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.CreateCollectionFolder",
+        "parameters": {
+          "collection_id": {
+            "value": "12345678-abcd-1234-efgh-0987654321ab",
+            "type": "string",
+            "required": true
+          },
+          "name": {
+            "value": "Authentication Endpoints",
+            "type": "string",
+            "required": true
+          },
+          "description": {
+            "value": "Contains all authentication-related API requests including login, logout, and token refresh.",
+            "type": "string",
+            "required": false
+          },
+          "parent_folder_id": {
+            "value": "87654321-hgfe-4321-dcba-1234567890cd",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CreateCollectionRequest",
+      "qualifiedName": "Postman.CreateCollectionRequest",
+      "fullyQualifiedName": "Postman.CreateCollectionRequest@0.1.0",
+      "description": "Add a request to a collection, optionally inside a folder.",
+      "parameters": [
+        {
+          "name": "collection_id",
+          "type": "string",
+          "required": true,
+          "description": "The collection id or uid to add the request to.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "Name for the new request.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "http_method",
+          "type": "string",
+          "required": true,
+          "description": "HTTP method for the request.",
+          "enum": [
+            "GET",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE",
+            "HEAD",
+            "OPTIONS"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "url",
+          "type": "string",
+          "required": true,
+          "description": "Request URL.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "folder_id",
+          "type": "string",
+          "required": false,
+          "description": "Id of a folder to place the request in. Leave empty to add at the top level.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The newly created request."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.CreateCollectionRequest",
+        "parameters": {
+          "collection_id": {
+            "value": "12345678-abc1-def2-ghij-1234567890ab",
+            "type": "string",
+            "required": true
+          },
+          "name": {
+            "value": "Get User Profile",
+            "type": "string",
+            "required": true
+          },
+          "http_method": {
+            "value": "GET",
+            "type": "string",
+            "required": true
+          },
+          "url": {
+            "value": "https://api.example.com/v1/users/{{userId}}",
+            "type": "string",
+            "required": true
+          },
+          "folder_id": {
+            "value": "abcdef12-3456-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CreateMock",
+      "qualifiedName": "Postman.CreateMock",
+      "fullyQualifiedName": "Postman.CreateMock@0.1.0",
+      "description": "Create a mock server from a collection so a client can call its simulated endpoints.",
+      "parameters": [
+        {
+          "name": "collection_id",
+          "type": "string",
+          "required": true,
+          "description": "Id or uid of the collection the mock server simulates. Prefer the uid: it avoids a resolving lookup (useful in batches) and reliably addresses a teammate-shared collection, whose bare id can be rejected.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Name for the mock server. Leave empty to let Postman name it.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "environment_id",
+          "type": "string",
+          "required": false,
+          "description": "Id or uid of an environment to bind to the mock. Prefer the uid for a teammate-shared environment, whose bare id can be rejected. Leave empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": false,
+          "description": "Workspace to create the mock in. Leave empty to use your personal (default) workspace; passing it avoids a default-workspace lookup, useful when creating many in a batch.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "private",
+          "type": "boolean",
+          "required": false,
+          "description": "Create the mock as private (true), so only requests carrying a valid Postman API key reach it, or public (false), reachable by anyone with the URL. Defaults to true; a public mock exposes the collection's saved example responses to anyone with the URL.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The newly created mock server and its public URL."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.CreateMock",
+        "parameters": {
+          "collection_id": {
+            "value": "12345678-a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": true
+          },
+          "name": {
+            "value": "Payments API Mock Server",
+            "type": "string",
+            "required": false
+          },
+          "environment_id": {
+            "value": "12345678-f9e8d7c6-b5a4-3210-fedc-ba0987654321",
+            "type": "string",
+            "required": false
+          },
+          "workspace_id": {
+            "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": false
+          },
+          "private": {
+            "value": true,
+            "type": "boolean",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "CreateMonitor",
+      "qualifiedName": "Postman.CreateMonitor",
+      "fullyQualifiedName": "Postman.CreateMonitor@0.1.0",
+      "description": "Create a monitor that runs a collection on a schedule to watch an API's health.",
+      "parameters": [
+        {
+          "name": "collection_id",
+          "type": "string",
+          "required": true,
+          "description": "Id or uid of the collection the monitor runs. Prefer the uid: it avoids a resolving lookup (useful in batches) and reliably addresses a teammate-shared collection, whose bare id can be rejected.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "Name for the monitor.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "cron",
+          "type": "string",
+          "required": false,
+          "description": "Cron expression for the run schedule (standard 5-field cron). Defaults to '0 0 * * *' (daily at midnight).",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "timezone",
+          "type": "string",
+          "required": false,
+          "description": "IANA timezone name for the schedule (e.g. America/New_York). Defaults to Etc/UTC.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "environment_id",
+          "type": "string",
+          "required": false,
+          "description": "Id or uid of an environment to run the monitor against. Prefer the uid for a teammate-shared environment, whose bare id can be rejected. Leave empty for none.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": false,
+          "description": "Workspace to create the monitor in. Leave empty to use your personal (default) workspace; passing it avoids a default-workspace lookup, useful when creating many in a batch.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The newly created monitor and its schedule."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.CreateMonitor",
+        "parameters": {
+          "collection_id": {
+            "value": "12345678-abc1-def2-ghij-1234567890ab",
+            "type": "string",
+            "required": true
+          },
+          "name": {
+            "value": "Production API Health Monitor",
+            "type": "string",
+            "required": true
+          },
+          "cron": {
+            "value": "0 */6 * * *",
+            "type": "string",
+            "required": false
+          },
+          "timezone": {
+            "value": "America/New_York",
+            "type": "string",
+            "required": false
+          },
+          "environment_id": {
+            "value": "98765432-xyz9-uvw8-mnop-9876543210yz",
+            "type": "string",
+            "required": false
+          },
+          "workspace_id": {
+            "value": "11223344-aaaa-bbbb-cccc-112233445566",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DeleteCollection",
+      "qualifiedName": "Postman.DeleteCollection",
+      "fullyQualifiedName": "Postman.DeleteCollection@0.1.0",
+      "description": "Permanently delete a collection. This cannot be undone.",
+      "parameters": [
+        {
+          "name": "collection_id",
+          "type": "string",
+          "required": true,
+          "description": "The collection id or uid to delete.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Confirmation that the collection was deleted."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.DeleteCollection",
+        "parameters": {
+          "collection_id": {
+            "value": "12345678-abcd-efgh-ijkl-1234567890ab",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DeleteCollectionItem",
+      "qualifiedName": "Postman.DeleteCollectionItem",
+      "fullyQualifiedName": "Postman.DeleteCollectionItem@0.1.0",
+      "description": "Delete a folder or request from a collection. This cannot be undone.\n\nDeleting a folder also removes the requests it contains.",
+      "parameters": [
+        {
+          "name": "collection_id",
+          "type": "string",
+          "required": true,
+          "description": "The collection id or uid containing the item.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "item_id",
+          "type": "string",
+          "required": true,
+          "description": "Id of the folder or request to delete.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "item_type",
+          "type": "string",
+          "required": true,
+          "description": "Whether the item is a folder or a request.",
+          "enum": [
+            "folder",
+            "request"
+          ],
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Confirmation that the folder or request was deleted."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.DeleteCollectionItem",
+        "parameters": {
+          "collection_id": {
+            "value": "12345678-abc12345-1234-5678-abcd-1234567890ab",
+            "type": "string",
+            "required": true
+          },
+          "item_id": {
+            "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": true
+          },
+          "item_type": {
+            "value": "folder",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DeleteEnvironment",
+      "qualifiedName": "Postman.DeleteEnvironment",
+      "fullyQualifiedName": "Postman.DeleteEnvironment@0.1.0",
+      "description": "Permanently delete an environment. This cannot be undone.",
+      "parameters": [
+        {
+          "name": "environment_id",
+          "type": "string",
+          "required": true,
+          "description": "The environment id or uid to delete.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Confirmation that the environment was deleted."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.DeleteEnvironment",
+        "parameters": {
+          "environment_id": {
+            "value": "5daabc50-8c4b-11e8-a200-6288b6b71b6e",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DeleteMock",
+      "qualifiedName": "Postman.DeleteMock",
+      "fullyQualifiedName": "Postman.DeleteMock@0.1.0",
+      "description": "Permanently delete a mock server. This cannot be undone.",
+      "parameters": [
+        {
+          "name": "mock_id",
+          "type": "string",
+          "required": true,
+          "description": "The mock server id to delete.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Confirmation that the mock server was deleted."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.DeleteMock",
+        "parameters": {
+          "mock_id": {
+            "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "DeleteMonitor",
+      "qualifiedName": "Postman.DeleteMonitor",
+      "fullyQualifiedName": "Postman.DeleteMonitor@0.1.0",
+      "description": "Permanently delete a monitor. This cannot be undone.",
+      "parameters": [
+        {
+          "name": "monitor_id",
+          "type": "string",
+          "required": true,
+          "description": "The monitor id or uid to delete.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "Confirmation that the monitor was deleted."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.DeleteMonitor",
+        "parameters": {
+          "monitor_id": {
+            "value": "1e6b6cc1-c760-48e0-968f-4bfaeeae9af1",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "delete"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ForkCollection",
+      "qualifiedName": "Postman.ForkCollection",
+      "fullyQualifiedName": "Postman.ForkCollection@0.1.0",
+      "description": "Fork a collection into a workspace as an independent, editable copy.",
+      "parameters": [
+        {
+          "name": "collection_id",
+          "type": "string",
+          "required": true,
+          "description": "The collection id or uid to fork.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "label",
+          "type": "string",
+          "required": true,
+          "description": "Label for the fork.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": false,
+          "description": "Workspace to create the fork in. Leave empty to use your personal (default) workspace; passing it avoids a default-workspace lookup, useful when creating many in a batch.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The forked copy of the collection."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.ForkCollection",
+        "parameters": {
+          "collection_id": {
+            "value": "12345678-abcd-1234-efgh-abcdef123456",
+            "type": "string",
+            "required": true
+          },
+          "label": {
+            "value": "feature/payment-api-v2-fork",
+            "type": "string",
+            "required": true
+          },
+          "workspace_id": {
+            "value": "87654321-dcba-4321-hgfe-654321fedcba",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read",
+            "create"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetApi",
+      "qualifiedName": "Postman.GetApi",
+      "fullyQualifiedName": "Postman.GetApi@0.1.0",
+      "description": "Inspect an API definition, including its name, summary, and attached schemas.",
+      "parameters": [
+        {
+          "name": "api_id",
+          "type": "string",
+          "required": true,
+          "description": "The API definition id.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The API definition with references to its schemas."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.GetApi",
+        "parameters": {
+          "api_id": {
+            "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetApiSchema",
+      "qualifiedName": "Postman.GetApiSchema",
+      "fullyQualifiedName": "Postman.GetApiSchema@0.1.0",
+      "description": "Read an API schema's files and their definition content.",
+      "parameters": [
+        {
+          "name": "api_id",
+          "type": "string",
+          "required": true,
+          "description": "The API definition id.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "schema_id",
+          "type": "string",
+          "required": true,
+          "description": "The id of the schema to read.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The schema's files and their definition content."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.GetApiSchema",
+        "parameters": {
+          "api_id": {
+            "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": true
+          },
+          "schema_id": {
+            "value": "s9f8e7d6-c5b4-3210-fedc-ba9876543210",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetCollection",
+      "qualifiedName": "Postman.GetCollection",
+      "fullyQualifiedName": "Postman.GetCollection@0.1.0",
+      "description": "Inspect a collection and return its variables and a flat tree of its folders and requests.",
+      "parameters": [
+        {
+          "name": "collection_id",
+          "type": "string",
+          "required": true,
+          "description": "The collection id or uid. Prefer the uid for a collection shared by a teammate, whose bare id can be rejected.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The collection with its folders and requests."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.GetCollection",
+        "parameters": {
+          "collection_id": {
+            "value": "12345678-abcd-1234-efgh-0987654321ab",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetCollectionOpenapi",
+      "qualifiedName": "Postman.GetCollectionOpenapi",
+      "fullyQualifiedName": "Postman.GetCollectionOpenapi@0.1.0",
+      "description": "Export a collection as an OpenAPI definition.",
+      "parameters": [
+        {
+          "name": "collection_id",
+          "type": "string",
+          "required": true,
+          "description": "The collection id or uid to export.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The collection exported as an OpenAPI definition."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.GetCollectionOpenapi",
+        "parameters": {
+          "collection_id": {
+            "value": "12345678-abcd-1234-efgh-567890ijklmn",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetEnvironment",
+      "qualifiedName": "Postman.GetEnvironment",
+      "fullyQualifiedName": "Postman.GetEnvironment@0.1.0",
+      "description": "Inspect an environment and return its variables.",
+      "parameters": [
+        {
+          "name": "environment_id",
+          "type": "string",
+          "required": true,
+          "description": "The environment id or uid. Prefer the uid for an environment shared by a teammate, whose bare id can be rejected.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The environment and its variables."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.GetEnvironment",
+        "parameters": {
+          "environment_id": {
+            "value": "5704-8b5c3d2a-1f4e-4a9b-bc7d-2e6f0a3c8d91",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetMock",
+      "qualifiedName": "Postman.GetMock",
+      "fullyQualifiedName": "Postman.GetMock@0.1.0",
+      "description": "Inspect a mock server, including its public URL and the collection it is based on.",
+      "parameters": [
+        {
+          "name": "mock_id",
+          "type": "string",
+          "required": true,
+          "description": "The mock server id.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The mock server, its public URL, and its linked collection."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.GetMock",
+        "parameters": {
+          "mock_id": {
+            "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetMonitor",
+      "qualifiedName": "Postman.GetMonitor",
+      "fullyQualifiedName": "Postman.GetMonitor@0.1.0",
+      "description": "Inspect a monitor, including its run schedule and most recent run result.",
+      "parameters": [
+        {
+          "name": "monitor_id",
+          "type": "string",
+          "required": true,
+          "description": "The monitor id or uid.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The monitor with its schedule and most recent run outcome."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.GetMonitor",
+        "parameters": {
+          "monitor_id": {
+            "value": "1e6b6cc1-c760-48e0-968f-4bfaeeae9af1",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "GetWorkspace",
+      "qualifiedName": "Postman.GetWorkspace",
+      "fullyQualifiedName": "Postman.GetWorkspace@0.1.0",
+      "description": "Inspect a workspace and list the collections, environments, mocks, and monitors in it.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": true,
+          "description": "The unique workspace identifier.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The workspace and the resources it contains."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.GetWorkspace",
+        "parameters": {
+          "workspace_id": {
+            "value": "1f0df51a-8658-4ee8-a2a1-d2567dfa09a9",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListApis",
+      "qualifiedName": "Postman.ListApis",
+      "fullyQualifiedName": "Postman.ListApis@0.1.0",
+      "description": "List the API definitions in a workspace.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": true,
+          "description": "The workspace whose API definitions to list.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0. Paging to a deep offset re-scans the preceding results on this endpoint, so prefer a modest limit over paging far.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The API definitions in the workspace."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.ListApis",
+        "parameters": {
+          "workspace_id": {
+            "value": "1f0df51a-8658-4ee8-a2a1-d2567dfa09a9",
+            "type": "string",
+            "required": true
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListCollections",
+      "qualifiedName": "Postman.ListCollections",
+      "fullyQualifiedName": "Postman.ListCollections@0.1.0",
+      "description": "List collections, optionally scoped to a workspace and filtered by name.\n\nWithout a workspace this returns the collections the API key can access: those you own or\nhave subscribed to. A collection another team member created in a shared workspace may not\nappear here until it is subscribed to; use get_workspace to see everything a workspace holds.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": false,
+          "description": "Scope results to this workspace. Leave empty to span all accessible workspaces.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Filter to collections whose name contains this text. Leave empty for no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The collections matching the filters."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.ListCollections",
+        "parameters": {
+          "workspace_id": {
+            "value": "1f0df51a-8658-4ee8-a2a1-d2567dfa09a9",
+            "type": "string",
+            "required": false
+          },
+          "name": {
+            "value": "Payment API",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListEnvironments",
+      "qualifiedName": "Postman.ListEnvironments",
+      "fullyQualifiedName": "Postman.ListEnvironments@0.1.0",
+      "description": "List environments, optionally scoped to a workspace and filtered by name.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": false,
+          "description": "Scope results to this workspace. Leave empty to span all accessible workspaces.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Filter to environments whose name contains this text. Leave empty for no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The environments matching the filters."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.ListEnvironments",
+        "parameters": {
+          "workspace_id": {
+            "value": "1f0df51a-8658-4ee8-a2a1-d2567dfa09a9",
+            "type": "string",
+            "required": false
+          },
+          "name": {
+            "value": "Production",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListMocks",
+      "qualifiedName": "Postman.ListMocks",
+      "fullyQualifiedName": "Postman.ListMocks@0.1.0",
+      "description": "List mock servers, optionally scoped to a workspace and filtered by name.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": false,
+          "description": "Scope results to this workspace. Leave empty to span all accessible workspaces.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Filter to mock servers whose name contains this text. Leave empty for no filter.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The mock servers matching the filters."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.ListMocks",
+        "parameters": {
+          "workspace_id": {
+            "value": "1f0df51a-8658-4ee8-a2a1-d2567dfa09a9",
+            "type": "string",
+            "required": false
+          },
+          "name": {
+            "value": "staging-mock",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListMonitors",
+      "qualifiedName": "Postman.ListMonitors",
+      "fullyQualifiedName": "Postman.ListMonitors@0.1.0",
+      "description": "List monitors, optionally scoped to a workspace.",
+      "parameters": [
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": false,
+          "description": "Scope results to this workspace. Leave empty to span all accessible workspaces.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The monitors matching the filters."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.ListMonitors",
+        "parameters": {
+          "workspace_id": {
+            "value": "1f0df51a-8658-4ee8-a2a1-d2567dfa09a9",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 25,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "ListWorkspaces",
+      "qualifiedName": "Postman.ListWorkspaces",
+      "fullyQualifiedName": "Postman.ListWorkspaces@0.1.0",
+      "description": "List the workspaces the API key can access, optionally filtered by type.",
+      "parameters": [
+        {
+          "name": "workspace_type",
+          "type": "string",
+          "required": false,
+          "description": "Filter to one workspace type. Defaults to ALL (no filter).",
+          "enum": [
+            "all",
+            "personal",
+            "team",
+            "private",
+            "public",
+            "partner"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "Maximum results to return (1-100). Defaults to 20.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "description": "0-indexed starting position. Defaults to 0.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The workspaces accessible to the API key."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.ListWorkspaces",
+        "parameters": {
+          "workspace_type": {
+            "value": "personal",
+            "type": "string",
+            "required": false
+          },
+          "limit": {
+            "value": 50,
+            "type": "integer",
+            "required": false
+          },
+          "offset": {
+            "value": 0,
+            "type": "integer",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "RunMonitor",
+      "qualifiedName": "Postman.RunMonitor",
+      "fullyQualifiedName": "Postman.RunMonitor@0.1.0",
+      "description": "Trigger a monitor to run now and return its pass/fail results.\n\nThe run is synchronous: Postman holds the connection until the collection finishes. A run\nthat outlasts the tool's bounded wait returns ``timed_out=true`` while still executing\nupstream; read the outcome from get_monitor's last-run fields rather than retrying.",
+      "parameters": [
+        {
+          "name": "monitor_id",
+          "type": "string",
+          "required": true,
+          "description": "The monitor id or uid to run.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The pass/fail outcome of the monitor run."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.RunMonitor",
+        "parameters": {
+          "monitor_id": {
+            "value": "1e6b8c2d-3f4a-5e7b-8c9d-0e1f2a3b4c5d",
+            "type": "string",
+            "required": true
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "opaque"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SaveCollection",
+      "qualifiedName": "Postman.SaveCollection",
+      "fullyQualifiedName": "Postman.SaveCollection@0.1.0",
+      "description": "Create a new collection, or update an existing one when collection_id is provided.",
+      "parameters": [
+        {
+          "name": "collection_id",
+          "type": "string",
+          "required": false,
+          "description": "Id or uid of the collection to update. Omit to create a new collection instead.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "When creating (no collection_id), the new collection's name. When updating, providing this renames the collection; omitting it leaves the name unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "required": false,
+          "description": "When creating, sets the description. When updating, providing this changes it; omitting it leaves the description unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": false,
+          "description": "When creating, the workspace to create the collection in; leave empty to use your personal (default) workspace (passing it avoids a default-workspace lookup, which matters when creating many in a batch). Ignored when updating an existing collection.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The created or updated collection."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.SaveCollection",
+        "parameters": {
+          "collection_id": {
+            "value": "12345678-abcd-1234-efgh-567890ijklmn",
+            "type": "string",
+            "required": false
+          },
+          "name": {
+            "value": "My API Collection",
+            "type": "string",
+            "required": false
+          },
+          "description": {
+            "value": "A collection of API endpoints for the project.",
+            "type": "string",
+            "required": false
+          },
+          "workspace_id": {
+            "value": "98765432-wxyz-9876-abcd-123456uvwxyz",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "SaveEnvironment",
+      "qualifiedName": "Postman.SaveEnvironment",
+      "fullyQualifiedName": "Postman.SaveEnvironment@0.1.0",
+      "description": "Create a new environment, or update an existing one when environment_id is provided.",
+      "parameters": [
+        {
+          "name": "environment_id",
+          "type": "string",
+          "required": false,
+          "description": "Id or uid of the environment to update. Omit to create a new environment instead.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "When creating (no environment_id), the new environment's name. When updating, providing this renames it; omitting it leaves the name unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "values",
+          "type": "array",
+          "innerType": "json",
+          "required": false,
+          "description": "The environment's variables. When creating, seeds them (omit or pass an empty list for none). When updating, providing this replaces the full set; omitting it leaves the existing variables unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "workspace_id",
+          "type": "string",
+          "required": false,
+          "description": "When creating, the workspace to create the environment in; leave empty to use your personal (default) workspace (passing it avoids a default-workspace lookup, which matters when creating many in a batch). Ignored when updating an existing environment.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The created or updated environment."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.SaveEnvironment",
+        "parameters": {
+          "environment_id": {
+            "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": false
+          },
+          "name": {
+            "value": "Production Environment",
+            "type": "string",
+            "required": false
+          },
+          "values": {
+            "value": [
+              {
+                "key": "BASE_URL",
+                "value": "https://api.example.com",
+                "enabled": true,
+                "type": "default"
+              },
+              {
+                "key": "API_VERSION",
+                "value": "v2",
+                "enabled": true,
+                "type": "default"
+              },
+              {
+                "key": "TIMEOUT",
+                "value": "30000",
+                "enabled": true,
+                "type": "default"
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
+          "workspace_id": {
+            "value": "9f8e7d6c-5b4a-3210-fedc-ba9876543210",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "create",
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "UpdateCollectionItem",
+      "qualifiedName": "Postman.UpdateCollectionItem",
+      "fullyQualifiedName": "Postman.UpdateCollectionItem@0.1.0",
+      "description": "Rename a folder or request, or change a request's method or URL.",
+      "parameters": [
+        {
+          "name": "collection_id",
+          "type": "string",
+          "required": true,
+          "description": "The collection id or uid containing the item.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "item_id",
+          "type": "string",
+          "required": true,
+          "description": "Id of the folder or request to update.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "item_type",
+          "type": "string",
+          "required": true,
+          "description": "Whether the item is a folder or a request.",
+          "enum": [
+            "folder",
+            "request"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "New name. Providing this renames the item; omitting it leaves the name unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "required": false,
+          "description": "New description. Providing this changes it; omitting it leaves it unchanged.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "http_method",
+          "type": "string",
+          "required": false,
+          "description": "New HTTP method (requests only). Omitting it leaves the method unchanged.",
+          "enum": [
+            "GET",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE",
+            "HEAD",
+            "OPTIONS"
+          ],
+          "inferrable": true
+        },
+        {
+          "name": "url",
+          "type": "string",
+          "required": false,
+          "description": "New request URL (requests only). Omitting it leaves the URL unchanged.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The updated folder or request."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.UpdateCollectionItem",
+        "parameters": {
+          "collection_id": {
+            "value": "12345678-abcd-1234-efgh-0987654321ab",
+            "type": "string",
+            "required": true
+          },
+          "item_id": {
+            "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": true
+          },
+          "item_type": {
+            "value": "request",
+            "type": "string",
+            "required": true
+          },
+          "name": {
+            "value": "Get User Profile",
+            "type": "string",
+            "required": false
+          },
+          "description": {
+            "value": "Fetches the profile details of an authenticated user.",
+            "type": "string",
+            "required": false
+          },
+          "http_method": {
+            "value": "GET",
+            "type": "string",
+            "required": false
+          },
+          "url": {
+            "value": "https://api.example.com/v1/users/{{userId}}/profile",
+            "type": "string",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": false,
+          "idempotent": false,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "UpdateEnvironmentVariables",
+      "qualifiedName": "Postman.UpdateEnvironmentVariables",
+      "fullyQualifiedName": "Postman.UpdateEnvironmentVariables@0.1.0",
+      "description": "Set or remove individual environment variables without resending the whole variable set.",
+      "parameters": [
+        {
+          "name": "environment_id",
+          "type": "string",
+          "required": true,
+          "description": "Id or uid of the environment to edit.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "set_variables",
+          "type": "array",
+          "innerType": "json",
+          "required": false,
+          "description": "Variables to add or change; each one upserts by key, replacing that variable's value while leaving every other variable untouched. Omit for no additions or changes.",
+          "enum": null,
+          "inferrable": true
+        },
+        {
+          "name": "unset_keys",
+          "type": "array",
+          "innerType": "string",
+          "required": false,
+          "description": "Keys of variables to remove. Keys that are not present are ignored. Omit to remove nothing.",
+          "enum": null,
+          "inferrable": true
+        }
+      ],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The environment with its updated variables."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.UpdateEnvironmentVariables",
+        "parameters": {
+          "environment_id": {
+            "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "string",
+            "required": true
+          },
+          "set_variables": {
+            "value": [
+              {
+                "key": "BASE_URL",
+                "value": "https://api.example.com/v1",
+                "type": "default",
+                "enabled": true
+              },
+              {
+                "key": "AUTH_TOKEN",
+                "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.example",
+                "type": "secret",
+                "enabled": true
+              },
+              {
+                "key": "TIMEOUT_MS",
+                "value": "5000",
+                "type": "default",
+                "enabled": true
+              }
+            ],
+            "type": "array",
+            "required": false
+          },
+          "unset_keys": {
+            "value": [
+              "DEPRECATED_ENDPOINT",
+              "OLD_API_VERSION"
+            ],
+            "type": "array",
+            "required": false
+          }
+        },
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "update"
+          ],
+          "readOnly": false,
+          "destructive": true,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    },
+    {
+      "name": "WhoAmI",
+      "qualifiedName": "Postman.WhoAmI",
+      "fullyQualifiedName": "Postman.WhoAmI@0.1.0",
+      "description": "Identify the Postman account the configured API key belongs to and its plan usage.",
+      "parameters": [],
+      "auth": null,
+      "secrets": [
+        "POSTMAN_API_KEY"
+      ],
+      "secretsInfo": [
+        {
+          "name": "POSTMAN_API_KEY",
+          "type": "api_key"
+        }
+      ],
+      "output": {
+        "type": "json",
+        "description": "The Postman account the API key belongs to."
+      },
+      "documentationChunks": [],
+      "codeExample": {
+        "toolName": "Postman.WhoAmI",
+        "parameters": {},
+        "requiresAuth": false,
+        "tabLabel": "Call the Tool"
+      },
+      "metadata": {
+        "classification": {
+          "serviceDomains": []
+        },
+        "behavior": {
+          "operations": [
+            "read"
+          ],
+          "readOnly": true,
+          "destructive": false,
+          "idempotent": true,
+          "openWorld": true
+        },
+        "extras": null
+      }
+    }
+  ],
+  "documentationChunks": [],
+  "customImports": [],
+  "subPages": [],
+  "generatedAt": "2026-07-15T11:37:37.701Z",
+  "summary": "Postman is an API development and testing platform; this toolkit lets Arcade agents manage Postman workspaces, collections, environments, mock servers, monitors, and API definitions programmatically.\n\n## Capabilities\n\n- **Collection management** — create, inspect, update, fork, export as OpenAPI, and permanently delete collections; add, rename, or remove folders and requests within them.\n- **Environment management** — create, inspect, update individual variables, and delete environments.\n- **Mock servers** — create mock servers from collections, inspect their public URLs, and delete them.\n- **Monitors** — create scheduled health monitors, inspect their run history and schedule, trigger on-demand runs with pass/fail results, and delete them.\n- **API definitions & schemas** — list APIs in a workspace, inspect API definitions, and read schema files with their content.\n- **Workspace & account inspection** — list and inspect workspaces (with all their resources), list collections/environments/mocks/monitors, and verify which Postman account and plan the API key belongs to.\n\n## Secrets\n\n`POSTMAN_API_KEY` — A Postman API key that authenticates every request made by this toolkit. Generate one in your Postman account under **Settings → API keys** ([Postman API key docs](https://learning.postman.com/docs/developer/postman-api/authentication/)). The key inherits the permissions of the generating account; for full toolkit functionality (creating/deleting resources across workspaces) the account must have the appropriate workspace role. Free and paid plans both support API keys, but certain workspace types or team features may require a paid plan.\n\nSee the [Arcade secrets guide](https://docs.arcade.dev/en/guides/create-tools/tool-basics/create-tool-secrets) for how to store secrets, or add them directly at [https://api.arcade.dev/dashboard/auth/secrets](https://api.arcade.dev/dashboard/auth/secrets)."
+}


### PR DESCRIPTION
This PR was generated after a Porter deploy succeeded.

- Trigger: schedule
- Deploy env: unknown
- Deploy SHA: unknown
- Run: https://github.com/ArcadeAI/docs/actions/runs/29412030938

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated documentation and metadata only; no application runtime or auth logic changes in this diff.
> 
> **Overview**
> Scheduled auto-sync of generated integration docs and toolkit JSON after a successful Porter deploy.
> 
> **New integrations in the docs nav:** **Postman** (development) and **Microsoft Power BI** (productivity), with a new `microsoftpowerbi.json` catalog (15 OAuth tools for workspaces, datasets, DAX, refresh, and gateway health).
> 
> **Gmail** bumps to **8.0.3** and adds **`Gmail.ChangeThreadLabels`** for thread-wide label changes; **`ChangeEmailLabels`** copy now documents case-insensitive label matching and confirmations based on labels actually applied.
> 
> Several Microsoft productivity toolkits get patch version bumps (Excel, OneDrive, Outlook Calendar/Mail, PowerPoint, SharePoint) with refreshed tool FQNs and summaries; `index.json` reflects new toolkit entries and Gmail’s tool count (19).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74eb19f733873d774e3d1f34c97f59417b3ee069. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->