### PR TITLE
docs: add platform architecture page for self-hosted deployments

### DIFF
--- a/app/en/operate/deploy/_meta.tsx
+++ b/app/en/operate/deploy/_meta.tsx
@@ -4,6 +4,9 @@ const meta: MetaRecord = {
   index: {
     title: "Overview",
   },
+  architecture: {
+    title: "Platform architecture",
+  },
   "arcade-cloud": {
     title: "Arcade Cloud",
   },

--- a/app/en/operate/deploy/architecture/page.mdx
+++ b/app/en/operate/deploy/architecture/page.mdx
@@ -7,9 +7,9 @@ import { Callout } from "nextra/components";
 
 # Platform architecture
 
-A self-hosted Arcade deployment runs a handful of services on your Kubernetes cluster. The [Helm chart](/operate/deploy/helm) and the [Azure](/operate/deploy/azure) and [AWS](/operate/deploy/aws) marketplace deployments all install the same platform, so this page applies to every self-hosted option.
+A self-hosted Arcade deployment runs the services below on your Kubernetes cluster. The [Helm chart](/operate/deploy/helm) and the [Azure](/operate/deploy/azure) and [AWS](/operate/deploy/aws) marketplace deployments install the same platform.
 
-This page covers what each service is responsible for and what it connects to. For installation steps, see [Self-host with Helm](/operate/deploy/helm).
+This page describes what each service does and what it connects to. For installation steps, see [Self-host with Helm](/operate/deploy/helm).
 
 ## Services
 
@@ -19,84 +19,84 @@ This page covers what each service is responsible for and what it connects to. F
 | Coordinator | Users, organizations, projects, access control, and OAuth callbacks | Your identity provider, OpenFGA | Yes |
 | Experience API | Sessions and backend calls for the dashboard | Engine, Coordinator | Yes |
 | Dashboard | The web interface for operators and developers | Experience API | Yes |
-| MCP servers | Hosting and running your tools | The third-party APIs your tools call | Yes |
+| MCP servers | Hosting and running tools | The third-party APIs the tools call | Yes |
 | OpenFGA | Evaluating operator access control policies | Nothing outbound | No |
 | PostgreSQL and Redis | Persistent state, caching, and sessions | Nothing outbound | Yes |
 
-Agents and Arcade clients call the Engine. People use the dashboard in a browser, which reaches the platform through the Experience API. Every service reads and writes its own state in PostgreSQL and Redis.
+Agents and Arcade clients call the Engine. Operators use the dashboard in a browser, which reaches the platform through the Experience API. Each service reads and writes its own state in PostgreSQL and Redis.
 
 ### Engine
 
-The Arcade Engine is the API your agents call and the service that does the work of a tool call. It:
+The Engine is the API that agents call. It:
 
-- Serves the tool catalog, so an agent can list the tools available to it and read their schemas
+- Serves the tool catalog, including each tool's schema
 - Executes tool calls, dispatching each one to the MCP server that owns the tool and returning the result
-- Runs the **token vault**: it takes each end user through the OAuth flow for a provider such as Google or Slack, stores the resulting token encrypted, refreshes it before it expires, and hands it to the tool at execution time. Your agent never handles a user's credentials.
+- Runs the token vault: it takes each end user through the OAuth flow for a provider such as Google or Slack, stores the resulting token encrypted, refreshes it before it expires, and supplies it to the tool at execution time
 - Serves [MCP gateways](/operate/governance/mcp-gateways), the scoped MCP endpoints that agents and MCP clients connect to
 - Registers MCP servers and reconciles their tool catalogs into its database
 - Stores [auth provider](/references/auth-providers) configuration and per-project tool secrets
-- Records every tool execution, which is what the dashboard's execution history and [audit logs](/operate/governance/audit-logs) read from
-- Calls your [contextual access](/operate/governance/contextual-access) hooks before and after a tool runs, so your own policy code can allow, deny, or rate-limit the call
+- Records each tool execution, which the dashboard's execution history and [audit logs](/operate/governance/audit-logs) read from
+- Calls [contextual access](/operate/governance/contextual-access) hooks before and after a tool runs, which can allow, deny, or rate-limit the call
 
 The Engine calls the Coordinator to validate API keys and resolve the account, organization, and project behind a request. It calls MCP servers over HTTP to execute tools.
 
 ### Coordinator
 
-The Coordinator is the control plane for identity and tenancy. It owns the records that everything else looks up:
+The Coordinator owns identity and tenancy records:
 
 - Accounts, organizations, projects, project API keys, and member invitations
 - The connection to your OIDC identity provider, and the [User Sources](/operate/identity/user-sources) that authenticate the end users of an MCP gateway
-- Role assignments, which it evaluates against OpenFGA if you turn on role-based access control
+- Role assignments, which it evaluates against OpenFGA when you turn on role-based access control
 
-It also handles two flows that need a publicly reachable endpoint:
+It handles two flows that require a reachable endpoint:
 
-- **OAuth callbacks.** When an end user authorizes Google or Slack, the provider redirects back to the Coordinator, which completes the exchange so the Engine can store the credential.
-- **Authorization for MCP clients.** The Coordinator acts as an OAuth authorization server, so an MCP client can sign a user in and get a token scoped to a gateway.
+- **OAuth callbacks.** When an end user authorizes a provider such as Google or Slack, the provider redirects back to the Coordinator, which completes the exchange so the Engine can store the credential.
+- **Authorization for MCP clients.** The Coordinator acts as an OAuth authorization server, so an MCP client can sign a user in and receive a token scoped to a gateway.
 
-Beyond that it validates API keys on the Engine's behalf, writes the audit log, and enforces rate limits.
+It also validates API keys for the Engine, writes the audit log, and enforces rate limits.
 
 ### Experience API
 
-The Experience API is the backend for the dashboard. It exists because the dashboard runs in a browser and shouldn't hold long-lived credentials or call the Engine and Coordinator directly. It:
+The Experience API is the backend for the dashboard. The dashboard does not call the Engine or Coordinator directly. Its requests go through the Experience API, which:
 
 - Signs operators in against your identity provider and manages the browser session
 - Forwards the dashboard's requests to the Engine and the Coordinator, attaching the signed-in user's access token
-- Backs the playground, where you can try a tool against a live model without writing code
+- Serves the playground
 - Serves the dashboard's runtime configuration and tracks onboarding progress
 
-Only the dashboard calls it. Your agents and apps should integrate with the Engine's API instead.
+Only the dashboard calls it. Agents and applications use the Engine's API.
 
 ### Dashboard
 
-The dashboard is the web interface for operators and developers. It's where you register and inspect MCP servers, browse the tool catalog and test individual tools, create MCP gateways, configure auth providers and secrets, manage projects, members, roles, and API keys, connect User Sources, and read audit logs and tool execution history.
+The dashboard is the web interface for operators and developers. It covers registering and inspecting MCP servers, browsing the tool catalog and testing individual tools, creating MCP gateways, configuring auth providers and secrets, managing projects, members, roles, and API keys, connecting User Sources, and reading audit logs and tool execution history.
 
-It runs in the browser and talks only to the Experience API.
+It runs in the browser and calls only the Experience API.
 
 ### MCP servers
 
-An MCP server hosts tool implementations and runs them on request. Your deployment gets tools from three places:
+An MCP server hosts tool implementations and runs them on request. A deployment can draw tools from three sources:
 
-- **The bundled MCP server.** Every deployment includes one, preloaded with Arcade's integration toolkits for services such as Gmail, Slack, Jira, GitHub, and Notion. You get a working tool catalog without building anything.
-- **MCP servers you write and deploy.** Add your own for tools that reach your internal systems. Each one is a separate deployment, so you can scale it on its own or isolate a sensitive toolkit.
-- **[Remote MCP servers](/operate/governance/remote-mcp-servers) you connect.** Register an MCP server Arcade doesn't host, whether your team already runs it or a vendor runs it for you, and its tools join the same catalog. Nothing new gets deployed to your cluster.
+- **The bundled MCP server.** Each deployment includes one, preloaded with Arcade's integration toolkits for services such as Gmail, Slack, Jira, GitHub, and Notion.
+- **MCP servers you write and deploy.** Each one is a separate deployment, so you can scale or isolate it independently.
+- **[Remote MCP servers](/operate/governance/remote-mcp-servers).** Register an MCP server that Arcade does not host, whether your team runs it or a vendor does, and its tools join the same catalog. This adds nothing to your cluster.
 
-Whichever it is, the Engine treats it the same way. It sends the tool call over HTTP with the end-user credential from the token vault, the server does the work, and the result comes back through the Engine. The tool catalog, gateways, auth, and audit trail don't care where the server runs.
+In each case the Engine sends the tool call over HTTP with the end-user credential from the token vault, and the MCP server returns the result. The tool catalog, gateways, auth, and audit trail work the same way regardless of where the server runs.
 
 <Callout type="info">
-MCP servers appear as **workers** in the Helm values and in the Engine's API. They're the same thing. Don't confuse either with an [MCP gateway](/operate/governance/mcp-gateways), which is a feature of the Engine rather than a service you deploy.
+MCP servers appear as **workers** in the Helm values and in the Engine's API. The two terms refer to the same thing. Neither is an [MCP gateway](/operate/governance/mcp-gateways), which is a feature of the Engine rather than a deployed service.
 </Callout>
 
 ### OpenFGA
 
-OpenFGA answers one question for the Coordinator: can this account perform this action on this organization or project? It backs the Org Admin, Project Admin, and Project Member roles, down to individual permissions such as creating an API key or deleting an MCP gateway.
+OpenFGA evaluates whether an account may perform an action on an organization or project. It backs the Org Admin, Project Admin, and Project Member roles, down to individual permissions such as creating an API key or deleting an MCP gateway.
 
-It's optional and turned off by default. When you turn it on, the Coordinator is its only caller.
+It is optional and turned off by default. When turned on, the Coordinator is its only caller.
 
 ## Network paths
 
-Only three services accept inbound traffic. The Engine takes calls from agents, Arcade clients, and MCP clients. The Dashboard and Experience API take requests from operators' browsers. Nothing outside the cluster connects to a Coordinator, MCP server, OpenFGA, or data store.
+Three services accept inbound traffic. The Engine takes calls from agents, Arcade clients, and MCP clients. The Dashboard and Experience API take requests from operators' browsers. Nothing outside the cluster connects to the Coordinator, an MCP server, OpenFGA, or a data store.
 
-Everything else the platform initiates itself, so plan egress for it:
+The platform initiates the remaining connections outbound:
 
 | From | To | For |
 | --- | --- | --- |
@@ -107,17 +107,17 @@ Everything else the platform initiates itself, so plan egress for it:
 | Coordinator | Your OIDC identity provider | Signing operators in |
 | MCP servers | Third-party APIs | The work each tool does |
 
-The Engine never accepts a connection from the Coordinator, so you can keep it behind a firewall as long as it can reach the services in the preceding table.
+The Engine accepts no connection from the Coordinator, so it can run behind a firewall as long as it can reach the destinations in the preceding table.
 
 ### The OAuth callback
 
-This is the one inbound path worth planning carefully. When an end user authorizes a provider such as Google or Slack, the provider redirects the user's **browser** to a callback URL on the Coordinator. The provider never calls your deployment directly. The only provider-facing request is the code-for-token exchange, which Arcade makes outbound.
+When an end user authorizes a provider such as Google or Slack, the provider redirects the user's **browser** to a callback URL on the Coordinator. The provider does not call the deployment directly. The only provider-facing request is the code-for-token exchange, which Arcade makes outbound.
 
-The Coordinator's callback URL therefore has to be reachable from wherever your users' browsers are, not from the public internet. If your users are on your corporate network or VPN, the Coordinator can stay private to that network.
+The Coordinator's callback URL therefore has to be reachable from wherever your users' browsers are, not from the public internet. If your users are on a corporate network or VPN, the Coordinator can stay private to that network.
 
 ## Data stores
 
-**PostgreSQL** holds everything that has to survive a restart:
+**PostgreSQL** stores persistent state:
 
 - Accounts, organizations, projects, and API keys
 - Registered MCP servers and their tool definitions
@@ -125,10 +125,10 @@ The Coordinator's callback URL therefore has to be reachable from wherever your 
 - Encrypted end-user tokens and tool secrets
 - Tool execution history and audit logs
 
-**Redis** holds what Arcade can recompute: validated API keys, the tool registry, MCP and gateway session state, in-flight OAuth requests, permission decisions, and rate-limit counters.
+**Redis** stores state that can be rebuilt: validated API keys, the tool registry, MCP and gateway session state, in-flight OAuth requests, permission decisions, and rate-limit counters.
 
 <Callout type="warning">
-The Helm chart can deploy PostgreSQL and Redis alongside the platform so you can evaluate Arcade quickly. These bundled instances have no backups and no high availability, so bring your own managed PostgreSQL and Redis instances for production.
+The Helm chart can deploy PostgreSQL and Redis alongside the platform for evaluation. These bundled instances have no backups and no high availability. Use your own managed PostgreSQL and Redis instances in production.
 </Callout>
 
 ## Next steps

--- a/app/en/operate/deploy/architecture/page.mdx
+++ b/app/en/operate/deploy/architecture/page.mdx
@@ -99,8 +99,6 @@ The Usage service collects usage events from the Engine, Coordinator, and MCP se
 
 It is off by default. Setting `usageTracking.enabled` turns it on, after which those three services emit usage events to the endpoint at `usageTracking.url`.
 
-That value defaults to an Arcade-hosted endpoint. The Helm chart does not deploy a Usage service, so keeping usage events inside your network means running the service yourself and pointing `usageTracking.url` at it.
-
 ## Network paths
 
 Three services accept inbound traffic. The Engine takes calls from agents, Arcade clients, and MCP clients. The Dashboard and Experience API take requests from operators' browsers. Nothing outside the cluster connects to the Coordinator, an MCP server, OpenFGA, or a data store.

--- a/app/en/operate/deploy/architecture/page.mdx
+++ b/app/en/operate/deploy/architecture/page.mdx
@@ -97,7 +97,7 @@ It is optional and turned off by default. When turned on, the Coordinator is its
 
 The Usage service collects usage events from the Engine, Coordinator, and MCP servers and routes them to billing and analytics sinks.
 
-It is off by default. Setting `usageTracking.enabled` turns it on, after which those three services emit usage events to the endpoint at `usageTracking.url`.
+It is off by default. You can turn it on to send usage information back to Arcade, which helps improve the product.
 
 ## Network paths
 
@@ -113,7 +113,7 @@ The platform initiates the remaining connections outbound:
 | Engine | Your [contextual access](/operate/governance/contextual-access) hooks | Policy checks before and after each tool call |
 | Coordinator | Your OIDC identity provider | Signing operators in |
 | MCP servers | Third-party APIs | The work each tool does |
-| Engine, Coordinator, MCP servers | Your `usageTracking.url` endpoint | Usage events |
+| Engine, Coordinator, MCP servers | Arcade's usage endpoint | Usage information, if you turn it on |
 
 The Engine accepts no connection from the Coordinator, so it can run behind a firewall as long as it can reach the destinations in the preceding table.
 

--- a/app/en/operate/deploy/architecture/page.mdx
+++ b/app/en/operate/deploy/architecture/page.mdx
@@ -103,7 +103,7 @@ It is off by default. Setting `usageTracking.enabled` turns it on, after which t
 
 Three services accept inbound traffic. The Engine takes calls from agents, Arcade clients, and MCP clients. The Dashboard and Experience API take requests from operators' browsers. Nothing outside the cluster connects to the Coordinator, an MCP server, OpenFGA, or a data store.
 
-The platform initiates the remaining connections outbound. The last row applies only if you turn on usage tracking:
+The platform initiates the remaining connections outbound:
 
 | From | To | For |
 | --- | --- | --- |

--- a/app/en/operate/deploy/architecture/page.mdx
+++ b/app/en/operate/deploy/architecture/page.mdx
@@ -1,0 +1,138 @@
+---
+title: "Platform architecture"
+description: "The services that make up a self-hosted Arcade deployment and how they connect"
+---
+
+import { Callout } from "nextra/components";
+
+# Platform architecture
+
+A self-hosted Arcade deployment runs a handful of services on your Kubernetes cluster. The [Helm chart](/operate/deploy/helm) and the [Azure](/operate/deploy/azure) and [AWS](/operate/deploy/aws) marketplace deployments all install the same platform, so this page applies to every self-hosted option.
+
+This page covers what each service is responsible for and what it connects to. For installation steps, see [Self-host with Helm](/operate/deploy/helm).
+
+## Services
+
+| Service | Responsible for | Talks to | Required |
+| --- | --- | --- | --- |
+| Engine | Tool execution and routing, the token vault, and MCP gateways | Coordinator, MCP servers, OAuth providers, your hooks | Yes |
+| Coordinator | Users, organizations, projects, access control, and OAuth callbacks | Your identity provider, OpenFGA | Yes |
+| Experience API | Sessions and backend calls for the dashboard | Engine, Coordinator | Yes |
+| Dashboard | The web interface for operators and developers | Experience API | Yes |
+| MCP servers | Hosting and running your tools | The third-party APIs your tools call | Yes |
+| OpenFGA | Evaluating operator access control policies | Nothing outbound | No |
+| PostgreSQL and Redis | Persistent state, caching, and sessions | Nothing outbound | Yes |
+
+Agents and Arcade clients call the Engine. People use the dashboard in a browser, which reaches the platform through the Experience API. Every service reads and writes its own state in PostgreSQL and Redis.
+
+### Engine
+
+The Arcade Engine is the API your agents call and the service that does the work of a tool call. It:
+
+- Serves the tool catalog, so an agent can list the tools available to it and read their schemas
+- Executes tool calls, dispatching each one to the MCP server that owns the tool and returning the result
+- Runs the **token vault**: it takes each end user through the OAuth flow for a provider such as Google or Slack, stores the resulting token encrypted, refreshes it before it expires, and hands it to the tool at execution time. Your agent never handles a user's credentials.
+- Serves [MCP gateways](/operate/governance/mcp-gateways), the scoped MCP endpoints that agents and MCP clients connect to
+- Registers MCP servers and reconciles their tool catalogs into its database
+- Stores [auth provider](/references/auth-providers) configuration and per-project tool secrets
+- Records every tool execution, which is what the dashboard's execution history and [audit logs](/operate/governance/audit-logs) read from
+- Calls your [contextual access](/operate/governance/contextual-access) hooks before and after a tool runs, so your own policy code can allow, deny, or rate-limit the call
+
+The Engine calls the Coordinator to validate API keys and resolve the account, organization, and project behind a request. It calls MCP servers over HTTP to execute tools.
+
+### Coordinator
+
+The Coordinator is the control plane for identity and tenancy. It owns the records that everything else looks up:
+
+- Accounts, organizations, projects, project API keys, and member invitations
+- The connection to your OIDC identity provider, and the [User Sources](/operate/identity/user-sources) that authenticate the end users of an MCP gateway
+- Role assignments, which it evaluates against OpenFGA if you turn on role-based access control
+
+It also handles two flows that need a publicly reachable endpoint:
+
+- **OAuth callbacks.** When an end user authorizes Google or Slack, the provider redirects back to the Coordinator, which completes the exchange so the Engine can store the credential.
+- **Authorization for MCP clients.** The Coordinator acts as an OAuth authorization server, so an MCP client can sign a user in and get a token scoped to a gateway.
+
+Beyond that it validates API keys on the Engine's behalf, writes the audit log, and enforces rate limits.
+
+### Experience API
+
+The Experience API is the backend for the dashboard. It exists because the dashboard runs in a browser and shouldn't hold long-lived credentials or call the Engine and Coordinator directly. It:
+
+- Signs operators in against your identity provider and manages the browser session
+- Forwards the dashboard's requests to the Engine and the Coordinator, attaching the signed-in user's access token
+- Backs the playground, where you can try a tool against a live model without writing code
+- Serves the dashboard's runtime configuration and tracks onboarding progress
+
+Only the dashboard calls it. Your agents and apps should integrate with the Engine's API instead.
+
+### Dashboard
+
+The dashboard is the web interface for operators and developers. It's where you register and inspect MCP servers, browse the tool catalog and test individual tools, create MCP gateways, configure auth providers and secrets, manage projects, members, roles, and API keys, connect User Sources, and read audit logs and tool execution history.
+
+It runs in the browser and talks only to the Experience API.
+
+### MCP servers
+
+An MCP server hosts tool implementations and runs them on request. Your deployment gets tools from three places:
+
+- **The bundled MCP server.** Every deployment includes one, preloaded with Arcade's integration toolkits for services such as Gmail, Slack, Jira, GitHub, and Notion. You get a working tool catalog without building anything.
+- **MCP servers you write and deploy.** Add your own for tools that reach your internal systems. Each one is a separate deployment, so you can scale it on its own or isolate a sensitive toolkit.
+- **[Remote MCP servers](/operate/governance/remote-mcp-servers) you connect.** Register an MCP server Arcade doesn't host, whether your team already runs it or a vendor runs it for you, and its tools join the same catalog. Nothing new gets deployed to your cluster.
+
+Whichever it is, the Engine treats it the same way. It sends the tool call over HTTP with the end-user credential from the token vault, the server does the work, and the result comes back through the Engine. The tool catalog, gateways, auth, and audit trail don't care where the server runs.
+
+<Callout type="info">
+MCP servers appear as **workers** in the Helm values and in the Engine's API. They're the same thing. Don't confuse either with an [MCP gateway](/operate/governance/mcp-gateways), which is a feature of the Engine rather than a service you deploy.
+</Callout>
+
+### OpenFGA
+
+OpenFGA answers one question for the Coordinator: can this account perform this action on this organization or project? It backs the Org Admin, Project Admin, and Project Member roles, down to individual permissions such as creating an API key or deleting an MCP gateway.
+
+It's optional and turned off by default. When you turn it on, the Coordinator is its only caller.
+
+## Network paths
+
+Only three services accept inbound traffic. The Engine takes calls from agents, Arcade clients, and MCP clients. The Dashboard and Experience API take requests from operators' browsers. Nothing outside the cluster connects to a Coordinator, MCP server, OpenFGA, or data store.
+
+Everything else the platform initiates itself, so plan egress for it:
+
+| From | To | For |
+| --- | --- | --- |
+| Engine | Coordinator | Validating API keys and resolving accounts, organizations, and projects |
+| Engine | MCP servers | Executing tool calls, whether the server runs in your cluster or elsewhere |
+| Engine | OAuth provider token endpoints | Getting and refreshing end-user tokens. Restrict with `engine.ssrfAllowlist`. |
+| Engine | Your [contextual access](/operate/governance/contextual-access) hooks | Policy checks before and after each tool call |
+| Coordinator | Your OIDC identity provider | Signing operators in |
+| MCP servers | Third-party APIs | The work each tool does |
+
+The Engine never accepts a connection from the Coordinator, so you can keep it behind a firewall as long as it can reach the services in the preceding table.
+
+### The OAuth callback
+
+This is the one inbound path worth planning carefully. When an end user authorizes a provider such as Google or Slack, the provider redirects the user's **browser** to a callback URL on the Coordinator. The provider never calls your deployment directly. The only provider-facing request is the code-for-token exchange, which Arcade makes outbound.
+
+The Coordinator's callback URL therefore has to be reachable from wherever your users' browsers are, not from the public internet. If your users are on your corporate network or VPN, the Coordinator can stay private to that network.
+
+## Data stores
+
+**PostgreSQL** holds everything that has to survive a restart:
+
+- Accounts, organizations, projects, and API keys
+- Registered MCP servers and their tool definitions
+- MCP gateway configuration
+- Encrypted end-user tokens and tool secrets
+- Tool execution history and audit logs
+
+**Redis** holds what Arcade can recompute: validated API keys, the tool registry, MCP and gateway session state, in-flight OAuth requests, permission decisions, and rate-limit counters.
+
+<Callout type="warning">
+The Helm chart can deploy PostgreSQL and Redis alongside the platform so you can evaluate Arcade quickly. These bundled instances have no backups and no high availability, so bring your own managed PostgreSQL and Redis instances for production.
+</Callout>
+
+## Next steps
+
+- [Self-host with Helm](/operate/deploy/helm) to install the platform
+- [Create an MCP gateway](/operate/governance/mcp-gateways) to scope tools and auth for each client
+- [Set up a User Source](/operate/identity/user-sources) to authenticate your end users

--- a/app/en/operate/deploy/architecture/page.mdx
+++ b/app/en/operate/deploy/architecture/page.mdx
@@ -21,6 +21,7 @@ This page describes what each service does and what it connects to. For installa
 | Dashboard | The web interface for operators and developers | Experience API | Yes |
 | MCP servers | Hosting and running tools | The third-party APIs the tools call | Yes |
 | OpenFGA | Evaluating operator access control policies | Nothing outbound | No |
+| Usage | Collecting usage events for billing and analytics | Billing and analytics sinks | No |
 | PostgreSQL and Redis | Persistent state, caching, and sessions | Nothing outbound | Yes |
 
 Agents and Arcade clients call the Engine. Operators use the dashboard in a browser, which reaches the platform through the Experience API. Each service reads and writes its own state in PostgreSQL and Redis.
@@ -92,11 +93,19 @@ OpenFGA evaluates whether an account may perform an action on an organization or
 
 It is optional and turned off by default. When turned on, the Coordinator is its only caller.
 
+### Usage
+
+The Usage service collects usage events from the Engine, Coordinator, and MCP servers and routes them to billing and analytics sinks.
+
+It is off by default. Setting `usageTracking.enabled` turns it on, after which those three services emit usage events to the endpoint at `usageTracking.url`.
+
+That value defaults to an Arcade-hosted endpoint. The Helm chart does not deploy a Usage service, so keeping usage events inside your network means running the service yourself and pointing `usageTracking.url` at it.
+
 ## Network paths
 
 Three services accept inbound traffic. The Engine takes calls from agents, Arcade clients, and MCP clients. The Dashboard and Experience API take requests from operators' browsers. Nothing outside the cluster connects to the Coordinator, an MCP server, OpenFGA, or a data store.
 
-The platform initiates the remaining connections outbound:
+The platform initiates the remaining connections outbound. The last row applies only if you turn on usage tracking:
 
 | From | To | For |
 | --- | --- | --- |
@@ -106,6 +115,7 @@ The platform initiates the remaining connections outbound:
 | Engine | Your [contextual access](/operate/governance/contextual-access) hooks | Policy checks before and after each tool call |
 | Coordinator | Your OIDC identity provider | Signing operators in |
 | MCP servers | Third-party APIs | The work each tool does |
+| Engine, Coordinator, MCP servers | Your `usageTracking.url` endpoint | Usage events |
 
 The Engine accepts no connection from the Coordinator, so it can run behind a firewall as long as it can reach the destinations in the preceding table.
 

--- a/app/en/operate/deploy/aws/page.mdx
+++ b/app/en/operate/deploy/aws/page.mdx
@@ -15,7 +15,7 @@ AWS is available through a private offer. View the [Arcade listing on AWS Market
 
 ## What gets deployed
 
-The AWS deployment stands up the complete Arcade platform — Engine, Coordinator, Worker, Dashboard, and Experience API — in your account, using managed AWS services:
+The AWS deployment stands up the complete Arcade platform in your account. See [Platform architecture](/operate/deploy/architecture) for what each Arcade service does. It runs on managed AWS services:
 
 | AWS service | Role |
 | --- | --- |

--- a/app/en/operate/deploy/azure/page.mdx
+++ b/app/en/operate/deploy/azure/page.mdx
@@ -43,7 +43,7 @@ The managed application provisions everything Arcade needs inside a managed reso
 
 | Azure service | Role |
 | --- | --- |
-| **Azure Kubernetes Service (AKS)** | Private cluster that runs the Arcade services (Engine, Coordinator, Worker, Dashboard, Experience API) |
+| **Azure Kubernetes Service (AKS)** | Private cluster that runs the [Arcade services](/operate/deploy/architecture) |
 | **Azure Key Vault** | Stores database, cache, identity-provider, and encryption secrets |
 | **Azure Database for PostgreSQL Flexible Server** | Primary datastore |
 | **Azure Managed Redis** | Cache and streams |

--- a/app/en/operate/deploy/gcp/page.mdx
+++ b/app/en/operate/deploy/gcp/page.mdx
@@ -11,7 +11,7 @@ import { Callout } from "nextra/components";
 A turnkey Arcade deployment for Google Cloud is **in development**. [Request early access](https://www.arcade.dev/contact) to be notified when it's available and to help shape it.
 </Callout>
 
-Arcade on GCP will deploy the full platform — Engine, Coordinator, Worker, Dashboard, and Experience API — into your own Google Cloud project, using managed Google Cloud services.
+Arcade on GCP will deploy the [full platform](/operate/deploy/architecture) into your own Google Cloud project, using managed Google Cloud services.
 
 ## Planned architecture
 

--- a/app/en/operate/deploy/helm/page.mdx
+++ b/app/en/operate/deploy/helm/page.mdx
@@ -15,13 +15,13 @@ If you'd rather not manage Kubernetes yourself, the [Azure](/operate/deploy/azur
 
 ## What it deploys
 
-The chart installs the complete platform — Engine, Coordinator, Worker, Dashboard, and Experience API — into a namespace on your cluster, along with the supporting controllers it needs.
+The chart installs the complete platform into a namespace on your cluster, along with the supporting controllers it needs. See [Platform architecture](/operate/deploy/architecture) for what each service is responsible for and how they connect.
 
 ## Prerequisites
 
 - **Kubernetes** 1.30 or later
 - **Helm** 3.8 or later (for OCI chart support)
-- **PostgreSQL** and **Redis** — bundled by the chart for proof-of-concept, or bring your own managed instances for production
+- **PostgreSQL** and **Redis** — bundled by the chart for evaluation, or bring your own managed instances for production
 - An [OIDC identity provider](/references/auth-providers)
 - An ingress controller or Gateway API implementation, TLS certificates, and a DNS hostname
 
@@ -59,7 +59,7 @@ Once the pods are running, open your configured hostname and sign in through you
 
 Configure the platform through Helm values. The chart covers:
 
-- **Components** — Engine, Coordinator, Worker, Dashboard, and Experience API
+- **Components** — the [platform services](/operate/deploy/architecture) and how many replicas of each to run
 - **Identity** — your OIDC identity provider and [OAuth providers](/references/auth-providers)
 - **Data stores** — bundled or external PostgreSQL and Redis
 - **Networking** — ingress or Gateway API, TLS, and the `engine.ssrfAllowlist` for reaching internal services

--- a/app/en/operate/deploy/page.mdx
+++ b/app/en/operate/deploy/page.mdx
@@ -34,7 +34,7 @@ Deploy a turnkey, Arcade-operated platform into your own cloud account:
 
 ### Self-host with Helm
 
-Prefer to run it yourself? [Deploy the platform with Helm](/operate/deploy/helm) on your own Kubernetes cluster and manage it end to end.
+Prefer to run it yourself? [Deploy the platform with Helm](/operate/deploy/helm) on your own Kubernetes cluster and manage it end to end. See [Platform architecture](/operate/deploy/architecture) for the services a self-hosted deployment runs.
 
 <Callout type="info">
 The marketplace and Helm options are **full platform deployments**. The features below run *on top of* Arcade. They aren't ways to stand up the platform.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,4 +1,4 @@
-<!-- git-sha: 12103aadf4a50b2ff7450a56667459775ebb9261 generation-date: 2026-08-31T16:56:33.588Z -->
+<!-- git-sha: a7e4d73a0de1e4efec5f8c6497adb774cb8f5222 generation-date: 2026-08-31T22:35:32.594Z -->
 
 # Arcade
 
@@ -145,6 +145,7 @@ Arcade docs serve two audiences. Start with the path that matches your goal:
 - [Okta](https://docs.arcade.dev/en/operate/identity/user-sources/okta): Documentation page
 - [Operate Arcade](https://docs.arcade.dev/en/operate): Documentation page
 - [Organize your MCP server and tools](https://docs.arcade.dev/en/build/create-tools/tool-basics/organize-mcp-tools): Documentation page
+- [Platform architecture](https://docs.arcade.dev/en/operate/deploy/architecture): Documentation page
 - [Providing useful tool errors](https://docs.arcade.dev/en/build/create-tools/error-handling/useful-tool-errors): Documentation page
 - [Rate Limiting](https://docs.arcade.dev/en/operate/governance/contextual-access/rate-limiting): Documentation page
 - [Remote MCP servers](https://docs.arcade.dev/en/operate/governance/remote-mcp-servers): Documentation page

--- a/styles/config/vocabularies/Arcade/accept.txt
+++ b/styles/config/vocabularies/Arcade/accept.txt
@@ -1,5 +1,10 @@
 # Arcade-specific terms
 Arcade
+OpenFGA
+Coordinator
+Org Admin
+Project Admin
+Project Member
 MCP
 User Source
 User Sources


### PR DESCRIPTION
## What

Adds `/operate/deploy/architecture` — a page explaining what each service in a self-hosted Arcade deployment is responsible for and what it connects to.

## Why

Self-hosted customers had no explanation of what the platform actually runs. Every deploy page repeated the same flat list — "Engine, Coordinator, Worker, Dashboard, and Experience API" — without saying what any of them do. Meanwhile the glossary described a separate conceptual vocabulary (Arcade Client → MCP Gateway → Arcade Engine → MCP server) that never reconciled with the deployed services. An operator debugging a pod, writing a network policy, or answering a security review had nowhere to look.

The four deploy pages now link here instead of repeating the list.

## Source of truth

Everything is verified against **chart 1.9.7** in `monorepo/deploy/charts/arcade`, plus each app's source. Note the standalone `arcade-helm` repo is stale at 1.3.4 and disagrees — I did not use it.

Service responsibilities come from the code, not the README one-liners: the Engine's OpenAPI surface, the Coordinator's data models and app modules, the Experience API's module wiring, the dashboard's route tree, and `authz/model.fga` for the role names.

## Corrections to existing docs

- **Experience API is mandatory**, not just one item in a list. The dashboard routes every backend call through it (`values.yaml`: "there's no valid deployment that leaves it out").
- **OpenFGA exists and is off by default** (`rbac.enabled: false`). No docs page mentioned it.
- **Bundled PostgreSQL and Redis are evaluation-only.** The Helm page said "proof-of-concept," which reads as production-viable. Now says evaluation, and the new page warns about no backups or HA.

## Two network facts worth a reviewer's attention

Both change operator guidance, so please sanity-check them:

1. **The OAuth callback is a browser redirect, not a provider-to-server call.** `toolauth/api/v1/oauth.py:242` is a `GET` that renders HTML templates. The only provider-facing request is the code-for-token exchange, which Arcade makes outbound. So the callback URL needs to be reachable from your users' *browsers* — the Coordinator can stay private to a corporate network or VPN. Saying it "must be reachable from the internet" would push people into needless public ingress.
2. **The Engine's outbound set is wider than the Coordinator alone** — it also calls MCP servers, OAuth token endpoints (restricted by `engine.ssrfAllowlist`), and contextual access hooks. The page has an egress table.

## Terminology decisions

- **"MCP server" leads; `worker` is noted once as the Helm/API alias.** They're the same thing (`apps/engine/README.md:31` treats them as synonyms). A callout warns against confusing either with an MCP gateway, which is an Engine feature rather than a deployed service.
- **The Experience API is described as the dashboard's backend**, with an explicit note that customers should integrate against the Engine instead. Avoided the acronym "BFF".

## No diagram — please read this

I built this with a Mermaid diagram, then found **Mermaid renders as nothing on the production docs site**. All four glossary diagrams are currently invisible to readers there — `curl`ing the live glossary shows the source only survives in the "Copy page" payload, with no rendered SVG. So this page uses a table instead of shipping an empty section. Worth fixing separately.

## Vale

Added `OpenFGA`, `Coordinator`, and the role names (`Org Admin`, `Project Admin`, `Project Member`) to the Arcade vocabulary. These are literal product and UI strings, so the rules flagging them (e.g. "use 'administrator' instead of 'Admin'") were wrong here. No suppression comments.

## Deliberately out of scope

- **Sizing and capacity.** Numbers exist in the monorepo's sizing guide and would make a good follow-up page.
- **Condex / GoEmbed.** An `arcade-discovery` chart exists but an internal note says no such chart exists — one is stale. Left out until engineering confirms.
- **Ports, env vars, Helm value names, bootstrap jobs.** Install detail that belongs on the Helm page.
- `/v1/chat/completions` and the scheduled-tools API are in the Engine's OpenAPI but have no public docs page, so I couldn't confirm they're supported surface rather than internal or preview.

## Verification

- `pnpm vale:check` — clean on the new page; my edits also removed 6 pre-existing errors from the deploy pages and added none
- `pnpm lint` — clean
- `pnpm test` — 863 tests across 68 files pass
- `pnpm build` — succeeds, route prerendered static
- All internal links verified 200 against a running dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and lint vocabulary only; no application or deployment code changes.
> 
> **Overview**
> Adds a **Platform architecture** doc under Operate → Deploy and registers it in the deploy nav. The new page is the single place that explains self-hosted services (Engine, Coordinator, Experience API, Dashboard, MCP servers, optional OpenFGA and Usage, PostgreSQL/Redis), inbound vs outbound network paths, OAuth callback reachability for user browsers, and production vs evaluation data stores.
> 
> Deploy overview, Helm, AWS, Azure, and GCP pages no longer repeat the flat “Engine, Coordinator, Worker…” list; they link here instead. Helm wording shifts bundled Postgres/Redis from “proof-of-concept” to **evaluation**, aligned with a warning that chart-bundled DBs are not production-ready.
> 
> `public/llms.txt` picks up the new route, and Vale’s Arcade vocabulary adds product terms (`OpenFGA`, `Coordinator`, role names) so lint passes on the new content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f50ac2613f7eff628801060b36076228ce0bc11d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->