### PR TITLE
docs: reframe ServiceNow toolkit-overlap callout around customer-extensibility

### DIFF
--- a/app/en/operate/governance/remote-mcp-servers/servicenow/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/servicenow/page.mdx
@@ -18,8 +18,16 @@ ServiceNow can host an [MCP server](https://www.servicenow.com/docs/r/intelligen
 </Callout>
 
 <Callout type="info">
-  This guide is about connecting to a ServiceNow-hosted MCP server. If you're
-  looking to call ServiceNow APIs from your own tools instead, build a custom
+  This guide is about connecting to a ServiceNow-hosted MCP server. Arcade
+  doesn't ship a ServiceNow toolkit today, but even a future one wouldn't
+  replace what MCP Server Console can front: tools no generic toolkit
+  could ever pre-build, since a customer defines them for their own
+  instance:
+
+  - Now Assist Skills and Subflows built around one company's own workflows
+  - Actions and Scripted REST APIs scoped to that company's specific ITSM, HR, or business-unit configuration
+
+  Need something even MCP Server Console doesn't expose? Build a custom
   tool with the [Arcade MCP SDK](/build/create-tools/tool-basics/build-mcp-server)
   against ServiceNow's Table API.
 </Callout>


### PR DESCRIPTION
## Summary
ServiceNow's guide is merged (#1145), so this is a follow-up correction on a new branch, mirroring how the Salesforce callout was corrected post-merge in #1149.

The existing callout only said "no toolkit exists, build a custom tool with the Arcade MCP SDK instead," which undersells the actual story. As part of a cross-vendor tiering pass across all seven remote MCP server guides, ServiceNow belongs in the "customer-extensible, durable value" tier alongside Salesforce and Snowflake: Now Assist Skills, Subflows, Actions, and Scripted REST APIs a customer configures for their own instance are tools no generic Arcade toolkit could ever pre-build — a permanent differentiator, unlike guides where the value is just "no toolkit exists *yet*" (Dynamics 365, Atlassian).

The callout now leads with that extensibility story and keeps the MCP SDK fallback for anything even MCP Server Console doesn't expose.

**Low risk, docs-only.** Single callout edit on an already-merged, already-live guide, no navigation or routing changes — same framing as #1149.

## Test plan
- [x] `vale` passes with 0 errors (same warning/suggestion profile as before the edit)
- [x] `internal-link-check` test passes
- [x] MDX compiles and renders locally (`pnpm dev`, confirmed 200 on the existing route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change on an existing guide; no product, auth, or routing impact.
> 
> **Overview**
> Updates the **info callout** on the ServiceNow remote MCP server guide so it explains why **MCP Server Console** stays the right path even without (or with) an Arcade ServiceNow toolkit: customers define instance-specific tools—Now Assist Skills/Subflows and Actions/Scripted REST APIs—that a generic toolkit could not pre-build.
> 
> The callout still points readers to the **Arcade MCP SDK** and Table API when they need capabilities **MCP Server Console** does not expose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97987ba93d4d7a5d93a6c3be488064fd2d3866ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->