### PR TITLE
docs: clarify project membership as a trust boundary for auth

### DIFF
--- a/app/en/guides/user-facing-agents/secure-auth-production/page.mdx
+++ b/app/en/guides/user-facing-agents/secure-auth-production/page.mdx
@@ -32,11 +32,14 @@ When you authorize a tool, you'll be prompted to sign in to your Arcade.dev acco
 The Arcade.dev user verifier helps keep your auth flows secure while you are building and testing your agent or app. When you're ready to share your work with others, implement a [custom user verifier](#build-a-custom-user-verifier) so your users don't need to sign in to Arcade.dev.
 
 <Callout type="info">
-  Arcade's default OAuth apps can *only* be used with the Arcade user verifier.
-  If you are building a multi-user production app, you must obtain your own
-  OAuth app credentials and add them to Arcade. For example, see our docs on
-  [configuring Google auth in the Arcade
-  Dashboard](/references/auth-providers/google#access-the-arcade-dashboard).
+  Arcade's default OAuth apps can *only* be used with the Arcade user verifier,
+  which requires each end user to sign in to an Arcade account that is a member
+  of your project. This ties end-user authorization to project membership, which
+  is why the default OAuth apps are intended for development and single-tenant
+  use. For a multi-user production app, add your own [OAuth app
+  credentials](/references/auth-providers) and pair them with a [custom user
+  verifier](#build-a-custom-user-verifier), so your end users are verified by
+  your app rather than by project membership.
 </Callout>
 
 ## Build a custom user verifier
@@ -267,8 +270,11 @@ In the [Auth > Settings section](https://api.arcade.dev/dashboard/auth/settings)
 
 <Callout type="info">
   Arcade's default OAuth apps *only* support the Arcade user verifier.
-  Authorization flows using Arcade's default OAuth apps will use the Arcade user
-  verifier even if you have a custom verifier route set up.
+  Authorization flows that use a default OAuth app always fall back to the Arcade
+  user verifier, even if you have a custom verifier route configured. Because the
+  Arcade user verifier requires the end user to be a signed-in member of your
+  project, authorizations through a default OAuth app are always gated by project
+  membership.
 </Callout>
 
 </Steps>

--- a/app/en/resources/glossary/page.mdx
+++ b/app/en/resources/glossary/page.mdx
@@ -126,6 +126,8 @@ A 'tenant' is a collection of projects with unified billing details. It is the t
 
 A 'project' is a collection of agents and tools. It is smallest unit of organization and isolation in Arcade. You can have multiple projects, and each project can have multiple agents and tools. Accounts can be members of multiple projects, and each project will have different API keys.
 
+A project is also a trust boundary. Everyone with membership in a project, or with one of its API keys, shares access to that project's users, brokered tokens, and secrets, and can start authorization flows on behalf of its users. Only invite people you trust into a project, and only join projects you trust.
+
 ### Arcade API
 
 The 'Arcade API' is a set of endpoints that allow you to interact with the Arcade platform. You can use the API to call tools, get tool definitions, manage user auth, and more. See the [Arcade API Reference](/references/api) for more details.


### PR DESCRIPTION
## What

Clarifies how project membership relates to authorization, so readers understand the trust boundary a project represents.

## Changes

- **`resources/glossary`** — the Project entry now states that a project is a trust boundary: its members (and API-key holders) share access to its users, brokered tokens, and secrets, with guidance to only invite/join projects you trust.
- **`guides/user-facing-agents/secure-auth-production`** — both verifier callouts clarified: the Arcade user verifier requires end users to be signed-in project members, which is why default OAuth apps are for development/single-tenant use, while production multi-user apps should use their own OAuth app plus a custom verifier.

Not changing the Google provider page — this behavior is generic to all default OAuth apps.

## Notes for reviewers

Vale's advisory PR reviewer can't parse `secure-auth-production.mdx` due to a pre-existing nested-`Tabs` quirk; not a regression, and it doesn't fail CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)