### PR TITLE
docs(tool-executions): fix an invented env var and a wrong host that just merged

### DIFF
--- a/app/en/operate/governance/tool-executions/page.mdx
+++ b/app/en/operate/governance/tool-executions/page.mdx
@@ -179,11 +179,11 @@ On Arcade Cloud, recording is enabled by default and the retention window is 7 d
 
 ### Change them yourself
 
-In the dashboard, open **Organization → Logging Policy**. Or call the API with an account-authenticated token — a project API key is refused, because the policy belongs to the organization rather than to a project:
+In the dashboard, open **Organization → Logging Policy**. Or call the API. The policy belongs to the organization, so this endpoint authenticates a user the same way the [audit log API](/operate/governance/audit-logs) does — a project API key is refused with a `401`:
 
 ```bash
-curl -s -X PUT "https://api.arcade.dev/v1/orgs/{org_id}/logging-config" \
-  -H "Authorization: Bearer $ARCADE_ACCOUNT_TOKEN" \
+curl -s -X PUT "https://cloud.arcade.dev/api/v1/orgs/{org_id}/logging-config" \
+  -H "Authorization: Bearer $ARCADE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"logging_data_retention": "ALLOWED", "default_log_retention_days": 30}'
 ```


### PR DESCRIPTION
**#1157 merged ten minutes before its own correction landed.** `add-doc-screenshots` currently carries two errors I introduced; this fixes both.

| Time (UTC) | |
| -- | -- |
| 17:45 | pushed `8e7c9a33` — `$ARCADE_ACCOUNT_TOKEN`, `api.arcade.dev/v1/...` |
| **18:00** | **#1157 merged** |
| 18:10 | pushed `7fba7342` — the correction, which missed the merge |

## What is wrong on the branch right now

```bash
curl -s -X PUT "https://api.arcade.dev/v1/orgs/{org_id}/logging-config" \
  -H "Authorization: Bearer $ARCADE_ACCOUNT_TOKEN" \
```

**`$ARCADE_ACCOUNT_TOKEN` does not exist.** I invented it. It appears nowhere in the product or on this site. A reader would export nothing, get a `401`, and have no name to look up.

**The URL is wrong in host and prefix.** `logging-config` is a control-plane route. Every other one on this site is `cloud.arcade.dev/api/v1/`; a live stack returns `404` for `/v1/orgs/...` and resolves `/api/v1/orgs/...`.

## What this changes it to

```bash
curl -s -X PUT "https://cloud.arcade.dev/api/v1/orgs/{org_id}/logging-config" \
  -H "Authorization: Bearer $ARCADE_API_KEY" \
```

`$ARCADE_API_KEY` matches the [audit log page](/operate/governance/audit-logs), which documents the same org-scoped shape as "User (API key/JWT)". The surviving, verified claim is narrower: a **project** key is refused with `401 Invalid credentials: missing account ID`, and the prose now says so.

## How this happened

I hit that `401` while testing with a project key from the fixtures, concluded the documented credential was wrong, and invented a replacement without checking that it existed. The check I skipped was one grep of the sibling page.

Worth reviewing this one on the diff rather than the description.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only fix for copy-paste API examples; no product or runtime behavior changes.
> 
> **Overview**
> Corrects the **Recording and retention → Change them yourself** example so org logging policy updates match how other control-plane routes are documented.
> 
> The `curl` example now uses **`https://cloud.arcade.dev/api/v1/orgs/{org_id}/logging-config`** instead of `api.arcade.dev/v1/...`, and **`$ARCADE_API_KEY`** instead of the nonexistent `$ARCADE_ACCOUNT_TOKEN`. The surrounding text now points readers to the same org-scoped user auth model as the [audit log API](/operate/governance/audit-logs) and states that a **project** API key gets **`401`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18b2a17b94c48d8c6f87168d02997eddfa410ca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->