### PR TITLE
docs: add GitHub Remote MCP Server connection guide

### DIFF
--- a/app/en/operate/governance/remote-mcp-servers/_meta.tsx
+++ b/app/en/operate/governance/remote-mcp-servers/_meta.tsx
@@ -10,6 +10,9 @@ const meta: MetaRecord = {
   servicenow: {
     title: "ServiceNow",
   },
+  github: {
+    title: "GitHub",
+  },
 };
 
 export default meta;

--- a/app/en/operate/governance/remote-mcp-servers/github/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/github/page.mdx
@@ -13,12 +13,17 @@ GitHub hosts a remote MCP server at `api.githubcopilot.com/mcp/`, exposing repos
 <Callout type="info">
   Arcade already ships an [Optimized GitHub
   toolkit](/resources/integrations/development/github) for curated,
-  agent-optimized repository and issue access with none of the setup below.
-  Reach for this remote-server path instead when you need the fuller tool
-  surface GitHub's own server exposes (Actions logs, Dependabot and code
-  scanning alerts, Projects V2, Copilot Spaces), or when you specifically
-  want access governed through GitHub's own PAT and OAuth App policies
-  rather than Arcade-maintained tool code.
+  agent-optimized repository and issue access, plus a separate `githubapi`
+  starter toolkit that wraps nearly the entire GitHub REST API, including
+  Actions run and job logs, Dependabot alerts, and code scanning alerts.
+  Between the two, almost everything this remote server exposes is already
+  reachable through Arcade. The one confirmed exception is Copilot Spaces,
+  which isn't covered by either toolkit today. Otherwise, reach for this
+  remote-server path when you want one connection instead of combining the
+  Optimized and starter toolkits, or when you specifically want access
+  governed through GitHub's own PAT and OAuth App policies, mirroring your
+  organization's existing GitHub access controls, rather than
+  Arcade-maintained tool code.
 </Callout>
 
 <Callout type="warning">

--- a/app/en/operate/governance/remote-mcp-servers/github/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/github/page.mdx
@@ -11,19 +11,16 @@ import { SignupLink } from "@/app/_components/analytics";
 GitHub hosts a remote MCP server at `api.githubcopilot.com/mcp/`, exposing repositories, issues, pull requests, Actions, code security alerts, Projects, and more through roughly 80 tools. This guide covers the Arcade-side setup for connecting it as a [remote MCP server](/operate/governance/remote-mcp-servers), plus the GitHub settings that most commonly trip people up.
 
 <Callout type="info">
-  Arcade already ships an [Optimized GitHub
-  toolkit](/resources/integrations/development/github) for curated,
-  agent-optimized repository and issue access, plus a separate `githubapi`
-  starter toolkit that wraps nearly the entire GitHub REST API, including
-  Actions run and job logs, Dependabot alerts, and code scanning alerts.
-  Between the two, almost everything this remote server exposes is already
-  reachable through Arcade. The one confirmed exception is Copilot Spaces,
-  which isn't covered by either toolkit today. Otherwise, reach for this
-  remote-server path when you want one connection instead of combining the
-  Optimized and starter toolkits, or when you specifically want access
-  governed through GitHub's own PAT and OAuth App policies, mirroring your
-  organization's existing GitHub access controls, rather than
-  Arcade-maintained tool code.
+  Arcade already covers most of this surface with two toolkits: the
+  [Optimized GitHub toolkit](/resources/integrations/development/github),
+  and the `githubapi` starter toolkit (818 tools, including Actions logs,
+  Dependabot alerts, and code scanning alerts). The one confirmed gap is
+  Copilot Spaces, which neither toolkit covers.
+
+  Reach for this remote server instead when you want:
+
+  - One connection instead of combining two toolkits
+  - Access governed by GitHub's own PAT and OAuth App policies, mirroring your organization's existing controls
 </Callout>
 
 <Callout type="warning">

--- a/app/en/operate/governance/remote-mcp-servers/github/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/github/page.mdx
@@ -11,11 +11,13 @@ import { SignupLink } from "@/app/_components/analytics";
 GitHub hosts a remote MCP server at `api.githubcopilot.com/mcp/`, exposing repositories, issues, pull requests, Actions, code security alerts, Projects, and more through roughly 80 tools. This guide covers the Arcade-side setup for connecting it as a [remote MCP server](/operate/governance/remote-mcp-servers), plus the GitHub settings that most commonly trip people up.
 
 <Callout type="info">
-  Arcade already covers most of this surface with two toolkits: the
-  [Optimized GitHub toolkit](/resources/integrations/development/github),
-  and the `githubapi` starter toolkit (818 tools, including Actions logs,
-  Dependabot alerts, and code scanning alerts). The one confirmed gap is
-  Copilot Spaces, which neither toolkit covers.
+  This guide is about connecting to GitHub's own remote MCP server, not the
+  Arcade GitHub toolkits. Arcade already covers most of this surface with
+  two toolkits: the [Optimized GitHub
+  toolkit](/resources/integrations/development/github), and the `githubapi`
+  starter toolkit (818 tools, including Actions logs, Dependabot alerts,
+  and code scanning alerts). The one confirmed gap is Copilot Spaces, which
+  neither toolkit covers.
 
   Reach for this remote server instead when you want:
 

--- a/app/en/operate/governance/remote-mcp-servers/github/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/github/page.mdx
@@ -1,0 +1,140 @@
+---
+title: "Connect a GitHub Remote MCP Server"
+description: "Connect Arcade to GitHub's hosted MCP server using a fine-grained PAT or a registered OAuth App / GitHub App"
+---
+
+import { Callout, Steps } from "nextra/components";
+import { SignupLink } from "@/app/_components/analytics";
+
+# Connect a GitHub Remote MCP Server
+
+GitHub hosts a remote MCP server at `api.githubcopilot.com/mcp/`, exposing repositories, issues, pull requests, Actions, code security alerts, Projects, and more through roughly 80 tools. This guide covers the Arcade-side setup for connecting it as a [remote MCP server](/operate/governance/remote-mcp-servers), plus the GitHub settings that most commonly trip people up.
+
+<Callout type="info">
+  Arcade already ships an [Optimized GitHub
+  toolkit](/resources/integrations/development/github) for curated,
+  agent-optimized repository and issue access with none of the setup below.
+  Reach for this remote-server path instead when you need the fuller tool
+  surface GitHub's own server exposes (Actions logs, Dependabot and code
+  scanning alerts, Projects V2, Copilot Spaces), or when you specifically
+  want access governed through GitHub's own PAT and OAuth App policies
+  rather than Arcade-maintained tool code.
+</Callout>
+
+<Callout type="warning">
+  This guide is sourced from [GitHub's own MCP server
+  documentation](https://github.com/github/github-mcp-server) and [policies
+  and governance
+  guide](https://github.com/github/github-mcp-server/blob/main/docs/policies-and-governance.md).
+  The Arcade-side field mapping hasn't been walked through end-to-end
+  against a live GitHub organization. Confirm before treating this as
+  authoritative.
+</Callout>
+
+GitHub supports two distinct auth paths for a remote MCP client, and which one fits depends on your governance requirements more than technical difficulty.
+
+<GuideOverview>
+<GuideOverview.Outcomes>
+
+Connect a GitHub Remote MCP server to Arcade and use its tools in gateways and SDKs.
+
+</GuideOverview.Outcomes>
+
+<GuideOverview.Prerequisites>
+
+- An <SignupLink linkLocation="docs:remote-mcp-servers-github">Arcade account</SignupLink>
+- A GitHub account or organization with access to the repositories you want to expose
+- For the OAuth path: ability to register an OAuth App or GitHub App (any GitHub user or org owner can do this; no approval from GitHub is required)
+
+</GuideOverview.Prerequisites>
+
+<GuideOverview.YouWillLearn>
+
+- Whether to authenticate with a fine-grained PAT or a registered OAuth App / GitHub App, and why
+- Which GitHub organization and enterprise settings matter for Arcade specifically
+- Diagnose the most common setup mistakes from their error messages
+
+</GuideOverview.YouWillLearn>
+</GuideOverview>
+
+## Set up GitHub
+
+### Option A: Fine-grained Personal Access Token (no app registration)
+
+A fine-grained PAT requires no app registration at all. Create one under **Settings → Developer settings → Personal access tokens → Fine-grained tokens**, scoped to exactly the repositories and permissions Arcade needs. This is GitHub's recommended token type over classic PATs, since access is explicitly scoped rather than applying to every repository the user can reach.
+
+This path doesn't use Arcade's OAuth2 configuration at all. It's a static credential passed as a header (see [Configure the remote server in Arcade](#configure-the-remote-server-in-arcade) below).
+
+Two things limit this path:
+- **PATs don't respect OAuth App or GitHub App installation policies.** If your organization governs third-party access through those mechanisms, a PAT bypasses that governance entirely, which is exactly why GitHub itself doesn't recommend PATs for production automation.
+- **Enterprise Managed Users (EMU) have PATs turned off by default.** If your organization uses EMU, this path may not be available until an enterprise administrator explicitly enables it.
+
+### Option B: Register an OAuth App or GitHub App (recommended for governed rollouts)
+
+Unlike AWS's managed MCP server, GitHub doesn't gate this behind an approval process. Any user or organization owner can register an OAuth App or GitHub App themselves, under **Settings → Developer settings**. This is the path that gives you per-user authorization and lets your existing GitHub access policies apply to Arcade's connection the same way they'd apply to any other third-party integration.
+
+A few organization-level settings affect whether this works smoothly:
+
+- **OAuth App access restrictions.** If your organization has this enabled, an organization administrator must explicitly approve Arcade's specific OAuth App before members can authorize through it, similar in spirit to Atlassian's domain allowlist. Notably, GitHub exempts Visual Studio Code and Visual Studio from this restriction by default; Arcade won't be exempt, so this step is required if the restriction is on.
+- **GitHub Enterprise Server (GHES) or `ghe.com`**: these self-hosted or data-residency variants require registering the OAuth App or GitHub App directly against that instance's own domain, not `github.com`. The server URL you register in Arcade will point at your enterprise's own domain instead of `api.githubcopilot.com`.
+
+## Configure the remote server in Arcade
+
+<Steps>
+
+### Register the server
+
+Go to the [MCP servers dashboard](https://app.arcade.dev/servers), click **Add Server**, choose **Remote MCP**, and enter a server ID and the server URL:
+
+```
+https://api.githubcopilot.com/mcp/
+```
+
+For GitHub Enterprise Server or `ghe.com`, use your instance's own domain instead. Check with your GitHub administrator for the exact remote MCP endpoint on your instance.
+
+### If using a fine-grained PAT
+
+Under **Advanced settings → Custom headers**, add:
+
+```
+Authorization: Bearer ${secret:GITHUB_PAT}
+```
+
+storing the PAT itself as a header secret. There's no OAuth2 configuration to fill in for this path.
+
+### If using an OAuth App or GitHub App
+
+Open **Advanced settings → OAuth2 authorization** and enter:
+
+- **Client ID** / **Client Secret**: from the OAuth App or GitHub App you registered.
+- **Authorization URL**: `https://github.com/login/oauth/authorize`
+- **Token URL**: `https://github.com/login/oauth/access_token`
+
+<Callout type="info">
+  GitHub doesn't offer Dynamic Client Registration for this. As with most of
+  the providers in this section, these fields need to be filled in manually
+  rather than left blank.
+</Callout>
+
+### Add the redirect URI to your OAuth App
+
+Only needed for the OAuth App / GitHub App path. Copy the redirect URI Arcade generates and add it to your OAuth App's or GitHub App's callback URL settings in GitHub.
+
+### Authorize and confirm
+
+Save the server to open the authorization prompt. Sign in with a GitHub account that has access to the repositories and organizations you intend to expose. Arcade discovers the available tool surface based on this identity's access at setup time.
+
+</Steps>
+
+## Troubleshooting
+
+- **Authorization fails, or GitHub shows an error about the app not being approved**: your organization has OAuth App access restrictions enabled, and an organization administrator needs to explicitly approve Arcade's OAuth App before members can use it.
+- **PAT-based connection returns fewer results than expected, or write actions fail silently**: the fine-grained PAT's scopes don't cover the repositories or permissions the tool call needs. Fine-grained PATs are not filtered the way classic PAT scopes are, so some tools may appear available even when the token can't actually use them. A visible tool isn't a guarantee of access.
+- **A PAT that should work returns an authentication error entirely**: your organization may be an Enterprise Managed User (EMU) tenant, where PATs are turned off by default. Confirm with an enterprise administrator whether PAT access has been explicitly enabled, or switch to the OAuth App path instead.
+- **Connection works for `github.com` repositories but not an internal GitHub Enterprise Server instance**: the server URL and the OAuth App/GitHub App registration both need to point at your enterprise instance's own domain, not `api.githubcopilot.com` or `github.com`.
+- **Calls start failing under moderate load, with rate-limit errors**: rate limits differ by auth method. A PAT or OAuth App is capped at 5,000 requests/hour, while a GitHub App installation scales with repos and users (up to 12,500, or 15,000 on GitHub Enterprise Cloud). A GitHub App may be worth the extra registration step for higher-volume usage.
+
+## Next steps
+
+- [Create an MCP Gateway](/operate/governance/mcp-gateways/create-via-dashboard) to expose this server's tools.
+- [Connect to MCP clients](/get-started/mcp-clients).

--- a/app/en/operate/governance/remote-mcp-servers/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/page.mdx
@@ -175,7 +175,7 @@ Common settings include:
   height={ADVANCED_SETTINGS_HEIGHT}
 />
 
-Some remote servers need provider-specific setup beyond these generic settings. See [Connect a Salesforce Hosted MCP Server](/operate/governance/remote-mcp-servers/salesforce) or [Connect a ServiceNow Hosted MCP Server](/operate/governance/remote-mcp-servers/servicenow) for fully worked examples.
+Some remote servers need provider-specific setup beyond these generic settings. See [Connect a Salesforce Hosted MCP Server](/operate/governance/remote-mcp-servers/salesforce), [Connect a ServiceNow Hosted MCP Server](/operate/governance/remote-mcp-servers/servicenow), or [Connect a GitHub Remote MCP Server](/operate/governance/remote-mcp-servers/github) for fully worked examples.
 
 ## Where the server's tools become available
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,4 +1,4 @@
-<!-- git-sha: bddaa1775cff648b6f9f0297210aa5aca9d20ae0 generation-date: 2026-08-28T19:13:11.500Z -->
+<!-- git-sha: 23fe2a48add7a58708e5c8e00c386002fa8df2a7 generation-date: 2026-08-28T19:21:13.355Z -->
 
 # Arcade
 
@@ -105,6 +105,7 @@ Arcade docs serve two audiences. Start with the path that matches your goal:
 - [Comparative evaluations](https://docs.arcade.dev/en/build/create-tools/evaluate-tools/comparative-evaluations): Documentation page
 - [Compare MCP Server Types](https://docs.arcade.dev/en/build/create-tools/tool-basics/compare-server-types): Documentation page
 - [Connect a Dynamics 365 Customer Service MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/dynamics-365-customer-service): Documentation page
+- [Connect a GitHub Remote MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/github): Documentation page
 - [Connect a HubSpot Remote MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/hubspot): Documentation page
 - [Connect a Salesforce Hosted MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/salesforce): Documentation page
 - [Connect a ServiceNow Hosted MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/servicenow): Documentation page


### PR DESCRIPTION
## Summary
- Adds a guide for connecting GitHub's hosted MCP server (`api.githubcopilot.com/mcp/`, ~80 tools across repos, issues, PRs, Actions, code security, Projects) as a remote MCP server, following the same structure as the existing [Salesforce](/operate/governance/remote-mcp-servers/salesforce), [ServiceNow](/operate/governance/remote-mcp-servers/servicenow), HubSpot (#1148), Dynamics 365 (#1147), Snowflake (#1150), and Atlassian (#1151) guides.
- Wires the new page into `_meta.tsx` and cross-links it from the `remote-mcp-servers` overview page.
- Discloses the overlap with Arcade's existing [GitHub toolkit](/resources/integrations/development/github) up front (confirmed it exists), same pattern as the other guides' toolkit-disclosure callouts.
- Covers GitHub's two distinct auth paths as a genuine governance decision, not just a technical one: a fine-grained PAT (no app registration, but bypasses OAuth App/GitHub App governance and is off by default for EMU tenants) vs. registering an OAuth App or GitHub App (per-user auth, subject to org OAuth App access restrictions, higher rate limits). Also flags GitHub Enterprise Server / `ghe.com`'s separate-domain requirement for both the server URL and the app registration.

## Update: toolkit-overlap callout corrected
A cross-vendor review found the original toolkit-disclosure callout overstated this guide's unique value: Arcade's Optimized `github` toolkit already includes Projects tools, and the `githubapi` starter toolkit (818 tools, an near-1:1 GitHub REST API wrapper that isn't just the curated Optimized toolkit) already covers Actions run/job logs, Dependabot alerts, and code scanning alerts — none of that is remote-server-exclusive. The callout now names the one capability confirmed absent from both toolkits (Copilot Spaces) and reframes the rest of the differentiator around operational convenience (one connection vs. two toolkits) and GitHub's own PAT/OAuth App governance model, rather than a coverage gap that doesn't actually exist.

## Update: callout readability
The corrected callout had grown into a dense wall of text. Reformatted it into a short lead sentence plus a bullet list of when to reach for the remote server, keeping the same content at a glance-able length.

## Update: tier framing
A final consistency pass sorted all seven remote MCP server guides into three value tiers. GitHub is **Tier 3 (fixed surface, gap already corrected)**, alongside HubSpot (#1148): Arcade already covers this surface via the Optimized + `githubapi` starter toolkits (Copilot Spaces is the one confirmed exception), so the differentiator is operational (one connection) and access-model, not tool coverage — unlike the Tier 1 guides (Salesforce #1149, ServiceNow #1153, Snowflake #1150). Added the same "this guide is about X, not the toolkit" opener HubSpot already had, for consistency.

## ⚠️ Not yet verified against a live organization
Sourced directly from [GitHub's own MCP server documentation](https://github.com/github/github-mcp-server) and its [policies and governance guide](https://github.com/github/github-mcp-server/blob/main/docs/policies-and-governance.md), but the Arcade-side field mapping **has not been walked through end-to-end against a live GitHub organization.** Same caveat as the other guides in this series — flagged in a warning callout in the doc.

## Test plan
- [x] `vale` passes with 0 errors
- [x] `internal-link-check` test passes
- [x] MDX compiles and renders locally (`pnpm dev`, confirmed 200 on the new route)
- [ ] Walk through both auth paths (fine-grained PAT and OAuth App) against a real GitHub organization
- [ ] Confirm the OAuth App access restriction and EMU PAT behavior against a live org

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or auth logic; the main caveat is unverified setup steps that could mislead operators until live validation.
> 
> **Overview**
> Adds a **Connect a GitHub Remote MCP Server** doc for registering GitHub’s hosted endpoint (`api.githubcopilot.com/mcp/`) in Arcade, aligned with the other provider-specific remote MCP guides.
> 
> The page walks through **fine-grained PAT** (custom `Authorization` header secret) versus **OAuth App / GitHub App** (manual OAuth URLs, redirect URI, org approval for OAuth App restrictions), plus **GHES / `ghe.com`** URL and app registration notes. An info callout contrasts this path with Arcade’s Optimized GitHub and `githubapi` toolkits (single connection and GitHub-native governance; **Copilot Spaces** called out as the main toolkit gap), and a warning notes the Arcade field mapping is **not yet verified** end-to-end on a live org.
> 
> Navigation is wired via `_meta.tsx`, the remote MCP servers overview now links the new guide, and `public/llms.txt` lists the page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65a7816ccec415efb0d21ef716db8a7806d89b35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



