### PR TITLE
docs: add HubSpot Remote MCP Server connection guide

### DIFF
--- a/app/en/operate/governance/remote-mcp-servers/_meta.tsx
+++ b/app/en/operate/governance/remote-mcp-servers/_meta.tsx
@@ -10,6 +10,9 @@ const meta: MetaRecord = {
   servicenow: {
     title: "ServiceNow",
   },
+  hubspot: {
+    title: "HubSpot",
+  },
 };
 
 export default meta;

--- a/app/en/operate/governance/remote-mcp-servers/hubspot/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/hubspot/page.mdx
@@ -11,11 +11,12 @@ import { SignupLink } from "@/app/_components/analytics";
 HubSpot hosts a remote MCP server at `mcp.hubspot.com`, exposing CRM records, activities, conversations, campaigns, and marketing email tools directly from a HubSpot portal. This guide covers the Arcade-side setup for connecting it as a [remote MCP server](/operate/governance/remote-mcp-servers), plus the HubSpot settings that most commonly trip people up.
 
 <Callout type="info">
-  This guide is about connecting to HubSpot's own remote MCP server, not the
-  Arcade HubSpot toolkit. Arcade already covers most of this surface: the
-  [HubSpot toolkit](/resources/integrations/sales/hubspot) for core CRM
-  objects, plus starter toolkits like `hubspotconversationsapi` and
-  `hubspotmarketingapi` for conversations, campaigns, and marketing email.
+  This guide is about connecting to HubSpot's own remote MCP server, not
+  the Arcade HubSpot toolkits. Arcade already covers most of this surface
+  across two toolkit tiers: the [HubSpot
+  toolkit](/resources/integrations/sales/hubspot) for core CRM objects, and
+  starter toolkits like `hubspotconversationsapi` and `hubspotmarketingapi`
+  for conversations, campaigns, and marketing email.
 
   Reach for this remote server instead when you want:
 

--- a/app/en/operate/governance/remote-mcp-servers/hubspot/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/hubspot/page.mdx
@@ -13,11 +13,15 @@ HubSpot hosts a remote MCP server at `mcp.hubspot.com`, exposing CRM records, ac
 <Callout type="info">
   This guide is about connecting to HubSpot's own remote MCP server. Arcade
   already ships an agent-optimized [HubSpot
-  toolkit](/resources/integrations/sales/hubspot) covering core CRM objects.
-  Reach for this remote server instead when you need conversations,
-  campaigns, or marketing email tools beyond the toolkit's coverage, and keep
-  in mind that every action here is scoped to whatever the authorizing
-  HubSpot user can already do in the portal, not to toolkit-defined scopes.
+  toolkit](/resources/integrations/sales/hubspot) for core CRM objects, plus
+  separate starter toolkits covering conversations, marketing and
+  campaigns, and more (`hubspotconversationsapi`, `hubspotmarketingapi`,
+  `hubspotcrmapi`, and others). Between them, there's little this remote
+  server exposes that Arcade can't already reach. The real differentiators
+  are operational: one connection here instead of wiring up the Optimized
+  toolkit plus as many as eight separate starter toolkits to cover the same
+  surface, and every action scoped to whatever the authorizing HubSpot user
+  can already do in the portal, rather than to a toolkit's fixed scopes.
 </Callout>
 
 <Callout type="warning">

--- a/app/en/operate/governance/remote-mcp-servers/hubspot/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/hubspot/page.mdx
@@ -1,0 +1,104 @@
+---
+title: "Connect a HubSpot Remote MCP Server"
+description: "Configure a HubSpot MCP Auth App and Arcade's OAuth 2.0 settings to connect the HubSpot Remote MCP Server"
+---
+
+import { Callout, Steps } from "nextra/components";
+import { SignupLink } from "@/app/_components/analytics";
+
+# Connect a HubSpot Remote MCP Server
+
+HubSpot hosts a remote MCP server at `mcp.hubspot.com`, exposing CRM records, activities, conversations, campaigns, and marketing email tools directly from a HubSpot portal. This guide covers the Arcade-side setup for connecting it as a [remote MCP server](/operate/governance/remote-mcp-servers), plus the HubSpot settings that most commonly trip people up.
+
+<Callout type="warning">
+  The HubSpot-side steps below are sourced directly from [HubSpot's own
+  documentation](https://developers.hubspot.com/docs/apps/developer-platform/build-apps/integrate-with-the-remote-hubspot-mcp-server)
+  for this server, which is unusually thorough. The Arcade-side field mapping
+  has not yet been walked through end-to-end against a live HubSpot portal.
+  Confirm before treating this as authoritative.
+</Callout>
+
+<GuideOverview>
+<GuideOverview.Outcomes>
+
+Connect a HubSpot Remote MCP server to Arcade and use its tools in gateways and SDKs.
+
+</GuideOverview.Outcomes>
+
+<GuideOverview.Prerequisites>
+
+- An <SignupLink linkLocation="docs:remote-mcp-servers-hubspot">Arcade account</SignupLink>
+- A HubSpot account with access to the Developer Platform (available on every hub and tier, no separate license required)
+
+</GuideOverview.Prerequisites>
+
+<GuideOverview.YouWillLearn>
+
+- Which HubSpot MCP Auth App settings matter for Arcade specifically, and why
+- Configure the remote server's OAuth 2.0 settings in Arcade
+- Diagnose the most common setup mistakes from their error messages
+
+</GuideOverview.YouWillLearn>
+</GuideOverview>
+
+## Set up HubSpot
+
+Follow HubSpot's guide to [create an MCP auth app](https://app.hubspot.com/l/mcp-auth-apps/): in your HubSpot account, go to **Development → MCP Auth Apps → Create MCP auth app**, and enter an app name, optional description, and a placeholder **Redirect URL** (you'll update this once Arcade generates its own; see [Add the redirect URI to your MCP auth app](#add-the-redirect-uri-to-your-mcp-auth-app) below). HubSpot supports multiple redirect URLs on one app, and the first one listed becomes the default, so adding Arcade's later won't disturb any existing entry.
+
+A few things about this integration are structurally different from Salesforce, ServiceNow, or Dynamics 365, and worth knowing before you configure Arcade:
+
+- **There's no scope picker.** Unlike the other providers in this section, you don't explicitly select OAuth scopes when creating the MCP auth app. Available scopes are determined automatically by whatever tools the MCP server currently exposes, and whatever the authorizing user grants during installation. If HubSpot adds tools to the MCP server later, previously authorized users need to reinstall the app to pick up the new scopes. If a capability that should exist suddenly seems missing, a stale authorization is worth checking before assuming a bug.
+
+- **Sensitive Data accounts lose activity and conversation access through MCP specifically.** If the HubSpot portal has [Sensitive Data](https://developers.hubspot.com/docs/api-reference/latest/crm/properties/sensitive-data) protection turned on, calls, emails, meetings, notes, tasks, and conversation data are blocked from the MCP server, even though the same data remains available through HubSpot's standard CRM API. This is MCP-specific behavior, not a permissions bug, and it can be mistaken for one if you're used to those objects being reachable via the API.
+
+- **PKCE is mandatory with no fallback.** HubSpot's MCP server requires OAuth 2.1 with PKCE (RFC 7636, S256) for every connection. There's no plain OAuth 2.0 or static-token path for production use.
+
+## Configure the remote server in Arcade
+
+<Steps>
+
+### Register the server
+
+Go to the [MCP servers dashboard](https://app.arcade.dev/servers), click **Add Server**, choose **Remote MCP**, and enter a server ID and the server URL:
+
+```
+https://mcp.hubspot.com
+```
+
+### Configure OAuth2 authorization
+
+Open **Advanced settings → OAuth2 authorization** and enter:
+
+- **Client ID** / **Client Secret**: from your MCP auth app's details page in HubSpot.
+- **Authorization URL** / **Token URL**: leave these empty. Arcade discovers HubSpot's OAuth endpoints automatically from the MCP server's own metadata, per the MCP authorization specification. Only set these manually if authorization still fails after confirming the redirect URI and PKCE configuration below.
+
+<Callout type="info">
+  HubSpot's documented integration path is a manually created MCP auth app.
+  There's no Dynamic Client Registration flow described for this server, so
+  leaving Client ID and Secret blank isn't expected to work here the way it
+  does for some other remote MCP servers.
+</Callout>
+
+### Add the redirect URI to your MCP auth app
+
+Copy the redirect URI Arcade generates and add it to your MCP auth app's **Redirect URL** field in HubSpot (you can have more than one; only the first is used as the default elsewhere, so appending Arcade's is safe). The redirect URL your MCP client presents during the OAuth flow must match one of the values configured here exactly.
+
+### Authorize and confirm
+
+Save the server to open the authorization prompt. During authorization you'll select which HubSpot account to connect, then grant permissions. These are scoped to whatever the signing-in user is themselves permitted to see and do in HubSpot, since all MCP server actions respect the authorizing user's existing HubSpot permissions.
+
+</Steps>
+
+## Troubleshooting
+
+- **Authentication fails during the OAuth handshake, with no clear HubSpot-side error**: confirm PKCE parameters are being sent correctly: `code_challenge` and `code_challenge_method=S256` on the authorization request, and the matching `code_verifier` on the token exchange. HubSpot enforces PKCE with no fallback, so a client that skips it fails silently rather than falling back to a simpler flow.
+- **`redirect_uri` mismatch, or authorization fails immediately after opening the consent screen**: the redirect URI Arcade is presenting doesn't exactly match one of the Redirect URLs configured on the MCP auth app (trailing slashes and protocol mismatches count).
+- **Connection stops working after a period of inactivity**: the access token expired and the refresh token either wasn't used or has itself expired or been invalidated. If refreshing doesn't recover it, re-run the full authorization flow from scratch.
+- **Activities (calls, emails, meetings, notes, tasks) or conversation data are missing from results, but the connection otherwise works**: the HubSpot portal has Sensitive Data protection enabled. This is expected MCP-specific behavior (see [Set up HubSpot](#set-up-hubspot)), not an authorization or scope problem.
+- **A capability that used to work stops returning results after a HubSpot MCP server update**: the app's granted scopes are tied to the tool set at the time of installation. Reinstall or reauthorize the app to pick up newly available scopes.
+- **Custom objects don't appear in search or record results**: the remote MCP server currently covers standard CRM objects and engagement history only. Custom objects aren't supported through MCP yet; use HubSpot's direct API for those.
+
+## Next steps
+
+- [Create an MCP Gateway](/operate/governance/mcp-gateways/create-via-dashboard) to expose this server's tools.
+- [Connect to MCP clients](/get-started/mcp-clients).

--- a/app/en/operate/governance/remote-mcp-servers/hubspot/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/hubspot/page.mdx
@@ -11,17 +11,16 @@ import { SignupLink } from "@/app/_components/analytics";
 HubSpot hosts a remote MCP server at `mcp.hubspot.com`, exposing CRM records, activities, conversations, campaigns, and marketing email tools directly from a HubSpot portal. This guide covers the Arcade-side setup for connecting it as a [remote MCP server](/operate/governance/remote-mcp-servers), plus the HubSpot settings that most commonly trip people up.
 
 <Callout type="info">
-  This guide is about connecting to HubSpot's own remote MCP server. Arcade
-  already ships an agent-optimized [HubSpot
-  toolkit](/resources/integrations/sales/hubspot) for core CRM objects, plus
-  separate starter toolkits covering conversations, marketing and
-  campaigns, and more (`hubspotconversationsapi`, `hubspotmarketingapi`,
-  `hubspotcrmapi`, and others). Between them, there's little this remote
-  server exposes that Arcade can't already reach. The real differentiators
-  are operational: one connection here instead of wiring up the Optimized
-  toolkit plus as many as eight separate starter toolkits to cover the same
-  surface, and every action scoped to whatever the authorizing HubSpot user
-  can already do in the portal, rather than to a toolkit's fixed scopes.
+  This guide is about connecting to HubSpot's own remote MCP server, not the
+  Arcade HubSpot toolkit. Arcade already covers most of this surface: the
+  [HubSpot toolkit](/resources/integrations/sales/hubspot) for core CRM
+  objects, plus starter toolkits like `hubspotconversationsapi` and
+  `hubspotmarketingapi` for conversations, campaigns, and marketing email.
+
+  Reach for this remote server instead when you want:
+
+  - One connection instead of wiring up the toolkit plus as many as eight starter toolkits
+  - Access scoped to whatever the authorizing HubSpot user can already do in the portal, not fixed toolkit scopes
 </Callout>
 
 <Callout type="warning">

--- a/app/en/operate/governance/remote-mcp-servers/hubspot/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/hubspot/page.mdx
@@ -10,6 +10,16 @@ import { SignupLink } from "@/app/_components/analytics";
 
 HubSpot hosts a remote MCP server at `mcp.hubspot.com`, exposing CRM records, activities, conversations, campaigns, and marketing email tools directly from a HubSpot portal. This guide covers the Arcade-side setup for connecting it as a [remote MCP server](/operate/governance/remote-mcp-servers), plus the HubSpot settings that most commonly trip people up.
 
+<Callout type="info">
+  This guide is about connecting to HubSpot's own remote MCP server. Arcade
+  already ships an agent-optimized [HubSpot
+  toolkit](/resources/integrations/sales/hubspot) covering core CRM objects.
+  Reach for this remote server instead when you need conversations,
+  campaigns, or marketing email tools beyond the toolkit's coverage, and keep
+  in mind that every action here is scoped to whatever the authorizing
+  HubSpot user can already do in the portal, not to toolkit-defined scopes.
+</Callout>
+
 <Callout type="warning">
   The HubSpot-side steps below are sourced directly from [HubSpot's own
   documentation](https://developers.hubspot.com/docs/apps/developer-platform/build-apps/integrate-with-the-remote-hubspot-mcp-server)

--- a/app/en/operate/governance/remote-mcp-servers/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/page.mdx
@@ -175,7 +175,7 @@ Common settings include:
   height={ADVANCED_SETTINGS_HEIGHT}
 />
 
-Some remote servers need provider-specific setup beyond these generic settings. See [Connect a Salesforce Hosted MCP Server](/operate/governance/remote-mcp-servers/salesforce) or [Connect a ServiceNow Hosted MCP Server](/operate/governance/remote-mcp-servers/servicenow) for fully worked examples.
+Some remote servers need provider-specific setup beyond these generic settings. See [Connect a Salesforce Hosted MCP Server](/operate/governance/remote-mcp-servers/salesforce), [Connect a ServiceNow Hosted MCP Server](/operate/governance/remote-mcp-servers/servicenow), or [Connect a HubSpot Remote MCP Server](/operate/governance/remote-mcp-servers/hubspot) for fully worked examples.
 
 ## Where the server's tools become available
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,4 +1,4 @@
-<!-- git-sha: ddbba82033a27d08f797c6290f6b9281843aefcf generation-date: 2026-08-24T16:34:32.400Z -->
+<!-- git-sha: b2dba1ba333234c538d32d41c80f45589a5077ea generation-date: 2026-08-28T18:56:07.796Z -->
 
 # Arcade
 
@@ -104,7 +104,10 @@ Arcade docs serve two audiences. Start with the path that matches your goal:
 - [Clerk](https://docs.arcade.dev/en/operate/identity/user-sources/clerk): Documentation page
 - [Comparative evaluations](https://docs.arcade.dev/en/build/create-tools/evaluate-tools/comparative-evaluations): Documentation page
 - [Compare MCP Server Types](https://docs.arcade.dev/en/build/create-tools/tool-basics/compare-server-types): Documentation page
+- [Connect a Dynamics 365 Customer Service MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/dynamics-365-customer-service): Documentation page
+- [Connect a HubSpot Remote MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/hubspot): Documentation page
 - [Connect a Salesforce Hosted MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/salesforce): Documentation page
+- [Connect a ServiceNow Hosted MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/servicenow): Documentation page
 - [Connect Arcade to your LLM](https://docs.arcade.dev/en/get-started/agent-frameworks/setup-arcade-with-your-llm-python): This documentation page guides users on how to connect Arcade to a Large Language Model (LLM) using Python by creating a "harness" that facilitates interaction between the user, the model, and various tools. Users will learn to set up an agent
 - [Connect to MCP Clients](https://docs.arcade.dev/en/get-started/mcp-clients): This documentation page provides guidance on connecting Arcade MCP servers to various MCP-compatible clients and development environments, enabling users to enhance their agent workflows.
 - [Contact Us](https://docs.arcade.dev/en/resources/contact-us): This documentation page provides users with information on how to connect with the Arcade team for support through various channels. It aims to facilitate communication and assistance for users and their agents.


### PR DESCRIPTION
## Summary
- Adds a guide for connecting HubSpot's remote MCP server (`mcp.hubspot.com`) via a HubSpot MCP Auth App, following the same structure as the existing [Salesforce](/operate/governance/remote-mcp-servers/salesforce), [ServiceNow](/operate/governance/remote-mcp-servers/servicenow), and Dynamics 365 (#1147) guides: provider-side setup, Arcade OAuth 2.0 config, and troubleshooting.
- Wires the new page into `_meta.tsx` and cross-links it from the `remote-mcp-servers` overview page.
- Calls out what's structurally different about this one: no explicit OAuth scope picker (scopes are implicit from installed tools + user grant), mandatory PKCE with no fallback, and a Sensitive Data portal setting that silently blocks activity/conversation data through MCP specifically (while leaving the same data reachable via HubSpot's standard CRM API).
- Discloses the overlap with Arcade's existing [HubSpot toolkit](/resources/integrations/sales/hubspot): a new callout right after the intro clarifies this guide is about the remote server specifically, and explains when to reach for it instead of the toolkit (conversations, campaigns, and marketing email beyond core CRM objects, with permissions scoped to the authorizing HubSpot user rather than toolkit-defined scopes).

## Update: toolkit-overlap callout corrected
A cross-vendor review found the callout above overstated this guide's unique value: Arcade already ships `arcade_starter` toolkits (`hubspotconversationsapi`, `hubspotmarketingapi`, `hubspotcrmapi`, and others) that cover conversations, campaigns, and marketing email — the exact gap the callout claimed was remote-server-only. The callout now names those starter toolkits and reframes the differentiator around operational convenience (one connection vs. wiring up the Optimized toolkit plus up to eight starter toolkits) and the portal-permission-scoped access model, rather than a tool-coverage gap that doesn't exist.

## Update: callout readability
The corrected callout had grown into a dense wall of text. Reformatted it into a short lead sentence plus a bullet list of when to reach for the remote server, keeping the same content at a glance-able length.

## Update: tier framing
A final consistency pass sorted all seven remote MCP server guides into three value tiers. HubSpot is **Tier 3 (fixed surface, gap already corrected)**, alongside GitHub (#1152): Arcade already covers this surface via the Optimized toolkit plus starter toolkits, so the differentiator is operational (one connection) and access-model, not tool coverage — unlike the Tier 1 guides (Salesforce #1149, ServiceNow #1153, Snowflake #1150), which have a permanent customer-extensibility story. Minor wording tweak ("two toolkit tiers") to match GitHub's phrasing; no change in meaning.

## ⚠️ Not yet verified against a live portal
Sourced directly from [HubSpot's own documentation](https://developers.hubspot.com/docs/apps/developer-platform/build-apps/integrate-with-the-remote-hubspot-mcp-server) for this server, but the Arcade-side field mapping **has not been walked through end-to-end against a live HubSpot portal.** Same caveat as ServiceNow (#1145) and Dynamics 365 (#1147) — flagged in a warning callout at the top of the doc.

## Test plan
- [x] `vale` passes with 0 errors
- [x] `internal-link-check` test passes
- [x] MDX compiles and renders locally (`pnpm dev`, confirmed 200 on the new route)
- [ ] Walk through the setup steps against a real HubSpot portal with an MCP auth app
- [ ] Confirm the Sensitive Data behavior and scope-reinstall behavior against a live portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or auth code paths affected; the main caveat is unverified live HubSpot setup steps in the new guide.
> 
> **Overview**
> Adds a **Connect a HubSpot Remote MCP Server** doc for registering `https://mcp.hubspot.com` in Arcade, aligned with the other provider-specific remote MCP guides.
> 
> The new page walks through HubSpot **MCP Auth App** setup, Arcade **OAuth2** fields (manual client credentials, optional auto-discovered auth/token URLs, redirect URI), authorization, and troubleshooting. It highlights HubSpot-specific behavior: **no explicit scope picker**, **mandatory PKCE**, **Sensitive Data** portals blocking activity/conversation data over MCP, and scope refresh after HubSpot adds MCP tools. An info callout contrasts the remote server with Arcade’s HubSpot toolkit plus starter toolkits (one connection vs many; portal-user-scoped access). A warning notes Arcade field mapping is **not yet verified** end-to-end on a live portal.
> 
> Navigation is updated via `_meta.tsx`, the remote MCP servers overview gains a HubSpot cross-link, and `public/llms.txt` lists the new page (plus related remote MCP entries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2969eebad510da16a611fe0992c5ae94e32affab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



