### PR TITLE
docs(tool-executions): say why this page calls two different hosts

### DIFF
--- a/app/en/operate/governance/tool-executions/page.mdx
+++ b/app/en/operate/governance/tool-executions/page.mdx
@@ -111,6 +111,8 @@ Two consequences are worth knowing.
 
 The same history is available over the Arcade API. The base URL is `https://api.arcade.dev`, and requests authenticate with a bearer token.
 
+Reading history and changing the policy are two different services, so they answer on two different hosts. Execution history is served by the Engine at `https://api.arcade.dev`; the recording and retention settings below belong to your organization and are served by the control plane at `https://cloud.arcade.dev`, alongside the [audit log API](/operate/governance/audit-logs). The host and the path prefix differ together — `/v1/...` on the Engine, `/api/v1/...` on the control plane.
+
 List the runs that failed, 25 at a time:
 
 ```bash


### PR DESCRIPTION
One sentence, split out from #1157 so it can be rejected on its own — it is a judgement call about how the docs explain Arcade's API surface, not a correction like the rest of that PR.

Stacked on [#1157](https://github.com/ArcadeAI/docs/pull/1157) → `add-doc-screenshots` → `main`.

## Why

After #1157 the page is correct but reads oddly. It says the base URL is `https://api.arcade.dev`, and thirty lines later calls `https://cloud.arcade.dev`. Both are right:

| Call | Service | Host | Prefix |
| -- | -- | -- | -- |
| `tool_executions` (read history) | Engine | `api.arcade.dev` | `/v1/...` |
| `logging-config` (change policy) | Control plane | `cloud.arcade.dev` | `/api/v1/...` |

Verified against the harness clients, which are the source of truth for these paths — `engine.ts` builds `v1/orgs/{org}/projects/{proj}`, `coordinator.ts` builds `api/v1/orgs/{org}`.

A reader who notices the difference cannot tell it from a typo, and guessing wrong costs a 404 on a path that looks right. That is not hypothetical: **I made exactly this mistake writing #1141**, applying the Engine's convention to a control-plane endpoint. It shipped and stood until this week.

## What it says

> Reading history and changing the policy are two different services, so they answer on two different hosts. Execution history is served by the Engine at `https://api.arcade.dev`; the recording and retention settings below belong to your organization and are served by the control plane at `https://cloud.arcade.dev`, alongside the [audit log API](/operate/governance/audit-logs). The host and the path prefix differ together — `/v1/...` on the Engine, `/api/v1/...` on the control plane.

@evantahler — worth your call on two things:

1. **Is this the page's job?** The split is site-wide, not specific to tool executions. If it belongs in a shared API-reference page instead, say so and I will move it there and drop this.
2. **Is "control plane" the right customer-facing word?** It is our internal name for the Coordinator. If the docs have an established term, I will use that.

## CI note

`Generate LLMs.txt` fails here, as it does on every PR in this repo since 2026-08-26 — it dies at checkout because `secrets.DOCS_PUBLISHABLE_GH_TOKEN` resolves empty. Unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification with no runtime or API behavior changes.
> 
> **Overview**
> Adds a short note in **Read executions from the API** so readers are not surprised when the same page uses `https://api.arcade.dev` for execution history and later `https://cloud.arcade.dev` for logging policy.
> 
> The new copy states that listing/reading tool runs is on the **Engine** (`/v1/...`), while org recording and retention settings (and the linked audit log API) live on the **control plane** (`/api/v1/...`), and that host and path prefix change together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 224846d564f6bfc58750e1bf50b12e7fcad33977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->