### PR TITLE
chore: update @arcadeai/design-system to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://arcade.dev/",
   "dependencies": {
-    "@arcadeai/design-system": "7.4.0",
+    "@arcadeai/design-system": "7.5.1",
     "@arcadeai/ui-kit": "0.14.0",
     "@mdx-js/mdx": "3.1.1",
     "@next/third-parties": "16.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,11 +17,11 @@ importers:
   .:
     dependencies:
       '@arcadeai/design-system':
-        specifier: 7.4.0
-        version: 7.4.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)
+        specifier: 7.5.1
+        version: 7.5.1(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)
       '@arcadeai/ui-kit':
         specifier: 0.14.0
-        version: 0.14.0(@ai-sdk/react@4.0.40(react@19.2.7)(zod@4.3.6))(@arcadeai/design-system@7.4.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0))(@tanstack/react-query@5.101.4(react@19.2.7))(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ai@7.0.37(zod@4.3.6))(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)
+        version: 0.14.0(@ai-sdk/react@4.0.40(react@19.2.7)(zod@4.3.6))(@arcadeai/design-system@7.5.1(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0))(@tanstack/react-query@5.101.4(react@19.2.7))(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ai@7.0.37(zod@4.3.6))(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)
       '@mdx-js/mdx':
         specifier: 3.1.1
         version: 3.1.1
@@ -292,8 +292,8 @@ packages:
     resolution: {integrity: sha512-DLpvvDBvRNjzVmFYJ+upPrUJ8YRBoGWqPfzhuFp2+lh5Shxm0l9qLwe1Ah4pKvuCatU7TLOOTkFpICitTuuJeQ==}
     hasBin: true
 
-  '@arcadeai/design-system@7.4.0':
-    resolution: {integrity: sha512-hCPmoFfRb+ljfBMPswuAz5qobeDao6KK/XAOv1SYik49aoWHhKQ6PdUFpUW1hTxNcn++C2QFrAoC4MqR16z31Q==}
+  '@arcadeai/design-system@7.5.1':
+    resolution: {integrity: sha512-m3hTvpvMsexbqoq7Q85+F1FAbAqKVJBHEBsuGrJVs4DUCyirW+3aSDU6bsGc3tbUAiy3L0H73xUwQ4xd+HuiPg==}
     engines: {bun: '>=1.3.5'}
     peerDependencies:
       '@hookform/resolvers': '>=5.2.1'
@@ -4822,7 +4822,7 @@ snapshots:
 
   '@arcadeai/arcadejs@2.4.1': {}
 
-  '@arcadeai/design-system@7.4.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)':
+  '@arcadeai/design-system@7.5.1(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)':
     dependencies:
       '@base-ui/react': 1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.16)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@base-ui/utils': 0.3.1(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -4853,11 +4853,11 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
-  '@arcadeai/ui-kit@0.14.0(@ai-sdk/react@4.0.40(react@19.2.7)(zod@4.3.6))(@arcadeai/design-system@7.4.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0))(@tanstack/react-query@5.101.4(react@19.2.7))(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ai@7.0.37(zod@4.3.6))(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)':
+  '@arcadeai/ui-kit@0.14.0(@ai-sdk/react@4.0.40(react@19.2.7)(zod@4.3.6))(@arcadeai/design-system@7.5.1(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0))(@tanstack/react-query@5.101.4(react@19.2.7))(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ai@7.0.37(zod@4.3.6))(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)':
     dependencies:
       '@ai-sdk/react': 4.0.40(react@19.2.7)(zod@4.3.6)
       '@arcadeai/arcadejs': 2.4.1
-      '@arcadeai/design-system': 7.4.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)
+      '@arcadeai/design-system': 7.5.1(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)
       '@tanstack/react-query': 5.101.4(react@19.2.7)
       '@tanstack/react-router': 1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-virtual': 3.14.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
This PR updates `@arcadeai/design-system` to the latest published version.

It runs a design-system compatibility test gate before opening this PR.
If that gate fails, the workflow stops and no PR is created.

- Trigger: `workflow_dispatch`
- Run: https://github.com/ArcadeAI/docs/actions/runs/31641038235

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine dependency version bump with no code edits; UI may shift slightly if 7.5.1 includes visual or API changes in the external package.
> 
> **Overview**
> Bumps **`@arcadeai/design-system`** from **7.4.0** to **7.5.1** in `package.json` and refreshes **`pnpm-lock.yaml`** so transitive resolution (including `@arcadeai/ui-kit`’s peer on design-system) points at the new version.
> 
> No application source changes—only dependency pins. Intended to pick up the latest published design-system release after the repo’s compatibility test gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77319dbddab7e2ba4a95cfb22edce8d0a79edd16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->