### PR TITLE
Make ContactEmail links look like links

### DIFF
--- a/app/_components/contact-email.tsx
+++ b/app/_components/contact-email.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Mail } from "lucide-react";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
@@ -10,6 +11,9 @@ import { useEffect, useState } from "react";
 // (e.g. via usePathname) and point at /<locale>/resources/contact-us.
 const CONTACT_PAGE = "/en/resources/contact-us";
 
+const linkClassName =
+  "inline-flex items-center gap-1 text-brand-accent underline decoration-from-font [text-underline-position:from-font]";
+
 type ContactEmailProps = {
   /** Local part of the address, e.g. "security" for security@arcade.dev. */
   user: string;
@@ -18,6 +22,15 @@ type ContactEmailProps = {
   /** Visible link text. Keep it free of the raw address (see below). */
   children: ReactNode;
 };
+
+function LinkContent({ children }: { children: ReactNode }) {
+  return (
+    <>
+      {children}
+      <Mail aria-hidden className="size-3.5 shrink-0" />
+    </>
+  );
+}
 
 /**
  * A mailto link whose address is assembled only after hydration.
@@ -38,8 +51,16 @@ export function ContactEmail({ user, domain, children }: ContactEmailProps) {
   }, [user, domain]);
 
   if (address) {
-    return <a href={`mailto:${address}`}>{children}</a>;
+    return (
+      <a className={linkClassName} href={`mailto:${address}`}>
+        <LinkContent>{children}</LinkContent>
+      </a>
+    );
   }
 
-  return <Link href={CONTACT_PAGE}>{children}</Link>;
+  return (
+    <Link className={linkClassName} href={CONTACT_PAGE}>
+      <LinkContent>{children}</LinkContent>
+    </Link>
+  );
 }

--- a/app/_components/contact-email.tsx
+++ b/app/_components/contact-email.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Mail } from "lucide-react";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
@@ -12,7 +11,7 @@ import { useEffect, useState } from "react";
 const CONTACT_PAGE = "/en/resources/contact-us";
 
 const linkClassName =
-  "inline-flex items-center gap-1 text-brand-accent underline decoration-from-font [text-underline-position:from-font]";
+  "text-brand-accent underline decoration-from-font [text-underline-position:from-font]";
 
 type ContactEmailProps = {
   /** Local part of the address, e.g. "security" for security@arcade.dev. */
@@ -22,15 +21,6 @@ type ContactEmailProps = {
   /** Visible link text. Keep it free of the raw address (see below). */
   children: ReactNode;
 };
-
-function LinkContent({ children }: { children: ReactNode }) {
-  return (
-    <>
-      {children}
-      <Mail aria-hidden className="size-3.5 shrink-0" />
-    </>
-  );
-}
 
 /**
  * A mailto link whose address is assembled only after hydration.
@@ -53,14 +43,14 @@ export function ContactEmail({ user, domain, children }: ContactEmailProps) {
   if (address) {
     return (
       <a className={linkClassName} href={`mailto:${address}`}>
-        <LinkContent>{children}</LinkContent>
+        {children}
       </a>
     );
   }
 
   return (
     <Link className={linkClassName} href={CONTACT_PAGE}>
-      <LinkContent>{children}</LinkContent>
+      {children}
     </Link>
   );
 }

--- a/app/en/resources/security-research-program/page.mdx
+++ b/app/en/resources/security-research-program/page.mdx
@@ -12,40 +12,42 @@ At Arcade, security is fundamental to our mission of building safe and reliable 
 ## Scope
 
 Our program covers security issues in:
-* Arcade production services and APIs
-* Agent authentication and authorization mechanisms
-* Data handling and storage systems
-* Published open-source components
+
+- Arcade production services and APIs
+- Agent authentication and authorization mechanisms
+- Data handling and storage systems
+- Published open-source components
 
 ## What we're looking for
 
 We're interested in reports about:
-* Authentication or authorization bypasses
-* Data exposure or leakage
-* Injection vulnerabilities
-* Logic flaws affecting agent behavior
-* Issues that could compromise user data or agent integrity
+
+- Authentication or authorization bypasses
+- Data exposure or leakage
+- Injection vulnerabilities
+- Logic flaws affecting agent behavior
+- Issues that could compromise user data or agent integrity
 
 ## Reporting process
 
 Please email <ContactEmail domain="arcade.dev" user="security">our security team</ContactEmail> with:
-* A clear description of the issue
-* Steps to reproduce
-* Potential impact assessment
-* Any relevant proof-of-concept code (please be responsible)
+
+- A clear description of the issue
+- Steps to reproduce
+- Potential impact assessment
+- Any relevant proof-of-concept code (please be responsible)
 
 We'll acknowledge receipt within 72 hours and aim to provide an initial assessment within one week.
 
 ## Guidelines
 
-* Please allow us reasonable time to address issues before public disclosure
-* Avoid automated scanning that could impact service availability
-* Do not access or modify other users' data
-* Keep any discovered vulnerabilities confidential until resolved
+- Please allow us reasonable time to address issues before public disclosure
+- Avoid automated scanning that could impact service availability
+- Do not access or modify other users' data
+- Keep any discovered vulnerabilities confidential until resolved
 
 ## Recognition
 
 While we're a small team with limited resources, we appreciate the effort researchers put into improving our security. We'll credit researchers (with permission) in our security updates and may provide modest rewards for significant findings on a case-by-case basis.
 
-For questions about this program, please contact <ContactEmail domain="arcade.dev" user="security">our security team</ContactEmail>.
-
+For questions about this program, please <ContactEmail domain="arcade.dev" user="security">contact our security team</ContactEmail>.


### PR DESCRIPTION
Before:

<img width="872" height="236" alt="Screenshot 2026-07-13 at 10 29 12 PM" src="https://github.com/user-attachments/assets/853a4002-a8d5-4c1e-9e12-f3270bc2a34d" />

After:

<img width="883" height="228" alt="Screenshot 2026-07-13 at 10 29 47 PM" src="https://github.com/user-attachments/assets/0fb5bf14-48e0-4ef6-993c-9fd5b93fb052" />

Did you even know there was a link in the first image?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS on a shared docs component; no auth, data, or email-obfuscation behavior changes.
> 
> **Overview**
> **`ContactEmail`** now applies a shared Tailwind class (`text-brand-accent` plus underline) on both the post-hydration `mailto:` anchor and the SSR fallback `Link`, so contact links read as links instead of plain text. Every docs page that uses the component picks up the styling without per-page changes.
> 
> The security research program MDX only adjusts list markup (bullets) and slightly rewords the closing **contact our security team** link text; behavior and obfuscation logic are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40d3a8b14dd0cfcbeba3720a90a1464420ff3b1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->