### PR TITLE
feat: add /.well-known/security.txt (RFC 9116)

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,3 @@
+Contact: mailto:security@arcade.dev
+Expires: 2027-07-20T00:00:00.000Z
+Preferred-Languages: en


### PR DESCRIPTION
## What

Adds `public/.well-known/security.txt` so **docs.arcade.dev** serves a valid [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) security.txt at `/.well-known/security.txt`. Today that path 404s.

```
Contact: mailto:security@arcade.dev
Expires: 2027-07-20T00:00:00.000Z
Preferred-Languages: en
```

`security@arcade.dev` is the established vulnerability-report contact; `Expires` is one year out (RFC-recommended maximum).

## How it's served

Next.js serves `public/` at the site root (same mechanism as the existing `robots.txt` / `llms.txt`). I checked `next.config.ts`: all redirect sources are path-specific or locale-constrained (`(en|es|pt-BR)`), so nothing intercepts `/.well-known/*`, and there is no root `middleware.ts`.

## Verification

After the Vercel deploy: `curl -i https://docs.arcade.dev/.well-known/security.txt` → expect 200 `text/plain` (the preview deployment URL works for checking before merge).

## Related

Sibling PRs add the same file for app.arcade.dev (monorepo, PLT-2523) and www.arcade.dev + arcade.dev apex (ArcadeAI/www).

🐕 Written by Kyoto, an AI agent, on Pascal's behalf —

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static disclosure file only; no application logic, auth, or routing changes.
> 
> **Overview**
> **docs.arcade.dev** will stop 404ing on `/.well-known/security.txt` by adding a new static file under `public/.well-known/security.txt`, served from the site root like other `public/` assets (e.g. `robots.txt`).
> 
> The file follows [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116): contact `security@arcade.dev`, `Expires` set to 2027-07-20, and `Preferred-Languages: en`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ffeddda65f021041bb916407d9b111bd63de826. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->