### PR TITLE
ci: authenticate docs automation with a GitHub App

### DIFF
--- a/.github/actions/app-token/action.yml
+++ b/.github/actions/app-token/action.yml
@@ -1,0 +1,59 @@
+name: Get app token
+description: >
+  Mint a short-lived installation token for the docs automation GitHub App and
+  resolve the git identity of its bot user.
+
+inputs:
+  app-id:
+    description: App ID or client ID of the docs automation app.
+    required: true
+  private-key:
+    description: Private key of the docs automation app.
+    required: true
+
+outputs:
+  token:
+    description: Installation token, scoped to this repository and valid for one hour.
+    value: ${{ steps.app-token.outputs.token }}
+  user-name:
+    description: Git user name of the app's bot user.
+    value: ${{ steps.bot-user.outputs.user-name }}
+  user-email:
+    description: Git email of the app's bot user, which links commits to the bot account.
+    value: ${{ steps.bot-user.outputs.user-email }}
+  committer:
+    description: Bot identity as a single `Name <email>` string, the form create-pull-request expects.
+    value: ${{ steps.bot-user.outputs.committer }}
+
+runs:
+  using: composite
+  steps:
+    - name: Mint an installation token
+      id: app-token
+      uses: actions/create-github-app-token@v2
+      with:
+        # `app-id` takes either the numeric app ID or the app's client ID.
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+
+    - name: Resolve the bot user identity
+      id: bot-user
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+      run: |
+        # Assign before echoing. `echo "id=$(gh api ...)"` reports echo's exit
+        # code, so a failed lookup would pass the step with an empty id, and
+        # the resulting address is one git accepts but GitHub cannot link to
+        # the bot — misattributed commits, no error anywhere.
+        id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+
+        name="${APP_SLUG}[bot]"
+        email="${id}+${APP_SLUG}[bot]@users.noreply.github.com"
+
+        {
+          echo "user-name=${name}"
+          echo "user-email=${email}"
+          echo "committer=${name} <${email}>"
+        } >>"$GITHUB_OUTPUT"

--- a/.github/workflows/generate-toolkit-docs.yml
+++ b/.github/workflows/generate-toolkit-docs.yml
@@ -97,13 +97,28 @@ jobs:
       - name: Sync toolkit sidebar navigation
         run: pnpm exec tsx toolkit-docs-generator/scripts/sync-toolkit-sidebar.ts --remove-empty-sections=false --verbose
 
+      - name: Get app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DOCS_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
+
+      - name: Get bot user ID
+        id: bot-user
+        run: echo "id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >>"$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Create pull request
         id: cpr
         uses: peter-evans/create-pull-request@v7
         env:
           HUSKY: 0
         with:
-          token: ${{ secrets.DOCS_PUBLISHABLE_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+          author: ${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.bot-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
+          committer: ${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.bot-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
           commit-message: "[AUTO] Adding MCP Servers docs update"
           title: "[AUTO] Adding MCP Servers docs update"
           body: |
@@ -130,7 +145,7 @@ jobs:
             echo "::warning::Could not request review on PR #${{ steps.cpr.outputs.pull-request-number }}: $(cat review-error.log)"
           fi
         env:
-          GH_TOKEN: ${{ secrets.DOCS_PUBLISHABLE_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Upload generation report
         if: always()

--- a/.github/workflows/generate-toolkit-docs.yml
+++ b/.github/workflows/generate-toolkit-docs.yml
@@ -99,16 +99,10 @@ jobs:
 
       - name: Get app token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: ./.github/actions/app-token
         with:
           app-id: ${{ secrets.DOCS_BOT_CLIENT_ID }}
           private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
-
-      - name: Get bot user ID
-        id: bot-user
-        run: echo "id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >>"$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Create pull request
         id: cpr
@@ -117,8 +111,8 @@ jobs:
           HUSKY: 0
         with:
           token: ${{ steps.app-token.outputs.token }}
-          author: ${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.bot-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
-          committer: ${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.bot-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
+          author: ${{ steps.app-token.outputs.committer }}
+          committer: ${{ steps.app-token.outputs.committer }}
           commit-message: "[AUTO] Adding MCP Servers docs update"
           title: "[AUTO] Adding MCP Servers docs update"
           body: |

--- a/.github/workflows/llmstxt.yml
+++ b/.github/workflows/llmstxt.yml
@@ -37,11 +37,24 @@ jobs:
         with:
           node-version: "22.x"
 
+      - name: Get app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DOCS_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
+
+      - name: Get bot user ID
+        id: bot-user
+        run: echo "id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >>"$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
-          token: ${{ secrets.DOCS_PUBLISHABLE_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install dependencies
         run: npm install -g pnpm
@@ -66,8 +79,8 @@ jobs:
       - name: Commit changes to PR
         if: steps.check-changes.outputs.has_changes == 'true' && github.event_name == 'pull_request'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.bot-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           git add public/llms.txt
           git commit -m "🤖 Regenerate LLMs.txt"
           git push
@@ -77,7 +90,9 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.DOCS_PUBLISHABLE_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+          author: ${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.bot-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
+          committer: ${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.bot-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
           commit-message: Regenerate LLMs.txt and related files
           branch: auto-update-llms-txt
           delete-branch: true
@@ -91,9 +106,9 @@ jobs:
         continue-on-error: true
         run: gh pr edit ${{ steps.cpr.outputs.pull-request-number }} --add-reviewer ArcadeAI/engineering-tools-and-dx
         env:
-          GH_TOKEN: ${{ secrets.DOCS_PUBLISHABLE_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Enable Pull Request Automerge
         if: steps.check-changes.outputs.has_changes == 'true' && github.event_name != 'pull_request'
         run: gh pr merge --squash --auto ${{ steps.cpr.outputs.pull-request-number }}
         env:
-          GH_TOKEN: ${{ secrets.DOCS_PUBLISHABLE_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/llmstxt.yml
+++ b/.github/workflows/llmstxt.yml
@@ -37,24 +37,14 @@ jobs:
         with:
           node-version: "22.x"
 
-      - name: Get app token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.DOCS_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
-
-      - name: Get bot user ID
-        id: bot-user
-        run: echo "id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >>"$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
-          token: ${{ steps.app-token.outputs.token }}
+          # No credentials to persist: the app token is minted further down,
+          # once there is something to push. The commit step below supplies it
+          # to git explicitly.
+          persist-credentials: false
 
       - name: Install dependencies
         run: npm install -g pnpm
@@ -76,14 +66,27 @@ jobs:
             echo "has_changes=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Get app token
+        if: steps.check-changes.outputs.has_changes == 'true'
+        id: app-token
+        uses: ./.github/actions/app-token
+        with:
+          app-id: ${{ secrets.DOCS_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
+
       - name: Commit changes to PR
         if: steps.check-changes.outputs.has_changes == 'true' && github.event_name == 'pull_request'
+        env:
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          USER_NAME: ${{ steps.app-token.outputs.user-name }}
+          USER_EMAIL: ${{ steps.app-token.outputs.user-email }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
-          git config user.email "${{ steps.bot-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git config user.name "$USER_NAME"
+          git config user.email "$USER_EMAIL"
           git add public/llms.txt
           git commit -m "🤖 Regenerate LLMs.txt"
-          git push
+          git push "https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${HEAD_REF}"
 
       - name: Create Pull Request (for scheduled/manual runs)
         if: steps.check-changes.outputs.has_changes == 'true' && github.event_name != 'pull_request'
@@ -91,8 +94,8 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
-          author: ${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.bot-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
-          committer: ${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.bot-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
+          author: ${{ steps.app-token.outputs.committer }}
+          committer: ${{ steps.app-token.outputs.committer }}
           commit-message: Regenerate LLMs.txt and related files
           branch: auto-update-llms-txt
           delete-branch: true
@@ -107,8 +110,9 @@ jobs:
         run: gh pr edit ${{ steps.cpr.outputs.pull-request-number }} --add-reviewer ArcadeAI/engineering-tools-and-dx
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Enable Pull Request Automerge
-        if: steps.check-changes.outputs.has_changes == 'true' && github.event_name != 'pull_request'
+        if: steps.check-changes.outputs.has_changes == 'true' && github.event_name != 'pull_request' && steps.cpr.outputs.pull-request-number != ''
         run: gh pr merge --squash --auto ${{ steps.cpr.outputs.pull-request-number }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update-design-system-dependency.yml
+++ b/.github/workflows/update-design-system-dependency.yml
@@ -12,6 +12,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Get app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DOCS_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
+
+      - name: Get bot user ID
+        id: bot-user
+        run: echo "id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >>"$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -55,7 +68,9 @@ jobs:
           HUSKY: 0
           SKIP_HUSKY: 1
         with:
-          token: ${{ secrets.DOCS_PUBLISHABLE_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+          author: ${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.bot-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
+          committer: ${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.bot-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
           commit-message: "chore: update @arcadeai/design-system to latest"
           title: "chore: update @arcadeai/design-system to latest"
           body: |
@@ -77,4 +92,4 @@ jobs:
         continue-on-error: true
         run: gh pr edit ${{ steps.cpr.outputs.pull-request-number }} --add-reviewer ArcadeAI/engineering-tools-and-dx
         env:
-          GH_TOKEN: ${{ secrets.DOCS_PUBLISHABLE_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update-design-system-dependency.yml
+++ b/.github/workflows/update-design-system-dependency.yml
@@ -12,19 +12,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get app token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.DOCS_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
-
-      - name: Get bot user ID
-        id: bot-user
-        run: echo "id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >>"$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -60,6 +47,14 @@ jobs:
           pnpm vitest run toolkit-docs-generator/tests/scripts/sync-toolkit-sidebar.test.ts toolkit-docs-generator/tests/sources/oauth-provider-resolver.test.ts
           pnpm run build
 
+      - name: Get app token
+        if: steps.check-changes.outputs.has_changes == 'true'
+        id: app-token
+        uses: ./.github/actions/app-token
+        with:
+          app-id: ${{ secrets.DOCS_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
+
       - name: Create pull request
         if: steps.check-changes.outputs.has_changes == 'true'
         id: cpr
@@ -69,8 +64,8 @@ jobs:
           SKIP_HUSKY: 1
         with:
           token: ${{ steps.app-token.outputs.token }}
-          author: ${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.bot-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
-          committer: ${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.bot-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
+          author: ${{ steps.app-token.outputs.committer }}
+          committer: ${{ steps.app-token.outputs.committer }}
           commit-message: "chore: update @arcadeai/design-system to latest"
           title: "chore: update @arcadeai/design-system to latest"
           body: |


### PR DESCRIPTION
## Why

`DOCS_PUBLISHABLE_GH_TOKEN` hit its one-year expiry on 2026-08-26. Every workflow that pushes a branch or opens a PR started failing the next morning with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

That's a 401 on the token, with git falling back to a credential prompt that no runner can answer. It took out three workflows at once: toolkit docs generation, llms.txt generation, and the design system dependency bump. It's also why the `Generate LLMs.txt` check is red on unrelated PRs right now.

A PAT means this is a scheduled outage every year, and it binds the automation to one person's account.

## What changed

A new composite action, `.github/actions/app-token`, mints a short-lived installation token from an org-owned GitHub App and resolves the git identity of its bot user. Each of the three workflows calls it in place of `secrets.DOCS_PUBLISHABLE_GH_TOKEN`:

```yaml
- name: Get app token
  id: app-token
  uses: ./.github/actions/app-token
  with:
    app-id: ${{ secrets.DOCS_BOT_CLIENT_ID }}
    private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
```

It outputs `token` plus `user-name`, `user-email`, and `committer` — the bot's identity in the two shapes the callers need, so the `...@users.noreply.github.com` address is written once rather than in six places.

| Workflow | Token refs swapped |
|---|---|
| `llmstxt.yml` | checkout, create-PR, reviewer, automerge |
| `generate-toolkit-docs.yml` | create-PR, reviewer |
| `update-design-system-dependency.yml` | create-PR, reviewer |

No references to the old secret remain in `.github/`.

Commits are also attributed to the app's bot rather than to `github.actor`, which is why generated commits were landing under a teammate's name. The slug and user id are looked up at runtime so attribution survives an app rename.

### Details worth a second look

**The bot user id is assigned before it's echoed.** Written as `echo "id=$(gh api ...)"`, the step reports echo's exit code, so a failed lookup passes green with an empty id. The resulting address is one git accepts but GitHub cannot link to the bot — the exact misattribution this PR set out to fix, restored silently. Assigning first lets `bash -e` fail the step.

**`llmstxt.yml` checks out before minting the token,** because a composite action has to exist on disk to run. Checkout therefore has no token to persist (`persist-credentials: false`), and the commit step pushes to an explicitly authenticated remote instead. The token is minted only when there are changes, matching the other two workflows.

**The automerge step picked up the `pull-request-number != ''` guard** its two neighbours already carried. Without it, a run where create-pull-request produced no PR called `gh pr merge` with no argument and failed.

**`update-design-system-dependency.yml` mints its token after the build gate,** so a one-hour credential isn't held across install and build, and isn't requested at all when there's no PR to open.

## Why an app rather than a fresh PAT

- The private key doesn't expire, so this doesn't recur next August.
- It belongs to the org, not to an individual account.
- The token is scoped to this repo and lives one hour, versus a year-long credential.
- The built-in `GITHUB_TOKEN` isn't an option here: pushes made with it don't trigger other workflows, so the auto-PRs would sit with no checks running.

## Setup already done

- App created and installed on `ArcadeAI/docs` by an org owner
- `DOCS_BOT_CLIENT_ID` and `DOCS_BOT_PRIVATE_KEY` added to repo secrets

## After merge

1. Run `gh workflow run generate-toolkit-docs.yml` — it exercises push, PR creation, and the reviewer request. (`workflow_dispatch` runs the file from `main`, so this needs to merge first.)
2. Check the **Request team review** step. If it still warns `Resource not accessible`, the app is missing the org-level **Members: Read** permission, which sits on a different settings tab from the repository permissions.
3. Delete `DOCS_PUBLISHABLE_GH_TOKEN` from repo secrets.
4. Once step 2 is confirmed working, consider narrowing the token with `permission-contents: write` and `permission-pull-requests: write`. Left off for now because those inputs drop every permission not listed, including the Members: Read that the reviewer request depends on.

Note that PRs already open need `main` merged in before their `Generate LLMs.txt` check can pass — for `pull_request` events GitHub runs the workflow file from the PR's own branch, not from `main`.

Nothing here runs on this PR: `Generate LLMs.txt` is path-filtered to `.mdx` and generator sources, none of which changed. The workflow edits are first exercised by step 1 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
