### PR TITLE
fix: restore static rendering and index toolkit pages (GRO-274)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,6 @@ import { TranslationBanner } from "@/app/_components/translation-banner";
 import "@/app/globals.css";
 import { Discord, Github } from "@arcadeai/design-system";
 import { GoogleTagManager } from "@next/third-parties/google";
-import { headers } from "next/headers";
 import Link from "next/link";
 import Script from "next/script";
 import { Head } from "nextra/components";
@@ -21,8 +20,6 @@ import {
   Navbar,
   Footer as NextraFooter,
 } from "nextra-theme-docs";
-
-const REGEX_LOCALE = /^\/([a-z]{2}(?:-[A-Z]{2})?)(?:\/|$)/;
 
 /**
  * Nextra's active-state detection only checks `item.route`, never `item.href`.
@@ -94,19 +91,21 @@ export function generateMetadata() {
   };
 }
 
-function getLocaleFromPathname(pathname: string): string {
-  const localeMatch = pathname.match(REGEX_LOCALE);
-  return localeMatch?.[1] || "en";
-}
-
 export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const headersList = await headers();
-  const pathname = headersList.get("x-pathname") || "/";
-  const lang = getLocaleFromPathname(pathname);
+  // proxy.ts redirects every request to a "/en/..." path — "es" and
+  // "pt-BR" routes bounce to their "/en" equivalent and unlocaled routes
+  // pick up "/en" from getPreferredLocale, which is hardcoded to return
+  // "en" unconditionally. So this layout only ever renders under "/en",
+  // and reading the locale here can be a constant instead of a header
+  // lookup. Awaiting headers() in the root layout previously forced the
+  // entire route tree into dynamic rendering. Restoring real i18n means
+  // moving this layout under an `app/[lang]/` route segment so the
+  // locale comes from routing params, not a request header.
+  const lang = "en";
 
   const dictionary = await getDictionary(lang);
   const rawPageMap = await getPageMap(`/${lang}`);

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -6,6 +6,9 @@ import { listValidIntegrationLinks } from "./_lib/toolkit-static-params";
 const SITE_URL = process.env.SITE_URL ?? "https://docs.arcade.dev";
 const NORMALIZED_SITE_URL = SITE_URL.replace(/\/+$/, "");
 const APP_DIR = path.join(process.cwd(), "app");
+const TOOLKIT_DATA_DIR =
+  process.env.TOOLKIT_DATA_DIR ??
+  path.join(process.cwd(), "toolkit-docs-generator", "data", "toolkits");
 const SKIP_DIRS = new Set(["_meta", "_api", "_redirects", "api"]);
 const INDEX_SUFFIX_REGEX = /\/index$/;
 let cachedRoutes: Promise<MetadataRoute.Sitemap> | null = null;
@@ -55,40 +58,52 @@ async function collectRoutes(dir: string): Promise<MetadataRoute.Sitemap> {
 async function collectToolkitRoutes(
   existingPaths: Set<string>
 ): Promise<MetadataRoute.Sitemap> {
-  const links = await listValidIntegrationLinks();
+  let links: Set<string>;
+  try {
+    links = await listValidIntegrationLinks();
+  } catch (error) {
+    // The sitemap is an auxiliary artifact. Keep static pages available if a
+    // malformed toolkit prevents the generated catalog from being enumerated;
+    // the normal page/static-param validation still fails the build loudly.
+    // biome-ignore lint/suspicious/noConsole: surface a best-effort sitemap degradation
+    console.warn("Unable to enumerate generated toolkit sitemap routes", error);
+    return [];
+  }
+
+  const toolkitDataMtime = await getToolkitDataMtime();
   const entries: MetadataRoute.Sitemap = [];
-  const categoryPageMtime = new Map<string, Date>();
 
   for (const link of links) {
     if (existingPaths.has(link)) {
       continue;
     }
 
-    const category = link.split("/").at(-2) ?? "";
-    let mtime = categoryPageMtime.get(category);
-    if (!mtime) {
-      const pageFile = path.join(
-        APP_DIR,
-        "en",
-        "resources",
-        "integrations",
-        category,
-        "[toolkitId]",
-        "page.mdx"
-      );
-      mtime = (await fs.stat(pageFile)).mtime;
-      categoryPageMtime.set(category, mtime);
-    }
-
     entries.push({
       url: `${NORMALIZED_SITE_URL}${link}`,
-      lastModified: mtime,
+      lastModified: toolkitDataMtime,
       changeFrequency: "weekly",
       priority: 0.7,
     });
   }
 
   return entries;
+}
+
+async function getToolkitDataMtime(): Promise<Date> {
+  const entries = await fs.readdir(TOOLKIT_DATA_DIR, { withFileTypes: true });
+  const mtimes = await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+      .map(
+        async (entry) =>
+          (await fs.stat(path.join(TOOLKIT_DATA_DIR, entry.name))).mtime
+      )
+  );
+
+  return mtimes.reduce(
+    (latest, mtime) => (mtime > latest ? mtime : latest),
+    new Date(0)
+  );
 }
 
 export default function sitemap(): Promise<MetadataRoute.Sitemap> {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { MetadataRoute } from "next";
+import { listValidIntegrationLinks } from "./_lib/toolkit-static-params";
 
 const SITE_URL = process.env.SITE_URL ?? "https://docs.arcade.dev";
 const NORMALIZED_SITE_URL = SITE_URL.replace(/\/+$/, "");
@@ -43,12 +44,66 @@ async function collectRoutes(dir: string): Promise<MetadataRoute.Sitemap> {
   return entries;
 }
 
+/**
+ * `[toolkitId]` directories are skipped above because they aren't literal
+ * URLs — but `listValidIntegrationLinks()` (the same enumeration the
+ * integrations index page uses) already resolves every toolkit that dynamic
+ * route serves, plus a handful of authored static partner pages living
+ * alongside it. Skip any link the directory walk already found (the static
+ * ones) so it isn't listed twice.
+ */
+async function collectToolkitRoutes(
+  existingPaths: Set<string>
+): Promise<MetadataRoute.Sitemap> {
+  const links = await listValidIntegrationLinks();
+  const entries: MetadataRoute.Sitemap = [];
+  const categoryPageMtime = new Map<string, Date>();
+
+  for (const link of links) {
+    if (existingPaths.has(link)) {
+      continue;
+    }
+
+    const category = link.split("/").at(-2) ?? "";
+    let mtime = categoryPageMtime.get(category);
+    if (!mtime) {
+      const pageFile = path.join(
+        APP_DIR,
+        "en",
+        "resources",
+        "integrations",
+        category,
+        "[toolkitId]",
+        "page.mdx"
+      );
+      mtime = (await fs.stat(pageFile)).mtime;
+      categoryPageMtime.set(category, mtime);
+    }
+
+    entries.push({
+      url: `${NORMALIZED_SITE_URL}${link}`,
+      lastModified: mtime,
+      changeFrequency: "weekly",
+      priority: 0.7,
+    });
+  }
+
+  return entries;
+}
+
 export default function sitemap(): Promise<MetadataRoute.Sitemap> {
   if (!cachedRoutes) {
-    cachedRoutes = collectRoutes(APP_DIR).then((routes) => {
-      routes.sort((a, b) => a.url.localeCompare(b.url));
-      return routes;
-    });
+    cachedRoutes = (async () => {
+      const routes = await collectRoutes(APP_DIR);
+      const existingPaths = new Set(
+        routes.map((route) => route.url.slice(NORMALIZED_SITE_URL.length))
+      );
+      const toolkitRoutes = await collectToolkitRoutes(existingPaths);
+
+      const allRoutes = [...routes, ...toolkitRoutes];
+      allRoutes.sort((a, b) => a.url.localeCompare(b.url));
+      return allRoutes;
+    })();
   }
 
   return cachedRoutes;

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { expect, test } from "vitest";
+import { proxy } from "../proxy";
+
+const requestFor = (pathname: string) =>
+  new NextRequest(`https://docs.example.test${pathname}`);
+
+test.each([
+  ["/es/guides/quickstart", "/en/guides/quickstart"],
+  ["/pt-BR/guides/quickstart", "/en/guides/quickstart"],
+  ["/guides/quickstart", "/en/guides/quickstart"],
+  ["/", "/en/home"],
+])("redirects %s to the English route %s", (pathname, destination) => {
+  const response = proxy(requestFor(pathname));
+
+  expect(response?.status).toBe(307);
+  expect(response?.headers.get("location")).toBe(
+    `https://docs.example.test${destination}`
+  );
+});
+
+test("passes English routes through", () => {
+  const response = proxy(requestFor("/en/guides/quickstart"));
+
+  expect(response?.status).toBe(200);
+  expect(response?.headers.get("location")).toBeNull();
+});

--- a/tests/sitemap-resilience.test.ts
+++ b/tests/sitemap-resilience.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+const listValidIntegrationLinks = vi.fn();
+
+vi.mock("../app/_lib/toolkit-static-params", () => ({
+  listValidIntegrationLinks,
+}));
+
+beforeEach(() => {
+  process.env.SITE_URL = "https://example.test";
+  listValidIntegrationLinks.mockRejectedValue(new Error("invalid toolkit"));
+});
+
+test("keeps static sitemap routes when toolkit enumeration fails", async () => {
+  const { default: sitemap } = await import("../app/sitemap");
+  const entries = await sitemap();
+  const urls = entries.map((entry) => entry.url);
+
+  expect(urls).toContain("https://example.test/en/references/changelog");
+  expect(urls).not.toContain(
+    "https://example.test/en/resources/integrations/development/github"
+  );
+});

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -1,6 +1,14 @@
 import { readFileSync } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { expect, test } from "vitest";
+
+const toolkitDataDir = join(
+  process.cwd(),
+  "toolkit-docs-generator",
+  "data",
+  "toolkits"
+);
 
 test("sitemap lists expected URLs", async () => {
   const previousSiteUrl = process.env.SITE_URL;
@@ -29,6 +37,36 @@ test("sitemap lists expected URLs", async () => {
     expect(urls).toContain(
       "https://example.test/en/resources/integrations/development/github"
     );
+    expect(urls).toContain(
+      "https://example.test/en/resources/integrations/productivity/gmail"
+    );
+    expect(urls).toContain(
+      "https://example.test/en/resources/integrations/search/exa-api"
+    );
+
+    // Hidden catalog entries must not become indexable sitemap URLs.
+    expect(urls).not.toContain(
+      "https://example.test/en/resources/integrations/productivity/notion"
+    );
+
+    const toolkitJson = await readdir(toolkitDataDir, {
+      withFileTypes: true,
+    });
+    const toolkitMtimes = await Promise.all(
+      toolkitJson
+        .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+        .map((entry) => stat(join(toolkitDataDir, entry.name)))
+    );
+    const latestToolkitMtime = toolkitMtimes.reduce(
+      (latest, current) => (current.mtime > latest ? current.mtime : latest),
+      new Date(0)
+    );
+    const github = entries.find(
+      (entry) =>
+        entry.url ===
+        "https://example.test/en/resources/integrations/development/github"
+    );
+    expect(github?.lastModified).toEqual(latestToolkitMtime);
 
     // No duplicates
     const duplicates = urls.filter(

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -22,6 +22,14 @@ test("sitemap lists expected URLs", async () => {
     // Known page should be present
     expect(urls).toContain("https://example.test/en/references/changelog");
 
+    // Generated toolkit pages (served by the `[toolkitId]` dynamic route,
+    // which the directory walk above can't see) must still make it into the
+    // sitemap. This fails if the toolkit-route merge in app/sitemap.ts is
+    // reverted.
+    expect(urls).toContain(
+      "https://example.test/en/resources/integrations/development/github"
+    );
+
     // No duplicates
     const duplicates = urls.filter(
       (url, index, arr) => arr.indexOf(url) !== index

--- a/toolkit-docs-generator/ARCHITECTURE.md
+++ b/toolkit-docs-generator/ARCHITECTURE.md
@@ -69,13 +69,6 @@ The generator does not run during a Vercel build. The generation workflow commit
 the JSON files and navigation changes through a pull request. Vercel then runs the
 root `pnpm build` command and compiles the committed files with Next.js.
 
-`app/_lib/toolkit-static-params.ts` enumerates routes from `index.json` and the
-per-toolkit files. `app/_lib/toolkit-data.ts` reads the same files for page
-rendering and the `/api/toolkit-data/[toolkitId]` route. The root layout no
-longer reads request headers — the locale it needs is a hardcoded constant,
-since `proxy.ts` redirects every request to an `/en` path — so Vercel can
-statically render the toolkit routes at build time from the committed JSON.
-
 ## Search indexing
 
 Search uses an external Algolia crawler. There is no Pagefind or local search

--- a/toolkit-docs-generator/ARCHITECTURE.md
+++ b/toolkit-docs-generator/ARCHITECTURE.md
@@ -71,9 +71,10 @@ root `pnpm build` command and compiles the committed files with Next.js.
 
 `app/_lib/toolkit-static-params.ts` enumerates routes from `index.json` and the
 per-toolkit files. `app/_lib/toolkit-data.ts` reads the same files for page
-rendering and the `/api/toolkit-data/[toolkitId]` route. The root layout reads
-request headers, so Vercel reports the docs routes as dynamic even though the
-toolkit parameter set is fixed at build time.
+rendering and the `/api/toolkit-data/[toolkitId]` route. The root layout no
+longer reads request headers — the locale it needs is a hardcoded constant,
+since `proxy.ts` redirects every request to an `/en` path — so Vercel can
+statically render the toolkit routes at build time from the committed JSON.
 
 ## Search indexing
 


### PR DESCRIPTION
This PR restores static rendering for the docs site and adds generated toolkit pages to `sitemap.xml`.

### Static rendering

The root layout previously awaited `headers()` to derive a locale that is always `en`. Because `headers()` makes the root route tree dynamic, this prevented the docs pages—including generated toolkit pages—from being prerendered.

The layout now uses the constant locale directly. This is safe while `proxy.ts` redirects every supported non-English or unlocalized path to `/en`. Restoring real i18n should use an `app/[lang]/` route segment rather than request-header parsing.

### Sitemap coverage

The sitemap directory walk skips `[toolkitId]` directories because they are dynamic route segments, so generated toolkit pages were missing from the sitemap. The sitemap now reuses `listValidIntegrationLinks()`, the same route enumeration used by the integrations index, and deduplicates authored static partner pages.

Generated toolkit entries use the newest toolkit JSON modification time, so changes to committed toolkit content advance their sitemap timestamps. Hidden toolkits remain excluded.

Sitemap generation is best effort: if toolkit enumeration fails, static sitemap routes are still returned and a warning is emitted. Normal page/static-param validation continues to fail loudly for invalid toolkit data.

### Verification

- `pnpm build` passes and generated toolkit pages remain prerendered.
- Targeted sitemap and proxy tests pass (10 tests).
- Tests cover representative toolkit categories, hidden-toolkit exclusion, timestamp tracking, redirect collisions, sitemap fallback behavior, and locale redirects.
