### PR TITLE
[PLT-3072] docs: explain connected account lifecycle recovery

### DIFF
--- a/app/en/build/eventing/page.mdx
+++ b/app/en/build/eventing/page.mdx
@@ -262,11 +262,11 @@ The sample records `received_at` for that cleanup policy but does not schedule t
 
 ## Recover expired connected accounts
 
-Subscribe to connection lifecycle events when your application should tell a user that an OAuth connection needs attention:
+Subscribe to connection lifecycle events when your app should tell a user that an OAuth connection needs attention:
 
-- `connected_account.created` — the connection became active for the first time.
-- `connected_account.expired` — Arcade can no longer use the connection.
-- `connected_account.reconnected` — reauthorization restored an expired connection.
+- `connected_account.created`—the connection became active for the first time.
+- `connected_account.expired`—Arcade can no longer use the connection.
+- `connected_account.reconnected`—reauthorization restored an expired connection.
 
 Create the project-scoped subscription:
 
@@ -303,7 +303,7 @@ All three events identify the `organization_id`, `user_id`, `provider_id`, `conn
 
 The public subscription API is project-scoped. Organization-bound lifecycle events omit `project_id` and are not delivered to a project subscription.
 
-In the Dashboard, open the expired connected user and choose **Reconnect**. The same action is available through `POST /v1/orgs/{org_id}/projects/{project_id}/auth/authorize`:
+In the Dashboard, open the expired connected user, and choose **Reconnect**. The same action is available through `POST /v1/orgs/{org_id}/projects/{project_id}/auth/authorize`:
 
 ```bash
 curl --fail-with-body --silent --show-error \
@@ -320,7 +320,7 @@ curl --fail-with-body --silent --show-error \
   }'
 ```
 
-Open the returned authorization URL. A successful flow restores the same connection and emits `connected_account.reconnected`; triggers pinned to it become healthy again. Ask for the connection's recorded scopes. Arcade also applies scopes configured on the provider. A reconnected event reports the OAuth state change, but normal scope checks still apply if the provider returns a reduced grant.
+Open the returned authorization URL. A successful flow restores the same connection and emits `connected_account.reconnected`. Triggers pinned to it become healthy again. Ask for the connection's recorded scopes. Arcade also applies scopes configured on the provider. A reconnected event reports the OAuth state change, but normal scope checks still apply if the provider returns a reduced grant.
 
 Engine does not observe MCP-managed OAuth refresh outcomes, so MCP-managed OAuth connections do not emit this lifecycle or use the standard OAuth Reconnect action.
 

--- a/app/en/build/eventing/page.mdx
+++ b/app/en/build/eventing/page.mdx
@@ -260,6 +260,70 @@ Use a persistent store in production. Keep each recorded `webhook-id` for at lea
 
 The sample records `received_at` for that cleanup policy but does not schedule the cleanup job for you. SQLite serializes these write transactions, so keep the handler's transactional work short and local; use a concurrent durable inbox for production receivers with parallel or network-bound work.
 
+## Recover expired connected accounts
+
+Subscribe to connection lifecycle events when your application should tell a user that an OAuth connection needs attention:
+
+- `connected_account.created` — the connection became active for the first time.
+- `connected_account.expired` — Arcade can no longer use the connection.
+- `connected_account.reconnected` — reauthorization restored an expired connection.
+
+Create the project-scoped subscription:
+
+```bash
+curl --fail-with-body --silent --show-error \
+  --request POST "$SCOPE/webhooks" \
+  --header "Authorization: Bearer $ARCADE_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data "{\"url\":\"$RECEIVER_URL\",\"event_types\":[\"connected_account.expired\"]}"
+```
+
+Arcade sends the Standard Webhooks envelope. Verify the Standard Webhooks signature against the raw body before reading it:
+
+```json
+{
+  "type": "connected_account.expired",
+  "timestamp": "2026-08-28T21:00:00Z",
+  "data": {
+    "organization_id": "org_123",
+    "project_id": "proj_123",
+    "user_id": "user@example.com",
+    "provider_id": "google",
+    "connection_id": "ac_123",
+    "status": "expired",
+    "reason": "refresh_failed"
+  }
+}
+```
+
+All three events identify the `organization_id`, `user_id`, `provider_id`, `connection_id`, and `status`. Project-bound events also include `project_id`. Only `connected_account.expired` includes `reason`:
+
+- `no_refresh_token` means the access token expired and no refresh token was available.
+- `refresh_failed` means the provider permanently rejected the refresh grant.
+
+The public subscription API is project-scoped. Organization-bound lifecycle events omit `project_id` and are not delivered to a project subscription.
+
+In the Dashboard, open the expired connected user and choose **Reconnect**. The same action is available through `POST /v1/orgs/{org_id}/projects/{project_id}/auth/authorize`:
+
+```bash
+curl --fail-with-body --silent --show-error \
+  --request POST "$SCOPE/auth/authorize" \
+  --header "Authorization: Bearer $ARCADE_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "user_id":"user@example.com",
+    "auth_requirement":{
+      "provider_id":"google",
+      "provider_type":"oauth2",
+      "oauth2":{"scopes":["https://www.googleapis.com/auth/gmail.readonly"]}
+    }
+  }'
+```
+
+Open the returned authorization URL. A successful flow restores the same connection and emits `connected_account.reconnected`; triggers pinned to it become healthy again. Ask for the connection's recorded scopes. Arcade also applies scopes configured on the provider. A reconnected event reports the OAuth state change, but normal scope checks still apply if the provider returns a reduced grant.
+
+Engine does not observe MCP-managed OAuth refresh outcomes, so MCP-managed OAuth connections do not emit this lifecycle or use the standard OAuth Reconnect action.
+
 ## Try a scheduled event
 
 A schedule is a configurable producer; every fire creates a separate retained Arcade event with its own delivery history. Use an interval for this check.

--- a/app/en/build/eventing/page.mdx
+++ b/app/en/build/eventing/page.mdx
@@ -301,7 +301,7 @@ All three events identify the `organization_id`, `user_id`, `provider_id`, `conn
 - `no_refresh_token` means the access token expired and no refresh token was available.
 - `refresh_failed` means the provider permanently rejected the refresh grant.
 
-The public subscription API is project-scoped. Organization-bound lifecycle events omit `project_id` and are not delivered to a project subscription.
+Each lifecycle event can originate from a project-bound or organization-bound connection. The public subscription API is project-scoped, so it delivers the project-bound events in the preceding example. Organization-bound lifecycle events omit `project_id` and are not delivered to a project subscription.
 
 In the Dashboard, open the expired connected user, and choose **Reconnect**. The same action is available through `POST /v1/orgs/{org_id}/projects/{project_id}/auth/authorize`:
 
@@ -320,7 +320,7 @@ curl --fail-with-body --silent --show-error \
   }'
 ```
 
-Open the returned authorization URL. A successful flow restores the same connection and emits `connected_account.reconnected`. Triggers pinned to it become healthy again. Ask for the connection's recorded scopes. Arcade also applies scopes configured on the provider. A reconnected event reports the OAuth state change, but normal scope checks still apply if the provider returns a reduced grant.
+Open the returned authorization URL. A successful flow restores the same connection and emits `connected_account.reconnected`. Triggers pinned to it become healthy again. Use the scopes on the connected-account record; Dashboard does this for you. Arcade also applies scopes configured on the provider. A reconnected event reports the OAuth state change, but normal scope checks still apply if the provider returns a reduced grant.
 
 Engine does not observe MCP-managed OAuth refresh outcomes, so MCP-managed OAuth connections do not emit this lifecycle or use the standard OAuth Reconnect action.
 

--- a/tests/eventing-guide.test.ts
+++ b/tests/eventing-guide.test.ts
@@ -10,6 +10,7 @@ const MODEL_SECTION_RE =
 const TABLE_DATA_ROW_RE = /^\| (?!Term \|)(?!-)[^|]+\|/gm;
 const ACCOUNT_LIFECYCLE_SECTION_RE =
   /## Recover expired connected accounts([\s\S]*?)## Try a scheduled event/;
+const JSON_BLOCK_RE = /```json\n([\s\S]*?)\n```/;
 const TIMESTAMP_TOLERANCE_RE = /through (\d+) seconds/;
 const TIMESTAMP_REJECTION_RE = /timestamps (\d+) seconds away/;
 const TOLERANCE_CONSTANT_RE = /TOLERANCE_SECONDS = (\d+)/;
@@ -118,16 +119,6 @@ describe("unified eventing guide", () => {
       '--request POST "$SCOPE/webhooks"',
       "event_types",
       "url",
-      '"type": "connected_account.expired"',
-      '"timestamp":',
-      '"data":',
-      "organization_id",
-      "project_id",
-      "user_id",
-      "provider_id",
-      "connection_id",
-      "status",
-      "reason",
       "no_refresh_token",
       "refresh_failed",
       "POST /v1/orgs/{org_id}/projects/{project_id}/auth/authorize",
@@ -140,6 +131,19 @@ describe("unified eventing guide", () => {
     expect(section).toContain("Organization-bound lifecycle events omit");
     expect(section).toContain("Verify the Standard Webhooks signature");
     expect(section).toContain("reduced grant");
+
+    const envelope = JSON.parse(section.match(JSON_BLOCK_RE)?.[1] ?? "{}");
+    expect(Object.keys(envelope).sort()).toEqual(["data", "timestamp", "type"]);
+    expect(envelope.type).toBe("connected_account.expired");
+    expect(Object.keys(envelope.data).sort()).toEqual([
+      "connection_id",
+      "organization_id",
+      "project_id",
+      "provider_id",
+      "reason",
+      "status",
+      "user_id",
+    ]);
   });
 
   test("documents the supported lifecycle without hiding retained events", () => {

--- a/tests/eventing-guide.test.ts
+++ b/tests/eventing-guide.test.ts
@@ -115,7 +115,9 @@ describe("unified eventing guide", () => {
       "connected_account.created",
       "connected_account.expired",
       "connected_account.reconnected",
-      '"event_types":["connected_account.expired"]',
+      '--request POST "$SCOPE/webhooks"',
+      "event_types",
+      "url",
       '"type": "connected_account.expired"',
       '"timestamp":',
       '"data":',
@@ -135,8 +137,8 @@ describe("unified eventing guide", () => {
     }
     expect(section).toContain("**Reconnect**");
     expect(section).toContain("public subscription API is project-scoped");
-    expect(section).toContain("organization-bound lifecycle events omit");
-    expect(section).toContain("verify the Standard Webhooks signature");
+    expect(section).toContain("Organization-bound lifecycle events omit");
+    expect(section).toContain("Verify the Standard Webhooks signature");
     expect(section).toContain("reduced grant");
   });
 

--- a/tests/eventing-guide.test.ts
+++ b/tests/eventing-guide.test.ts
@@ -8,6 +8,8 @@ const TITLE_RE = /title:\s*"Build event-driven integrations"/;
 const MODEL_SECTION_RE =
   /## The eventing model([\s\S]*?)## Choose your deployment origin/;
 const TABLE_DATA_ROW_RE = /^\| (?!Term \|)(?!-)[^|]+\|/gm;
+const ACCOUNT_LIFECYCLE_SECTION_RE =
+  /## Recover expired connected accounts([\s\S]*?)## Try a scheduled event/;
 const TIMESTAMP_TOLERANCE_RE = /through (\d+) seconds/;
 const TIMESTAMP_REJECTION_RE = /timestamps (\d+) seconds away/;
 const TOLERANCE_CONSTANT_RE = /TOLERANCE_SECONDS = (\d+)/;
@@ -105,6 +107,37 @@ describe("unified eventing guide", () => {
       expect(page).toContain(value);
     }
     expect(page).toContain("[Arcade API reference](/references/api)");
+  });
+
+  test("documents the complete connected-account recovery contract", () => {
+    const section = page.match(ACCOUNT_LIFECYCLE_SECTION_RE)?.[1] ?? "";
+    for (const value of [
+      "connected_account.created",
+      "connected_account.expired",
+      "connected_account.reconnected",
+      '"event_types":["connected_account.expired"]',
+      '"type": "connected_account.expired"',
+      '"timestamp":',
+      '"data":',
+      "organization_id",
+      "project_id",
+      "user_id",
+      "provider_id",
+      "connection_id",
+      "status",
+      "reason",
+      "no_refresh_token",
+      "refresh_failed",
+      "POST /v1/orgs/{org_id}/projects/{project_id}/auth/authorize",
+      "MCP-managed OAuth",
+    ]) {
+      expect(section).toContain(value);
+    }
+    expect(section).toContain("**Reconnect**");
+    expect(section).toContain("public subscription API is project-scoped");
+    expect(section).toContain("organization-bound lifecycle events omit");
+    expect(section).toContain("verify the Standard Webhooks signature");
+    expect(section).toContain("reduced grant");
   });
 
   test("documents the supported lifecycle without hiding retained events", () => {


### PR DESCRIPTION
## Why

When a connected account expires, operators need to understand the lifecycle event and reconnect the existing account without recreating triggers.

## What

- documents `connected_account.created`, `connected_account.expired`, and `connected_account.reconnected`
- explains the tenant-scoped envelope, expiry reasons, subscription, and Dashboard/API recovery
- records the MCP-managed OAuth and reduced-grant boundaries
- extends the unified eventing guide tests with the lifecycle contract

## Verification

- full docs suite: 874/874 pass
- executable receiver tests: 11/11 pass
- lint and typecheck: clean
- production build: `/en/build/eventing` rendered successfully
- branch rebased to contain only five lifecycle commits over the unified guide

## Merge gate

Ready for review as a child of ArcadeAI/docs#1146. Merge and publication remain intentionally gated on the parent guide and corresponding Engine release.

Linear: https://linear.app/arcadedev/issue/PLT-3072

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and contract tests only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds a **Recover expired connected accounts** section to the unified eventing guide, placed before the scheduled-event walkthrough.
> 
> The new content covers subscribing to `connected_account.created`, `connected_account.expired`, and `connected_account.reconnected`; verifying Standard Webhooks signatures; the expired-event payload and `no_refresh_token` / `refresh_failed` reasons; project-scoped subscriptions vs organization-bound connections (no `project_id`); and recovery via Dashboard **Reconnect** or `POST .../auth/authorize`, including scope behavior and trigger health after `connected_account.reconnected`. It also states that MCP-managed OAuth does not emit these lifecycle events or use the standard reconnect path.
> 
> **tests/eventing-guide.test.ts** gains a section-scoped test that asserts those strings, API paths, and the documented JSON envelope field set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddc3363e80658c2b0c7ebe2c7a1ec0478b4bb0ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->