### PR TITLE
docs: add Dynamics 365 Customer Service MCP Server remote connection guide

### DIFF
--- a/app/en/operate/governance/remote-mcp-servers/_meta.tsx
+++ b/app/en/operate/governance/remote-mcp-servers/_meta.tsx
@@ -10,6 +10,9 @@ const meta: MetaRecord = {
   servicenow: {
     title: "ServiceNow",
   },
+  "dynamics-365-customer-service": {
+    title: "Dynamics 365 Customer Service",
+  },
 };
 
 export default meta;

--- a/app/en/operate/governance/remote-mcp-servers/dynamics-365-customer-service/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/dynamics-365-customer-service/page.mdx
@@ -10,6 +10,16 @@ import { SignupLink } from "@/app/_components/analytics";
 
 Microsoft fronts the **Dynamics 365 CX MCP Server - Service** with **Agent 365 Tooling Gateway (ATG)**, a Microsoft-hosted gateway that handles authentication to Dataverse and exposes Customer Service tools (case management, knowledge search, activity timelines, and email drafting) over MCP. This guide covers the Arcade-side setup for connecting it as a [remote MCP server](/operate/governance/remote-mcp-servers), plus the Microsoft Entra settings that most commonly trip people up.
 
+<Callout type="info">
+  This guide is about connecting to the Dynamics 365 CX MCP Server -
+  Service, not an Arcade toolkit. Arcade doesn't ship a Dynamics 365
+  Customer Service toolkit today, so this remote server is currently the
+  only way to reach this data from Arcade. It's a fixed, Microsoft-defined
+  tool set (case management, knowledge search, activity timelines, email
+  drafting), not something a customer can extend, so that advantage goes
+  away if Arcade ships a native toolkit for it later.
+</Callout>
+
 <Callout type="warning">
   The Microsoft-side steps below are sourced directly from [Microsoft's own
   documentation](https://learn.microsoft.com/en-us/dynamics365/customer-service/develop/connect-agent-model-context-protocol)

--- a/app/en/operate/governance/remote-mcp-servers/dynamics-365-customer-service/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/dynamics-365-customer-service/page.mdx
@@ -1,0 +1,128 @@
+---
+title: "Connect a Dynamics 365 Customer Service MCP Server"
+description: "Configure a Microsoft Entra app registration and Arcade's OAuth 2.0 settings to connect the Dynamics 365 CX MCP Server - Service through Agent 365 Tooling Gateway"
+---
+
+import { Callout, Steps } from "nextra/components";
+import { SignupLink } from "@/app/_components/analytics";
+
+# Connect a Dynamics 365 Customer Service MCP Server
+
+Microsoft fronts the **Dynamics 365 CX MCP Server - Service** with **Agent 365 Tooling Gateway (ATG)**, a Microsoft-hosted gateway that handles authentication to Dataverse and exposes Customer Service tools (case management, knowledge search, activity timelines, and email drafting) over MCP. This guide covers the Arcade-side setup for connecting it as a [remote MCP server](/operate/governance/remote-mcp-servers), plus the Microsoft Entra settings that most commonly trip people up.
+
+<Callout type="warning">
+  The Microsoft-side steps below are sourced directly from [Microsoft's own
+  documentation](https://learn.microsoft.com/en-us/dynamics365/customer-service/develop/connect-agent-model-context-protocol)
+  for this server. The Arcade-side field mapping (which Arcade dashboard field
+  takes which value) has not yet been walked through end-to-end against a live
+  tenant. Confirm before treating this as authoritative.
+</Callout>
+
+<GuideOverview>
+<GuideOverview.Outcomes>
+
+Connect a Dynamics 365 Customer Service MCP server to Arcade and use its tools in gateways and SDKs.
+
+</GuideOverview.Outcomes>
+
+<GuideOverview.Prerequisites>
+
+- An <SignupLink linkLocation="docs:remote-mcp-servers-dynamics365-customer-service">Arcade account</SignupLink>
+- A Dynamics 365 Customer Service environment with the CX MCP Server - Service enabled
+- Tenant administrator (or delegated admin-consent) permissions in Microsoft Entra
+- The target environment's Dataverse environment ID
+
+</GuideOverview.Prerequisites>
+
+<GuideOverview.YouWillLearn>
+
+- Which Microsoft Entra and Agent 365 Tooling Gateway settings matter for Arcade specifically, and why
+- Configure the remote server's OAuth 2.0 settings in Arcade
+- Diagnose the most common setup mistakes from their error messages
+
+</GuideOverview.YouWillLearn>
+</GuideOverview>
+
+## Set up Dynamics 365 and Microsoft Entra
+
+Agent 365 Tooling Gateway is a shared, Microsoft-hosted OAuth 2.0-protected resource that fronts several Dynamics 365 MCP servers, not just Customer Service. Before Arcade (or any client app) can request a token for it, two separate things need to exist in your tenant: the gateway's own service principal, and a client app registration you create for Arcade.
+
+- **Provision the Agent 365 Tooling Gateway service principal and grant admin consent.** This is a one-time, tenant-wide step, independent of any specific client. As a tenant administrator, visit:
+
+  ```
+  https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/adminconsent?client_id=ea9ffc3e-8a23-4a7d-836d-234d7c7565c1
+  ```
+
+  Replace `00000000-0000-0000-0000-000000000000` with your tenant ID (Microsoft Entra admin center → **Overview** → **Tenant ID**). The `client_id` value, `ea9ffc3e-8a23-4a7d-836d-234d7c7565c1`, is Microsoft's fixed Entra app ID for Agent 365 Tooling Gateway. It's the same for every tenant. Approving this creates the gateway's resource service principal under **Enterprise applications**. Skipping this step is the most common cause of authorization failing outright: no client app registration can get a token for a resource that doesn't yet exist as a service principal in your tenant.
+
+- **Create a dedicated Entra app registration for Arcade.** This is *not* the Dynamics 365 first-party app. It's your own confidential client, single-tenant. Create a client secret and copy the value; you'll paste it into Arcade's OAuth settings. Leave the **Web** redirect URI empty for now.
+
+- **Add the delegated permission.** Under **API permissions → Add a permission → APIs my organization uses**, search for the Agent 365 Tooling Gateway app (by the preceding app ID) and add its delegated permission, `McpServers.D365Service.All`. Then select **Grant admin consent**.
+
+  This permission uses the `/.default` scope pattern, which doesn't support incremental or per-user consent. The preceding admin consent step has to happen up front, not on first sign-in. If a user hits a consent screen that seems to be missing permissions, or authorization fails silently, this is the first thing to check.
+
+- **Note that this is environment-specific.** The scope and server URL both encode the Dataverse environment ID. A tenant with multiple Customer Service environments needs a separate Arcade server registration and separate OAuth scope per environment.
+
+- **Roles**: configuring the MCP server itself requires **System Administrator** or **Omnichannel Administrator**. The account that authorizes Arcade's connection to actually use the tools needs **Customer Service Representative** or **CSR Manager**.
+
+<Callout type="warning">
+  FedRAMP High tenants get a specific warning here: enabling this MCP server
+  lets Customer Service data egress the FedRAMP High boundary, since Agent 365
+  Tooling Gateway is a Microsoft cloud service outside that boundary. Confirm
+  with your tenant administrator that this meets your compliance requirements
+  before connecting it in a regulated environment.
+</Callout>
+
+## Configure the remote server in Arcade
+
+<Steps>
+
+### Register the server
+
+Go to the [MCP servers dashboard](https://app.arcade.dev/servers), click **Add Server**, choose **Remote MCP**, and enter a server ID and the server URL:
+
+```
+https://agent365.svc.cloud.microsoft/mcp/environments/11111111-1111-1111-1111-111111111111/servers/mcp_D365CX_Service
+```
+
+Replace `11111111-1111-1111-1111-111111111111` with your Dataverse environment ID. The `/mcp/environments/.../servers/` path segment is required; omitting or mistyping it returns a `404 RouteNotFound` from the gateway itself, before authentication is even attempted.
+
+### Configure OAuth2 authorization
+
+Open **Advanced settings → OAuth2 authorization** and enter:
+
+- **Client ID** / **Client Secret**: from the Entra app registration you created above.
+- **Authorization URL**: `https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/authorize`, with your tenant ID in place of the example GUID.
+- **Token URL**: `https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token`, with your tenant ID in place of the example GUID.
+- **Scope**: `ea9ffc3e-8a23-4a7d-836d-234d7c7565c1/.default`, the Agent 365 Tooling Gateway app ID with `/.default` appended, not a Dynamics-specific scope string.
+
+<Callout type="info">
+  Microsoft Entra doesn't support Dynamic Client Registration, so, as with
+  Salesforce and ServiceNow, you must supply the Client ID and Secret
+  manually. If you leave these blank, Arcade attempts Dynamic Client
+  Registration and Entra rejects it.
+</Callout>
+
+### Add the redirect URI to your Entra app
+
+Copy the redirect URI Arcade generates and add it as a **Web** redirect URI on the Entra app registration you created for Arcade. Microsoft's own guidance for this same app in Copilot Studio is to leave the redirect URI blank until this point, specifically because the value isn't known ahead of time. The same applies here.
+
+### Authorize and confirm
+
+Save the server to open the authorization prompt. Sign in with an account that has access to the target Customer Service environment and the **Customer Service Representative** or **CSR Manager** role. The token audience is the tooling gateway, and Agent 365 Tooling Gateway performs an on-behalf-of exchange to reach Dataverse using that identity's permissions.
+
+</Steps>
+
+## Troubleshooting
+
+- **`404 RouteNotFound` when registering the server**: the server URL is missing the `/mcp/environments/.../servers/mcp_D365CX_Service` path segment, or the environment ID is wrong.
+- **Authorization fails outright, with no clear consent screen**: the Agent 365 Tooling Gateway service principal hasn't been provisioned and admin-consented in this tenant yet. See [Set up Dynamics 365 and Microsoft Entra](#set-up-dynamics-365-and-microsoft-entra); this is a separate, tenant-wide step from your Arcade app's own permissions.
+- **Consent looks incomplete, or a permission seems to silently not apply**: the `/.default` scope requires admin consent granted in advance. It doesn't support incremental consent during the OAuth flow itself.
+- **Tool list is empty, or every call returns a 404 despite a valid token**: the environment ID in the server URL doesn't match the scope's environment, or doesn't match the environment where the Customer Service MCP Server is actually enabled. Both the URL and the scope are environment-specific.
+- **Authorization succeeds, but tool calls return 403**: the signing-in user doesn't have the Customer Service Representative or CSR Manager role, even though their Entra sign-in itself succeeded.
+- **Connection blocked or flagged in a regulated tenant**: check with the tenant administrator about the FedRAMP High data-egress notice. Some tenants turn off this class of connection by policy.
+
+## Next steps
+
+- [Create an MCP Gateway](/operate/governance/mcp-gateways/create-via-dashboard) to expose this server's tools.
+- [Connect to MCP clients](/get-started/mcp-clients).

--- a/app/en/operate/governance/remote-mcp-servers/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/page.mdx
@@ -175,7 +175,7 @@ Common settings include:
   height={ADVANCED_SETTINGS_HEIGHT}
 />
 
-Some remote servers need provider-specific setup beyond these generic settings. See [Connect a Salesforce Hosted MCP Server](/operate/governance/remote-mcp-servers/salesforce) or [Connect a ServiceNow Hosted MCP Server](/operate/governance/remote-mcp-servers/servicenow) for fully worked examples.
+Some remote servers need provider-specific setup beyond these generic settings. See [Connect a Salesforce Hosted MCP Server](/operate/governance/remote-mcp-servers/salesforce), [Connect a ServiceNow Hosted MCP Server](/operate/governance/remote-mcp-servers/servicenow), or [Connect a Dynamics 365 Customer Service MCP Server](/operate/governance/remote-mcp-servers/dynamics-365-customer-service) for fully worked examples.
 
 ## Where the server's tools become available
 


### PR DESCRIPTION
## Summary
- Adds a guide for connecting the Dynamics 365 CX MCP Server - Service (fronted by Microsoft's Agent 365 Tooling Gateway) as a remote MCP server, following the same structure as the existing [Salesforce](/operate/governance/remote-mcp-servers/salesforce) and [ServiceNow](/operate/governance/remote-mcp-servers/servicenow) guides: provider-side setup, Arcade OAuth 2.0 config, and troubleshooting.
- Wires the new page into `_meta.tsx` and cross-links it from the `remote-mcp-servers` overview page.

## Update: toolkit-overlap callout added, tier framing
A cross-vendor consistency pass sorted all seven remote MCP server guides into three value tiers. Dynamics 365 CS had no toolkit-overlap callout at all, since no Arcade toolkit exists for it. Added one in **Tier 2 (fixed surface, real gap today, but temporary)**, alongside Atlassian (#1151): this remote server is currently the only path to this data, but it's a fixed, Microsoft-defined tool set with no customer-extensibility, so the advantage evaporates if Arcade ships a native toolkit later. Framed honestly rather than implying permanent value, unlike the Tier 1 guides (Salesforce #1149, ServiceNow #1153, Snowflake #1150).

## ⚠️ Not yet verified against a live tenant
The Microsoft-side steps are sourced directly from [Microsoft's own documentation](https://learn.microsoft.com/en-us/dynamics365/customer-service/develop/connect-agent-model-context-protocol) for this server, but the Arcade-side field mapping (which dashboard field takes which value) **has not been walked through end-to-end against a live Dynamics 365 tenant.** The doc calls this out with a warning callout at the top. This is the same caveat as the ServiceNow guide (#1145) — confirm against a real tenant with Agent 365 Tooling Gateway provisioned before treating this as authoritative.

## Test plan
- [x] `vale` passes with 0 errors (warnings/suggestions left are proper nouns or Microsoft-specific technical terms, e.g. "admin consent", "Microsoft Entra admin center")
- [x] `internal-link-check` test passes
- [x] MDX compiles and renders locally (`pnpm dev`, confirmed 200 on the new route)
- [ ] Walk through the setup steps against a real Dynamics 365 Customer Service environment with Agent 365 Tooling Gateway provisioned
- [ ] Have someone with Entra tenant-admin access confirm the admin-consent flow and scope string

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or auth code; the main caveat is unverified Arcade OAuth field mapping, which the doc itself flags for readers.
> 
> **Overview**
> Adds **documentation** for connecting Microsoft’s **Dynamics 365 CX MCP Server - Service** (via **Agent 365 Tooling Gateway**) as a remote MCP server in Arcade, in the same style as the existing Salesforce and ServiceNow guides.
> 
> The new page covers Entra admin consent and app registration, environment-specific gateway URL and `/.default` scope, Arcade **OAuth2** dashboard fields, redirect URI handling, role requirements, FedRAMP egress notes, and a troubleshooting section. A **warning callout** states that Microsoft steps follow official docs but Arcade field mapping is **not yet verified end-to-end** on a live tenant.
> 
> Navigation is updated in `_meta.tsx`, and the remote MCP servers overview now links to this guide alongside Salesforce and ServiceNow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caed2048396fe0c283f72641a711040d98a7dab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
