### PR TITLE
docs: diagram the generation pipeline end to end

### DIFF
--- a/toolkit-docs-generator/ARCHITECTURE.md
+++ b/toolkit-docs-generator/ARCHITECTURE.md
@@ -27,7 +27,8 @@ flowchart TD
     changed -->|yes| merger
 
     design["@arcadeai/design-system<br/>TOOLKITS"] -->|"category, label, icon, docsLink, flags"| merger
-    curation["curation/toolkit/"] -->|"chunks, imports, subpages"| merger
+    author["Docs author"] -->|"writes and reviews in a PR"| curation
+    curation["curation/toolkit/<br/>chunks/*.mdx<br/>imports/*.mdx<br/>pages/**/*.mdx"] -->|"documentationChunks, customImports, subPages"| merger
     anthropic["Anthropic"] -->|"code examples, summaries, secret edits"| merger
     previous -->|"carried-forward examples and summaries"| merger
 
@@ -51,6 +52,11 @@ a toolkit's placement and identity, `curation/` owns hand-authored prose, and th
 LLM owns code examples and summaries. When a source fails, the merger falls back
 to the previous run's file rather than inventing a value, and reports what it
 recovered.
+
+`curation/` is the one input a person edits directly. Those Markdown and MDX
+files live in this repository and merge like any other change, so a prose edit
+reaches the site through the next generation run rather than through a manual
+edit of the generated JSON.
 
 Two things the diagram deliberately shows as separate. A second workflow
 regenerates `llms.txt` when the data files change, so the generator never writes

--- a/toolkit-docs-generator/ARCHITECTURE.md
+++ b/toolkit-docs-generator/ARCHITECTURE.md
@@ -10,12 +10,51 @@ The generator does **not** render HTML. It produces structured JSON and optional
 
 ## Data flow
 
-1. Fetch tool definitions from the Engine API or Arcade API.
-2. Load toolkit metadata from the design system or mock metadata.
-3. Compile hand-authored Markdown and MDX curation (optional).
-4. Merge all data into `MergedToolkit` objects.
-5. Write a JSON file per toolkit and an `index.json` file.
-6. Optionally verify output and compute diffs.
+Nothing in this pipeline runs at request time, and nothing reaches the site
+without a human merging a pull request.
+
+```mermaid
+flowchart TD
+    schedule["Schedule<br/>11:00 UTC daily"] --> generate
+    manual["Manual run<br/>workflow_dispatch"] --> generate
+    porter["Porter deploy succeeded<br/>repository_dispatch"] --> generate
+
+    engine["Engine API<br/>/v1/tool_metadata"] -->|"tools, parameters, auth, secrets"| generate
+    previous["data/toolkits/*.json<br/>previous run"] -->|"signatures and curation hashes"| generate
+
+    generate["generate --all --skip-unchanged"] --> changed{"Changed since<br/>last run?"}
+    changed -->|no| skipped["Left untouched"]
+    changed -->|yes| merger
+
+    design["@arcadeai/design-system<br/>TOOLKITS"] -->|"category, label, icon, docsLink, flags"| merger
+    curation["curation/toolkit/"] -->|"chunks, imports, subpages"| merger
+    anthropic["Anthropic"] -->|"code examples, summaries, secret edits"| merger
+    previous -->|"carried-forward examples and summaries"| merger
+
+    merger["DataMerger"] --> json["data/toolkits/*.json<br/>and index.json"]
+    merger -->|"recovered failures"| report["failed-tools.json"]
+    report --> slack["Slack alert"]
+
+    json --> verify["Verify output"]
+    verify --> sidebar["Sync sidebar _meta.tsx"]
+    sidebar --> pr["Pull request on<br/>automation/toolkit-docs"]
+    pr --> llms["llms.txt workflow<br/>regenerates public/llms.txt"]
+    llms --> pr
+    pr -->|"a human merges"| main["main"]
+    main --> vercel["Vercel: next build"]
+    vercel --> pages["Static toolkit pages"]
+```
+
+Each field in a toolkit JSON file comes from exactly one of those inputs. The
+Engine API owns everything about a tool, the design system owns everything about
+a toolkit's placement and identity, `curation/` owns hand-authored prose, and the
+LLM owns code examples and summaries. When a source fails, the merger falls back
+to the previous run's file rather than inventing a value, and reports what it
+recovered.
+
+Two things the diagram deliberately shows as separate. A second workflow
+regenerates `llms.txt` when the data files change, so the generator never writes
+it. The sidebar sync writes navigation only, and never touches toolkit JSON.
 
 ## Core components
 


### PR DESCRIPTION
## Why

`ARCHITECTURE.md` described the pipeline as six steps that began at "fetch tool definitions" and ended at "write JSON". Nothing said what triggers a run, which input owns which field, or how the output reaches the site. Answering "where did this value come from?" meant reading the workflow and the merger together.

That gap is what made today's `MicrosoftUsers` alert hard to parse: the failure was a missing design-system entry, but nothing written down says the design system is what supplies category, label, icon, and docs link.

## What's here

One Mermaid diagram in the `Data flow` section, covering trigger through published page:

- **Triggers** — nightly schedule, manual dispatch, Porter deploy
- **Inputs, each labeled with what it contributes** — Engine API (tools, parameters, auth, secrets), design system (category, label, icon, docsLink, flags), `curation/` (chunks, imports, subpages), Anthropic (examples, summaries, secret edits), previous output (change detection and carry-forward)
- **Change detection** as an explicit branch, since `--skip-unchanged` is why most toolkits are untouched on most runs
- **Output path** — JSON, verify, sidebar sync, PR on `automation/toolkit-docs`, human merge, Vercel build, static pages
- **Failure path** — `failed-tools.json` to Slack

Plus two adjacent pieces that are easy to misattribute to the generator: `llms.txt` has its own workflow triggered by the data change, and the sidebar sync writes navigation only.

## Verification

Parsed the block with mermaid v11 (`mermaid.parse`) rather than eyeballing it. Vale clean on the new section; lint passes. Docs only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to ARCHITECTURE.md with no runtime or build behavior impact.
> 
> **Overview**
> **Replaces** the six-step numbered list in `ARCHITECTURE.md`’s **Data flow** section with an end-to-end **Mermaid** flowchart and supporting prose.
> 
> The diagram documents **triggers** (daily schedule, manual dispatch, Porter deploy), **inputs and field ownership** (Engine API, design system, `curation/`, Anthropic, previous JSON), **`--skip-unchanged`** branching, the path through verify → sidebar sync → PR on `automation/toolkit-docs` → human merge → Vercel → static pages, plus **failure recovery** (`failed-tools.json` → Slack). New text clarifies that nothing is request-time, merger fallbacks use the previous run, and that **`llms.txt`** and **sidebar sync** are separate from JSON generation.
> 
> **Docs only** — no generator or site code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6553e08582edc5c9d57104d0505e7c4c4ae2577. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->