### PR TITLE
fix: stop anchor links from scrolling headings behind the navbar

### DIFF
--- a/app/_components/toolkit-docs/components/documentation-chunk-renderer.tsx
+++ b/app/_components/toolkit-docs/components/documentation-chunk-renderer.tsx
@@ -214,7 +214,7 @@ function ChunkContent({ chunk }: { chunk: DocumentationChunk }) {
   // Render complex MDX content directly
   if (type === "markdown" || hasJSXContent(content)) {
     return (
-      <section className="my-3 scroll-mt-20" id={anchorId}>
+      <section className="my-3" id={anchorId}>
         <MdxContent content={content} />
       </section>
     );
@@ -231,7 +231,7 @@ function ChunkContent({ chunk }: { chunk: DocumentationChunk }) {
   }
 
   return (
-    <section className="scroll-mt-20" id={anchorId}>
+    <section id={anchorId}>
       <Callout title={title} type={calloutType}>
         <MdxContent content={content} />
       </Callout>

--- a/app/_components/toolkit-docs/components/tool-section.tsx
+++ b/app/_components/toolkit-docs/components/tool-section.tsx
@@ -552,7 +552,7 @@ export function ToolSection({
 
   return (
     <section
-      className="mt-10 scroll-mt-20 rounded-xl border-neutral-dark-high/20 border-b bg-neutral-dark/20 p-6 last:border-b-0"
+      className="mt-10 rounded-xl border-neutral-dark-high/20 border-b bg-neutral-dark/20 p-6 last:border-b-0"
       id={anchorId}
       ref={sectionRef}
     >

--- a/app/_components/toolkit-docs/components/toolkit-page.tsx
+++ b/app/_components/toolkit-docs/components/toolkit-page.tsx
@@ -583,7 +583,7 @@ export function ToolkitPage({ data }: ToolkitPageProps) {
   return (
     <div className="w-full">
       {/* Overview section */}
-      <section className="scroll-mt-20" id={TOOLKIT_PAGE_OVERVIEW_LINK.id}>
+      <section id={TOOLKIT_PAGE_OVERVIEW_LINK.id}>
         <BreadcrumbBar category={data.metadata?.category} label={data.label} />
         <PageActionsBar toolkitId={data.id} />
         <h1 className="mb-6 font-bold text-4xl text-foreground tracking-tight">
@@ -684,7 +684,7 @@ export function ToolkitPage({ data }: ToolkitPageProps) {
         position="after"
       />
 
-      <div className="mt-10 scroll-mt-20" id="available-tools">
+      <div className="mt-10" id="available-tools">
         <h2 className="flex items-center gap-3 font-semibold text-2xl">
           <span className="rounded-lg bg-brand-accent/10 p-2">
             <svg
@@ -745,7 +745,7 @@ export function ToolkitPage({ data }: ToolkitPageProps) {
         tools={tools}
       />
 
-      <section className="mt-10 scroll-mt-20" id="get-building">
+      <section className="mt-10" id="get-building">
         <DocumentationChunkRenderer
           chunks={documentationChunks}
           location="footer"

--- a/app/_components/toolkit-docs/components/toolkit-tool-detail.tsx
+++ b/app/_components/toolkit-docs/components/toolkit-tool-detail.tsx
@@ -53,7 +53,7 @@ export function ToolkitToolDetail({
   return (
     <>
       {shouldShowSelection && (
-        <section className="mt-10 scroll-mt-20" id={SELECTED_TOOLS_SECTION_ID}>
+        <section className="mt-10" id={SELECTED_TOOLS_SECTION_ID}>
           <ScopePicker
             onSelectedToolsChange={onScopeSelectionChange}
             selectedTools={Array.from(selectedTools)}

--- a/app/en/resources/integrations/components/toolkits-client.tsx
+++ b/app/en/resources/integrations/components/toolkits-client.tsx
@@ -141,7 +141,7 @@ export default function ToolkitsClient({ toolkits }: ToolkitsClientProps) {
             </div>
           </div>
         </div>
-        <div className="mx-auto max-w-7xl scroll-mt-20 px-4" id="list">
+        <div className="mx-auto max-w-7xl px-4" id="list">
           <Separator className="mt-4" />
           <FiltersBar resultsCount={resultsCount} />
           <main className="mx-auto max-w-7xl px-4 pt-2 pb-8 sm:pb-12">

--- a/app/globals.css
+++ b/app/globals.css
@@ -265,3 +265,18 @@ nav > div:has(.algolia-search-button) {
   --x-color-primary-700: color-mix(in oklch, var(--primary) 85%, white);
   --x-color-primary-800: color-mix(in oklch, var(--primary) 70%, white);
 }
+
+/*
+ * Anchor scroll offset. Nextra sets `scroll-padding-top` to exactly the navbar
+ * height, so a heading lands flush against the navbar's bottom edge with no
+ * gap, and it scopes that to `html:not(:has(*:focus))` — so when a click leaves
+ * focus on the page the offset disappears entirely and the heading ends up
+ * hidden behind the navbar. Set it unconditionally, with room to breathe.
+ *
+ * `html:root` matches Nextra's specificity and wins on source order. Headings
+ * and sections should not add their own `scroll-mt-*`; it stacks on top of this
+ * and leaves a large empty band above the target.
+ */
+html:root {
+  scroll-padding-top: calc(var(--nextra-navbar-height) + 1.5rem);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -280,3 +280,19 @@ nav > div:has(.algolia-search-button) {
 html:root {
   scroll-padding-top: calc(var(--nextra-navbar-height) + 1.5rem);
 }
+
+/*
+ * The smooth anchor scrolling on this site came from zenscroll (bundled with
+ * swagger-ui-react), which app/layout.tsx now stands down because it ignored
+ * the offset above. Ask the browser for the same easing instead — native
+ * scrolling honors scroll-padding-top.
+ */
+html {
+  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -130,6 +130,20 @@ export default async function RootLayout({
         <link href="https://www.googletagmanager.com" rel="dns-prefetch" />
       </Head>
       <body>
+        {/*
+          swagger-ui-react bundles zenscroll, which installs a document-wide
+          click handler as soon as its module is evaluated. That handler
+          intercepts every in-page anchor click, computes the destination as
+          "element top minus a 10px edge offset", and animates there with
+          window.scrollTo. CSS scroll-padding-top never enters the
+          calculation, so headings land under the sticky navbar. Standing
+          zenscroll's automatic anchor handling down hands anchor scrolling
+          back to the browser, which does honor scroll-padding-top. The
+          zenscroll methods swagger-ui calls itself keep working.
+        */}
+        <Script id="disable-zenscroll-anchors" strategy="beforeInteractive">
+          {"window.noZensmooth = true;"}
+        </Script>
         {lang !== "en" && (
           <TranslationBanner dictionary={dictionary} locale={lang} />
         )}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -112,7 +112,12 @@ export default async function RootLayout({
   const pageMap = addRoutesToHrefItems(rawPageMap) as typeof rawPageMap;
 
   return (
-    <html dir="ltr" lang={lang} suppressHydrationWarning>
+    <html
+      data-scroll-behavior="smooth"
+      dir="ltr"
+      lang={lang}
+      suppressHydrationWarning
+    >
       <Head
         backgroundColor={{
           dark: "#0a0a0a",


### PR DESCRIPTION
## What

Clicking a link in "On this page" scrolled the target heading behind the sticky navbar — the heading was invisible and the page appeared to start mid-section. Now the heading lands 24px below the navbar.

## Why it happened

`swagger-ui-react` bundles [zenscroll](https://github.com/zengabor/zenscroll), and webpack puts it in a shared chunk that loads on **every** docs page, not just the API reference. On import, zenscroll installs a document-wide click handler that intercepts every in-page anchor click and does this:

```js
targetY = zenscroll.getTopOf(targetElem)       // element top in the document
targetY = Math.max(0, targetY - edgeOffset)    // edgeOffset = 10px
zenscroll.toY(targetY, ...)                    // window.scrollTo(0, targetY)
```

CSS `scroll-padding-top` plays no part in that calculation, so the heading landed 10px from the top of the viewport, under the 64px navbar. Traced on the preview deployment:

```
window.scrollTo → [0, 3000]
  at Object.toY (chunks/74945-49b6d34f962e3bc2.js)   ← zenscroll, 792 KB chunk
heading document top: 3010   →   heading viewport top: 10
```

Separately, Nextra's own `scroll-padding-top` is set to exactly `var(--nextra-navbar-height)`, so even with native scrolling the target cleared the navbar by 0px, and Nextra scopes that rule to `html:not(:has(*:focus))` — with anything focused the offset vanishes.

**This only reproduces in a production build.** Dev builds do not pull the swagger-ui chunk into ordinary docs pages, so anchor scrolling in `pnpm dev` is native and looks fine. Everything below was verified with `pnpm build && pnpm start`.

## The fix

**`app/layout.tsx`** — stand zenscroll's automatic anchor handling down before hydration:

```tsx
<Script id="disable-zenscroll-anchors" strategy="beforeInteractive">
  {"window.noZensmooth = true;"}
</Script>
```

`noZensmooth` is zenscroll's own opt-out and gates only the global click handler. The zenscroll methods swagger-ui calls itself are untouched.

**`app/globals.css`** — a real offset, and the smooth easing zenscroll was providing:

```css
html:root {
  scroll-padding-top: calc(var(--nextra-navbar-height) + 1.5rem);
}

html {
  scroll-behavior: smooth;
}
```

`html:root` matches the specificity of Nextra's selector and wins on source order; dropping the `:has(*:focus)` guard means the offset applies no matter what has focus. `scroll-behavior` is turned off under `prefers-reduced-motion`.

I also removed `scroll-mt-20` from the six toolkit sections that carried it — those stack on top of the root padding and were landing 144px down the page.

## Before / after

Same page and link as the bug report: **Grant the OIDC permissions** on the Microsoft Entra ID user source page, 1440x900, production build.

**Before** — the heading is behind the navbar; the page opens on the paragraph after it:

![before](https://raw.githubusercontent.com/ArcadeAI/docs/49613c4daba127ead04e191c4c373fd109459288/before-crop.png)

**After**:

![after](https://raw.githubusercontent.com/ArcadeAI/docs/49613c4daba127ead04e191c4c373fd109459288/after-crop.png)

### Recordings

Three TOC links clicked in sequence.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ArcadeAI/docs/49613c4daba127ead04e191c4c373fd109459288/before.gif) | ![after](https://raw.githubusercontent.com/ArcadeAI/docs/49613c4daba127ead04e191c4c373fd109459288/after.gif) |

<details>
<summary>Full viewport screenshots</summary>

**Before**

![before full](https://raw.githubusercontent.com/ArcadeAI/docs/49613c4daba127ead04e191c4c373fd109459288/before-full.png)

**After**

![after full](https://raw.githubusercontent.com/ArcadeAI/docs/49613c4daba127ead04e191c4c373fd109459288/after-full.png)

</details>

## Measurements

Production build. Navbar bottom edge at `y = 64`; numbers are the heading's viewport top after the scroll settles.

| Case | Before | After |
| --- | --- | --- |
| TOC link, MDX guide page | 10 (behind the navbar) | 88 |
| TOC link, toolkit page | 10 | 88 |
| \`scrollIntoView()\` on a heading, with focus on the page | 0 | 88 |
| Toolkit section carrying \`scroll-mt-20\`, native scrolling | 144 (80px of dead space above it) | 88 |

Checked on an MDX guide page and a toolkit page, and confirmed on this PR's preview deployment (`viewTop: 88`, `noZensmooth: true`, `scroll-padding-top: 88px`). `pnpm lint` and `pnpm build` pass.

On the API reference page swagger still mounts with no new console errors. Its operation list can't be exercised on a preview origin — `https://api.arcade.dev/v1/swagger` is CORS-restricted to the production domain, which predates this change — but per zenscroll's source, `noZensmooth` gates only the automatic anchor click handler; the exported methods swagger-ui calls are built and returned either way.

## Worth a follow-up, not fixed here

That 792 KB swagger-ui chunk loads on every docs page. Scoping it to the API reference routes would cut a large amount of JavaScript from every other page. Filed separately from this fix since it needs a look at how `references/api` imports it.

## Note on the media

The screenshots and GIFs live on the `pr-assets-anchor-scroll-offset` branch so they stay out of this repo's history. Safe to delete once this PR is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only scroll/anchor behavior; zenscroll opt-out affects global click handling but leaves swagger-ui’s direct zenscroll API calls intact.
> 
> **Overview**
> Fixes **in-page anchor navigation** (TOC / hash links) so targets land **below the sticky navbar** with consistent spacing instead of hidden under it or with a large empty gap.
> 
> **Root layout** sets `window.noZensmooth = true` via a `beforeInteractive` script so **zenscroll** (pulled in through `swagger-ui-react`) stops hijacking anchor clicks with a fixed 10px offset that ignored CSS `scroll-padding-top`. The root `<html>` also gets `data-scroll-behavior="smooth"`.
> 
> **Global CSS** overrides Nextra with `html:root { scroll-padding-top: calc(var(--nextra-navbar-height) + 1.5rem) }`, enables native `scroll-behavior: smooth` (with `prefers-reduced-motion: auto`), and documents that per-element `scroll-mt-*` should not be used because it stacks on the global padding.
> 
> **Toolkit and integrations UI** drops `scroll-mt-20` from anchored sections (`documentation-chunk-renderer`, toolkit page sections, tool sections, integrations `#list`) so scroll position matches the new global offset (~88px below the navbar top in production).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb106417338e22d8dc36f3d3b17fd5fe19cade6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->