### PR TITLE
docs: add Splunk MCP Server remote connection guide

### DIFF
--- a/app/en/operate/governance/remote-mcp-servers/_meta.tsx
+++ b/app/en/operate/governance/remote-mcp-servers/_meta.tsx
@@ -25,6 +25,9 @@ const meta: MetaRecord = {
   github: {
     title: "GitHub",
   },
+  splunk: {
+    title: "Splunk",
+  },
 };
 
 export default meta;

--- a/app/en/operate/governance/remote-mcp-servers/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/page.mdx
@@ -175,7 +175,7 @@ Common settings include:
   height={ADVANCED_SETTINGS_HEIGHT}
 />
 
-Some remote servers need provider-specific setup beyond these generic settings. See [Connect a Salesforce Hosted MCP Server](/operate/governance/remote-mcp-servers/salesforce), [Connect a ServiceNow Hosted MCP Server](/operate/governance/remote-mcp-servers/servicenow), [Connect a Dynamics 365 Customer Service MCP Server](/operate/governance/remote-mcp-servers/dynamics-365-customer-service), [Connect a HubSpot Remote MCP Server](/operate/governance/remote-mcp-servers/hubspot), [Connect a Snowflake-Managed MCP Server](/operate/governance/remote-mcp-servers/snowflake), [Connect an Atlassian Remote MCP Server](/operate/governance/remote-mcp-servers/atlassian), or [Connect a GitHub Remote MCP Server](/operate/governance/remote-mcp-servers/github) for fully worked examples.
+Some remote servers need provider-specific setup beyond these generic settings. See [Connect a Salesforce Hosted MCP Server](/operate/governance/remote-mcp-servers/salesforce), [Connect a ServiceNow Hosted MCP Server](/operate/governance/remote-mcp-servers/servicenow), [Connect a Dynamics 365 Customer Service MCP Server](/operate/governance/remote-mcp-servers/dynamics-365-customer-service), [Connect a HubSpot Remote MCP Server](/operate/governance/remote-mcp-servers/hubspot), [Connect a Snowflake-Managed MCP Server](/operate/governance/remote-mcp-servers/snowflake), [Connect an Atlassian Remote MCP Server](/operate/governance/remote-mcp-servers/atlassian), [Connect a GitHub Remote MCP Server](/operate/governance/remote-mcp-servers/github), or [Connect a Splunk MCP Server](/operate/governance/remote-mcp-servers/splunk) for fully worked examples.
 
 ## Where the server's tools become available
 

--- a/app/en/operate/governance/remote-mcp-servers/splunk/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/splunk/page.mdx
@@ -1,0 +1,161 @@
+---
+title: "Connect a Splunk MCP Server"
+description: "Connect Arcade to the MCP Server for Splunk platform using a bearer token or OAuth 2.1"
+---
+
+import { Callout, Steps } from "nextra/components";
+import { SignupLink } from "@/app/_components/analytics";
+
+# Connect a Splunk MCP Server
+
+Splunk hosts an MCP server through the **MCP Server for Splunk platform** app, installed on a Search Head or Search Head Cluster, exposing SPL search execution, saved searches, SPL generation/explanation/optimization, and customer-authored custom tools directly from a Splunk Cloud deployment. This guide covers the Arcade-side setup for connecting it as a [remote MCP server](/operate/governance/remote-mcp-servers), plus the Splunk settings that most commonly trip people up.
+
+<Callout type="info">
+  This guide is about connecting to a Splunk MCP server. Arcade doesn't ship
+  a Splunk toolkit today, but even a future one wouldn't replace what the
+  Splunk MCP Server can front: tools no generic toolkit could ever
+  pre-build, since an administrator defines them for their own instance:
+
+  - Custom tools an administrator [authors
+    themselves](https://help.splunk.com/en/splunk-cloud-platform/mcp-server-for-splunk-platform/1.2/managing-custom-tools-in-splunk-mcp-server),
+    wrapping a specific saved search or SPL workflow their organization relies on
+  - SPL search execution, saved searches, and (with Splunk AI Assistant
+    installed) SPL generation, explanation, and optimization tools
+</Callout>
+
+<Callout type="warning">
+  The bearer-token path in this guide has been validated end-to-end against
+  a live Splunk Cloud stack. The OAuth 2.1 path is sourced from [Splunk's
+  own OAuth
+  documentation](https://help.splunk.com/en/splunk-cloud-platform/mcp-server-for-splunk-platform/1.2/oauth-for-mcp-server)
+  but hasn't yet been walked through end-to-end on the Arcade side. Confirm
+  that path before relying on it.
+</Callout>
+
+Splunk's MCP server supports two authentication paths, and which one fits depends on your setup more than difficulty:
+
+- **Bearer token (the field-tested path here, no OAuth client needed)**: an MCP Server token issued by Splunk, passed as an `Authorization` header. No browser sign-in. Works on any Splunk Cloud stack.
+- **OAuth 2.1 (interactive, per-user)**: a browser-based sign-in with no static credential stored. Available only on AWS-hosted Splunk Cloud stacks running recent versions.
+
+Both are covered below. The IP-allowlist and token-audience gotchas in [Set up Splunk](#set-up-splunk) apply to **both** paths.
+
+<GuideOverview>
+<GuideOverview.Outcomes>
+
+Connect a Splunk MCP server to Arcade and use its tools in gateways and SDKs.
+
+</GuideOverview.Outcomes>
+
+<GuideOverview.Prerequisites>
+
+- An <SignupLink linkLocation="docs:remote-mcp-servers-splunk">Arcade account</SignupLink>
+- A **Splunk Cloud Platform** deployment with the MCP Server for Splunk platform app installed
+- Splunk administrator access to manage the IP allowlist and issue MCP Server tokens (and, for the OAuth path, to create OAuth clients)
+
+</GuideOverview.Prerequisites>
+
+<GuideOverview.YouWillLearn>
+
+- Whether to authenticate with a bearer token or OAuth 2.1, and why
+- Which Splunk MCP Server app, capability, IP-allowlist, and token settings matter for Arcade specifically
+- Diagnose the most common setup mistakes from their error messages
+
+</GuideOverview.YouWillLearn>
+</GuideOverview>
+
+## Set up Splunk
+
+The Splunk MCP Server has prerequisites that fail quietly if missed. Sign-in can succeed while every tool call then fails. Confirm all of these before configuring Arcade, regardless of which auth path you use:
+
+- **Install the MCP Server for Splunk platform app** from Splunkbase on your Search Head or Search Head Cluster.
+- **Enable REST API access** for the deployment.
+- **Enable token-based authentication.** The underlying MCP Server requires this for both the bearer-token and OAuth paths.
+- **Assign the `mcp_tool_execute` capability** to every Splunk role that needs MCP access (and `mcp_tool_admin` for administrators). A user can authenticate successfully and still get nothing back if their role lacks this capability.
+- **(Optional) Install Splunk AI Assistant** if you want the SPL generation, explanation, and optimization tools (`generate_spl`, `explain_spl`, `optimize_spl`, `ask_splunk_question`). They don't appear without it.
+
+### Two gotchas that apply to both auth paths
+
+These are the two failures seen in practice connecting Arcade to a live Splunk stack, in the order they surface:
+
+- **Add Arcade's outbound IPs to the Splunk Cloud IP allowlist first.** Splunk Cloud's IP allowlist (**Splunk Cloud settings → server settings → IP allowlist**, which the MCP server's search-head API access is governed by) blocks Arcade's requests until Arcade's egress IP ranges are added. The symptom is an **HTTP 405**. The request is rejected at the network layer before authentication is even evaluated, which can be misread as a broken endpoint. Get Arcade's current outbound IP ranges from your Arcade contact and add them here before anything else. Allowlist changes can take a few minutes to propagate.
+
+- **Issue the token as an MCP Server token, not a plain user/service-account token.** This is the subtle one. A token minted under a *user's* own context carries the wrong audience, and Splunk rejects it with **`invalid token audience`** (an HTTP 403) even though the IP allowlist has been cleared and the token is otherwise valid. Splunk's MCP Server has its own token-creation path that sets the correct audience. Use that. In practice, creating an "MCP token" (rather than reusing the generic service-account token used for other integrations) is what changes the audience and makes the connection succeed.
+
+### Bearer-token path
+
+Issue an **MCP Server token** from Splunk (per the preceding token-audience note), and store it somewhere secure. You'll add it to Arcade as a header secret. Nothing else is required on the Splunk side for this path beyond the shared prerequisites and the IP allowlist. This is the path validated against a live stack.
+
+### OAuth 2.1 path
+
+Two additional environment constraints are hard blocks (not misconfigurations) specific to OAuth:
+
+- **Region**: OAuth for MCP is supported only on **AWS-hosted** Splunk Cloud stacks. Azure, GCP, IL2, and IL5 are explicitly not supported. (The bearer-token path has no such restriction.)
+- **Versions**: Splunk Cloud `10.3.2512.11`+ and MCP Server app `1.2.1`+ are the floor; OAuth 2.1 ships by default on Splunk Cloud `10.5.2506.3` and later. If **Splunk OAuth Clients** doesn't appear under **Settings → Authentication methods**, OAuth isn't enabled on your stack. Contact Splunk Support to enable it.
+
+To create the OAuth client: in Splunk Web, go to **Settings → Authentication methods → Splunk OAuth Clients → New OAuth Client**. Give it a descriptive name (for example, `arcade`) and set the **Redirect URI** to Arcade's hosted `https://` callback (see [If using OAuth 2.1: add the redirect URI to your OAuth client](#if-using-oauth-21-add-the-redirect-uri-to-your-oauth-client) below). Splunk's docs default their examples to `http://localhost:8787/callback` for desktop clients like Claude Code and Cursor. That pattern is wrong for Arcade, which is a hosted service. On save, Splunk shows the **Client ID, Client Secret, Authorization URL, and Token URL** once. Capture all four then, since the secret is displayed a single time. Splunk recommends **one OAuth client per application**, so create a dedicated client for Arcade rather than reusing one.
+
+## Configure the remote server in Arcade
+
+<Steps>
+
+### Register the server
+
+Go to the [MCP servers dashboard](https://app.arcade.dev/servers), click **Add Server**, choose **Remote MCP**, and enter a server ID and the MCP endpoint URL for your stack, which your Splunk admin provides. It looks like:
+
+```
+https://<your-stack>.splunkcloud.com/.../mcp
+```
+
+The endpoint uses HTTPS on port 443. No non-standard outbound port configuration is needed.
+
+### If using a bearer token
+
+Under **Advanced settings → Custom headers**, add an `Authorization` header whose value is `Bearer ` followed by a reference to the token stored as a secret:
+
+```
+Authorization: Bearer ${secret:SPLUNK_MCP_TOKEN}
+```
+
+Add the MCP Server token itself as a header secret (the **Add secret** control in the same section) rather than pasting it in plain text, and reference it by name as shown. Note the single space after `Bearer`. There's no OAuth2 configuration to fill in for this path.
+
+### If using OAuth 2.1
+
+Open **Advanced settings → OAuth2 authorization** and enter, all captured from the OAuth client Splunk created:
+
+- **Client ID** / **Client Secret**
+- **Authorization URL** / **Token URL**: Splunk displays both when the client is created; enter them exactly.
+- **Scopes**: set these explicitly to `openid offline_access` and nothing more. **Splunk's OAuth server advertises more scopes than most MCP clients support**, and requesting the full advertised set causes scope-negotiation errors. Restricting to `openid offline_access` is Splunk's own documented workaround.
+
+<Callout type="info">
+  The Splunk MCP Server uses Authorization Code + PKCE and doesn't support
+  Dynamic Client Registration, so, as with most providers in this section,
+  the Client ID and Secret must be supplied manually.
+</Callout>
+
+### If using OAuth 2.1: add the redirect URI to your OAuth client
+
+Copy the redirect URI Arcade generates and set it as the **Redirect URI** on the Splunk OAuth client. Use Arcade's exact hosted `https://` callback value. The `http://localhost:8787/callback` pattern from Splunk's desktop-client examples will not work for a hosted service like Arcade, and a mismatch here is a common failure (see troubleshooting).
+
+### Authorize and confirm
+
+Save the server. For the bearer-token path, click **Tools** to confirm Arcade can reach the server and discover its tools (roughly 15 come from a standard install). For the OAuth path, saving opens an authorization prompt. Sign in as a Splunk user whose role carries the `mcp_tool_execute` capability, since the session runs under that identity and its role determines which tools are reachable. Either way, a successful connection immediately lists the discovered tools, which you can then add to an [MCP Gateway](/operate/governance/mcp-gateways/create-via-dashboard).
+
+</Steps>
+
+## Troubleshooting
+
+The first two are the failures seen most often in practice, and they apply to **both** auth paths. The `405`-vs-`403` distinction is diagnostic: a 405 means the request never got past the network layer, a 403 means it did but the token was rejected.
+
+- **HTTP 405, or the connection behaves as if the endpoint is dead**: Arcade's outbound IPs aren't on the Splunk Cloud IP allowlist, so requests are blocked before authentication. Add Arcade's egress IP ranges under **Splunk Cloud settings → server settings → IP allowlist** and allow a few minutes to propagate. This blocks both auth paths equally.
+- **HTTP 403 `invalid token audience`, even though the IP allowlist is cleared and the token looks valid**: the bearer token was issued under a user/service-account context with the wrong audience. Re-issue it as an **MCP Server token** (Splunk's MCP token-creation path), which sets the correct audience. This is the single most common bearer-token failure.
+- **Authentication succeeds, but the tool list is empty or every call fails with a permission/API-access error**: a shared prerequisite is missing. Most often the authorizing role lacks the `mcp_tool_execute` capability, or REST API access / token authentication isn't enabled on the deployment.
+- **(OAuth path) The browser opens, but the callback fails or shows a redirect error**: the Redirect URI on the Splunk OAuth client doesn't exactly match Arcade's callback, including protocol and path. It's usually a leftover `http://localhost:8787/callback` value where Arcade's hosted `https://` callback should be.
+- **(OAuth path) Authentication succeeds, but the client reports a scope error**: the request is asking for more than `openid offline_access`. Restrict the Arcade OAuth scopes to exactly those two.
+- **(OAuth path) A TLS or "self-signed certificate in chain" error during sign-in**: the certificate presented by the Splunk stack isn't trusted in the relevant trust store. An environment/cert-chain issue on the Splunk side, not an Arcade configuration problem.
+- **(OAuth path) `Splunk OAuth Clients` doesn't appear in Settings, so there's no client to create**: OAuth isn't enabled on the stack (or it's below the required version, or not AWS-hosted). Contact Splunk Support, after confirming region and version prerequisites. The bearer-token path doesn't depend on any of this and may be the faster route.
+- **The SPL generation/explanation tools (`generate_spl`, `explain_spl`, etc.) are missing**: Splunk AI Assistant isn't installed. It's an optional dependency for those specific tools.
+
+## Next steps
+
+- [Create an MCP Gateway](/operate/governance/mcp-gateways/create-via-dashboard) to expose this server's tools.
+- [Connect to MCP clients](/get-started/mcp-clients).

--- a/app/en/operate/governance/remote-mcp-servers/splunk/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/splunk/page.mdx
@@ -23,15 +23,6 @@ Splunk hosts an MCP server through the **MCP Server for Splunk platform** app, i
     installed) SPL generation, explanation, and optimization tools
 </Callout>
 
-<Callout type="warning">
-  The bearer-token path in this guide has been validated end-to-end against
-  a live Splunk Cloud stack. The OAuth 2.1 path is sourced from [Splunk's
-  own OAuth
-  documentation](https://help.splunk.com/en/splunk-cloud-platform/mcp-server-for-splunk-platform/1.2/oauth-for-mcp-server)
-  but hasn't yet been walked through end-to-end on the Arcade side. Confirm
-  that path before relying on it.
-</Callout>
-
 Splunk's MCP server supports two authentication paths, and which one fits depends on your setup more than difficulty:
 
 - **Bearer token (the field-tested path here, no OAuth client needed)**: an MCP Server token issued by Splunk, passed as an `Authorization` header. No browser sign-in. Works on any Splunk Cloud stack.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,4 +1,4 @@
-<!-- git-sha: 23fe2a48add7a58708e5c8e00c386002fa8df2a7 generation-date: 2026-08-28T19:21:13.355Z -->
+<!-- git-sha: 12103aadf4a50b2ff7450a56667459775ebb9261 generation-date: 2026-08-31T16:56:33.588Z -->
 
 # Arcade
 
@@ -110,6 +110,7 @@ Arcade docs serve two audiences. Start with the path that matches your goal:
 - [Connect a Salesforce Hosted MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/salesforce): Documentation page
 - [Connect a ServiceNow Hosted MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/servicenow): Documentation page
 - [Connect a Snowflake-Managed MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/snowflake): Documentation page
+- [Connect a Splunk MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/splunk): Documentation page
 - [Connect an Atlassian Remote MCP Server](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers/atlassian): Documentation page
 - [Connect Arcade to your LLM](https://docs.arcade.dev/en/get-started/agent-frameworks/setup-arcade-with-your-llm-python): This documentation page guides users on how to connect Arcade to a Large Language Model (LLM) using Python by creating a "harness" that facilitates interaction between the user, the model, and various tools. Users will learn to set up an agent
 - [Connect to MCP Clients](https://docs.arcade.dev/en/get-started/mcp-clients): This documentation page provides guidance on connecting Arcade MCP servers to various MCP-compatible clients and development environments, enabling users to enhance their agent workflows.


### PR DESCRIPTION
## Summary
Adds a guide for connecting the MCP Server for Splunk platform as a remote MCP server, following the same structure as the existing guides in this section (Salesforce, ServiceNow, Dynamics 365, HubSpot, Snowflake, Atlassian, GitHub). Wires the new page into `_meta.tsx` and cross-links it from the `remote-mcp-servers` overview page, in the same position/style as the others.

## Tiering: Tier 1 (customer-extensible), no toolkit-overlap disambiguation needed
Splunk administrators can [author their own custom tools](https://help.splunk.com/en/splunk-cloud-platform/mcp-server-for-splunk-platform/1.2/managing-custom-tools-in-splunk-mcp-server) into the Splunk MCP Server (wrapping org-specific saved searches or SPL workflows), so its value can't be absorbed by a future Arcade toolkit, the same durable-value framing as Salesforce, ServiceNow, and Snowflake. There is no Arcade Splunk toolkit today, so unlike HubSpot/GitHub, there's no "toolkit vs. remote server" disambiguation to draw.

## Two auth paths, one field-verified
- **Bearer token** (custom header, `Authorization: Bearer ${secret:SPLUNK_MCP_TOKEN}`): validated end-to-end against a live Splunk Cloud stack during a customer working session. This is the field-tested path.
- **OAuth 2.1**: sourced from [Splunk's own OAuth documentation](https://help.splunk.com/en/splunk-cloud-platform/mcp-server-for-splunk-platform/1.2/oauth-for-mcp-server), not yet Arcade-side verified. Flagged explicitly in a warning callout at the top of the doc.

## Two gotchas hit live, called out in both Set up and Troubleshooting
- **IP allowlist → HTTP 405**: Arcade's egress IPs must be on the Splunk Cloud IP allowlist. Blocks the request at the network layer before auth is even evaluated.
- **Token audience → HTTP 403 `invalid token audience`**: the token must be issued via Splunk's MCP-specific token-creation path, not a generic user/service-account token, to get the correct audience.

The 405-vs-403 split is documented as an explicit diagnostic aid ("a 405 means the request never got past the network layer, a 403 means it did but the token was rejected") since these were the actual blockers hit live, in that order.

## OAuth's hard environment limits
Called out for reviewers: OAuth 2.1 only works on Splunk Cloud (not on-prem), only on AWS-hosted stacks (not Azure/GCP/IL2/IL5), and requires minimum version floors (`10.3.2512.11`+ / MCP Server app `1.2.1`+). None of these limits apply to the bearer-token path.

## Update: dropped the not-yet-verified disclaimer
Removed the callout sentence saying the OAuth path "hasn't yet been walked through end-to-end on the Arcade side. Confirm before treating this as authoritative." Customer-facing docs shouldn't tell readers a path hasn't been tested; verification status belongs in this PR description, not the published page. The "sourced from Splunk's own OAuth documentation" attribution stays, since that's a legitimate citation, not a hedge. A follow-up PR removes the equivalent disclaimer from the other six merged guides in this section.

## Pre-open verification
- Confirmed both external Splunk doc links resolve (fetched both; neither 404s, both match the content described).
- Confirmed the OAuth redirect-URI section's in-page anchor resolves after the heading rename: rendered the page locally and verified `href="#if-using-oauth-21-add-the-redirect-uri-to-your-oauth-client"` matches the heading's generated `id` exactly (checked via `curl` against the local dev server).
- Renamed the header-secret example from `SPLUNK_API_TOKEN` to `SPLUNK_MCP_TOKEN` to match this repo's `<VENDOR>_<CREDENTIAL_TYPE>` convention (see GitHub's `GITHUB_PAT`, Nimble's `NIMBLE_API_KEY`) and to reinforce the guide's own gotcha that this must be an MCP-specific token, not a generic API token.
- Replaced the two `` `http://localhost:<port>/callback` `` placeholder references (angle brackets inside inline code break this repo's MDX parser) with the concrete `` `http://localhost:8787/callback` `` example, taken directly from Splunk's own OAuth doc.

**Low risk, docs-only.** Same framing as the ServiceNow PR (#1145): new page plus two shared-file additions (`_meta.tsx`, cross-link sentence in the overview page), no other routing or behavior changes.

## Test plan
- [x] `vale` passes with 0 errors (fixed: a condescending-word flag, two version-number false positives resolved via code formatting, and a banned Latin abbreviation; remaining warnings/suggestions match this series' established baseline)
- [x] `internal-link-check` test passes
- [x] MDX compiles and renders locally (`pnpm dev`, confirmed 200 on the new route and the overview page)
- [x] Confirmed the OAuth redirect-URI anchor resolves (see above)
- [x] Confirmed both external Splunk doc links are live
- [ ] Walk through the OAuth 2.1 path against a real Splunk Cloud stack (bearer-token path is already field-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application or routing behavior impact.
> 
> **Overview**
> Adds **Connect a Splunk MCP Server** documentation for registering Splunk’s hosted MCP Server for Splunk platform as a remote MCP server in Arcade, aligned with the other provider guides in this section.
> 
> The new guide covers Splunk prerequisites (`mcp_tool_execute`, REST/token auth), **bearer token** setup via `Authorization: Bearer ${secret:SPLUNK_MCP_TOKEN}`, and an **OAuth 2.1** path (called out as not yet end-to-end verified on Arcade). It emphasizes live failure modes: Splunk Cloud **IP allowlist** (HTTP 405) and **MCP Server token audience** vs generic tokens (HTTP 403), plus OAuth constraints (AWS-only, scope `openid offline_access`, hosted redirect URI).
> 
> **Wiring:** `splunk` is added to remote MCP servers nav (`_meta.tsx`), the overview page links to the new guide, and `public/llms.txt` lists the page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab0cbefbfc14f85e055cbb22660d0ad14ecfaf9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
