### PR TITLE
ci: accept an explicit version in the design-system dependency update

### DIFF
--- a/.github/workflows/update-design-system-dependency.yml
+++ b/.github/workflows/update-design-system-dependency.yml
@@ -44,10 +44,7 @@ jobs:
         env:
           VERSION: ${{ inputs.version || 'latest' }}
         run: |
-          # --save-exact because every dependency here is pinned exactly and
-          # no save-prefix is configured, so the default would write a caret
-          # range and quietly loosen the pin.
-          pnpm install --save-exact "@arcadeai/design-system@${VERSION}"
+          pnpm install "@arcadeai/design-system@${VERSION}"
           # Report the version actually written to package.json, so the PR
           # names a release rather than the `latest` alias.
           installed=$(jq -r '.dependencies["@arcadeai/design-system"]' package.json)

--- a/.github/workflows/update-design-system-dependency.yml
+++ b/.github/workflows/update-design-system-dependency.yml
@@ -2,6 +2,16 @@ name: Update design system dependency
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: >-
+          Exact version to install, e.g. 7.9.2. Defaults to whatever the
+          registry currently tags as latest. The design-system publish
+          workflow passes the version it just published, so the bump lands on
+          that release rather than on whichever one `latest` resolves to when
+          this run happens to read the registry.
+        required: false
+        default: latest
 
 permissions:
   contents: write
@@ -29,8 +39,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Update @arcadeai/design-system to latest
-        run: pnpm install @arcadeai/design-system@latest
+      - name: Update @arcadeai/design-system
+        id: update
+        env:
+          VERSION: ${{ inputs.version || 'latest' }}
+        run: |
+          # --save-exact because every dependency here is pinned exactly and
+          # no save-prefix is configured, so the default would write a caret
+          # range and quietly loosen the pin.
+          pnpm install --save-exact "@arcadeai/design-system@${VERSION}"
+          # Report the version actually written to package.json, so the PR
+          # names a release rather than the `latest` alias.
+          installed=$(jq -r '.dependencies["@arcadeai/design-system"]' package.json)
+          echo "installed=${installed}" >> "$GITHUB_OUTPUT"
 
       - name: Check for changes
         id: check-changes
@@ -66,15 +87,16 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           author: ${{ steps.app-token.outputs.committer }}
           committer: ${{ steps.app-token.outputs.committer }}
-          commit-message: "chore: update @arcadeai/design-system to latest"
-          title: "chore: update @arcadeai/design-system to latest"
+          commit-message: "chore: update @arcadeai/design-system to ${{ steps.update.outputs.installed }}"
+          title: "chore: update @arcadeai/design-system to ${{ steps.update.outputs.installed }}"
           body: |
-            This PR updates `@arcadeai/design-system` to the latest published version.
+            This PR updates `@arcadeai/design-system` to `${{ steps.update.outputs.installed }}`.
 
             It runs a design-system compatibility test gate before opening this PR.
             If that gate fails, the workflow stops and no PR is created.
 
             - Trigger: `${{ github.event_name }}`
+            - Requested version: `${{ inputs.version || 'latest' }}`
             - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           add-paths: |
             package.json


### PR DESCRIPTION
Prerequisite for [ArcadeAI/monorepo#3913](https://github.com/ArcadeAI/monorepo/pull/3913). **Merge this first** — that PR starts passing `--field version=`, which fails against a workflow that doesn't declare the input.

## Problem

This workflow resolves the version itself:

```yaml
- name: Update @arcadeai/design-system to latest
  run: pnpm install @arcadeai/design-system@latest
```

then decides whether to open a PR by diffing `package.json` and `pnpm-lock.yaml`.

npm can serve a packument that doesn't yet include a just-published version. The design-system publish workflow dispatches this one the moment `bun publish` returns, so a run landing inside that window resolves `latest` to the version already pinned here, finds no diff, and exits green having done nothing.

That's what happened with 7.9.2: dispatched at 16:33 UTC, published at 16:37, no PR, and `main` stayed on 7.9.1 — which kept the toolkit docs generator excluding ServiceNow, since it drops any provider missing from the design-system catalog.

## Change

Take `version` as a dispatch input, defaulting to `latest` so manual runs behave exactly as before. The publish workflow passes the version it just published. That pins the bump to the release that triggered it rather than to whatever `latest` resolves to at read time, and an unresolvable exact version now fails the install instead of silently resolving to the older release.

The PR this opens also names the version actually written to `package.json`, read back after the install, rather than saying "latest" in its title and body.

## Verification

Workflow YAML parses and the `version` input defaults to `latest`.

Checked against the live registry and a local install:

- `npm view "@arcadeai/design-system@7.9.2" version` exits 0; an unpublished version exits 1. That's the property the publish-side wait in #3913 depends on.
- `pnpm install @arcadeai/design-system@7.9.2` writes the pin as `7.9.2`, and `@latest` currently resolves to `7.9.2` and writes it the same way.

Not exercised end to end — that needs a real publish to dispatch it.

## Note on an earlier revision of this PR

An earlier push added `--save-exact` along with a claim that pnpm's default would write `^7.9.2` and loosen the pin. That was wrong: pnpm keeps an existing dependency's range style, so a plain install of an exact-pinned package writes an exact pin. Verified by running it both ways. The flag has been removed, since it changed nothing.

Also checked, since it looked like a risk: `minimumReleaseAge: 10080` in `pnpm-workspace.yaml` does not block a direct add of a package published minutes ago. `@latest` resolved to same-day 7.9.2 without complaint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)