### PR TITLE
fix(deps): bump @arcadeai/design-system to 7.9.1 to publish Mixpanel

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://arcade.dev/",
   "dependencies": {
-    "@arcadeai/design-system": "7.8.0",
+    "@arcadeai/design-system": "7.9.1",
     "@arcadeai/ui-kit": "0.14.0",
     "@mdx-js/mdx": "3.1.1",
     "@next/third-parties": "16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,11 +20,11 @@ importers:
   .:
     dependencies:
       '@arcadeai/design-system':
-        specifier: 7.8.0
-        version: 7.8.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)
+        specifier: 7.9.1
+        version: 7.9.1(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)
       '@arcadeai/ui-kit':
         specifier: 0.14.0
-        version: 0.14.0(@ai-sdk/react@4.0.40(react@19.2.7)(zod@4.3.6))(@arcadeai/design-system@7.8.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0))(@tanstack/react-query@5.101.4(react@19.2.7))(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ai@7.0.37(zod@4.3.6))(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)
+        version: 0.14.0(@ai-sdk/react@4.0.40(react@19.2.7)(zod@4.3.6))(@arcadeai/design-system@7.9.1(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0))(@tanstack/react-query@5.101.4(react@19.2.7))(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ai@7.0.37(zod@4.3.6))(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)
       '@mdx-js/mdx':
         specifier: 3.1.1
         version: 3.1.1
@@ -295,8 +295,8 @@ packages:
     resolution: {integrity: sha512-DLpvvDBvRNjzVmFYJ+upPrUJ8YRBoGWqPfzhuFp2+lh5Shxm0l9qLwe1Ah4pKvuCatU7TLOOTkFpICitTuuJeQ==}
     hasBin: true
 
-  '@arcadeai/design-system@7.8.0':
-    resolution: {integrity: sha512-DjRx4jWw0So6mdfjnR1ANiRu9ciqdpyvjGX0t93xRJxDqz2RMbv1MOQog0M0X7KADsgjNCljtAwdj5tCCBdYGg==}
+  '@arcadeai/design-system@7.9.1':
+    resolution: {integrity: sha512-oabHpcw7+wdyPboX/0QWMaCSWvXO4SfZLPANwvhGfT/4ki2Qw5BqVl4Pj+GFisjqax4UHs9rlB15NTdcIFeoaw==}
     engines: {bun: '>=1.3.5'}
     peerDependencies:
       '@hookform/resolvers': '>=5.2.1'
@@ -4818,7 +4818,7 @@ snapshots:
 
   '@arcadeai/arcadejs@2.4.1': {}
 
-  '@arcadeai/design-system@7.8.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)':
+  '@arcadeai/design-system@7.9.1(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)':
     dependencies:
       '@base-ui/react': 1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.16)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@base-ui/utils': 0.3.1(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -4849,11 +4849,11 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
-  '@arcadeai/ui-kit@0.14.0(@ai-sdk/react@4.0.40(react@19.2.7)(zod@4.3.6))(@arcadeai/design-system@7.8.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0))(@tanstack/react-query@5.101.4(react@19.2.7))(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ai@7.0.37(zod@4.3.6))(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)':
+  '@arcadeai/ui-kit@0.14.0(@ai-sdk/react@4.0.40(react@19.2.7)(zod@4.3.6))(@arcadeai/design-system@7.9.1(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0))(@tanstack/react-query@5.101.4(react@19.2.7))(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ai@7.0.37(zod@4.3.6))(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)':
     dependencies:
       '@ai-sdk/react': 4.0.40(react@19.2.7)(zod@4.3.6)
       '@arcadeai/arcadejs': 2.4.1
-      '@arcadeai/design-system': 7.8.0(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)
+      '@arcadeai/design-system': 7.9.1(@date-fns/tz@1.4.1)(@hookform/resolvers@5.2.2(react-hook-form@7.77.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.77.0(react@19.2.7))(react@19.2.7)(recharts@3.6.0(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1))(tailwindcss@4.3.0)
       '@tanstack/react-query': 5.101.4(react@19.2.7)
       '@tanstack/react-router': 1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-virtual': 3.14.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
Fixes the [#proj-docs alert](https://arcade-ai.slack.com/archives/C0BP8M8KF7G/p1788347999159619): *"Mixpanel is missing from the docs site — missing design-system metadata"*.

A toolkit reaches the docs site only when `@arcadeai/design-system` carries metadata for it **and** the pin here is new enough to see it. Mixpanel shipped upstream in 7.9.1; this repo was pinned to 7.8.0, so `DataMerger` found no metadata and omitted the toolkit.

## Is the bump legit?

I diffed toolkit metadata between the two versions rather than trusting the version number:

| | 7.8.0 | 7.9.1 |
|---|---|---|
| Toolkit entries | 177 | 178 |
| Added | — | `Mixpanel` |
| Removed | — | none |

Mixpanel resolves to `category: development`, `type: arcade`, `isHidden: false` — an existing category, so no new route directory is needed.

Of 996 dist files, 24 differ: the new Mixpanel icon, plus a new `mcp-server-picker-dialog` organism and a changed `server-avatar-stack` molecule. Neither component is imported anywhere in this repo (only design-system barrel files reference them), so nothing rendered here changes except the new icon.

## This adds the metadata, not the page

The page needs `data/toolkits/Mixpanel.json` from a generation run. Until then Mixpanel resolves with `hasPage: false`, which `toolkits-client.tsx` renders as a **non-clickable coming-soon card** — not a link to a 404. The next nightly `Generate toolkit docs` run fills it in.

## Verification

Locally on Node 22 (the version CI uses — Node 25 fails this build for unrelated reasons): `pnpm test` 873 passed, `pnpm run build` exit 0, `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump with no local code edits; main risk is incidental UI/metadata from the design-system release, not auth or data paths.
> 
> **Overview**
> Bumps **`@arcadeai/design-system`** from **7.8.0** to **7.9.1** in `package.json` and refreshes **`pnpm-lock.yaml`** so the docs site picks up upstream toolkit metadata—especially **Mixpanel**, which was absent at the old pin and caused `DesignSystemMetadataSource` / **`DataMerger`** to omit it from integrations.
> 
> There are **no application source changes** in this diff; behavior shifts come from the new package version (e.g. Mixpanel can appear on the integrations index, likely as a **coming-soon** card until `data/toolkits/Mixpanel.json` is generated by the toolkit docs pipeline).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92e2b877ca68a3a79735c278c775e560e53b47fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->