### PR TITLE
Fix run commands on the Contextual Access examples page

### DIFF
--- a/app/en/guides/contextual-access/examples/page.mdx
+++ b/app/en/guides/contextual-access/examples/page.mdx
@@ -3,7 +3,7 @@ title: "Running a Server"
 description: "Run open-source example webhook servers to get started with Contextual Access"
 ---
 
-# Running an Server
+# Running a Server
 
 The fastest way to get started with Contextual Access is to run one of the open-source example servers. These are example Go implementations you can use as-is or as a starting point for your own server.
 
@@ -43,7 +43,7 @@ cd logic-extensions-examples/
 **Advanced server (with web dashboard):**
 
 ```bash
-go run ./examples/contextual_access/advanced_server -config ./examples/advanced_server/example-config.yaml
+go run ./examples/contextual_access/advanced_server -config ./examples/contextual_access/advanced_server/example-config.yaml
 ```
 
 **Focused examples:**
@@ -56,24 +56,24 @@ go run ./examples/contextual_access/pii_redactor -types "email,ssn,credit_card"
 go run ./examples/contextual_access/user_blocking -block "user1,user2"
 
 # Content filter (access, pre, post)
-go run ./examples/contextual_access/content_filter -config ./examples/content_filter/example-config.yaml
+go run ./examples/contextual_access/content_filter -config ./examples/contextual_access/content_filter/example-config.yaml
 
 # A/B testing (pre-hook)
-go run ./examples/contextual_access/ab_testing -config ./examples/ab_testing/example-config.yaml
+go run ./examples/contextual_access/ab_testing -config ./examples/contextual_access/ab_testing/example-config.yaml
 
 # Basic rules (all hooks, configurable via YAML)
-go run ./examples/contextual_access/basic_rules -config ./examples/basic_rules/example-config.yaml
+go run ./examples/contextual_access/basic_rules -config ./examples/contextual_access/basic_rules/example-config.yaml
 ```
 
 Each server exposes `GET /health`, `POST /access`, `POST /pre`, and `POST /post` (or a subset, depending on which hook points it implements).
 
-## Connect to the Arcade
+## Connect to Arcade
 
 Once your server is running:
 
 1. Open the **Arcade Dashboard** and navigate to **Contextual Access**
 2. Click **Create Extension** and enter your server's base URL and endpoint paths
-4. Create **hook configurations** to attach the extension to the hook points you want
+3. Create **hook configurations** to attach the extension to the hook points you want
 
 See [How Hooks Work](/guides/contextual-access/how-hooks-work) for details on configuring extensions and hook points.
 


### PR DESCRIPTION
## What

Fixes the quick-start run commands on `guides/contextual-access/examples` so they work as copy-pasted.

Four of the `-config` paths were missing the `contextual_access/` segment (e.g. `./examples/advanced_server/example-config.yaml` instead of `./examples/contextual_access/advanced_server/example-config.yaml`), so `go run` fails with a config-not-found error for the advanced_server, content_filter, ab_testing, and basic_rules examples. Verified each corrected path against a fresh clone of [logic-extensions-examples](https://github.com/ArcadeAI/logic-extensions-examples) and ran the advanced server end to end with the corrected command (health + all three hook endpoints respond).

## Also fixed on the same page

- Heading typo: "Running an Server" -> "Running a Server"
- Numbered list under "Connect to Arcade" went 1, 2, 4
- "Connect to the Arcade" -> "Connect to Arcade"

## Notes

- The example's own README in the logic-extensions-examples repo has the same class of path bug (drops `contextual_access/` from both the binary and config paths); happy to follow up with a PR there too.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes to an MDX guide; no runtime, auth, or application code affected.
> 
> **Overview**
> Fixes **copy-paste `go run` commands** on the Contextual Access examples guide so `-config` paths include the `contextual_access/` segment for `advanced_server`, `content_filter`, `ab_testing`, and `basic_rules` (previously they pointed at non-existent paths under `./examples/...`).
> 
> Also corrects minor page copy: heading **"Running a Server"**, **"Connect to Arcade"** (drops extra "the"), and the dashboard setup list is renumbered so steps run **1–3** instead of skipping step 3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7ae45aa462df2a690658bd9fd567c552582aed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->