### PR TITLE
docs(mcp-clients): surface Streamable HTTP + tool-picker for zero-hit Algolia queries

### DIFF
--- a/app/en/get-started/mcp-clients/cursor/page.mdx
+++ b/app/en/get-started/mcp-clients/cursor/page.mdx
@@ -1,7 +1,14 @@
+---
+title: "Use Arcade in Cursor"
+description: "Connect Cursor to an Arcade MCP Gateway over Streamable HTTP and pick which tools Cursor can use."
+---
+
 import { Steps, Callout, Tabs } from "nextra/components";
 import { SignupLink } from "@/app/_components/analytics";
 
 # Use Arcade in Cursor
+
+Cursor is an MCP client. Point it at an Arcade [MCP Gateway](/operate/governance/mcp-gateways) URL over the Streamable HTTP transport and Cursor's agent can call any tool you selected on that gateway — GitHub, Linear, Gmail, Slack, or any other toolkit from the [Arcade integrations catalog](/resources/integrations), plus tools from your own [custom MCP servers](/build/create-tools/tool-basics/build-mcp-server).
 
 <GuideOverview>
 <GuideOverview.Outcomes>
@@ -75,3 +82,9 @@ Cursor will open the MCP settings file, and you can add a new entry to the `mcpS
 1. Open the chat pane (typically command-l)
 1. Make sure you are in **Agent** mode
 1. Ask the agent to use a tool!
+
+## Pick which tools Cursor sees
+
+A gateway is the filter that decides which tools Cursor can call. On the [MCP Gateways dashboard](https://api.arcade.dev/dashboard/mcp-gateways), open your gateway's **Allowed Tools** picker and search or filter across every server in scope — Arcade-hosted toolkits, [remote MCP servers](/operate/governance/remote-mcp-servers) you registered, and your own [Arcade-deployed MCP servers](/build/arcade-deploy). Save the gateway and Cursor immediately sees the new tool list on its next request; no restart or client-side config change is needed.
+
+Popular starting points for a Cursor gateway: GitHub, Linear, Gmail, Slack, Google Calendar, Notion, Jira, Confluence — plus any [remote MCP server](/operate/governance/remote-mcp-servers) or [custom MCP server](/build/create-tools/tool-basics/build-mcp-server) you have registered. Browse the full [integrations catalog](/resources/integrations) for the rest.

--- a/app/en/get-started/mcp-clients/page.mdx
+++ b/app/en/get-started/mcp-clients/page.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Connect to MCP Clients"
-description: "Learn how to connect your MCP servers to various MCP-compatible clients and development environments"
+description: "Learn how to connect Cursor, Claude Desktop, Claude Code, VS Code, GitHub Copilot, and Copilot Studio to Arcade MCP Gateways over Streamable HTTP."
 ---
 
 import { MCPClientGrid } from "./mcp-client-grid";
@@ -8,5 +8,7 @@ import { MCPClientGrid } from "./mcp-client-grid";
 # Connect to MCP Clients
 
 You can connect [Arcade MCP servers](/resources/integrations) to MCP-compatible clients and development environments to unlock powerful flows for your agents.
+
+Every supported MCP client — Cursor, Claude Desktop, Claude Code, VS Code, GitHub Copilot, and Copilot Studio — connects to an Arcade [MCP Gateway](/operate/governance/mcp-gateways) over the Streamable HTTP transport. The gateway decides which tools the client can call: pick from Arcade-hosted toolkits (GitHub, Linear, Gmail, Slack, Google Calendar, Notion, Jira, Confluence, and dozens more in the [integrations catalog](/resources/integrations)), from [remote MCP servers](/operate/governance/remote-mcp-servers) you registered, and from your own [custom MCP servers](/build/create-tools/tool-basics/build-mcp-server) hosted with [Arcade Deploy](/build/arcade-deploy).
 
 <MCPClientGrid />


### PR DESCRIPTION
## Summary

The latest weekly Algolia summary (`Aug 24 – Aug 30`) reports a **27.27% no-result rate** on the docs search. Digging into the ten zero-hit queries showed a cluster centered on Cursor / MCP Gateways / Streamable HTTP / tool picking — topics that _are_ documented, but not from a page a searcher for these phrases would land on. The Cursor page in particular was a five-line config snippet with no prose to anchor the search, and the `/get-started/mcp-clients` landing page was a single sentence plus a grid.

This PR adds real prose (plus proper frontmatter on the Cursor page, which was missing `title`/`description`) so those queries have something to match against. No component changes, no behavior changes — content only.

## Zero-result queries from the Algolia weekly report

All ten from the `Aug 24 – Aug 30` summary:

1. `todoist`
2. `hermes agent mcp client integration`
3. `mcp clients cursor recommended tools github linear`
4. `connect mcp client gateway streamable http configuration`
5. `mcp gateway cursor connect tool search filter tools`
6. `host custom mcp server add server to gateway`
7. `triggers events webhooks subscribe to gmail email received`
8. `arcade deploy worker persistent storage state`
9. `build custom toolkit mcp server python create tool`
10. `scheduled cron trigger background job deployed server`

## What this PR fixes vs. leaves alone

**Addressed by this PR** (queries 3, 4, 5, and partially 6, 9): these all name existing features (Cursor, Streamable HTTP, MCP Gateway tool picker, remote/custom MCP servers, Arcade Deploy) but the pages users would land on didn't carry enough of that vocabulary to rank. Added:

- `app/en/get-started/mcp-clients/cursor/page.mdx` — frontmatter (`title`, `description`), a prose intro naming Streamable HTTP + example toolkits (GitHub, Linear, Gmail, Slack), and a new `## Pick which tools Cursor sees` section that names the **Allowed Tools** picker, remote MCP servers, custom MCP servers, and Arcade Deploy explicitly.
- `app/en/get-started/mcp-clients/page.mdx` — a parallel sentence that names every supported client (Cursor, Claude Desktop, Claude Code, VS Code, GitHub Copilot, Copilot Studio), the Streamable HTTP transport, and the tool-selection surface, so the mcp-clients landing page has enough content to rank on those keywords.

**Not fixed here** (out of scope for a content PR): queries 1, 2, 7, 8, 10 point at features Arcade doesn't ship today (Todoist toolkit, "Hermes" agent framework, Gmail email-received triggers/webhooks, worker persistent storage, scheduled cron triggers), and query 6's "add server to gateway" phrasing is a separate discoverability issue on the remote-MCP-servers page. Worth a follow-up if these queries keep showing up.

## Test plan

- [ ] `pnpm build` succeeds on this branch
- [ ] `pnpm vale:check` passes on the two modified files
- [ ] Broken-link check passes (all added links target existing pages: `/operate/governance/mcp-gateways`, `/operate/governance/remote-mcp-servers`, `/build/create-tools/tool-basics/build-mcp-server`, `/build/arcade-deploy`, `/resources/integrations`, `/get-started/setup/api-keys`, `/operate/identity/user-sources`)
- [ ] After merge + reindex, search for `cursor streamable http`, `mcp gateway filter tools`, and `recommended tools cursor github linear` returns the Cursor / mcp-clients pages instead of zero results

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and SEO copy only; no runtime, auth, or API behavior changes.
> 
> **Overview**
> **Docs-only** update to improve search discoverability for Cursor / MCP Gateway / Streamable HTTP / tool-filtering queries (no app or component changes).
> 
> On **`cursor/page.mdx`**, adds missing **frontmatter** (`title`, `description`), an intro that frames Cursor as an MCP client using an Arcade gateway over **Streamable HTTP** with named example toolkits, and a new **`## Pick which tools Cursor sees`** section that documents the gateway **Allowed Tools** picker, remote/custom MCP servers, and that tool list updates apply on the next request without restarting Cursor.
> 
> On **`mcp-clients/page.mdx`**, rewrites the **meta description** and adds a landing-page paragraph that lists every supported client, **Streamable HTTP**, and how gateways expose Arcade, remote, and custom/deployed tools—matching vocabulary users were searching for but that wasn’t on these pages before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c37a89b9e3d61e4f71c139af05cd1ebe1d96ab25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->