### PR TITLE
fix(integrations): correct Nimble page tool list and naming

### DIFF
--- a/app/en/references/changelog/page.mdx
+++ b/app/en/references/changelog/page.mdx
@@ -13,7 +13,7 @@ _Here's what's new at Arcade.dev!_
 
 **Misc**
 
-- `[feature - 🚀]` Add Nimble as a Partner MCP Server for real-time web data in the search integrations catalog.
+- `[feature - 🚀]` Add Nimble as a Partner MCP server for real-time web data in the search integrations catalog.
 
 ## 2026-07-24
 

--- a/app/en/resources/integrations/search/nimble/page.mdx
+++ b/app/en/resources/integrations/search/nimble/page.mdx
@@ -32,17 +32,19 @@ Set these under **Advanced settings → Custom headers** when you add the server
 
 ## What you can do
 
-Once you register Nimble in your Arcade project, Arcade discovers its tools automatically. Nimble exposes 27 tools, because most capabilities ship more than one tool: a synchronous call, an asynchronous variant, and status or listing calls. They group into these capabilities:
+Once you register Nimble in your Arcade project, Arcade discovers its tools automatically. Nimble groups them into these capabilities:
 
-| Capability | Tools | What it does |
-| --- | --- | --- |
-| Search | 1 | Real-time web search with configurable content richness. |
-| Extract | 2 | Pull structured content from a specific URL, synchronously or asynchronously. |
-| Crawl | 4 | Crawl multiple pages on a site, then check progress, list jobs, or cancel a run. |
-| Map | 1 | Discover the URLs on a site by crawling its pages and sitemap. |
-| Extract templates | 7 | Browse the template catalog, run templates against a URL, and generate or refine custom ones. |
-| Web search agents | 11 | Create, update, and run research agents, then poll runs and read their results. |
-| Task results | 1 | Fetch the status and results of any async task. |
+| Capability | What it does |
+| --- | --- |
+| Search | Real-time web search with configurable content richness. |
+| Extract | Pull structured content from a specific URL, synchronously or asynchronously. |
+| Crawl | Crawl multiple pages on a site, then check progress, list jobs, or cancel a run. |
+| Map | Discover the URLs on a site by crawling its pages and sitemap. |
+| Extract templates | Browse the template catalog, run templates against a URL, and generate or refine custom ones. |
+| Web search agents | Create, update, and run research agents, then poll runs and read their results. |
+| Task results | Fetch the status and results of any async task. |
+
+Most capabilities ship more than one tool: a synchronous call, an asynchronous variant, and status or listing calls. Expect roughly two dozen individual tools in the tool picker rather than seven. The exact set depends on your Nimble plan and on the account you connect with, so [connect as an admin user](/guides/mcp-gateways/add-remote-servers#save-and-confirm-the-connection) to discover the broadest list, and check the picker for what your project actually has.
 
 Nimble prefixes its own tools with `nimble_`, and Arcade namespaces each tool under the server ID you choose when you add the server. With the server ID `nimble`, tool names appear as `nimble.nimble_search` in the Playground, the gateway tool picker, and SDK calls. Copy the exact name from the tool picker before calling it.
 
@@ -53,6 +55,8 @@ Nimble prefixes its own tools with `nimble_`, and Arcade namespaces each tool un
   the polling tools alongside the tools that start the work, or your agent will
   kick off jobs it cannot read back.
 </Callout>
+
+Most Nimble tools only read. The exceptions write to your Nimble account: the tools that create, update, run, or delete agents, and the ones that generate extract templates. If you are building a research gateway, leave the write tools out of it.
 
 Compose these tools with Google Docs, Slack, Salesforce, GitHub, or any of Arcade's native servers in a single MCP Gateway, so an agent can research, draft, and act in one flow, with authorization and audit from Arcade's runtime.
 

--- a/app/en/resources/integrations/search/nimble/page.mdx
+++ b/app/en/resources/integrations/search/nimble/page.mdx
@@ -47,14 +47,16 @@ Nimble prefixes its own tools with `nimble_`, and Arcade namespaces each tool un
 
 Compose these tools with Google Docs, Slack, Salesforce, GitHub, or any of Arcade's native servers in a single MCP Gateway, so an agent can research, draft, and act in one flow, with authorization and audit from Arcade's runtime.
 
-## Token usage
+## Cost and token usage
 
-Web retrieval returns large payloads, and MCP routes every result through the model's context window, so these tools can consume tokens quickly. Two things help:
+Nimble designs its [MCP server](https://www.nimbleway.com/mcp) around retrieval efficiency. It describes a proprietary index and memory that "gets smarter with every query" to compound accuracy over time, and cutting token costs "by retrieving exactly what's needed," without redundant searches or parsing raw pages through an LLM. Its tools return schema-consistent JSON, so your model spends tokens reasoning over results rather than parsing raw HTML. This behavior runs server-side at Nimble.
+
+Web retrieval still returns large payloads, and MCP routes every result through the model's context window. Two things keep that in check:
 
 - **Expose only the tools you need.** An MCP Gateway sends just the tools you select, so an agent that only searches never loads the crawl and template tool definitions.
-- **Prefer the narrowest tool.** Reach for Search or Extract before Crawl or the web search agent, which return content across many pages.
+- **Prefer the narrowest tool.** Reach for search or extract before crawl or the web search agent, which return content across many pages.
 
-Nimble also documents a [CLI skill](https://docs.nimbleway.com/integrations/agent-skills/web-tools-skills/nimble-web-expert) that it recommends over MCP for typical web retrieval on token-efficiency grounds. Use the MCP server when you want Nimble governed alongside your other tools, with Arcade handling per-user authorization and audit at runtime.
+For high-volume retrieval, Nimble also documents a [CLI skill](https://docs.nimbleway.com/integrations/agent-skills/web-tools-skills/nimble-web-expert) as a more token-efficient path than MCP. Use the MCP server when you want Nimble governed alongside your other tools, with Arcade adding per-user authorization and audit at runtime.
 
 ## Add Nimble to your Arcade project
 

--- a/app/en/resources/integrations/search/nimble/page.mdx
+++ b/app/en/resources/integrations/search/nimble/page.mdx
@@ -40,15 +40,21 @@ Once you register Nimble in your Arcade project, Arcade discovers its tools auto
 | Extract | Pull structured content from a specific URL, with sync and async extraction. |
 | Crawl | Crawl multiple pages with path filtering, subdomain control, and progress tracking. |
 | Map | Discover the URLs on a site through link-following and sitemaps. |
-| Templates | Run pre-built extraction templates for common websites. |
+| Extract templates | Browse, run, and generate pre-built extraction templates for popular websites. |
+| Web search agent | Create, run, and poll research agents, and read their cited results. |
 
-Arcade namespaces each tool under the server ID you choose when you add the server, so tool names appear as `<your-server-id>.<tool>` in the Playground and gateway tool picker.
+Nimble prefixes its own tools with `nimble_`, and Arcade namespaces each tool under the server ID you choose when you add the server. With the server ID `nimble`, tool names appear as `nimble.nimble_search` in the Playground, the gateway tool picker, and SDK calls. Copy the exact name from the tool picker before calling it.
 
 Compose these tools with Google Docs, Slack, Salesforce, GitHub, or any of Arcade's native servers in a single MCP Gateway, so an agent can research, draft, and act in one flow, with authorization and audit from Arcade's runtime.
 
-## Caching and cost
+## Token usage
 
-Nimble's tools sit behind a cache and a memory layer. The cache stores sources, search history, and responses; the memory layer extracts key learnings after each run and feeds them into the next search plan. Together they retrieve only what an agent needs, which avoids redundant searches and the token cost they add, and refines results for a given domain over time. This behavior runs server-side at Nimble. When you call these tools through an Arcade gateway, Arcade adds per-user authorization and audit on top.
+Web retrieval returns large payloads, and MCP routes every result through the model's context window, so these tools can consume tokens quickly. Two things help:
+
+- **Expose only the tools you need.** An MCP Gateway sends just the tools you select, so an agent that only searches never loads the crawl and template tool definitions.
+- **Prefer the narrowest tool.** Reach for Search or Extract before Crawl or the web search agent, which return content across many pages.
+
+Nimble also documents a [CLI skill](https://docs.nimbleway.com/integrations/agent-skills/web-tools-skills/nimble-web-expert) that it recommends over MCP for typical web retrieval on token-efficiency grounds. Use the MCP server when you want Nimble governed alongside your other tools, with Arcade handling per-user authorization and audit at runtime.
 
 ## Add Nimble to your Arcade project
 

--- a/app/en/resources/integrations/search/nimble/page.mdx
+++ b/app/en/resources/integrations/search/nimble/page.mdx
@@ -32,18 +32,27 @@ Set these under **Advanced settings → Custom headers** when you add the server
 
 ## What you can do
 
-Once you register Nimble in your Arcade project, Arcade discovers its tools automatically. They cover these capabilities:
+Once you register Nimble in your Arcade project, Arcade discovers its tools automatically. Nimble exposes 27 tools, because most capabilities ship more than one tool: a synchronous call, an asynchronous variant, and status or listing calls. They group into these capabilities:
 
-| Capability | What it does |
-| --- | --- |
-| Search | Real-time web search across multiple engines, with configurable depth and focus. |
-| Extract | Pull structured content from a specific URL, with sync and async extraction. |
-| Crawl | Crawl multiple pages with path filtering, subdomain control, and progress tracking. |
-| Map | Discover the URLs on a site through link-following and sitemaps. |
-| Extract templates | Browse, run, and generate pre-built extraction templates for popular websites. |
-| Web search agent | Create, run, and poll research agents, and read their cited results. |
+| Capability | Tools | What it does |
+| --- | --- | --- |
+| Search | 1 | Real-time web search with configurable content richness. |
+| Extract | 2 | Pull structured content from a specific URL, synchronously or asynchronously. |
+| Crawl | 4 | Crawl multiple pages on a site, then check progress, list jobs, or cancel a run. |
+| Map | 1 | Discover the URLs on a site by crawling its pages and sitemap. |
+| Extract templates | 7 | Browse the template catalog, run templates against a URL, and generate or refine custom ones. |
+| Web search agents | 11 | Create, update, and run research agents, then poll runs and read their results. |
+| Task results | 1 | Fetch the status and results of any async task. |
 
 Nimble prefixes its own tools with `nimble_`, and Arcade namespaces each tool under the server ID you choose when you add the server. With the server ID `nimble`, tool names appear as `nimble.nimble_search` in the Playground, the gateway tool picker, and SDK calls. Copy the exact name from the tool picker before calling it.
+
+<Callout type="info">
+  Many Nimble tools are asynchronous: they return a task ID immediately, and
+  your agent polls a companion tool such as `nimble_task_results` or
+  `nimble_agents_run_status` for the outcome. When you build a gateway, select
+  the polling tools alongside the tools that start the work, or your agent will
+  kick off jobs it cannot read back.
+</Callout>
 
 Compose these tools with Google Docs, Slack, Salesforce, GitHub, or any of Arcade's native servers in a single MCP Gateway, so an agent can research, draft, and act in one flow, with authorization and audit from Arcade's runtime.
 


### PR DESCRIPTION
Follow-up to #1097 — the "improved version" from the Slack thread, since #1097 was intentionally merged as-is to unblock shipping the URL.

**Verified against the live server**, not just published docs: `tools/list` handshake against `mcp.nimbleway.com/mcp` (Nimble 3.4.3, protocol 2025-06-18) using our trial account.

### The tool list was wrong: 27 tools, not 6

Nimble's docs describe six capability families, and the page reproduced those as six rows. The live server exposes **27 tools** — each family ships multiple tools for synchronous, asynchronous, and status/listing calls.

This matters in Arcade specifically. The gateway tool picker lists *individual* tools, so someone who reads "6 capabilities" and then sees 27 checkboxes has no way to map between them. The table now carries a per-capability tool count and the total:

| Capability | Tools |
| --- | --- |
| Search | 1 |
| Extract | 2 |
| Crawl | 4 |
| Map | 1 |
| Extract templates | 7 |
| Web search agents | 11 |
| Task results | 1 |

Also added **web search agents** as a capability, which the original page omitted entirely — it's the largest family on the server at 11 tools.

### Async polling gotcha

Many Nimble tools return a task ID and require polling a companion tool (`nimble_task_results`, `nimble_agents_run_status`, `nimble_crawl_status`). Since selecting a subset of tools is the normal gateway workflow, it's easy to build a gateway with only the starting tools and leave your agent kicking off jobs it can't read back. Now called out.

### Tool naming was misleading

The page said tools appear as `<your-server-id>.<tool>`. Nimble prefixes its tools with `nimble_`, so with server ID `nimble` the real name is `nimble.nimble_search` — a doubled prefix that surprises people mid-integration. Confirmed `nimble_search` exists on the live server.

### Cost section: attributed, not asserted

I initially removed this believing it was unsourced. **That was my error** — I'd only checked `docs.nimbleway.com`. It's published on nimbleway.com/mcp and in Nimble's MCP blog post:

> "Compound accuracy over time through a Proprietary Index and Memory that gets smarter with every query"
> "Cut token costs by retrieving exactly what's needed — no redundant searches, no parsing raw pages with an LLM"

Restored with two adjustments:

1. **Attributed to Nimble** rather than asserted as fact — product claims about a third party's internals that we can't verify from outside, on a partner-facing page.
2. **Dropped the detail that outran the source.** The original said the cache stores "sources, search history, and responses" and the memory layer "extracts key learnings after each run and feeds them into the next search plan." Nimble publishes "Proprietary Index and Memory" and "auditable Search Plans" — not that breakdown.

Kept the practical MCP token caveat alongside it. The two sources genuinely conflict: the product page sells retrieval efficiency, while Nimble's docs warn MCP "can consume tokens quickly" and point high-volume users at their CLI skill. Readers should see both.

### Stale tool names on Nimble's marketing page

Worth passing back to Nimble: nimbleway.com/mcp advertises `nimble_deep_web_search`, `nimble_google_maps_search`, and `nimble_google_maps_reviews`. **None of these exist on the live server.** Their docs were right and their product page is out of date — a heads-up they'd probably want, since it's the page prospects read.

### Style

Changelog said "Partner MCP Server"; STYLEGUIDE.md specifies lowercase "MCP server". Page body was already correct.

### Verified, not changed

- `Authorization: Bearer ${secret:NIMBLE_API_KEY}` matches both Nimble's "store the raw key, Bearer prefix goes in the header" instruction and the `${secret:NAME}` syntax in add-remote-servers — confirmed working against the live server
- All external links and internal anchors resolve, including `#configure-advanced-settings`
- `pnpm build` passes, route compiles, Vale clean (two remaining warnings are pre-existing false positives on UI labels after colons)
- Nimble absent from `search/_meta.tsx`, but so is Tavily — partner pages are reached via the catalog card, existing pattern
- `llms.txt` gives Nimble the placeholder "Documentation page", but that hits 21 entries including Tavily (generator fallback when summarization fails). Systemic, worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the Nimble integration page and changelog; no runtime, auth, or API behavior changes.
> 
> **Overview**
> Updates the **Nimble** partner integration doc and a one-line **changelog** style fix so they match the live MCP server and Arcade gateway behavior.
> 
> The capabilities section now reflects **seven families** (including **web search agents**), explains that the tool picker shows **~two dozen** individual tools—not one row per capability—and documents **`nimble_` prefixes** and names like `nimble.nimble_search`. A callout warns gateway builders to include **async polling** tools (`nimble_task_results`, `nimble_agents_run_status`) with starters, and the page notes which tools **write** to the Nimble account.
> 
> **Cost and token usage** replaces the old caching narrative with Nimble-attributed retrieval claims, practical MCP token guidance (narrow tool selection, prefer search/extract), and a pointer to Nimble’s CLI skill for high-volume use.
> 
> Changelog entry wording changes **Partner MCP Server** to **Partner MCP server** for style consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1d6e47ef5ad844c813123a501ab8905571abc87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->