### PR TITLE
docs(tool-executions): recording and retention are self-service [PLT-2978]

### DIFF
--- a/app/en/operate/governance/tool-executions/page.mdx
+++ b/app/en/operate/governance/tool-executions/page.mdx
@@ -3,9 +3,11 @@ title: "Tool Executions"
 description: "Review every tool run in a project: what ran, for whom, and why it failed, with tool inputs and outputs held to project admins."
 ---
 
+import { Callout } from "nextra/components";
+
 # Tool executions
 
-Arcade records every tool run in a project, including which tool ran, for which end user, when, and how it went, and exposes that history in the dashboard and over the API.
+Arcade records every tool run in a project, including which tool ran, for which end user, when, and how it went, and exposes that history in the dashboard and over the API. Recording is on by default and is an organization-wide setting — see [Recording and retention](#recording-and-retention).
 
 This page serves two jobs:
 
@@ -166,11 +168,50 @@ Two behaviors trip up API callers:
 
 Find your organization and project IDs in the dashboard URL: `/orgs/{org_id}/projects/{project_id}`. For the full request and response schemas, see the [API reference](/references/api).
 
-## Retention
+## Recording and retention
 
-Execution logging runs by default, and each project keeps its history for a bounded retention window: 7 days unless your organization sets a different default or a project overrides it. Past the window, Arcade deletes the records and they stop appearing in the history and the API.
+Two settings govern the history, both organization-wide and both set by an organization admin. They apply to every project in the organization.
 
-To change the retention window, or to turn off execution logging and delete the history for your organization, contact Arcade support.
+| Setting | What it decides |
+| -- | -- |
+| Recording | Whether new tool runs are written down at all |
+| Retention window | How long a recorded run is kept |
+
+Recording is on and the window is 7 days unless your organization changes them. Past the window, Arcade deletes the records and they stop appearing in the history and the API.
+
+### Change them yourself
+
+Open your organization in the dashboard and select **Execution Logging**, or call the API:
+
+```bash
+curl -s -X PUT "https://api.arcade.dev/v1/orgs/{org_id}/logging-config" \
+  -H "Authorization: Bearer $ARCADE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"logging_data_retention": "ALLOWED", "default_log_retention_days": 30}'
+```
+
+Send either field on its own; an omitted field is left alone, so changing the window cannot switch recording off by accident.
+
+A window must be at least 1 day and no longer than the platform maximum, which is 90 days on Arcade Cloud and is reported as `max_log_retention_days` on the organization read. Anything outside that is refused with a `422` rather than quietly adjusted. Zero is not "keep nothing" — it is refused, because turning recording off is the way to stop recording.
+
+Changing the policy takes organization-admin authority. The organization read reports `can_edit_logging` so a client can tell whether the caller may change it before offering the control.
+
+### What each setting does to history you already have
+
+These come apart, and the difference matters:
+
+- **Turning recording off** stops new runs being written down. It leaves what is already stored in place, and those records go on expiring under the window as before. It is not an erasure control.
+- **Shortening the window** applies to records you already have. Going from 90 days to 7 deletes everything older than 7 days across every project in the organization, shortly after you save, and it cannot be undone.
+
+If you want existing history gone, shortening the window is the control that deletes it.
+
+<Callout type="info">
+Turning recording on permits projects to record; it does not compel it. While recording is organization-wide the two are indistinguishable, and that stops being true if project-level settings arrive later.
+</Callout>
+
+### When the history is empty
+
+An empty list has more than one cause, so the dashboard says which applies rather than leaving you to guess. If recording is off, Tool Executions says so instead of telling you that runs will appear once tools run. The project read also reports where the window in force came from and whether the project may change it, so a reader who cannot change it knows who to ask.
 
 ## Related content
 

--- a/app/en/operate/governance/tool-executions/page.mdx
+++ b/app/en/operate/governance/tool-executions/page.mdx
@@ -175,7 +175,7 @@ Two organization-wide settings govern the history, and are configured by an orga
 | Recording (boolean) | Whether new tool runs are written down at all |
 | Retention window (number) | How long a recorded run is kept |
 
-By default, recording is enabled and the retention window is 7 days. Past the window, Arcade deletes the records and they stop appearing in the history and the API.
+On Arcade Cloud, recording is enabled by default and the retention window is 7 days. Past the window, Arcade deletes the records and they stop appearing in the history and the API. A self-hosted deployment sets its own defaults, and records nothing until execution logging is turned on in the Engine configuration.
 
 ### Change them yourself
 

--- a/app/en/operate/governance/tool-executions/page.mdx
+++ b/app/en/operate/governance/tool-executions/page.mdx
@@ -3,8 +3,6 @@ title: "Tool Executions"
 description: "Review every tool run in a project: what ran, for whom, and why it failed, with tool inputs and outputs held to project admins."
 ---
 
-import { Callout } from "nextra/components";
-
 # Tool executions
 
 Arcade records every tool run in a project, including which tool ran, for which end user, when, and how it went, and exposes that history in the dashboard and over the API. Recording is on by default and is an organization-wide setting — see [Recording and retention](#recording-and-retention).
@@ -170,14 +168,14 @@ Find your organization and project IDs in the dashboard URL: `/orgs/{org_id}/pro
 
 ## Recording and retention
 
-Two settings govern the history, both organization-wide and both set by an organization admin. They apply to every project in the organization.
+Two organization-wide settings govern the history, and are configured by an organization admin. They apply to every project in the organization.
 
 | Setting | What it decides |
 | -- | -- |
-| Recording | Whether new tool runs are written down at all |
-| Retention window | How long a recorded run is kept |
+| Recording (boolean) | Whether new tool runs are written down at all |
+| Retention window (number) | How long a recorded run is kept |
 
-Recording is on and the window is 7 days unless your organization changes them. Past the window, Arcade deletes the records and they stop appearing in the history and the API.
+By default, recording is enabled and the retention window is 7 days. Past the window, Arcade deletes the records and they stop appearing in the history and the API.
 
 ### Change them yourself
 
@@ -194,24 +192,10 @@ Send either field on its own; an omitted field is left alone, so changing the wi
 
 A window must be at least 1 day and no longer than the platform maximum, which is 90 days on Arcade Cloud and is reported as `max_log_retention_days` on the organization read. Anything outside that is refused with a `422` rather than quietly adjusted. Zero is not "keep nothing" — it is refused, because turning recording off is the way to stop recording.
 
-Changing the policy takes organization-admin authority. The organization read reports `can_edit_logging` so a client can tell whether the caller may change it before offering the control.
-
 ### What each setting does to history you already have
-
-These come apart, and the difference matters:
 
 - **Turning recording off** stops new runs being written down. It leaves what is already stored in place, and those records go on expiring under the window as before. It is not an erasure control.
 - **Shortening the window** applies to records you already have. Going from 90 days to 7 deletes everything older than 7 days across every project in the organization, shortly after you save, and it cannot be undone.
-
-If you want existing history gone, shortening the window is the control that deletes it.
-
-<Callout type="info">
-Turning recording on permits projects to record; it does not compel it. While recording is organization-wide the two are indistinguishable, and that stops being true if project-level settings arrive later.
-</Callout>
-
-### When the history is empty
-
-An empty list has more than one cause, so the dashboard says which applies rather than leaving you to guess. If recording is off, Tool Executions says so instead of telling you that runs will appear once tools run. The project read also reports where the window in force came from and whether the project may change it, so a reader who cannot change it knows who to ask.
 
 ## Related content
 


### PR DESCRIPTION
Stacked onto #1129 so nothing on that branch is rewritten — merge this into it and the page is current.

## Why

The **Retention** section describes the world before [PLT-2978](https://linear.app/arcadedev/issue/PLT-2978). It says:

> To change the retention window, or to turn off execution logging and delete the history for your organization, contact Arcade support.

That capability is being shipped as self-service in a stack now in review (`monorepo` #3165 the API, #3243 the dashboard page). The stale instruction is the obvious problem, but three smaller ones matter more, because each would mislead a reader who acts on it.

**It offered project-level overrides** — "7 days unless your organization sets a different default or a project overrides it". Project-level settings are an explicit non-goal of the spec. Nothing customer-reachable sets a project's own window, and the API reports `retention_changeable_at_project: false` for exactly this reason. A reader would go looking for a control that does not exist.

**It folded two different actions together** — "turn off execution logging and delete the history". They are not the same operation and behave differently. Turning recording off stops new runs being written down and leaves what is stored to expire on the window; the retention sweep marks on the window alone and never reads whether recording is on. Shortening the window is the control that deletes, and it reaches records already held. Someone who turns recording off expecting an erasure gets neither the deletion nor a warning.

**It gave no bounds**, so nothing told a reader that `0` and `400` are refused with a `422` rather than clamped.

## What changed

One file, `app/en/operate/governance/tool-executions/page.mdx`. The section is now **Recording and retention** and covers:

- the two settings, both organization-wide, and that an organization admin sets them
- how to change them — the dashboard page and `PUT /v1/orgs/{org_id}/logging-config`
- the bounds, and that out-of-range is a `422`
- **what each setting does to history you already have** — the distinction above, stated plainly, including that shortening the window cannot be undone
- what a reader sees when the list is empty, since an empty history has several causes and the product now says which applies

The intro also picks up a pointer, since "Arcade records every tool run" is only true while recording is on.

## Checked

`bun run build` passes. It caught a real mistake first: I used `<Note>`, which this site does not have — the convention is `<Callout>` (282 uses) and it needs an explicit `import { Callout } from "nextra/components"`. Prerendering failed until both were right.

Every claim is checked against the implementation rather than the spec prose:

| Claim | Source |
| -- | -- |
| Default 7 days, max 90 | `ORG_DEFAULT_LOG_RETENTION_DAYS`, `MAX_LOG_RETENTION_DAYS` in `core/conf.py` |
| Out-of-range is 422 | `within_platform_maximum` on the FastAPI-validated body |
| Recording off does not delete | `runMarkPhase` reads `LogRetentionDays` only, never `LoggingEnabled` |
| Shortening deletes retroactively | the mark phase re-evaluates all unmarked rows against the current window |
| Org-admin authority | `logging_config_update`, org-admin only, plus `can_edit_logging` on the org read |

## Sequencing

This documents behaviour that is **not merged yet**. #3165 and #3243 are green and awaiting review, not released. If #1129 is likely to ship first, hold this one until the stack lands — otherwise the page promises a dashboard page that isn't there. Happy to gate it however you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior modified in this PR.
> 
> **Overview**
> Updates the **Tool Executions** governance doc so it matches org-wide, self-service execution logging instead of “contact support” and misleading retention behavior.
> 
> The intro now states that recording is on by default and points to the new **Recording and retention** section. That section replaces the old **Retention** block: it describes two org-admin settings (recording on/off and retention days), Cloud defaults (7-day window, 90-day max) vs self-hosted, and how to change them via the dashboard **Execution Logging** page or `PUT /v1/orgs/{org_id}/logging-config`. It documents validation (`422` for out-of-range values, minimum 1 day, zero is not valid) and clarifies that **turning recording off** only stops new writes while existing rows expire on the window, whereas **shortening the window** retroactively deletes older history org-wide and cannot be undone. Project-level retention overrides are no longer implied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df4f7551ed8c8e04e79b7e06d1d9d12cf61e5692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->