### PR TITLE
fix(integrations): derive "coming soon" from whether a page exists

### DIFF
--- a/app/_lib/integration-index.ts
+++ b/app/_lib/integration-index.ts
@@ -66,7 +66,15 @@ export function resolveIndexToolkits(
       }
       seen.add(link);
     }
-    resolved.push({ ...toolkit, hasPage });
+
+    // "Coming soon" means there is nothing to read yet, so derive it from
+    // whether a page exists rather than trusting the design-system flag. That
+    // flag is a hand-maintained constant in a published package, so it goes
+    // stale the moment a toolkit ships and keeps a live toolkit looking
+    // unavailable. Deriving it here also keeps the badge and the sort order
+    // (`use-toolkit-filters`) reading the same value, which they previously
+    // did not.
+    resolved.push({ ...toolkit, hasPage, isComingSoon: !hasPage });
   }
 
   return resolved;

--- a/app/en/resources/integrations/components/toolkits-client.tsx
+++ b/app/en/resources/integrations/components/toolkits-client.tsx
@@ -182,12 +182,10 @@ export default function ToolkitsClient({ toolkits }: ToolkitsClientProps) {
                       icon={IconComponent}
                       iconUrl={iconUrl}
                       isByoc={toolkit.isBYOC}
-                      // Doc-less toolkits have no page; render them as
-                      // non-clickable (coming-soon) cards instead of links to
-                      // a 404.
-                      isComingSoon={
-                        toolkit.isComingSoon || toolkit.hasPage === false
-                      }
+                      // Resolved in `resolveIndexToolkits` from whether a page
+                      // exists, so doc-less toolkits still render as
+                      // non-clickable cards instead of links to a 404.
+                      isComingSoon={toolkit.isComingSoon}
                       isPartner={toolkit.isPartner}
                       isPro={toolkit.isPro}
                       key={toolkit.id}


### PR DESCRIPTION
The Snowflake tile still reads "Coming soon" even though its docs generated and merged in #1114.

The index took `isComingSoon` from the design-system catalog, which is a hand-maintained constant in a published package. It goes stale the moment a toolkit ships, and the generator copies it straight into the toolkit JSON, so a nightly run keeps writing it back.

This derives the flag from `hasPage` instead. The badge means "there is nothing to read yet", which is what `hasPage` already answers, and it no longer waits on a package release. **One tile changes: Snowflake.**

It also makes the badge and the sort agree. `use-toolkit-filters` sorted on the raw design-system flag while the card rendered on `isComingSoon || !hasPage`, so seven toolkits (CloseIO, Discord, GoogleForms, Notion, Obsidian, Twilio, Twitch) showed a "Coming soon" badge while sorting among the available ones. They now sort with the other unavailable toolkits.

Verified locally: the Snowflake card renders "Arcade Optimized MCP Server" with no badge and links through to the toolkit page. Every entry now satisfies `isComingSoon === !hasPage`. 796 tests pass.

The design-system entry is still stale (`isComingSoon: true`, `category: "development"`) and worth correcting separately, but the docs site no longer depends on it for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small display/sort fix on the integrations index; no auth, data, or API changes.
> 
> **Overview**
> **Coming soon** on the integrations index is now **`isComingSoon: !hasPage`** in `resolveIndexToolkits`, instead of the design-system catalog flag that can stay `true` after docs ship (e.g. Snowflake).
> 
> `ToolkitsClient` passes **`toolkit.isComingSoon` only**—it no longer ORs with `hasPage === false`, because resolution already aligns badge, click behavior, and **`use-toolkit-filters`** sort on the same value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3903d32b1282bb1f94576be9cac197d8a0027396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->