### PR TITLE
Remove chat.arcade.dev references

### DIFF
--- a/app/en/home/landing-page.tsx
+++ b/app/en/home/landing-page.tsx
@@ -641,13 +641,7 @@ export function LandingPage() {
               <ArrowRight className="ml-2 h-4 w-4" />
             </Button>
           </div>
-          <div className="grid grid-cols-1 gap-8 min-[1062px]:grid-cols-3">
-            <SampleAppCard
-              blank
-              description="A chatbot that can help you with your daily tasks."
-              href="https://chat.arcade.dev/"
-              title="Arcade Chat"
-            />
+          <div className="grid grid-cols-1 gap-8 min-[1062px]:grid-cols-2">
             <SampleAppCard
               description="A bot for Slack that can act on your behalf."
               href="https://github.com/ArcadeAI/ArcadeSlackAgent"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the Arcade Chat sample application card from the docs landing page, which was the only remaining link to `https://chat.arcade.dev/`.

The Sample Applications grid is adjusted from three columns to two for the remaining examples (Archer and YouTube Podcast Summarizer).

No other `chat.arcade.dev` URLs were found in the repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f95ff48-9b09-42d0-a0fa-24484051f54a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f95ff48-9b09-42d0-a0fa-24484051f54a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

