### PR TITLE
Validate rich toolkit subpages

### DIFF
--- a/toolkit-docs-generator/src/sources/custom-sections-file.ts
+++ b/toolkit-docs-generator/src/sources/custom-sections-file.ts
@@ -7,7 +7,10 @@
 import { access, readFile } from "fs/promises";
 import { z } from "zod";
 import type { CustomSections } from "../types/index.js";
-import { DocumentationChunkSchema } from "../types/index.js";
+import {
+  DocumentationChunkSchema,
+  ToolkitSubPageSchema,
+} from "../types/index.js";
 import { normalizeId } from "../utils/fp.js";
 import type { ICustomSectionsSource } from "./interfaces.js";
 
@@ -20,7 +23,7 @@ const CustomSectionsFileSchema = z.record(
   z.object({
     documentationChunks: z.array(DocumentationChunkSchema).default([]),
     customImports: z.array(z.string()).default([]),
-    subPages: z.array(z.string()).default([]),
+    subPages: z.array(ToolkitSubPageSchema).default([]),
     toolChunks: z
       .record(z.string(), z.array(DocumentationChunkSchema))
       .default({}),

--- a/toolkit-docs-generator/src/types/index.ts
+++ b/toolkit-docs-generator/src/types/index.ts
@@ -316,13 +316,22 @@ export type ToolCodeExample = z.infer<typeof ToolCodeExampleSchema>;
 // Custom Sections Schema (extracted from MDX)
 // ============================================================================
 
+export const ToolkitSubPageSchema = z.union([
+  z.string(),
+  z.object({
+    type: z.string().min(1),
+    content: z.string(),
+    relativePath: z.string().min(1),
+  }),
+]);
+
 export const CustomSectionsSchema = z.object({
   /** Toolkit-level documentation chunks */
   documentationChunks: z.array(DocumentationChunkSchema).default([]),
   /** Custom imports needed for the MDX file */
   customImports: z.array(z.string()).default([]),
   /** Sub-pages that exist for this toolkit */
-  subPages: z.array(z.string()).default([]),
+  subPages: z.array(ToolkitSubPageSchema).default([]),
   /** Per-tool documentation chunks (keyed by tool name) */
   toolChunks: z
     .record(z.string(), z.array(DocumentationChunkSchema))
@@ -428,9 +437,7 @@ export const MergedToolkitSchema = z.object({
    * Each entry is either a string (legacy slug) or a rich object with
    * { type, content, relativePath } for inline MDX sub-page content.
    */
-  subPages: z
-    .array(z.union([z.string(), z.record(z.string(), z.unknown())]))
-    .default([]),
+  subPages: z.array(ToolkitSubPageSchema).default([]),
   /** Generation metadata */
   generatedAt: z.string().optional(),
 });

--- a/toolkit-docs-generator/tests/sources/custom-sections-file.test.ts
+++ b/toolkit-docs-generator/tests/sources/custom-sections-file.test.ts
@@ -53,6 +53,25 @@ describe("CustomSectionsFileSource", () => {
     expect(result?.toolChunks).toEqual({});
   });
 
+  it("loads rich subpage entries supported by generated toolkit output", async () => {
+    tempDir = await createTempDir();
+    const filePath = join(tempDir, "custom-sections.json");
+    const subPage = {
+      type: "mdx",
+      content: "# Setup",
+      relativePath: "setup/page.mdx",
+    };
+    await writeFile(
+      filePath,
+      JSON.stringify({ Github: { subPages: [subPage] } }, null, 2)
+    );
+
+    const source = createCustomSectionsFileSource(filePath);
+    const result = await source.getCustomSections("Github");
+
+    expect(result?.subPages).toEqual([subPage]);
+  });
+
   it("throws a helpful error when JSON is invalid", async () => {
     tempDir = await createTempDir();
     const filePath = join(tempDir, "invalid.json");
@@ -79,6 +98,21 @@ describe("CustomSectionsFileSource", () => {
         null,
         2
       )
+    );
+
+    const source = createCustomSectionsFileSource(filePath);
+
+    await expect(source.getAllCustomSections()).rejects.toThrow(
+      `Custom sections file has invalid schema (${filePath})`
+    );
+  });
+
+  it("rejects malformed rich subpage entries", async () => {
+    tempDir = await createTempDir();
+    const filePath = join(tempDir, "invalid-subpage.json");
+    await writeFile(
+      filePath,
+      JSON.stringify({ Github: { subPages: [{ type: "mdx" }] } }, null, 2)
     );
 
     const source = createCustomSectionsFileSource(filePath);


### PR DESCRIPTION
## Summary
- validate rich subpage objects with the same schema used by generated toolkit output
- reject malformed custom-section files before generation
- retain support for legacy string subpage entries

## Test plan
- `pnpm exec tsc --noEmit --project toolkit-docs-generator/tsconfig.json`
- `pnpm exec vitest run --root toolkit-docs-generator`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema tightening in the docs generator only; legacy string sub-pages remain valid and invalid files fail earlier with clearer errors.
> 
> **Overview**
> **Toolkit sub-pages** in custom-sections JSON and merged toolkit output now share a single `ToolkitSubPageSchema`: each entry is either a legacy string slug or a rich object with `type`, `content`, and `relativePath`.
> 
> The custom-sections file loader uses that schema instead of treating `subPages` as plain strings, so malformed rich objects fail at parse time with the same rules as generated toolkit JSON. `MergedToolkitSchema` drops the looser `z.record` union in favor of the same schema.
> 
> Tests cover successful load of rich sub-pages and rejection when required fields are missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6a56125cc02a0010313b0231a39d38c95776a97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->