### PR TITLE
docs: drop not-yet-verified disclaimers from remote MCP server guides

### DIFF
--- a/app/en/operate/governance/remote-mcp-servers/atlassian/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/atlassian/page.mdx
@@ -28,13 +28,11 @@ Atlassian hosts a remote MCP server at `mcp.atlassian.com`, exposing Jira, Confl
   those products.
 </Callout>
 
-<Callout type="warning">
+<Callout type="info">
   This guide is sourced from [Atlassian's own support
   documentation](https://support.atlassian.com/security-and-access-policies/docs/understand-atlassian-rovo-mcp-server/)
   and the [official
   atlassian-mcp-server repo](https://github.com/atlassian/atlassian-mcp-server).
-  The Arcade-side field mapping hasn't been walked through end-to-end against
-  a live site. Confirm before treating this as authoritative.
 </Callout>
 
 Atlassian's setup is structurally different from the other guides in this section. Salesforce, ServiceNow, Dynamics 365, and Snowflake all require an administrator to manually create an OAuth app or security integration and hand Arcade a Client ID and Secret. Atlassian's Rovo MCP server instead supports **OAuth 2.1 with Dynamic Client Registration (DCR)**: Arcade registers itself as a client automatically on first connection. There's no app-creation step on Atlassian's side at all. The administrative work here is entirely about *who's allowed to connect and what they can touch*, not about provisioning credentials.

--- a/app/en/operate/governance/remote-mcp-servers/dynamics-365-customer-service/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/dynamics-365-customer-service/page.mdx
@@ -20,12 +20,10 @@ Microsoft fronts the **Dynamics 365 CX MCP Server - Service** with **Agent 365 T
   away if Arcade ships a native toolkit for it later.
 </Callout>
 
-<Callout type="warning">
+<Callout type="info">
   The Microsoft-side steps below are sourced directly from [Microsoft's own
   documentation](https://learn.microsoft.com/en-us/dynamics365/customer-service/develop/connect-agent-model-context-protocol)
-  for this server. The Arcade-side field mapping (which Arcade dashboard field
-  takes which value) has not yet been walked through end-to-end against a live
-  tenant. Confirm before treating this as authoritative.
+  for this server.
 </Callout>
 
 <GuideOverview>

--- a/app/en/operate/governance/remote-mcp-servers/github/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/github/page.mdx
@@ -25,14 +25,11 @@ GitHub hosts a remote MCP server at `api.githubcopilot.com/mcp/`, exposing repos
   - Access governed by GitHub's own PAT and OAuth App policies, mirroring your organization's existing controls
 </Callout>
 
-<Callout type="warning">
+<Callout type="info">
   This guide is sourced from [GitHub's own MCP server
   documentation](https://github.com/github/github-mcp-server) and [policies
   and governance
   guide](https://github.com/github/github-mcp-server/blob/main/docs/policies-and-governance.md).
-  The Arcade-side field mapping hasn't been walked through end-to-end
-  against a live GitHub organization. Confirm before treating this as
-  authoritative.
 </Callout>
 
 GitHub supports two distinct auth paths for a remote MCP client, and which one fits depends on your governance requirements more than technical difficulty.

--- a/app/en/operate/governance/remote-mcp-servers/hubspot/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/hubspot/page.mdx
@@ -24,12 +24,10 @@ HubSpot hosts a remote MCP server at `mcp.hubspot.com`, exposing CRM records, ac
   - Access scoped to whatever the authorizing HubSpot user can already do in the portal, not fixed toolkit scopes
 </Callout>
 
-<Callout type="warning">
+<Callout type="info">
   The HubSpot-side steps below are sourced directly from [HubSpot's own
   documentation](https://developers.hubspot.com/docs/apps/developer-platform/build-apps/integrate-with-the-remote-hubspot-mcp-server)
-  for this server, which is unusually thorough. The Arcade-side field mapping
-  has not yet been walked through end-to-end against a live HubSpot portal.
-  Confirm before treating this as authoritative.
+  for this server, which is unusually thorough.
 </Callout>
 
 <GuideOverview>

--- a/app/en/operate/governance/remote-mcp-servers/snowflake/page.mdx
+++ b/app/en/operate/governance/remote-mcp-servers/snowflake/page.mdx
@@ -23,14 +23,12 @@ Snowflake can host an MCP server object inside a database and schema, exposing C
   - Cortex Analyst, Cortex Search, and Cortex Agents as callable tools
 </Callout>
 
-<Callout type="warning">
+<Callout type="info">
   This guide draws directly from [Snowflake's own MCP server
   documentation](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-agents-mcp),
   which is unusually precise about exact SQL, error strings, and failure
   modes, more so than the vendor docs behind some of the other guides in this
-  section. Even so, the Arcade-side field mapping hasn't been walked through
-  end-to-end against a live account. Confirm before treating this as
-  authoritative.
+  section.
 </Callout>
 
 <GuideOverview>


### PR DESCRIPTION
## Summary
Removes the "Arcade-side field mapping hasn't been walked through end-to-end against a live [X]. Confirm before treating this as authoritative." sentence from the sourcing callout on five already-merged remote MCP server guides: Dynamics 365, HubSpot, Snowflake, Atlassian, and GitHub.

**Why:** these are customer-facing docs, and telling a reader a documented path hasn't been tested undermines confidence in the guide without giving them anything actionable. Verification status is better tracked in the originating PR description (which each of these already had) than published on the live page.

**What stays:** the vendor sourcing attribution itself, e.g. "This guide is sourced from GitHub's own MCP server documentation and policies and governance guide." That's a legitimate citation, not a hedge, so it's kept as-is. Each callout's `type` changes from `warning` to `info` since it's now a plain attribution note rather than a caveat.

**Not touched:** Salesforce and ServiceNow never had this pattern (confirmed by grep across both files). Splunk (#1167, still open) drops the same sentence directly on its own branch rather than through this PR, since that guide hasn't merged yet.

## Test plan
- [x] `vale` passes with 0 errors on all five files (same warning/suggestion baseline as before the edit)
- [x] `internal-link-check` test passes
- [x] MDX compiles and renders locally (`pnpm dev`, confirmed 200 on all five routes)

**Low risk, docs-only.** Five callout edits, no navigation, routing, or structural changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only callout copy and styling on five MDX pages; no product, auth, or routing changes.
> 
> **Overview**
> Updates the **vendor sourcing** callouts on five remote MCP guides (Atlassian, Dynamics 365 Customer Service, GitHub, HubSpot, and Snowflake) so they read as straightforward citations instead of caveats.
> 
> Each guide **removes** the sentence that Arcade dashboard field mapping had not been verified end-to-end on a live tenant and that readers should confirm before treating the guide as authoritative. The **vendor doc links and attribution stay**; only the hedge is gone. Callout **`type` changes from `warning` to `info`** because the note is attribution, not a warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2ca98119b581275faa7efa0c16834d52d3aa223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->