### PR TITLE
docs: surface Algolia zero-hit terms in auth guides

### DIFF
--- a/app/en/guides/user-facing-agents/secure-auth-production/page.mdx
+++ b/app/en/guides/user-facing-agents/secure-auth-production/page.mdx
@@ -217,7 +217,7 @@ Content-Type: application/json
 
 **Invalid Response**
 
-If the user's ID does not match the ID specified at the start of the authorization flow (a **user mismatch**), the response will contain an error.
+If the user's ID does not match the ID specified at the start of the authorization flow (a **user mismatch**), the response will contain an error. Arcade returns the `user_mismatch` error code so your verifier route can distinguish a mismatched identity from other verification failures and route the user accordingly (for example, back to your sign-in page).
 
 <Tabs items={["JavaScript","Python","REST"]} storageKey="preferredLanguage">
 <Tabs.Tab>

--- a/app/en/guides/user-facing-agents/secure-auth-production/page.mdx
+++ b/app/en/guides/user-facing-agents/secure-auth-production/page.mdx
@@ -250,6 +250,7 @@ Content-Type: application/json
 
 {
   "code": 400,
+  "error": "user_mismatch",
   "msg": "An error occurred during verification"
 }
 ```

--- a/app/en/guides/user-sources/page.mdx
+++ b/app/en/guides/user-sources/page.mdx
@@ -37,7 +37,7 @@ Before you create a User Source in Arcade, register a confidential OAuth client 
 
 ### Configure the redirect URL
 
-Set the redirect URL on the OAuth client to `https://cloud.arcade.dev/oauth2/intermediate_callback`.
+Set the redirect URL (some identity providers call this the **redirect URI** or **callback URL**) on the OAuth client to `https://cloud.arcade.dev/oauth2/intermediate_callback`.
 
 Your identity provider will redirect end users back to this URL after they sign in, and Arcade exchanges the resulting code for an ID token.
 


### PR DESCRIPTION
## Summary

The Aug 03 2026 Algolia weekly summary for `docs.arcade.dev` (`BJB8PBSQ9T`, index `docs_arcade_dev_bjb8pbsq9t_docsearch`) reported a **17.27% no-result rate** across 110 searches for the week of Jul 27–Aug 02. This PR closes two of the ten zero-hit queries where the concept _is_ documented but the exact token users searched for is missing from the page — so Algolia indexed the surrounding prose without the discoverable keyword.

Small in-place tweaks only — no new pages, no restructuring.

### Zero-hit queries addressed

| Query | Fix |
|---|---|
| `custom user verifier verification route user_mismatch` | The [Secure Auth in Production](https://docs.arcade.dev/en/guides/user-facing-agents/secure-auth-production) page describes a "user mismatch" in prose but never uses the literal API error code. Added the `user_mismatch` error code to the invalid-response description **and** to the sample JSON error body, so developers hitting this error in their logs can find the guide by searching the code. |
| `user source oidc identity provider setup redirect uri` | The [User Sources](https://docs.arcade.dev/en/guides/user-sources) OIDC setup step is titled "Configure the redirect URL," so a search for the equally common OAuth term "redirect URI" (or "callback URL") missed. Added the alternate names inline. |

### Zero-hit queries NOT addressed here (out of scope for a keyword-only tweak)

All ten zero-hit queries from the Aug 03 summary, for the PR record:

1. `privacy concern` — no dedicated privacy page in the docs; needs a content decision, not an indexing fix.
2. `alpaca stock trading market data toolkit` — Arcade doesn't ship an Alpaca toolkit. Google Finance covers stock data but that's a real product-catalog gap, not a docs bug.
3. `available toolkits list market data finance stock` — the [MCP Servers](https://docs.arcade.dev/en/resources/integrations) page already mentions Google Finance for market data; likely a reindex latency issue since `removeWordsIfNoResults: allOptional` should partial-match here.
4. `custom user verifier verification route user_mismatch` — **fixed here**.
5. `user source oidc identity provider setup redirect uri` — **fixed here**.
6. `gdpr uk` — no compliance/GDPR page in `app/en`; needs a content decision, not an indexing fix.
7. `semantic search` — the Weaviate toolkit page (auto-generated from `weaviateapi.json`) doesn't include the terms "semantic search" or "vector search" in its summary. Fixing this belongs in the toolkit-docs-generator source, not here.
8. `github toolkit tool list secret scanning code scanning alerts` — `githubapi.json` has 55 mentions of secret/code scanning already; likely a reindex latency issue.
9. `market data stock quotes finance toolkit` — same as (3).
10. `available toolkits list market data finance` — same as (3).

## Test plan

- [ ] `pnpm build` renders both pages without MDX errors.
- [ ] After merge, the sync-crawler workflow reindexes and the two searched terms return hits.
- [ ] Confirm the sample JSON error body still parses (it does — added a comma before the `error` key).

---

_Filed by the scheduled Algolia zero-hit sweep._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> In-place MDX copy and sample JSON only; no runtime, auth, or security logic changes.
> 
> **Overview**
> **Docs-only search discoverability fixes** for two Algolia zero-hit queries; no API or product behavior changes.
> 
> On **Secure Auth in Production**, the invalid custom-verifier response section now names the **`user_mismatch`** error code and shows it in the REST sample JSON, so developers searching logs or API errors can find the guide.
> 
> On **User Sources**, the OIDC redirect setup step now mentions **redirect URI** and **callback URL** alongside redirect URL, matching common IdP terminology.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d6a876d037d072828d011b567f053b4093e8d5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->