### PR TITLE
Reuse a consistent toolkit data snapshot

### DIFF
--- a/toolkit-docs-generator/src/cli/generate-flow.ts
+++ b/toolkit-docs-generator/src/cli/generate-flow.ts
@@ -15,6 +15,21 @@ export const collectRemovedToolkitIds = (
       .map((c) => c.toolkitId.toLowerCase())
   );
 
+/**
+ * Protect incremental runs from treating a transient empty API response as a
+ * request to delete every previously generated toolkit.
+ */
+export const assertSafeCurrentToolkitSnapshot = (
+  currentToolkitCount: number,
+  previousToolkitCount: number
+): void => {
+  if (currentToolkitCount === 0 && previousToolkitCount > 0) {
+    throw new Error(
+      `Current toolkit snapshot is empty; refusing to remove all ${previousToolkitCount} existing toolkits.`
+    );
+  }
+};
+
 export interface ProcessingStats {
   totalToolkits: number;
   effectiveSkipped: number;

--- a/toolkit-docs-generator/src/cli/index.ts
+++ b/toolkit-docs-generator/src/cli/index.ts
@@ -46,6 +46,7 @@ import { createMockMetadataSource } from "../sources/mock-metadata.js";
 import { createDesignSystemProviderIdResolver } from "../sources/oauth-provider-resolver.js";
 import {
   createArcadeToolkitDataSource,
+  createCachedToolkitDataSource,
   createEngineToolkitDataSource,
   createMockToolkitDataSource,
   type IToolkitDataSource,
@@ -65,6 +66,7 @@ import {
 } from "../utils/run-logs.js";
 import { cleanupExcludedToolkitOutput } from "./exclusion-cleanup.js";
 import {
+  assertSafeCurrentToolkitSnapshot,
   collectRemovedToolkitIds,
   computeProcessingStats,
   filterProvidersBySkipIds,
@@ -1209,13 +1211,15 @@ program
 
         // Create toolkit data source based on API source
         const apiSource = resolveApiSource(options);
-        const toolkitDataSource = createToolkitDataSourceForApi(
-          apiSource,
-          options,
-          metadataSource,
-          mockDataDir,
-          options.verbose,
-          spinner
+        const toolkitDataSource = createCachedToolkitDataSource(
+          createToolkitDataSourceForApi(
+            apiSource,
+            options,
+            metadataSource,
+            mockDataDir,
+            options.verbose,
+            spinner
+          )
         );
 
         const needsExamples = !options.skipExamples;
@@ -1386,6 +1390,10 @@ program
             }
             currentToolkitDataForDiff.set(id, data);
           }
+          assertSafeCurrentToolkitSnapshot(
+            currentToolkitDataForDiff.size,
+            previousToolkits?.size ?? 0
+          );
 
           // Detect changes
           const compareStartedAt = Date.now();
@@ -2144,13 +2152,15 @@ program
 
         // Create toolkit data source based on API source
         const apiSource = resolveApiSource(options);
-        const toolkitDataSource = createToolkitDataSourceForApi(
-          apiSource,
-          options,
-          metadataSource,
-          mockDataDir,
-          options.verbose,
-          spinner
+        const toolkitDataSource = createCachedToolkitDataSource(
+          createToolkitDataSourceForApi(
+            apiSource,
+            options,
+            metadataSource,
+            mockDataDir,
+            options.verbose,
+            spinner
+          )
         );
 
         const needsExamples = !options.skipExamples;
@@ -2727,13 +2737,15 @@ program
         });
 
         const apiSource = resolveApiSource(options);
-        const toolkitDataSource = createToolkitDataSourceForApi(
-          apiSource,
-          options,
-          metadataSource,
-          mockDataDir,
-          false, // not verbose during fetch
-          spinner
+        const toolkitDataSource = createCachedToolkitDataSource(
+          createToolkitDataSourceForApi(
+            apiSource,
+            options,
+            metadataSource,
+            mockDataDir,
+            false, // not verbose during fetch
+            spinner
+          )
         );
 
         // Fetch current data from API
@@ -2758,6 +2770,11 @@ program
         );
         const loadPreviousDurationMs = Date.now() - loadPreviousStartedAt;
         const previousToolkits = previousToolkitLoad.toolkits;
+
+        assertSafeCurrentToolkitSnapshot(
+          currentToolkitDataForDiff.size,
+          previousToolkits.size
+        );
 
         // Detect changes
         spinner.text = "Comparing tool definitions...";

--- a/toolkit-docs-generator/src/sources/toolkit-data-source.ts
+++ b/toolkit-docs-generator/src/sources/toolkit-data-source.ts
@@ -75,6 +75,30 @@ export interface IToolkitDataSource {
   readonly isAvailable: () => Promise<boolean>;
 }
 
+/**
+ * Reuse one all-toolkit snapshot for the lifetime of a generation run.
+ *
+ * Change detection, progress setup, and merging all consume the same data
+ * instead of issuing independent API reads that can disagree mid-run.
+ */
+export const createCachedToolkitDataSource = (
+  source: IToolkitDataSource
+): IToolkitDataSource => {
+  let allToolkitsSnapshot:
+    | Promise<ReadonlyMap<string, ToolkitData>>
+    | undefined;
+
+  return {
+    fetchToolkitData: (toolkitId, version) =>
+      source.fetchToolkitData(toolkitId, version),
+    fetchAllToolkitsData: () => {
+      allToolkitsSnapshot ??= source.fetchAllToolkitsData();
+      return allToolkitsSnapshot;
+    },
+    isAvailable: () => source.isAvailable(),
+  };
+};
+
 // ============================================================================
 // Combined Implementation (Current: Separate Sources)
 // ============================================================================

--- a/toolkit-docs-generator/tests/cli/generate-flow.test.ts
+++ b/toolkit-docs-generator/tests/cli/generate-flow.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  assertSafeCurrentToolkitSnapshot,
   collectRemovedToolkitIds,
   computeProcessingStats,
   filterProvidersBySkipIds,
@@ -69,6 +70,19 @@ describe("collectRemovedToolkitIds", () => {
 
   it("returns empty set for empty change list", () => {
     expect(collectRemovedToolkitIds(makeResult([])).size).toBe(0);
+  });
+});
+
+describe("assertSafeCurrentToolkitSnapshot", () => {
+  it("rejects an empty current snapshot when previous output exists", () => {
+    expect(() => assertSafeCurrentToolkitSnapshot(0, 115)).toThrow(
+      "refusing to remove all 115 existing toolkits"
+    );
+  });
+
+  it("allows an empty initial snapshot and non-empty updates", () => {
+    expect(() => assertSafeCurrentToolkitSnapshot(0, 0)).not.toThrow();
+    expect(() => assertSafeCurrentToolkitSnapshot(114, 115)).not.toThrow();
   });
 });
 

--- a/toolkit-docs-generator/tests/sources/toolkit-data-source.test.ts
+++ b/toolkit-docs-generator/tests/sources/toolkit-data-source.test.ts
@@ -11,7 +11,11 @@ import {
   InMemoryToolDataSource,
 } from "../../src/sources/in-memory.js";
 import type { IMetadataSource } from "../../src/sources/internal.js";
-import { createCombinedToolkitDataSource } from "../../src/sources/toolkit-data-source.js";
+import {
+  createCachedToolkitDataSource,
+  createCombinedToolkitDataSource,
+  type IToolkitDataSource,
+} from "../../src/sources/toolkit-data-source.js";
 import type { ToolDefinition, ToolkitMetadata } from "../../src/types/index.js";
 
 const createTool = (
@@ -404,5 +408,44 @@ describe("CombinedToolkitDataSource", () => {
     const result = await dataSource.fetchAllToolkitsData();
     expect(result.get("Github")?.metadata?.label).toBe("GitHub");
     expect(lookedUpIds).toEqual([]);
+  });
+});
+
+describe("createCachedToolkitDataSource", () => {
+  it("reuses one immutable all-toolkit snapshot within a run", async () => {
+    const snapshot = new Map([
+      [
+        "Github",
+        {
+          tools: [createTool()],
+          metadata: createMetadata(),
+        },
+      ],
+    ]);
+    const githubData = snapshot.get("Github");
+    if (!githubData) {
+      throw new Error("Expected GitHub fixture");
+    }
+    let fetchAllCalls = 0;
+    const source: IToolkitDataSource = {
+      fetchToolkitData: async () => githubData,
+      fetchAllToolkitsData: async () => {
+        fetchAllCalls += 1;
+        return snapshot;
+      },
+      isAvailable: async () => true,
+    };
+    const cached = createCachedToolkitDataSource(source);
+
+    const [first, second, third] = await Promise.all([
+      cached.fetchAllToolkitsData(),
+      cached.fetchAllToolkitsData(),
+      cached.fetchAllToolkitsData(),
+    ]);
+
+    expect(fetchAllCalls).toBe(1);
+    expect(first).toBe(snapshot);
+    expect(second).toBe(first);
+    expect(third).toBe(first);
   });
 });


### PR DESCRIPTION
## Summary
- cache one all-toolkit API snapshot for change detection, progress, and merging
- reject a transient empty snapshot when prior generated output contains toolkits
- cover repeated reads and destructive-delete protection with deterministic tests

## Test plan
- `pnpm exec tsc --noEmit --project toolkit-docs-generator/tsconfig.json`
- `pnpm exec vitest run --root toolkit-docs-generator`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect incremental generation and change detection against live APIs; a false positive on the empty-snapshot guard could block legitimate runs, while the cache fixes real consistency bugs during multi-phase CLI flows.
> 
> **Overview**
> Generation runs now wrap the toolkit data source with **`createCachedToolkitDataSource`**, so **`fetchAllToolkitsData`** is called once per run and change detection, progress, and merging share the same in-memory map instead of independent API reads that can diverge mid-run.
> 
> Incremental and dry-run flows add **`assertSafeCurrentToolkitSnapshot`**, which **fails** when the current snapshot is empty but prior generated output still has toolkits—blocking mistaken “remove everything” cleanup from a transient empty API response. **`generate --skip-unchanged`** and **`check-changes`** invoke this guard before diffing.
> 
> Vitest coverage was added for the cache wrapper (single fetch, shared promise) and the snapshot safety check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e705cb7d31f1a040637df1e6dfea0215dbaae2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->