### PR TITLE
fix(search): prevent duplicate h1 in toolkit summaries causing bad Algolia lvl0

### DIFF
--- a/app/_components/toolkit-docs/components/toolkit-page.tsx
+++ b/app/_components/toolkit-docs/components/toolkit-page.tsx
@@ -641,7 +641,10 @@ export function ToolkitPage({ data }: ToolkitPageProps) {
 
         {data.summary && (
           <div className="prose prose-sm dark:prose-invert mt-6 max-w-none text-foreground">
-            <ReactMarkdown rehypePlugins={[rehypeNeutralizeEmails]}>
+            <ReactMarkdown
+              components={{ h1: "h2" }}
+              rehypePlugins={[rehypeNeutralizeEmails]}
+            >
               {data.summary}
             </ReactMarkdown>
           </div>

--- a/toolkit-docs-generator/src/llm/toolkit-summary-generator.ts
+++ b/toolkit-docs-generator/src/llm/toolkit-summary-generator.ts
@@ -79,7 +79,7 @@ const buildPrompt = (toolkit: MergedToolkit): string => {
     `- If auth type is oauth2 or mixed, add an **OAuth** section that names the provider and links to the Arcade provider docs at ${ARCADE_AUTH_PROVIDERS_BASE_URL}/<providerId> (use the OAuth provider ID supplied in the Auth line below as the slug). Do NOT list scopes — the provider page already documents them and repeating scopes here drifts.`,
     "- If auth type is api_key or mixed, mention API key usage under **OAuth** or a dedicated heading.",
     `- If any secrets exist, add a **Secrets** section. List every secret by its exact name in backticks. For each secret, give a factual explanation of what it is and how a developer obtains it from the provider — use as much detail as the secret actually needs (a short URL override may be one line; a scoped API key may need several sentences naming the provider dashboard page, required scopes/permissions, and any account tier). When possible include an inline markdown link to the provider's own documentation page that tells the reader how to create/retrieve that specific secret. If you do not know the provider's docs URL, omit the link rather than inventing one. End the section with the Arcade config docs link: ${ARCADE_SECRETS_DOC_URL} (and optionally mention ${ARCADE_SECRETS_DASHBOARD_URL}).`,
-    "- Use Markdown. Developer-focused. Say 'Arcade' (never 'Arcade AI').",
+    "- Use Markdown. Developer-focused. Say 'Arcade' (never 'Arcade AI'). Do not use h1 headings (no `# Title` lines); use h2 (`##`) or lower for any section headings.",
     "- Do not add marketing copy, repetition, or filler.",
     "",
     `Toolkit: ${toolkit.label} (${toolkit.id})`,


### PR DESCRIPTION
## Summary

- Some LLM-generated toolkit summaries start with a Markdown h1 (e.g. `# GitHub Toolkit`), which ReactMarkdown renders as a second `<h1>` inside the page's `<article>` element
- The Algolia docsearch helper concatenates all `article h1` elements, producing garbled search titles like "GitHubGitHub Toolkit"
- 8+ toolkits affected: github, apollo, discordbot, glean, hubspotcrmapi, linear, math, telegram, stripeapi

## Changes

- **`toolkit-page.tsx`**: Map `h1 → h2` in ReactMarkdown when rendering the `summary` field — the page already has its own `<h1>{data.label}</h1>` so summary headings should be h2 at most
- **`toolkit-summary-generator.ts`**: Update the LLM prompt to explicitly prohibit h1 headings in future auto-generated summaries

## After merging

A fresh Algolia reindex is needed to clear the doubled titles from search results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentation and prompt tweaks on toolkit docs pages; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes **garbled DocSearch titles** (e.g. duplicated toolkit names) when LLM-generated toolkit summaries include a Markdown `#` heading alongside the page’s existing `<h1>`.
> 
> **`toolkit-page.tsx`** now renders the `summary` field with ReactMarkdown `components={{ h1: "h2" }}`, so summary headings stay at h2 or below and Algolia’s `article h1` → **lvl0** mapping only picks up the real page title.
> 
> **`toolkit-summary-generator.ts`** adds an explicit prompt rule: no h1 in generated markdown—use `##` or lower for sections—so future summaries avoid reintroducing the issue. A **fresh Algolia reindex** is still needed to clear already-indexed doubled titles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ff1dac826101f35a668b01833a5ae70b8cad6f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->