### PR TITLE
docs: add Atlassian Remote MCP Server connection guide

### DIFF
--- a/app/en/operate/governance/remote-mcp-servers/_meta.tsx
+++ b/app/en/operate/governance/remote-mcp-servers/_meta.tsx
@@ -10,6 +10,9 @@ const meta: MetaRecord = {
   servicenow: {
     title: "ServiceNow",
   },
+  atlassian: {
+    title: "Atlassian",
+  },
 };
 
 export default meta;

--- a/app/en/operate/governance/remote-mcp-servers/atlassian/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/atlassian/page.mdx
@@ -11,14 +11,21 @@ import { SignupLink } from "@/app/_components/analytics";
 Atlassian hosts a remote MCP server at `mcp.atlassian.com`, exposing Jira, Confluence, Jira Service Management, Bitbucket, and Compass tools from an Atlassian Cloud site. This guide covers the Arcade-side setup for connecting it as a [remote MCP server](/operate/governance/remote-mcp-servers), plus the Atlassian administrator controls that most commonly trip people up.
 
 <Callout type="info">
-  Arcade already ships Optimized [Jira](/resources/integrations/productivity/jira)
-  and [Confluence](/resources/integrations/productivity/confluence) toolkits,
+  This guide is about connecting to Atlassian's Rovo MCP server, not an
+  Arcade toolkit. Arcade already ships Optimized
+  [Jira](/resources/integrations/productivity/jira) and
+  [Confluence](/resources/integrations/productivity/confluence) toolkits,
   with none of the setup below.
 
   Reach for this remote-server path instead when you need:
 
-  - Compass or Jira Service Management coverage (neither has an Arcade toolkit today)
+  - Jira Service Management, Bitbucket Cloud, or Compass coverage (no Arcade toolkit exists for any of the three today)
   - Access enforced entirely through Atlassian's own domain, permission-group, and IP controls
+
+  Rovo's tool set is fixed and Atlassian-defined, not something a customer
+  can extend, so the JSM/Bitbucket/Compass advantage above is a gap-filler,
+  not a permanent one: it goes away if Arcade ships native toolkits for
+  those products.
 </Callout>
 
 <Callout type="warning">

--- a/app/en/operate/governance/remote-mcp-servers/atlassian/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/atlassian/page.mdx
@@ -1,0 +1,113 @@
+---
+title: "Connect an Atlassian Remote MCP Server"
+description: "Connect Arcade to Atlassian's Rovo MCP server and configure the site-level domain, permission, and IP controls that govern access"
+---
+
+import { Callout, Steps } from "nextra/components";
+import { SignupLink } from "@/app/_components/analytics";
+
+# Connect an Atlassian Remote MCP Server
+
+Atlassian hosts a remote MCP server at `mcp.atlassian.com`, exposing Jira, Confluence, Jira Service Management, Bitbucket, and Compass tools from an Atlassian Cloud site. This guide covers the Arcade-side setup for connecting it as a [remote MCP server](/operate/governance/remote-mcp-servers), plus the Atlassian administrator controls that most commonly trip people up.
+
+<Callout type="info">
+  Arcade already ships Optimized [Jira](/resources/integrations/productivity/jira)
+  and [Confluence](/resources/integrations/productivity/confluence) toolkits
+  for curated, agent-optimized access with none of the setup below. Reach for
+  this remote-server path instead when you specifically need Compass or Jira
+  Service Management coverage (neither has an Arcade toolkit today), or when
+  you want access enforced entirely through Atlassian's own domain,
+  permission-group, and IP controls rather than Arcade-maintained tool code.
+</Callout>
+
+<Callout type="warning">
+  This guide is sourced from [Atlassian's own support
+  documentation](https://support.atlassian.com/security-and-access-policies/docs/understand-atlassian-rovo-mcp-server/)
+  and the [official
+  atlassian-mcp-server repo](https://github.com/atlassian/atlassian-mcp-server).
+  The Arcade-side field mapping hasn't been walked through end-to-end against
+  a live site. Confirm before treating this as authoritative.
+</Callout>
+
+Atlassian's setup is structurally different from the other guides in this section. Salesforce, ServiceNow, Dynamics 365, and Snowflake all require an administrator to manually create an OAuth app or security integration and hand Arcade a Client ID and Secret. Atlassian's Rovo MCP server instead supports **OAuth 2.1 with Dynamic Client Registration (DCR)**: Arcade registers itself as a client automatically on first connection. There's no app-creation step on Atlassian's side at all. The administrative work here is entirely about *who's allowed to connect and what they can touch*, not about provisioning credentials.
+
+<GuideOverview>
+<GuideOverview.Outcomes>
+
+Connect an Atlassian Remote MCP server to Arcade and use its tools in gateways and SDKs.
+
+</GuideOverview.Outcomes>
+
+<GuideOverview.Prerequisites>
+
+- An <SignupLink linkLocation="docs:remote-mcp-servers-atlassian">Arcade account</SignupLink>
+- An Atlassian Cloud site (Jira and/or Confluence)
+- Organization administrator access to Atlassian Administration, to configure Rovo MCP server settings
+
+</GuideOverview.Prerequisites>
+
+<GuideOverview.YouWillLearn>
+
+- Which Atlassian domain, permission, and IP controls matter for Arcade specifically, and why
+- Register the remote server in Arcade without manually configuring OAuth credentials
+- Diagnose the most common setup mistakes from their error messages
+
+</GuideOverview.YouWillLearn>
+</GuideOverview>
+
+## Set up Atlassian
+
+- **Allow Arcade's domain to connect.** In Atlassian Administration, go to **Rovo → Rovo MCP server**, and check the domain settings. Atlassian's default **Allow Atlassian supported domains** setting covers Atlassian's own launch partners; it's unlikely to include Arcade automatically. Add Arcade explicitly under allowed domains, or connections will be blocked at the domain-allowlist stage before OAuth is even attempted, regardless of how permissions are otherwise configured.
+
+- **Set permission groups to Allowed for the products you need.** Under the same **Rovo MCP server** area, open **Permissions**. Atlassian groups tools by intent (for example `read_jira`, `write_confluence`, `search_atlassian`), and each tool inherits its group's setting. A connection can complete OAuth successfully and still fail every tool call with an access-denied error if the relevant group isn't set to **Allowed**.
+
+- **Check your org's IP allowlist separately.** If your organization has IP allowlisting configured, it applies independently of the preceding domain allowlist. Arcade's outbound IP addresses need to be added there too, or calls get blocked with an IP-specific error even when the domain and permission settings are both correct.
+
+- **Complete the first-time install with a broadly permissioned account.** The first user to complete the OAuth consent flow for your site needs access to every Atlassian app you want to expose. If that first consent happens with a Jira-only account, Confluence tools never get registered for the site, even for other users who do have Confluence access. Use an account with both Jira and Confluence access (whichever products you're exposing) for that first authorization.
+
+- **API token auth is available as an alternative, but changes the model.** For headless or service-style connections, an organization administrator can enable API token authentication instead of per-user OAuth 2.1 consent (**Rovo MCP server → Authentication**). This is also the *only* supported auth method for Jira Service Management and Bitbucket Cloud tools; those two product surfaces aren't reachable through the OAuth 2.1 flow at all. If you need JSM or Bitbucket tools, plan for a scoped API token rather than expecting OAuth to cover them.
+
+## Configure the remote server in Arcade
+
+<Steps>
+
+### Register the server
+
+Go to the [MCP servers dashboard](https://app.arcade.dev/servers), click **Add Server**, choose **Remote MCP**, and enter a server ID and the server URL:
+
+```
+https://mcp.atlassian.com/v1/mcp
+```
+
+<Callout type="info">
+  Atlassian has changed this endpoint before. The legacy `/v1/sse`
+  Server-Sent Events path is still supported but deprecated, and some
+  documentation references `/v1/mcp/authv2`. Confirm the current recommended
+  path in Atlassian's docs if the connection behaves unexpectedly.
+</Callout>
+
+### Configure OAuth2 authorization
+
+Open **Advanced settings → OAuth2 authorization** and **leave Client ID, Client Secret, Authorization URL, and Token URL all empty.** This is the opposite guidance from the other guides in this section: Atlassian's server supports Dynamic Client Registration, so populating these fields isn't necessary and there's nothing to create on the Atlassian side to get them from. Arcade registers a client and discovers the authorization server automatically on first connection.
+
+There's no redirect URI to manually configure anywhere in Atlassian Administration, either. DCR handles that as part of client registration.
+
+### Authorize and confirm
+
+Save the server to open the authorization prompt. If this is the first time anyone has connected an MCP client to this site, sign in with the broadly permissioned account described in [Set up Atlassian](#set-up-atlassian) above, so the site-level app registration picks up access to every product you intend to expose.
+
+</Steps>
+
+## Troubleshooting
+
+- **"Access denied: Your organization admin has not authorized..."**: the relevant permission group (read, write, or search, per product) isn't set to **Allowed** under **Rovo MCP server → Permissions**, even though OAuth itself succeeded.
+- **"You don't have permission to connect from this IP"**: Arcade's outbound IP addresses aren't on the organization's IP allowlist. This is a separate control from the domain allowlist and needs its own configuration.
+- **Authorization fails outright, before any consent screen appears**: Arcade's domain isn't in the allowed domains list under **Rovo MCP server** settings. "Allow Atlassian supported domains" being enabled doesn't guarantee Arcade is covered by it.
+- **Confluence (or Jira) tools never show up, even for a user with access to that product**: the first user to complete the site's initial OAuth consent didn't have access to that product. Have an administrator with access to all needed products redo the initial authorization.
+- **The connection stops responding, or behaves inconsistently**: confirm you're pointed at the current MCP endpoint rather than the deprecated `/v1/sse` path.
+- **Jira Service Management or Bitbucket Cloud tools are missing**: those tool families require API token authentication, not OAuth 2.1. They won't appear through a pure OAuth-based connection regardless of permission group settings.
+
+## Next steps
+
+- [Create an MCP Gateway](/operate/governance/mcp-gateways/create-via-dashboard) to expose this server's tools.
+- [Connect to MCP clients](/get-started/mcp-clients).

--- a/app/en/operate/governance/remote-mcp-servers/atlassian/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/atlassian/page.mdx
@@ -12,12 +12,13 @@ Atlassian hosts a remote MCP server at `mcp.atlassian.com`, exposing Jira, Confl
 
 <Callout type="info">
   Arcade already ships Optimized [Jira](/resources/integrations/productivity/jira)
-  and [Confluence](/resources/integrations/productivity/confluence) toolkits
-  for curated, agent-optimized access with none of the setup below. Reach for
-  this remote-server path instead when you specifically need Compass or Jira
-  Service Management coverage (neither has an Arcade toolkit today), or when
-  you want access enforced entirely through Atlassian's own domain,
-  permission-group, and IP controls rather than Arcade-maintained tool code.
+  and [Confluence](/resources/integrations/productivity/confluence) toolkits,
+  with none of the setup below.
+
+  Reach for this remote-server path instead when you need:
+
+  - Compass or Jira Service Management coverage (neither has an Arcade toolkit today)
+  - Access enforced entirely through Atlassian's own domain, permission-group, and IP controls
 </Callout>
 
 <Callout type="warning">

--- a/app/en/operate/governance/remote-mcp-servers/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/page.mdx
@@ -175,7 +175,7 @@ Common settings include:
   height={ADVANCED_SETTINGS_HEIGHT}
 />
 
-Some remote servers need provider-specific setup beyond these generic settings. See [Connect a Salesforce Hosted MCP Server](/operate/governance/remote-mcp-servers/salesforce) or [Connect a ServiceNow Hosted MCP Server](/operate/governance/remote-mcp-servers/servicenow) for fully worked examples.
+Some remote servers need provider-specific setup beyond these generic settings. See [Connect a Salesforce Hosted MCP Server](/operate/governance/remote-mcp-servers/salesforce), [Connect a ServiceNow Hosted MCP Server](/operate/governance/remote-mcp-servers/servicenow), or [Connect an Atlassian Remote MCP Server](/operate/governance/remote-mcp-servers/atlassian) for fully worked examples.
 
 ## Where the server's tools become available
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,4 +1,4 @@
-<!-- git-sha: 6355c6c66c1ce10676cbd3826539899df7d193d3 generation-date: 2026-08-28T19:04:21.370Z -->
+<!-- git-sha: bddaa1775cff648b6f9f0297210aa5aca9d20ae0 generation-date: 2026-08-28T19:13:11.500Z -->
 
 # Arcade
 
@@ -109,6 +109,7 @@ Arcade docs serve two audiences. Start with the path that matches your goal:
 - [Connect a Salesforce Hosted MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/salesforce): Documentation page
 - [Connect a ServiceNow Hosted MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/servicenow): Documentation page
 - [Connect a Snowflake-Managed MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/snowflake): Documentation page
+- [Connect an Atlassian Remote MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/atlassian): Documentation page
 - [Connect Arcade to your LLM](https://docs.arcade.dev/en/get-started/agent-frameworks/setup-arcade-with-your-llm-python): This documentation page guides users on how to connect Arcade to a Large Language Model (LLM) using Python by creating a "harness" that facilitates interaction between the user, the model, and various tools. Users will learn to set up an agent
 - [Connect to MCP Clients](https://docs.arcade.dev/en/get-started/mcp-clients): This documentation page provides guidance on connecting Arcade MCP servers to various MCP-compatible clients and development environments, enabling users to enhance their agent workflows.
 - [Contact Us](https://docs.arcade.dev/en/resources/contact-us): This documentation page provides users with information on how to connect with the Arcade team for support through various channels. It aims to facilitate communication and assistance for users and their agents.


### PR DESCRIPTION
## Summary
- Adds a guide for connecting Atlassian's Rovo MCP server (`mcp.atlassian.com`, covering Jira, Confluence, Jira Service Management, Bitbucket, and Compass) as a remote MCP server, following the same structure as the existing [Salesforce](/operate/governance/remote-mcp-servers/salesforce), [ServiceNow](/operate/governance/remote-mcp-servers/servicenow), HubSpot (#1148), Dynamics 365 (#1147), and Snowflake (#1150) guides.
- Wires the new page into `_meta.tsx` and cross-links it from the `remote-mcp-servers` overview page.
- Discloses the overlap with Arcade's existing [Jira](/resources/integrations/productivity/jira) and [Confluence](/resources/integrations/productivity/confluence) toolkits up front (confirmed both exist; confirmed no Compass or Bitbucket toolkit exists, matching this guide's framing), same pattern as the HubSpot/Snowflake/Salesforce (#1149) callouts.
- Calls out what's structurally different about this one versus every other guide in the section: Atlassian supports **Dynamic Client Registration**, so there's no OAuth app to manually create and no Client ID/Secret to configure in Arcade at all (the opposite of every other guide here). The real admin work is Atlassian's domain allowlist, permission groups, and IP allowlist, plus the requirement that the *first* user to authorize the site have access to every product being exposed. Also flags that Jira Service Management and Bitbucket Cloud tools require API token auth and aren't reachable through OAuth 2.1 at all.

## Update: callout readability
A cross-vendor readability pass found the toolkit-overlap callout above had grown into a dense wall of text. Reformatted it into a short lead sentence plus a bullet list of when to reach for the remote server, keeping the same content at a glance-able length.

## Update: tier framing, Bitbucket added
A final consistency pass sorted all seven remote MCP server guides into three value tiers. Atlassian is **Tier 2 (fixed surface, real gap today, but temporary)**, alongside Dynamics 365 (#1147): Rovo's tool set is Atlassian-defined with no customer-extensibility, so the JSM/Bitbucket/Compass advantage is a gap-filler that closes if Arcade ships native toolkits for those products — unlike the Tier 1 guides (Salesforce #1149, ServiceNow #1153, Snowflake #1150). Also fixed an omission: the callout named Compass and JSM as toolkit gaps but dropped Bitbucket Cloud, which has no Arcade toolkit either.

## ⚠️ Not yet verified against a live site
Sourced directly from [Atlassian's own support documentation](https://support.atlassian.com/security-and-access-policies/docs/understand-atlassian-rovo-mcp-server/) and the [official atlassian-mcp-server repo](https://github.com/atlassian/atlassian-mcp-server), but the Arcade-side field mapping **has not been walked through end-to-end against a live Atlassian Cloud site.** Same caveat as ServiceNow (#1145), Dynamics 365 (#1147), HubSpot (#1148), and Snowflake (#1150) — flagged in a warning callout in the doc.

## Test plan
- [x] `vale` passes with 0 errors
- [x] `internal-link-check` test passes
- [x] MDX compiles and renders locally (`pnpm dev`, confirmed 200 on the new route)
- [ ] Walk through the setup steps against a real Atlassian Cloud site with Rovo MCP server enabled
- [ ] Confirm the domain/permission-group/IP allowlist error messages and the first-authorization behavior against a live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or auth code; the main caveat is that Arcade setup steps are not yet validated on a live Atlassian site.
> 
> **Overview**
> Adds documentation for connecting **Atlassian’s Rovo MCP server** (`https://mcp.atlassian.com/v1/mcp`) as a remote MCP server in Arcade, alongside the existing Salesforce, ServiceNow, HubSpot, Dynamics 365, and Snowflake guides.
> 
> The new page explains when to use Rovo versus Arcade’s native **Jira** and **Confluence** toolkits, and documents Atlassian-specific setup: domain allowlist, Rovo permission groups, IP allowlisting, first-user OAuth scope, and **OAuth 2.1 with Dynamic Client Registration** (leave OAuth client fields empty in Arcade—no manual Atlassian OAuth app). It also notes **API token** auth for JSM/Bitbucket and includes troubleshooting plus an unverified-against-live-site warning.
> 
> Navigation is wired via `_meta.tsx`, the remote MCP overview links to the new guide, and `public/llms.txt` lists the page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fd6f2924090353a7a1f2381656db49228161b6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


