### PR TITLE
docs: add Workday auth provider (TOO-424)

### DIFF
--- a/app/en/references/auth-providers/page.mdx
+++ b/app/en/references/auth-providers/page.mdx
@@ -142,6 +142,13 @@ For more information on how to customize your auth provider, select an auth prov
     category="Auth"
   />
   <ToolCard
+    name="Workday"
+    image="workday"
+    summary="Authorize tools and agents with Workday"
+    link="/references/auth-providers/workday"
+    category="Auth"
+  />
+  <ToolCard
     name="X"
     image="twitter"
     summary="Authorize tools and agents with X (Twitter)"

--- a/app/en/references/auth-providers/workday/page.mdx
+++ b/app/en/references/auth-providers/workday/page.mdx
@@ -1,0 +1,173 @@
+import { Tabs, Callout, Steps } from "nextra/components";
+
+# Workday
+
+<Callout type="info">
+  Arcade does not offer a default Workday auth provider. Each customer registers
+  an API client in their own Workday tenant.
+</Callout>
+
+The Workday auth provider lets tools and agents call Workday APIs as the signed-in employee.
+
+This page is used by Arcade's Workday tools, [app code](#using-workday-auth-in-app-code) that calls Workday APIs, and [custom tools](#using-workday-auth-in-custom-tools).
+
+## Create a Workday API client
+
+<Callout type="info">
+  When using your own app credentials, configure your project to use a [custom
+  user
+  verifier](/build/user-facing-agents/secure-auth-production#build-a-custom-user-verifier).
+  Without this, end-users cannot use your app or agent in production.
+</Callout>
+
+In Workday, search for **Register API Client** (not **Register API Client for Integrations**).
+
+- Grant type: **Authorization Code**
+- Redirect URI: the redirect URL Arcade shows when you add the provider (see below)
+- Scopes: the [functional areas](#scopes) your tools need
+
+Copy the **Client ID**, **Client Secret**, **Authorization Endpoint**, and **Token Endpoint** from the client page after you save.
+
+Do not use a Workday Extend / Developer Site client unless your tenant already uses that path.
+
+<Callout>
+  The exact Register API Client fields will be listed here after we review
+  Workday's admin guide (Community login required). Until then, use the values
+  Workday shows on the client you just created.
+</Callout>
+
+## Set Workday secrets
+
+Add these secrets in the [Arcade Dashboard](https://api.arcade.dev/dashboard/auth/secrets):
+
+| Secret | Example |
+| --- | --- |
+| `WORKDAY_BASE_URL` | `https://wd2-impl-services1.workday.com/ccx/api` |
+| `WORKDAY_TENANT_NAME` | your tenant name |
+
+These are the REST API host and tenant. They are not the OAuth login URLs.
+
+## Scopes
+
+Pick only the areas your tools need. Arcade's Workday tools use:
+
+- `Time Off and Leave` — time-off balance, history, and requests
+- `Contact Information` — home and mailing address
+- `Staffing` — the signed-in worker (`workers/me`)
+- `Tenant Non-Configurable` — business process actions on those writes
+
+## Configuring Workday auth
+
+<Tabs items={["Dashboard GUI"]}>
+<Tabs.Tab>
+
+### Configure Workday auth in the Arcade Dashboard
+
+<Steps>
+
+#### Open Connected Apps
+
+Go to the [Arcade Dashboard](https://api.arcade.dev/dashboard). Under **Connections**, click **Connected Apps**.
+
+#### Add a custom provider
+
+- Click **Add OAuth Provider**
+- Open the **Custom Provider** tab
+
+#### Enter the provider details
+
+- **ID:** `workday` (required for Arcade's Workday tools)
+- **Client ID** and **Client Secret** from the Workday API client
+- **Authorization Endpoint** and **Token Endpoint** from the Workday API client
+- **Refresh Token Endpoint:** the same Token Endpoint
+- Leave token introspection **disabled** unless Workday documents an introspect URL for your client
+- Note the **Redirect URL** Arcade generates and set it as the Workday client's redirect URI
+
+#### Create the provider
+
+Click **Create**.
+
+</Steps>
+</Tabs.Tab>
+</Tabs>
+
+## Using Workday auth in app code
+
+See [authorizing agents with Arcade](/get-started/about-arcade).
+
+<Tabs items={["Python", "JavaScript"]} storageKey="preferredLanguage">
+<Tabs.Tab>
+
+```python {6-10}
+from arcadepy import Arcade
+
+client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
+
+auth_response = client.auth.start(
+    user_id="{arcade_user_id}",
+    provider="workday",
+    scopes=["Time Off and Leave"],
+)
+
+if auth_response.status != "completed":
+    print("Please complete the authorization challenge in your browser:")
+    print(auth_response.url)
+
+auth_response = client.auth.wait_for_completion(auth_response)
+token = auth_response.context.token
+```
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+```javascript {8-11}
+import { Arcade } from "@arcadeai/arcadejs";
+
+const client = new Arcade(); // Automatically finds the `ARCADE_API_KEY` env variable
+
+const userId = "{arcade_user_id}";
+
+let authResponse = await client.auth.start(userId, {
+  provider: "workday",
+  scopes: ["Time Off and Leave"],
+});
+
+if (authResponse.status !== "completed") {
+  console.log("Please complete the authorization challenge in your browser:");
+  console.log(authResponse.url);
+}
+
+authResponse = await client.auth.waitForCompletion(authResponse);
+const token = authResponse.context.token;
+```
+
+</Tabs.Tab>
+</Tabs>
+
+## Using Workday auth in custom tools
+
+```python
+from typing import Annotated, Any
+
+import httpx
+from arcade_tdk import ToolContext, tool
+from arcade_tdk.auth import OAuth2
+
+
+@tool(
+    requires_auth=OAuth2(id="workday", scopes=["Staffing"]),
+    requires_secrets=["WORKDAY_BASE_URL", "WORKDAY_TENANT_NAME"],
+)
+async def get_my_worker(
+    context: ToolContext,
+) -> Annotated[dict[str, Any], "The signed-in worker"]:
+    """Get the signed-in employee's Workday worker record."""
+    token = context.get_auth_token_or_empty()
+    base_url = context.get_secret("WORKDAY_BASE_URL").rstrip("/")
+    tenant = context.get_secret("WORKDAY_TENANT_NAME")
+    url = f"{base_url}/staffing/v7/{tenant}/workers/me"
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, headers={"Authorization": f"Bearer {token}"})
+        resp.raise_for_status()
+        return resp.json()
+```

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,4 +1,4 @@
-<!-- git-sha: 8506404dc386b44fe86bf5535101f00410166813 generation-date: 2026-08-17T20:58:23.032Z -->
+<!-- git-sha: b976e390df091b96dd4b504026ee5d56137966b8 generation-date: 2026-08-24T17:14:23.679Z -->
 
 # Arcade
 
@@ -65,6 +65,7 @@ Arcade docs serve two audiences. Start with the path that matches your goal:
 - [The Arcade CLI](https://docs.arcade.dev/en/references/arcade-cli): The Arcade CLI documentation provides users with comprehensive instructions on how to install, upgrade, and utilize the Arcade command-line tool for managing Arcade deployments and MCP servers. It includes detailed commands for various functionalities, such as logging in, creating projects, and deploying applications
 - [TickTick](https://docs.arcade.dev/en/references/auth-providers/ticktick): This documentation page provides guidance on configuring the TickTick authentication provider for use with Arcade, enabling users to integrate and call TickTick APIs via OAuth 2.0. It outlines the steps to create a TickTick app, set up OAuth credentials, and
 - [Twitch](https://docs.arcade.dev/en/references/auth-providers/twitch): This documentation page provides guidance on how to set up and configure a custom Twitch authentication provider within the Arcade platform, enabling users to access the Twitch API on behalf of their users. It outlines the steps for creating a Twitch app, configuring OAuth credentials, and
+- [Workday](https://docs.arcade.dev/en/references/auth-providers/workday): Documentation page
 - [X](https://docs.arcade.dev/en/references/auth-providers/x): This documentation page provides guidance on configuring and using the X (Twitter) authentication provider with Arcade, enabling users to call the X API on behalf of their applications or agents. It outlines the steps for creating an X app, setting up OAuth credentials, and
 - [Zendesk](https://docs.arcade.dev/en/references/auth-providers/zendesk): This documentation page provides guidance on configuring and using the Zendesk authentication provider within the Arcade platform, enabling users to call Zendesk APIs on behalf of users. It outlines the steps necessary to create a Zendesk app, set up OAuth clients, and manage
 - [Zoho](https://docs.arcade.dev/en/references/auth-providers/zoho): This documentation page provides guidance on configuring the Zoho authentication provider for use with Arcade, enabling users to call Zoho APIs via OAuth 2.0. It outlines the steps to create a Zoho app, set up app credentials, and integrate Zo


### PR DESCRIPTION
## Summary

Adds a Workday auth provider page and a catalog card so a customer can wire user-context OAuth the same way we do for Zendesk: Custom Provider, id `workday`, REST host and tenant as secrets.

We do not ship an Arcade-hosted Workday app. Each tenant registers its own **Register API Client** (Authorization Code), not **Register API Client for Integrations**.

## Design decisions

- Endpoints stay "copy from the client Workday just created." The admin-guide topic is behind Resource Center login, so we should not invent authorize / token URL templates here.
- No `engine.yaml` tab until those URLs are confirmed.
- Workday MCP server docs are out of this PR.

Linear: [TOO-424](https://linear.app/arcadedev/issue/TOO-424/update-docs-workday-connector-availability-via-gateway-ui)

Resolves: TOO-424

## Test plan

- [ ] Preview `/references/auth-providers/workday` and the catalog card
- [ ] Confirm we never tell the reader to use an ISU / Integrations client
- [ ] After Community login: fill the Register API Client field list and the exact authorize / token URLs