### PR TITLE
Document the CI-driven llms.txt workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Arcade documentation site built with Next.js + Nextra (App Router), using pnpm a
 
 ```bash
 pnpm dev              # Local dev server (port 3000)
-pnpm build            # Full production build (toolkit-markdown → next build → pagefind)
+pnpm build            # Full Next.js production build
 pnpm lint             # Lint with Ultracite (Biome-based)
 pnpm format           # Auto-format with Ultracite
 pnpm test             # Run all Vitest tests
@@ -27,7 +27,7 @@ pnpm vitest run tests/broken-link-check.test.ts
 - **`app/_lib/`** — Data-fetching utilities (toolkit catalog, slug generation, static params).
 - **`app/api/`** — API routes (markdown export, toolkit-data, glossary).
 - **`toolkit-docs-generator/`** — Generates MCP toolkit documentation from server metadata JSON files in `toolkit-docs-generator/data/toolkits/`.
-- **`scripts/`** — Build/CI scripts (Vale style fixes, redirect checking, pagefind indexing, i18n sync).
+- **`scripts/`** — Build/CI scripts (Vale style fixes, redirect checking, llms.txt generation, i18n sync).
 - **`tests/`** — Vitest tests (broken links, internal link validation, sitemap, smoke tests).
 - **`lib/`** — Next.js utilities (glossary remark plugin, llmstxt plugin).
 - **`next.config.ts`** — Contains ~138 redirect rules.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ pnpm vitest run tests/broken-link-check.test.ts
 - **`toolkit-docs-generator/`** — Generates MCP toolkit documentation from server metadata JSON files in `toolkit-docs-generator/data/toolkits/`.
 - **`scripts/`** — Build/CI scripts (Vale style fixes, redirect checking, llms.txt generation, i18n sync).
 - **`tests/`** — Vitest tests (broken links, internal link validation, sitemap, smoke tests).
-- **`lib/`** — Next.js utilities (glossary remark plugin, llmstxt plugin).
+- **`lib/`** — Next.js utilities (glossary remark plugin).
 - **`next.config.ts`** — Contains ~138 redirect rules.
 
 ## Content Authoring

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ The `vale:fix` command requires an API key in `.env.local`. Without one, you can
 - [STYLEGUIDE.md](./STYLEGUIDE.md) - Writing standards for voice, tone, and structure
 - [AGENTS.md](./AGENTS.md) - Instructions for AI assistants working on docs
 
-## llms.txt Generation
+## llms.txt generation
 
-The project includes a Next.js plugin that automatically generates an `llms.txt` file following the [llms.txt specification](https://llmstxt.org/). This file helps LLMs understand and navigate the documentation.
+The project includes a script that generates an `llms.txt` file following the [llms.txt specification](https://llmstxt.org/). This file helps LLMs understand and navigate the documentation.
 
-**Automatic generation**: Runs during production builds (`pnpm build`)
+**Automatic generation**: Runs in the `Generate LLMs.txt` GitHub workflow
 
 **Manual generation**: Run `pnpm llmstxt` to regenerate the file
 


### PR DESCRIPTION
## Summary
- clarify that llms.txt generation runs in its GitHub workflow rather than during every production build
- update contributor guidance for the script-backed process
- remove the stale llms.txt plugin reference from the contributor architecture map

## Test plan
- documentation-only change; `git diff --check origin/main...HEAD`