### PR TITLE
docs: clarify toolkit vs. Hosted MCP Server vs. custom tool in Salesforce guide

### DIFF
--- a/app/en/operate/governance/remote-mcp-servers/salesforce/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/salesforce/page.mdx
@@ -11,9 +11,14 @@ import { SignupLink } from "@/app/_components/analytics";
 Salesforce can host an [MCP server](https://developer.salesforce.com/docs/platform/hosted-mcp-servers/guide/hosted-mcp-servers-overview.html) for an org, exposing tools such as SOQL queries directly from Salesforce data. This guide covers the Arcade-side setup for connecting a Salesforce Hosted MCP Server as a [remote MCP server](/operate/governance/remote-mcp-servers), plus the handful of Salesforce settings that most commonly trip people up.
 
 <Callout type="info">
-  This guide is about connecting to a Salesforce Hosted MCP Server. If you're
-  looking to call Salesforce APIs from your own tools instead, see the
-  [Arcade Salesforce toolkit](/resources/integrations/sales/salesforce).
+  This guide is about connecting to a Salesforce Hosted MCP Server. Arcade
+  already ships an agent-optimized [Salesforce
+  toolkit](/resources/integrations/sales/salesforce) covering standard CRM
+  objects like accounts, contacts, leads, opportunities, and tasks. Reach for
+  the Hosted MCP Server instead when you need Apex, Agentforce, or Einstein
+  Trust Layer access that the toolkit doesn't cover, and build a custom tool
+  with the [Arcade MCP SDK](/build/create-tools/tool-basics/build-mcp-server)
+  against Salesforce's own APIs for anything neither one covers.
 </Callout>
 
 <GuideOverview>

--- a/app/en/operate/governance/remote-mcp-servers/salesforce/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/salesforce/page.mdx
@@ -16,8 +16,13 @@ Salesforce can host an [MCP server](https://developer.salesforce.com/docs/platfo
   toolkit](/resources/integrations/sales/salesforce) covers standard CRM
   objects: accounts, contacts, leads, opportunities, and tasks.
 
-  - Need Apex, Agentforce, or Einstein Trust Layer access? Use the Hosted MCP Server (this guide).
-  - Need something neither one covers? Build a custom tool with the [Arcade MCP SDK](/build/create-tools/tool-basics/build-mcp-server) against Salesforce's own APIs.
+  The Hosted MCP Server can front tools no generic toolkit could ever
+  pre-build, since a customer defines them for their own org:
+
+  - Custom Apex classes, Agentforce actions, and Named Queries built for org-specific processes (a GC Cloud or TPM workflow, for example)
+  - SOQL execution and Einstein Trust Layer access, beyond the toolkit's fixed CRM objects
+
+  Need something neither one covers? Build a custom tool with the [Arcade MCP SDK](/build/create-tools/tool-basics/build-mcp-server) against Salesforce's own APIs.
 </Callout>
 
 <GuideOverview>

--- a/app/en/operate/governance/remote-mcp-servers/salesforce/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/salesforce/page.mdx
@@ -11,14 +11,13 @@ import { SignupLink } from "@/app/_components/analytics";
 Salesforce can host an [MCP server](https://developer.salesforce.com/docs/platform/hosted-mcp-servers/guide/hosted-mcp-servers-overview.html) for an org, exposing tools such as SOQL queries directly from Salesforce data. This guide covers the Arcade-side setup for connecting a Salesforce Hosted MCP Server as a [remote MCP server](/operate/governance/remote-mcp-servers), plus the handful of Salesforce settings that most commonly trip people up.
 
 <Callout type="info">
-  This guide is about connecting to a Salesforce Hosted MCP Server. Arcade
-  already ships an agent-optimized [Salesforce
-  toolkit](/resources/integrations/sales/salesforce) covering standard CRM
-  objects like accounts, contacts, leads, opportunities, and tasks. Reach for
-  the Hosted MCP Server instead when you need Apex, Agentforce, or Einstein
-  Trust Layer access that the toolkit doesn't cover, and build a custom tool
-  with the [Arcade MCP SDK](/build/create-tools/tool-basics/build-mcp-server)
-  against Salesforce's own APIs for anything neither one covers.
+  This guide is about connecting to a Salesforce Hosted MCP Server, not the
+  Arcade Salesforce toolkit. Arcade's [Salesforce
+  toolkit](/resources/integrations/sales/salesforce) covers standard CRM
+  objects: accounts, contacts, leads, opportunities, and tasks.
+
+  - Need Apex, Agentforce, or Einstein Trust Layer access? Use the Hosted MCP Server (this guide).
+  - Need something neither one covers? Build a custom tool with the [Arcade MCP SDK](/build/create-tools/tool-basics/build-mcp-server) against Salesforce's own APIs.
 </Callout>
 
 <GuideOverview>


### PR DESCRIPTION
## Summary
- The Salesforce Hosted MCP Server guide's existing callout only said "if you want to call Salesforce APIs from your own tools, see the toolkit," which under-specifies the actual decision. Replaces it with a three-way split, in the same style as the toolkit-disclosure callouts on the HubSpot guide (#1148):
  - What the existing [Arcade Salesforce toolkit](/resources/integrations/sales/salesforce) covers (standard CRM objects: accounts, contacts, leads, opportunities, tasks)
  - When to reach for the Hosted MCP Server instead (Apex, Agentforce, Einstein Trust Layer access the toolkit doesn't cover)
  - When to build a custom tool with the Arcade MCP SDK instead (anything neither one covers)
- Confirmed there's no Arcade ServiceNow toolkit yet, so `servicenow/page.mdx` is intentionally left unchanged (one is being built separately).

**Low risk, docs-only.** Same framing as the ServiceNow PR (#1145): a single callout edit on an already-merged, already-live guide, no navigation or routing changes.

## Update: callout readability
A cross-vendor readability pass found the callout above had grown into a dense wall of text. Reformatted it into a short lead sentence plus a two-item bullet list contrasting the Hosted MCP Server path against building a custom MCP SDK tool, keeping the same content at a glance-able length.

## Update: tier framing
A final consistency pass sorted all seven remote MCP server guides into three value tiers. Salesforce is **Tier 1 (customer-extensible, durable value)**, alongside ServiceNow (#1153) and Snowflake (#1150): custom Apex, Agentforce actions, and Named Queries a customer builds for their own org are tools no generic Arcade toolkit could ever pre-build. The callout now leads with that framing instead of just listing capabilities.

## Test plan
- [x] `vale` passes with 0 errors (same warning/suggestion profile as before the edit)
- [x] `internal-link-check` test passes
- [x] MDX compiles and renders locally (`pnpm dev`, confirmed 200 on the existing route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single MDX callout edit on an existing docs page; no code, routing, or behavior changes.
> 
> **Overview**
> **Docs-only update** to the Salesforce Hosted MCP Server guide info callout so readers can choose the right integration path.
> 
> The previous callout only pointed people at the Arcade Salesforce toolkit for “calling APIs from your own tools.” It now spells out a **three-way split**: the toolkit for standard CRM objects; the **Hosted MCP Server** for org-defined tools (custom Apex, Agentforce, Named Queries, SOQL, Einstein Trust Layer); and the **Arcade MCP SDK** when neither fits.
> 
> The same content is **reformatted** for skimmability—a short lead sentence plus a two-item bullet list—without changing the rest of the guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eb05ad12803021e733444a740087d75917aa279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


