### PR TITLE
chore(deps): pin dompurify and protobufjs to patch Vanta CVEs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,8 @@ overrides:
   '@xmldom/xmldom': '>=0.9.10'
   esbuild: 0.28.1
   form-data: 4.0.6
+  dompurify: '>=3.4.7 <4'
+  protobufjs: '>=7.6.3 <8'
 
 importers:
 
@@ -1093,17 +1095,14 @@ packages:
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  '@protobufjs/inquire@1.1.2':
-    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
-
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
 
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.1':
-    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -2488,8 +2487,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  dompurify@3.4.1:
-    resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -3605,8 +3604,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.6.2:
-    resolution: {integrity: sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   proxy-from-env@2.1.0:
@@ -5303,7 +5302,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      protobufjs: 7.6.2
+      protobufjs: 7.6.5
 
   '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -5366,13 +5365,11 @@ snapshots:
 
   '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.2': {}
-
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.1': {}
+  '@protobufjs/utf8@1.1.2': {}
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -7035,7 +7032,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dompurify@3.4.1:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7944,7 +7941,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.19
-      dompurify: 3.4.1
+      dompurify: 3.4.12
       es-toolkit: 1.47.0
       katex: 0.16.27
       khroma: 2.1.0
@@ -8567,7 +8564,7 @@ snapshots:
       '@posthog/core': 1.30.3
       '@posthog/types': 1.379.0
       core-js: 3.47.0
-      dompurify: 3.4.1
+      dompurify: 3.4.12
       fflate: 0.4.8
       preact: 10.29.1
       query-selector-shadow-dom: 1.0.1
@@ -8589,7 +8586,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@7.6.2:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -8597,10 +8594,9 @@ snapshots:
       '@protobufjs/eventemitter': 1.1.1
       '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.1
+      '@protobufjs/utf8': 1.1.2
       '@types/node': 22.19.17
       long: 5.3.2
 
@@ -9357,7 +9353,7 @@ snapshots:
       classnames: 2.5.1
       css.escape: 1.5.1
       deep-extend: 0.6.0
-      dompurify: 3.4.1
+      dompurify: 3.4.12
       ieee754: 1.2.1
       immutable: 3.8.3
       js-file-download: 0.4.12

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,7 @@ overrides:
   esbuild: "0.28.1"
   # Force form-data to a patched version across all transitive dependents (CVE-2026-12143, CRLF header injection)
   form-data: "4.0.6"
+  # Force dompurify (via mermaid, posthog-js, swagger-ui-react) past mXSS advisories (CVE-2026-49459, CVE-2026-49458 fixed in 3.4.6; GHSA-76mc-f452-cxcm fixed in 3.4.7). Cap below 4 to stay within consumers' ^3 range.
+  dompurify: ">=3.4.7 <4"
+  # Force protobufjs (via @opentelemetry/otlp-transformer) past prototype-pollution advisory (CVE-2026-54269, fixed in 7.6.3). Cap below 8 to stay within otlp-transformer's ^7 range.
+  protobufjs: ">=7.6.3 <8"


### PR DESCRIPTION
Remediates the four Vanta/Dependabot advisories (all MEDIUM) by adding pnpm overrides in `pnpm-workspace.yaml` that force the transitive dompurify (`>=3.4.7 <4`, pulled by mermaid/posthog-js/swagger-ui-react) and protobufjs (`>=7.6.3 <8`, pulled by @opentelemetry/otlp-transformer) past the vulnerable versions, resolving to dompurify@3.4.12 and protobufjs@7.6.5. This clears CVE-2026-49459, CVE-2026-49458, and GHSA-76mc-f452-cxcm (dompurify) plus CVE-2026-54269 (protobufjs). Both ranges are capped below the next major so the bump stays within each consumer's declared semver and doesn't pull a breaking major. `pnpm-lock.yaml` was regenerated and the full test suite passes (767/767).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency pinning with semver caps below the next major; no runtime code changes.
> 
> **Overview**
> Adds **pnpm workspace overrides** for transitive **dompurify** (`>=3.4.7 <4`) and **protobufjs** (`>=7.6.3 <8`), following the same pattern as existing security pins in `pnpm-workspace.yaml`. The lockfile is updated so installs resolve to **dompurify@3.4.12** (replacing 3.4.1) and **protobufjs@7.6.5** (replacing 7.6.2), including consumers such as mermaid, posthog-js, swagger-ui-react, and `@opentelemetry/otlp-transformer`.
> 
> The **protobufjs** bump also drops `@protobufjs/inquire` from the resolved tree and bumps `@protobufjs/utf8` to 1.1.2. No application source changes—dependency resolution only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 803e1b5330c17caabdc9cd59f1203216cc72b0e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->