### PR TITLE
docs(mcp-clients): document custom MCP clients and user authorization

### DIFF
--- a/app/en/get-started/mcp-clients/page.mdx
+++ b/app/en/get-started/mcp-clients/page.mdx
@@ -1,12 +1,40 @@
 ---
 title: "Connect to MCP Clients"
-description: "Learn how to connect your MCP servers to various MCP-compatible clients and development environments"
+description: "Connect any MCP client — including a custom or unlisted client — to an Arcade MCP Gateway, and configure user authorization for your end users."
 ---
 
 import { MCPClientGrid } from "./mcp-client-grid";
 
 # Connect to MCP Clients
 
-You can connect [Arcade MCP servers](/resources/integrations) to MCP-compatible clients and development environments to unlock powerful flows for your agents.
+You can connect [Arcade MCP servers](/en/resources/integrations) to any MCP-compatible client through an [Arcade MCP Gateway](/en/operate/governance/mcp-gateways). The gateway exposes the tools you have selected at a single HTTP endpoint, and the client points at that endpoint's URL.
+
+## What you need
+
+1. An Arcade account and an [Arcade API key](/en/get-started/setup/api-keys).
+2. An [Arcade MCP Gateway](/en/operate/governance/mcp-gateways) with the tools you want to expose to the client.
+3. An MCP-compatible client. Step-by-step guides for common clients are linked below; any other client that supports remote HTTP MCP servers works against the same gateway URL.
+
+## Connect a custom or unlisted MCP client
+
+If your MCP client is not one of the clients listed below — for example, a custom in-house client, an SDK you are building against, or a third-party client Arcade has not documented individually — connect it the same way you would add any remote HTTP MCP server:
+
+- **Transport**: remote HTTP (sometimes called `http` or `streamable-http`, depending on the client).
+- **Server URL**: your Arcade MCP Gateway URL, copied from the gateway's page in the Arcade dashboard.
+- **Authentication**: pick the authentication mode when you create the gateway (see [User authorization](#user-authorization) below).
+
+There is no client-side Arcade SDK involved. Any MCP client that speaks the remote HTTP transport can talk to an Arcade gateway.
+
+## User authorization
+
+An Arcade MCP Gateway authenticates every end user before it lets the client call a tool. Pick one of these authentication modes on the gateway:
+
+- **Arcade Auth** — every end user is a member of your Arcade project. On first connect, the client redirects the user through Arcade's OAuth flow. Good for development, testing, and internal use.
+- **User Source** *(recommended for production)* — the gateway delegates sign-in to your own OIDC identity provider (Entra ID, Okta, Auth0, Clerk, Stytch, or similar). Each end user signs in with the identity they already have. See [User Sources](/en/operate/identity/user-sources).
+- **Arcade Headers** — the client passes an end-user identifier and an Arcade API key in HTTP headers. Use this when the client cannot run a browser-based OAuth flow.
+
+Once the end user is signed in, Arcade handles per-user authorization for each downstream tool (GitHub, Slack, Google Workspace, and so on). The first time a tool needs access, the user is prompted to authorize the underlying service, and Arcade stores and refreshes those tokens per user from then on. See [MCP Gateways](/en/operate/governance/mcp-gateways) for the full comparison of authentication modes and how to pick one when you create a gateway.
+
+## Client-specific guides
 
 <MCPClientGrid />


### PR DESCRIPTION
## Summary

The Algolia weekly report for **Aug 03 - Aug 09** showed a 12.17% no-result rate on the primary docs index. The one long-tail zero-hit query that pointed at a real, fixable content gap was:

- `connect a custom mcp client to an arcade gateway, user authorization`

`app/en/get-started/mcp-clients/page.mdx` was 5 lines of intro plus a client grid, with no server-rendered prose on either half of that question. Nothing on the page named the pattern for connecting an *unlisted* or *custom* MCP client, and nothing named the user-authorization modes a gateway supports.

This PR replaces that shell with:

1. **What you need** — account + API key, MCP Gateway, and a client. Frames the page for someone landing cold on the overview.
2. **Connect a custom or unlisted MCP client** — names the generic pattern (remote HTTP transport, gateway URL, no client-side Arcade SDK). This is the paragraph the zero-hit query should land on.
3. **User authorization** — lists the three gateway auth modes (Arcade Auth, User Source, Arcade Headers), the per-user OAuth story for downstream tools, and links to `/en/operate/identity/user-sources` and `/en/operate/governance/mcp-gateways` for the full comparison.

The existing `<MCPClientGrid />` still renders under **Client-specific guides**.

## Zero-hit search terms addressed

From the Aug 03 - Aug 09 Algolia report, on `docs_arcade_dev_bjb8pbsq9t_docsearch`:

- `connect a custom mcp client to an arcade gateway, user authorization` (1 search) — **fixed** here.

### Other zero-hit terms from the same report, and why they are not addressed in this PR

- `snowflake` (1) — the Snowflake MCP server page was added to `toolkit-docs-generator/data/toolkits/snowflake.json` on Aug 13 (PR #1128), after the reporting window. The next weekly crawl will index it. No docs change needed.
- `mariadb` (1), `doordash` (1), `door dash` (1) — no MariaDB or DoorDash MCP server exists. Product/roadmap call, not a docs fix.
- `mcp_authentication_failed_error` (1) — error string is not documented anywhere in the repo and its provenance is unclear from the report alone. Worth a follow-up once the emitting component is confirmed, rather than inventing content.
- `createnewrequ` (1) — truncated typo; intent unclear.
- `xyzzyqwerty12345nonsense` (2), `zzzzqwxxyznotarealdocpage999` (1), `xyzzyqwertynonsense99999` (1) — obvious probe / test queries. Ignored.

## Changes

- `app/en/get-started/mcp-clients/page.mdx` — 12 lines → 40 lines. Adds three sections above the existing client grid.

## Test plan

- [ ] `pnpm build` locally, confirm `/en/get-started/mcp-clients` still renders and the grid still loads.
- [ ] `pnpm vale:check app/en/get-started/mcp-clients/page.mdx`.
- [ ] After merge, wait for the next `algolia-reindex.yml` run (or trigger it manually) and confirm the target query now returns the MCP Clients overview page as its top hit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3181a5a0ea52e2426cce9332520bbe1245b03f76. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->