### PR TITLE
fix(algolia): relax query matching + index code blocks to cut no-result rate

### DIFF
--- a/algolia/crawler-config.js
+++ b/algolia/crawler-config.js
@@ -52,7 +52,10 @@ export const crawlerConfig = {
             lvl3: "article h4",
             lvl4: "article h5",
             lvl5: "article h6",
-            content: "article p, article li, article td",
+            // Include `pre` so terms that only appear in code samples
+            // (e.g. `arcade_api_key`, `tool_choice`, `chat.completions`) are
+            // searchable — several no-result queries were code-only terms.
+            content: "article p, article li, article td, article pre",
           },
           indexHeadings: true,
           aggregateContent: true,
@@ -64,6 +67,12 @@ export const crawlerConfig = {
     docs_arcade_dev_bjb8pbsq9t_docsearch: {
       distinct: true,
       attributeForDistinct: "url_without_anchor",
+      // Long, keyword-heavy queries (often from agents/LLMs) used to return
+      // nothing because Algolia's default `removeWordsIfNoResults: "none"`
+      // requires every word to match a single record. Relax to "allOptional"
+      // so a query still surfaces its best partial matches instead of zero.
+      removeWordsIfNoResults: "allOptional",
+      ignorePlurals: true,
       searchableAttributes: [
         "unordered(hierarchy.lvl0)",
         "unordered(hierarchy.lvl1)",


### PR DESCRIPTION
## Why

The most recent Algolia weekly report (Jul 20–26) showed a **24.66% no-result rate**. Reviewing the 10 zero-hit queries against the docs, **8 of 10 map to content that exists but wasn't matching**. (The other two — `screens bulk`, `update screens in bulk` — have no corresponding docs and look off-topic.)

Two root causes, both in `algolia/crawler-config.js`:

1. **No query relaxation.** `removeWordsIfNoResults` was unset, so Algolia used its default `"none"` — every word in a query had to match a single record. The long, agent/LLM-style keyword queries in the report (8+ tokens) could never match any one page, so they returned zero even though the topic is well documented.
2. **Code blocks weren't indexed.** The content selector was `article p, article li, article td` — excluding `pre`. Terms that only appear in code samples (`arcade_api_key`, `tool_choice`, `chat.completions`) were unsearchable.

(A third suspect — repeated `SafeReindexingError` reindex blocks — was already fixed separately; the index is fresh.)

## Changes

- `removeWordsIfNoResults: "allOptional"` + `ignorePlurals: true` — long queries now surface their best partial matches instead of zero.
- Added `article pre` to the content selector so code-sample terms are searchable.

## Notes / review

- `allOptional` maximizes recall (chosen deliberately for the agent-query pattern); it trades a bit of precision. Alternative is `lastWords` if we want to be conservative.
- Adding `pre` only **adds** records, so it won't trip the `SafeReindexingError` (too-few-records) guard.
- Recommend previewing extraction in the Algolia dashboard **URL Tester** before merge, per `algolia/README.md`.
- On merge, `sync-crawler-config.yml` pushes this config and triggers a reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Search indexing and ranking settings only; no application auth or data paths, with an intentional tradeoff toward higher recall.
> 
> **Overview**
> Targets a high **no-result rate** on docs search by changing how the Algolia crawler indexes content and how the index treats queries.
> 
> **Indexing:** The docsearch `content` selector now includes **`article pre`**, so terms that only appear in code samples (API keys, SDK symbols, etc.) are indexed instead of being invisible to search.
> 
> **Query behavior:** Index settings add **`removeWordsIfNoResults: "allOptional"`** and **`ignorePlurals: true`**, so long keyword-heavy queries can return partial matches instead of requiring every token to hit one record (the previous default behavior). This favors recall for agent/LLM-style queries at some cost to precision.
> 
> Changes live in `algolia/crawler-config.js`; merge triggers the existing sync workflow and a reindex.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17f7087909b4ee46d2268fbda4db6fc36079da0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->