### PR TITLE
chore(deps): patch 13 Dependabot advisories via pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "next-validate-link": "1.6.6",
     "openai": "6.41.0",
     "ora": "9.4.0",
-    "postcss": "8.5.15",
+    "postcss": "8.5.26",
     "tailwindcss": "4.3.0",
     "tsx": "^4.23.8",
     "typescript": "5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,16 +5,19 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  postcss: '>=8.5.15'
-  '@xmldom/xmldom': '>=0.9.10'
+  postcss: '>=8.5.26 <8.5.27'
+  '@xmldom/xmldom': '>=0.9.12'
   esbuild: 0.28.1
   form-data: 4.0.6
-  dompurify: '>=3.4.7 <4'
+  dompurify: '>=3.4.13 <4'
   protobufjs: '>=7.6.3 <8'
   axios: '>=1.19.0 <2'
   brace-expansion: '>=5.0.9 <6'
   js-yaml: '>=4.3.1 <5'
   '@opentelemetry/core': '>=2.8.0 <2.11.0'
+  mermaid: '>=11.16.1 <12'
+  nanoid: '>=3.3.18 <4'
+  fflate: '>=0.4.9 <0.5'
 
 importers:
 
@@ -166,8 +169,8 @@ importers:
         specifier: 9.4.0
         version: 9.4.0
       postcss:
-        specifier: '>=8.5.15'
-        version: 8.5.19
+        specifier: '>=8.5.26 <8.5.27'
+        version: 8.5.26
       tailwindcss:
         specifier: 4.3.0
         version: 4.3.0
@@ -414,8 +417,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@braintree/sanitize-url@7.1.1':
-    resolution: {integrity: sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==}
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
@@ -798,8 +801,8 @@ packages:
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
-  '@mermaid-js/parser@1.1.1':
-    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
+  '@mermaid-js/parser@1.2.1':
+    resolution: {integrity: sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==}
 
   '@napi-rs/simple-git-android-arm-eabi@0.1.22':
     resolution: {integrity: sha512-JQZdnDNm8o43A5GOzwN/0Tz3CDBQtBUNqzVwEopm32uayjdjxev1Csp1JeaqF3v9djLDIvsSE39ecsN2LhCKKQ==}
@@ -2073,10 +2076,9 @@ packages:
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+  '@xmldom/xmldom@0.9.12':
+    resolution: {integrity: sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==}
     engines: {node: '>=14.6'}
-    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -2356,8 +2358,8 @@ packages:
     peerDependencies:
       cytoscape: ^3.2.0
 
-  cytoscape@3.33.1:
-    resolution: {integrity: sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==}
+  cytoscape@3.34.2:
+    resolution: {integrity: sha512-Cm2jaj1X/PBNlzV9yH8zcfGOxO7U+CJ/+mxSBVPSchLaugdp4jtlGx5qaHtPRZ6tgiZ5P+o1XoRfJA+ba6KM3g==}
     engines: {node: '>=0.10'}
 
   d3-array@2.12.1:
@@ -2505,8 +2507,8 @@ packages:
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
-  dayjs@1.11.19:
-    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
+  dayjs@1.11.23:
+    resolution: {integrity: sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2556,8 +2558,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.14:
+    resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -2604,9 +2606,6 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
-
-  es-toolkit@1.47.0:
-    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
   es-toolkit@1.49.0:
     resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
@@ -2685,6 +2684,9 @@ packages:
   fast-json-patch@3.1.1:
     resolution: {integrity: sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==}
 
+  fastdom@1.0.12:
+    resolution: {integrity: sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==}
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -2703,8 +2705,8 @@ packages:
       picomatch:
         optional: true
 
-  fflate@0.4.8:
-    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -3033,6 +3035,10 @@ packages:
     resolution: {integrity: sha512-aeQoDkuRWSqQN6nSvVCEFvfXdqo1OQiCmmW1kc9xSdjutPv7BGO7pqY9sQRJpMOGrEdfDgF2TfRXe5eUAD2Waw==}
     hasBin: true
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
@@ -3257,8 +3263,8 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  mermaid@11.15.0:
-    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
+  mermaid@11.17.2:
+    resolution: {integrity: sha512-V6K3C8EBdEsPFZXSKMJe6ppQOENxuHARr9GvHX4hh47lAbhMRD9qf4oEK7LoaRQxULMa80/qt5gHO73aCleBBg==}
 
   mhchemparser@4.2.1:
     resolution: {integrity: sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==}
@@ -3435,8 +3441,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3652,8 +3658,8 @@ packages:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
 
-  postcss@8.5.19:
-    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   posthog-js@1.379.0:
@@ -4184,6 +4190,9 @@ packages:
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
+
+  strictdom@1.0.1:
+    resolution: {integrity: sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -4927,7 +4936,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.3.2':
     optional: true
 
-  '@braintree/sanitize-url@7.1.1': {}
+  '@braintree/sanitize-url@7.1.2': {}
 
   '@chevrotain/types@11.1.2': {}
 
@@ -5237,7 +5246,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mermaid-js/parser@1.1.1':
+  '@mermaid-js/parser@1.2.1':
     dependencies:
       '@chevrotain/types': 11.1.2
 
@@ -6442,7 +6451,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.19
+      postcss: 8.5.26
       tailwindcss: 4.3.0
 
   '@tailwindcss/typography@0.5.19(tailwindcss@4.3.0)':
@@ -6494,7 +6503,7 @@ snapshots:
 
   '@theguild/remark-mermaid@0.3.0(react@19.2.7)':
     dependencies:
-      mermaid: 11.15.0
+      mermaid: 11.17.2
       react: 19.2.7
       unist-util-visit: 5.1.0
 
@@ -6780,7 +6789,7 @@ snapshots:
 
   '@workflow/serde@4.1.0': {}
 
-  '@xmldom/xmldom@0.9.10': {}
+  '@xmldom/xmldom@0.9.12': {}
 
   abbrev@1.1.1: {}
 
@@ -7031,17 +7040,17 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.1):
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.2):
     dependencies:
       cose-base: 1.0.3
-      cytoscape: 3.33.1
+      cytoscape: 3.34.2
 
-  cytoscape-fcose@2.2.0(cytoscape@3.33.1):
+  cytoscape-fcose@2.2.0(cytoscape@3.34.2):
     dependencies:
       cose-base: 2.2.0
-      cytoscape: 3.33.1
+      cytoscape: 3.34.2
 
-  cytoscape@3.33.1: {}
+  cytoscape@3.34.2: {}
 
   d3-array@2.12.1:
     dependencies:
@@ -7217,7 +7226,7 @@ snapshots:
 
   date-fns@4.4.0: {}
 
-  dayjs@1.11.19: {}
+  dayjs@1.11.23: {}
 
   debug@4.4.3:
     dependencies:
@@ -7255,7 +7264,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dompurify@3.4.12:
+  dompurify@3.4.14:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7296,8 +7305,6 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.4
-
-  es-toolkit@1.47.0: {}
 
   es-toolkit@1.49.0: {}
 
@@ -7419,6 +7426,10 @@ snapshots:
 
   fast-json-patch@3.1.1: {}
 
+  fastdom@1.0.12:
+    dependencies:
+      strictdom: 1.0.1
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -7435,7 +7446,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  fflate@0.4.8: {}
+  fflate@0.4.9: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -7827,6 +7838,10 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   khroma@2.1.0: {}
 
   layout-base@1.0.2: {}
@@ -8156,23 +8171,24 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@11.15.0:
+  mermaid@11.17.2:
     dependencies:
-      '@braintree/sanitize-url': 7.1.1
+      '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.0
-      '@mermaid-js/parser': 1.1.1
+      '@mermaid-js/parser': 1.2.1
       '@types/d3': 7.4.3
       '@upsetjs/venn.js': 2.0.0
-      cytoscape: 3.33.1
-      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.1)
-      cytoscape-fcose: 2.2.0(cytoscape@3.33.1)
+      cytoscape: 3.34.2
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.2)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.2)
       d3: 7.9.0
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
-      dayjs: 1.11.19
-      dompurify: 3.4.12
-      es-toolkit: 1.47.0
-      katex: 0.16.27
+      dayjs: 1.11.23
+      dompurify: 3.4.14
+      es-toolkit: 1.49.0
+      fastdom: 1.0.12
+      katex: 0.16.47
       khroma: 2.1.0
       marked: 16.4.2
       roughjs: 4.6.6
@@ -8513,7 +8529,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.18: {}
 
   negotiator@1.0.0: {}
 
@@ -8546,7 +8562,7 @@ snapshots:
       '@swc/helpers': 0.5.23
       baseline-browser-mapping: 2.10.33
       caniuse-lite: 1.0.30001760
-      postcss: 8.5.19
+      postcss: 8.5.26
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(react@19.2.7)
@@ -8772,9 +8788,9 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.19:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -8788,8 +8804,8 @@ snapshots:
       '@posthog/core': 1.30.3
       '@posthog/types': 1.379.0
       core-js: 3.47.0
-      dompurify: 3.4.12
-      fflate: 0.4.8
+      dompurify: 3.4.14
+      fflate: 0.4.9
       preact: 10.29.1
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.2.0
@@ -9478,7 +9494,7 @@ snapshots:
 
   speech-rule-engine@4.1.2:
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.9.12
       commander: 13.1.0
       wicked-good-xpath: 1.3.0
 
@@ -9496,7 +9512,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
       marked: 17.0.3
-      mermaid: 11.15.0
+      mermaid: 11.17.2
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       rehype-harden: 1.1.8
@@ -9512,6 +9528,8 @@ snapshots:
       unist-util-visit-parents: 6.0.2
     transitivePeerDependencies:
       - supports-color
+
+  strictdom@1.0.1: {}
 
   string-argv@0.3.2: {}
 
@@ -9607,7 +9625,7 @@ snapshots:
       classnames: 2.5.1
       css.escape: 1.5.1
       deep-extend: 0.6.0
-      dompurify: 3.4.12
+      dompurify: 3.4.14
       ieee754: 1.2.1
       immutable: 4.3.9
       js-file-download: 0.4.12
@@ -9947,7 +9965,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.19
+      postcss: 8.5.26
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  postcss: '>=8.5.26 <8.5.27'
+  postcss: 8.5.26
   '@xmldom/xmldom': '>=0.9.12'
   esbuild: 0.28.1
   form-data: 4.0.6
@@ -169,7 +169,7 @@ importers:
         specifier: 9.4.0
         version: 9.4.0
       postcss:
-        specifier: '>=8.5.26 <8.5.27'
+        specifier: 8.5.26
         version: 8.5.26
       tailwindcss:
         specifier: 4.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,16 +3,16 @@ settings:
   minimumReleaseAge: 10080
 
 overrides:
-  # Force next's transitive postcss to the same safe version as the direct dep
-  postcss: ">=8.5.15"
-  # rule-engine pulls a vulnerable @xmldom/xmldom (XML injection / uncontrolled recursion)
-  "@xmldom/xmldom": ">=0.9.10"
+  # Force next's transitive postcss to the same safe version as the direct dep. 8.5.23 fixes the sourceMappingURL arbitrary .map file read (GHSA-6g55-p6wh-862q follow-up). Capped below 8.5.27 because later releases are still inside the 7-day minimumReleaseAge window above; raise the cap once they age out.
+  postcss: ">=8.5.26 <8.5.27"
+  # rule-engine pulls a vulnerable @xmldom/xmldom (XML injection / uncontrolled recursion). 0.9.12 fixes the EntityReference.nodeName fragment injection.
+  "@xmldom/xmldom": ">=0.9.12"
   # Force vite's transitive esbuild off the vulnerable dev-server file-read advisory (GHSA-g7r4-m6w7-qqqr)
   esbuild: "0.28.1"
   # Force form-data to a patched version across all transitive dependents (CVE-2026-12143, CRLF header injection)
   form-data: "4.0.6"
   # Force dompurify (via mermaid, posthog-js, swagger-ui-react) past mXSS advisories (CVE-2026-49459, CVE-2026-49458 fixed in 3.4.6; GHSA-76mc-f452-cxcm fixed in 3.4.7). Cap below 4 to stay within consumers' ^3 range.
-  dompurify: ">=3.4.7 <4"
+  dompurify: ">=3.4.13 <4"
   # Force protobufjs (via @opentelemetry/otlp-transformer) past prototype-pollution advisory (CVE-2026-54269, fixed in 7.6.3). Cap below 8 to stay within otlp-transformer's ^7 range.
   protobufjs: ">=7.6.3 <8"
   # Force axios (via @ory/client, @swagger-api/apidom-reference) past the absolute-URL redirect advisory (GHSA-gcfj-64vw-6mp9, fixed in 1.18.0). Cap below 2 to stay within consumers' ^1 range.
@@ -23,3 +23,9 @@ overrides:
   js-yaml: ">=4.3.1 <5"
   # Force @opentelemetry/core (via posthog-js) past the unbounded W3C Baggage allocation advisory (CVE-2026-54285, fixed in 2.8.0). Capped below 2.11.0 because that release is still inside the 7-day minimumReleaseAge window above; raise the cap once it ages out.
   "@opentelemetry/core": ">=2.8.0 <2.11.0"
+  # Force mermaid (via @theguild/remark-mermaid, streamdown) past the XY-chart and radar DoS loops, architecture/config prototype pollution, and sibling CSS injection (all fixed in 11.16.1). Cap below 12 to stay within consumers' ^11 range.
+  mermaid: ">=11.16.1 <12"
+  # Force nanoid (via postcss) past the infinite loops on zero and negative size (fixed in 3.3.18). Cap below 4 to stay within postcss's ^3 range.
+  nanoid: ">=3.3.18 <4"
+  # Force fflate (via posthog-js) past the unzipSync infinite loop on malformed ZIP64 archives (fixed in 0.4.9). Cap below 0.5 to stay within posthog-js's ^0.4.8 range.
+  fflate: ">=0.4.9 <0.5"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,8 +3,8 @@ settings:
   minimumReleaseAge: 10080
 
 overrides:
-  # Force next's transitive postcss to the same safe version as the direct dep. 8.5.23 fixes the sourceMappingURL arbitrary .map file read (GHSA-6g55-p6wh-862q follow-up). Capped below 8.5.27 because later releases are still inside the 7-day minimumReleaseAge window above; raise the cap once they age out.
-  postcss: ">=8.5.26 <8.5.27"
+  # Force next's transitive postcss to the same safe version as the direct dep in package.json. 8.5.23 fixes the sourceMappingURL arbitrary .map file read (GHSA-6g55-p6wh-862q follow-up). Pinned (not a range) because 8.5.27+ are still inside the 7-day minimumReleaseAge window above.
+  postcss: "8.5.26"
   # rule-engine pulls a vulnerable @xmldom/xmldom (XML injection / uncontrolled recursion). 0.9.12 fixes the EntityReference.nodeName fragment injection.
   "@xmldom/xmldom": ">=0.9.12"
   # Force vite's transitive esbuild off the vulnerable dev-server file-read advisory (GHSA-g7r4-m6w7-qqqr)


### PR DESCRIPTION
Closes 13 of the 15 open Dependabot alerts on this repo.

## Changes

| Package | Was | Now | Alerts |
| --- | --- | --- | --- |
| `postcss` (direct + transitive) | 8.5.19 | 8.5.26 | #247, #246, #242 |
| `mermaid` | 11.15.0 | 11.17.2 | #252, #251, #250, #249, #248 |
| `nanoid` | 3.3.12 | 3.3.18 | #257, #256 |
| `dompurify` | 3.4.12 | 3.4.14 | #253 |
| `fflate` | 0.4.8 | 0.4.9 | #261 |
| `@xmldom/xmldom` | 0.9.10 | 0.9.12 | #260 |

All six are pinned through `pnpm-workspace.yaml` overrides (matching the existing pattern in that file), with caps that stay inside each consumer's declared range. `postcss` is also bumped as a direct dependency in `package.json`.

## Not fixed: `qs` (#259, #258)

The only patched release is `qs@6.16.0`, published 2026-08-29. This repo sets `minimumReleaseAge: 10080` (7 days) to guard against supply-chain attacks, and 6.16.0 does not clear that window until 2026-09-05. Adding the override now would mean pulling a package the repo's own policy says to wait on, so it's left for a follow-up tomorrow.

`postcss` is capped at `<8.5.27` for the same reason — 8.5.27 and 8.5.28 both shipped 2026-09-03. 8.5.26 is well past the 8.5.23 fix.

## Verification

- `pnpm install` clean
- `pnpm build` succeeds
- `pnpm test` — 875 tests across 69 files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are dependency and lockfile-only security patches with version caps inside consumer semver ranges; no auth or business logic is modified.
> 
> **Overview**
> Addresses **13 open Dependabot alerts** by tightening **`pnpm-workspace.yaml` overrides** and refreshing the lockfile, with no application source changes.
> 
> **Direct bump:** `postcss` in `package.json` goes from **8.5.15 → 8.5.26**, with the override **pinned** to that version (not a range) so it aligns with Next’s transitive PostCSS while staying outside the repo’s 7-day `minimumReleaseAge` window for newer 8.5.27+ releases.
> 
> **New or raised override floors** force patched transitive versions: **`mermaid`** (11.17.2), **`nanoid`**, **`fflate`**, stricter **`dompurify`** and **`@xmldom/xmldom`**, plus the existing **`postcss`** alignment. Comments in the workspace file document which CVEs/GHSAs each floor targets.
> 
> The lockfile reflects the cascade (e.g. Mermaid parser/cytoscape/katex bumps, removal of deprecated `@xmldom/xmldom@0.9.10`). **`qs`** advisories are intentionally left for a follow-up once a patched release clears `minimumReleaseAge`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea8f06e4cbed184fa54e442beb6a253212b2a0a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->