### PR TITLE
fix(deps): pin @opentelemetry/core to 2.10.0 (CVE-2026-54285)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   axios: '>=1.19.0 <2'
   brace-expansion: '>=5.0.9 <6'
   js-yaml: '>=4.3.1 <5'
+  '@opentelemetry/core': '>=2.8.0 <2.11.0'
 
 importers:
 
@@ -1023,14 +1024,8 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/core@2.2.0':
-    resolution: {integrity: sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/core@2.5.0':
-    resolution: {integrity: sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==}
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -5421,12 +5416,7 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
-  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.39.0
-
-  '@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.39.0
@@ -5435,7 +5425,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.208.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-exporter-base': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
@@ -5443,14 +5433,14 @@ snapshots:
   '@opentelemetry/otlp-exporter-base@0.208.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.208.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
@@ -5460,32 +5450,32 @@ snapshots:
   '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
 
   '@opentelemetry/resources@2.5.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.5.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
 
   '@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.208.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,3 +21,5 @@ overrides:
   brace-expansion: ">=5.0.9 <6"
   # Force js-yaml (via next-validate-link, swagger-client, swagger-ui-react) past CVE-2026-59869 (fixed in 4.3.0). Cap below 5 to stay within consumers' ^4 range.
   js-yaml: ">=4.3.1 <5"
+  # Force @opentelemetry/core (via posthog-js) past the unbounded W3C Baggage allocation advisory (CVE-2026-54285, fixed in 2.8.0). Capped below 2.11.0 because that release is still inside the 7-day minimumReleaseAge window above; raise the cap once it ages out.
+  "@opentelemetry/core": ">=2.8.0 <2.11.0"


### PR DESCRIPTION
## What changed

Adds a pnpm override forcing `@opentelemetry/core` to `>=2.8.0 <2.11.0` (resolves to 2.10.0), replacing the 2.2.0 and 2.5.0 copies that were being installed transitively.

## Why

`posthog-js` pulls `@opentelemetry/core` in two places — via `@opentelemetry/exporter-logs-otlp-http` (2.2.0) and `@opentelemetry/resources` (2.5.0). Both are affected by [GHSA-8988-4f7v-96qf](https://github.com/advisories/GHSA-8988-4f7v-96qf) / CVE-2026-54285 (moderate, CWE-770):

> `W3CBaggagePropagator.extract()` does not enforce size limits when parsing inbound `baggage` HTTP headers, so parsing oversized baggage allocates memory proportional to the header size without any cap.

Fixed upstream in 2.8.0, which enforces the W3C Baggage limits (8,192 bytes total, 180 entries, 4,096 bytes per entry) on the inbound path.

Nothing in this repo depends on OpenTelemetry directly — it arrives entirely through the PostHog browser SDK.

## Notes for reviewers

- **Real-world exposure here is minimal.** The affected code path parses inbound `baggage` headers, which a statically-rendered docs site doesn't exercise, and Node's default 16 KB header limit constrains it regardless. This is a Dependabot-quieting patch, not an incident response.
- **Why the upper cap.** The OTel sibling packages pin `@opentelemetry/core` to an exact version, so an override is the only way to lift it. The cap sits below 2.11.0 because that release was published two days ago and is still inside the 7-day `minimumReleaseAge` window this repo sets for supply-chain safety. Raise the cap once 2.11.0 ages out.
- **Separate issue spotted:** with `>=2.8.0 <3`, pnpm 10.11.0 resolved 2.11.0 anyway — the `minimumReleaseAge: 10080` guard did not filter it. Worth checking whether that setting is supported at the pinned pnpm version; the cap in this PR sidesteps it but doesn't fix it.
- Follows the same override pattern already used in `pnpm-workspace.yaml` for `dompurify`, `protobufjs`, `axios`, `js-yaml`, and others.

## Verification

- `pnpm audit` no longer reports CVE-2026-54285 (moderate count 11 → 9)
- `pnpm build` passes clean
- `pnpm test` — 873 tests across 69 files, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump with no application code changes; exposure on a static docs site is minimal, though it touches telemetry code pulled in by PostHog.
> 
> **Overview**
> Adds a **pnpm override** for `@opentelemetry/core` (`>=2.8.0 <2.11.0`, resolving to **2.10.0**) in `pnpm-workspace.yaml` and updates the lockfile so transitive copies **2.2.0** and **2.5.0** from **posthog-js**’s OpenTelemetry stack are replaced with a patched release.
> 
> This addresses **CVE-2026-54285** (unbounded memory allocation when parsing oversized W3C `baggage` headers in `W3CBaggagePropagator.extract()`). The upper bound stays below **2.11.0** to respect the repo’s **7-day `minimumReleaseAge`** supply-chain policy until that version ages out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ef592c5718c104b68378148bfd880c724f3548a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->