### PR TITLE
docs: warn against sending client credentials twice in custom OAuth 2.0 providers

### DIFF
--- a/app/en/references/auth-providers/oauth2/page.mdx
+++ b/app/en/references/auth-providers/oauth2/page.mdx
@@ -200,6 +200,18 @@ This section configures the code/token exchange request, after the user has appr
 - `auth_method` _(optional, default none)_: The authentication method to use. Supported values are none (omitted) and `client_secret_basic`.
 - `params`: A map of parameter keys and values to include in the token request.
 
+<Callout type="warning">
+  Use exactly one client authentication method per request. If you set
+  `auth_method: client_secret_basic`, omit `client_id` and `client_secret` from
+  `params`. Sending client credentials in both the `Authorization` header and
+  the request body violates [RFC 6749, Section
+  2.3.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1), and
+  strict authorization servers such as Okta reject the token exchange (Okta's
+  System Log shows `multiple_client_credentials`). In Arcade this surfaces as a
+  successful login page while the authorization stays `pending` and never
+  receives a token.
+</Callout>
+
 These placeholders are available in `params`:
 
 - `{{client_id}}`: The configured client ID.
@@ -221,7 +233,7 @@ token_request:
     grant_type: authorization_code
     redirect_uri: "{{redirect_uri}}"
     client_id: "{{client_id}}"
-    client_secret: "{{client_secret}}" # Omit if using PKCE
+    client_secret: "{{client_secret}}" # Omit if using PKCE or client_secret_basic
 ```
 
 - `response_content_type` _(optional, default `application/json`)_: The expected content type of the response. Supported values are `application/json` and `application/x-www-form-urlencoded`.
@@ -241,6 +253,13 @@ These placeholders are available in `params`:
 - `{{client_id}}`: The configured client ID.
 - `{{client_secret}}`: The configured client secret.
 
+<Callout type="warning">
+  The single-authentication-method rule applies here too: if you set
+  `auth_method: client_secret_basic`, omit `client_id` and `client_secret` from
+  `params`. A misconfigured refresh request fails later than the token request,
+  when the first access token expires, so it is easy to miss in testing.
+</Callout>
+
 For most providers, `oauth2.refresh_request.params` will look like:
 
 ```yaml
@@ -249,7 +268,7 @@ refresh_request:
   params:
     grant_type: refresh_token
     client_id: "{{client_id}}"
-    client_secret: "{{client_secret}}"
+    client_secret: "{{client_secret}}" # Omit if using client_secret_basic
 ```
 
 - `response_content_type` _(optional, default `application/json`)_: The expected content type of the response. Supported values are `application/json` and `application/x-www-form-urlencoded`.


### PR DESCRIPTION
## What

Adds a warning callout to the custom OAuth 2.0 provider reference (`token_request` and `refresh_request` sections): use exactly one client authentication method. If `auth_method: client_secret_basic` is set, `client_id` and `client_secret` must be omitted from `params`, otherwise the credentials are sent in both the Authorization header and the request body. Also updates the two example blocks' comments to match.

## Why

Hit in the field on 2026-08-10: a customer registered a custom OAuth 2.0 provider against an Okta authorization server, completed the login, and the authorization stayed `pending` with no token. Okta's System Log showed the token exchange rejected with `multiple_client_credentials`, because credentials arrived via both channels. RFC 6749 Section 2.3.1 forbids using more than one client authentication method per request, and Okta enforces it strictly. Removing the two params from the provider's request configuration fixed it immediately.

The refresh request has the same failure mode but surfaces only when the first access token expires, which is easy to miss in testing, so the callout is mirrored there.

Verified against the engine behavior: the token exchange fills `{{client_secret}}` into the request body from `token_request.params` and independently adds the Basic Authorization header when `auth_method: client_secret_basic` is set, with no deduplication between the two paths.

Vale run locally: error/warning profile identical to main (all pre-existing, none on changed lines).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or configuration behavior impact.
> 
> **Overview**
> Adds **warning callouts** to the custom OAuth 2.0 provider docs for `token_request` and `refresh_request`: when using `auth_method: client_secret_basic`, omit `client_id` and `client_secret` from `params` so credentials are not sent twice.
> 
> Also updates the example YAML comments to note omitting `client_secret` for `client_secret_basic` (and PKCE on the token request).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf88638cac1840019a4561fabffcfd974bd11f84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->