### PR TITLE
chore(deps): force qs >=6.16.0 via pnpm override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   mermaid: '>=11.16.1 <12'
   nanoid: '>=3.3.18 <4'
   fflate: '>=0.4.9 <0.5'
+  qs: '>=6.16.0 <7'
 
 importers:
 
@@ -3695,8 +3696,8 @@ packages:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   query-selector-shadow-dom@1.0.1:
@@ -4123,8 +4124,8 @@ packages:
     resolution: {integrity: sha512-KRT/hufMSxXKEDSQujfVE0Faa/kZ51ihUcZQAcmP04t00DvPj7Ox5anHke1sJYUtzSuiT/Y5uyzg/W7bBEGhCg==}
     hasBin: true
 
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
@@ -4135,8 +4136,8 @@ packages:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
     engines: {node: '>= 0.4'}
 
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -7746,7 +7747,7 @@ snapshots:
       htm: 3.1.1
       instantsearch-ui-components: 0.29.0(react@19.2.7)
       preact: 10.29.1
-      qs: 6.15.2
+      qs: 6.16.0
       react: 19.2.7
       search-insights: 2.17.3
 
@@ -8842,9 +8843,10 @@ snapshots:
 
   proxy-from-env@2.1.0: {}
 
-  qs@6.15.2:
+  qs@6.16.0:
     dependencies:
-      side-channel: 1.1.0
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   query-selector-shadow-dom@1.0.1: {}
 
@@ -9445,7 +9447,7 @@ snapshots:
 
   short-unique-id@5.3.2: {}
 
-  side-channel-list@1.0.0:
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -9465,11 +9467,11 @@ snapshots:
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
-  side-channel@1.1.0:
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-      side-channel-list: 1.0.0
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,3 +29,5 @@ overrides:
   nanoid: ">=3.3.18 <4"
   # Force fflate (via posthog-js) past the unzipSync infinite loop on malformed ZIP64 archives (fixed in 0.4.9). Cap below 0.5 to stay within posthog-js's ^0.4.8 range.
   fflate: ">=0.4.9 <0.5"
+  # Force qs (via instantsearch.js) past the array-limit bypass on bracket-key comma parsing (CVE-2026-82562) and the attacker-controlled isBuffer DoS (CVE-2026-82417), both fixed in 6.16.0. Cap below 7 to stay within instantsearch.js's ^6.5.1 range.
+  qs: ">=6.16.0 <7"


### PR DESCRIPTION
Resolves [PLT-3415](https://linear.app/arcadedev/issue/PLT-3415/qs-cve-2026-82417-cve-2026-82562-in-arcadeaidocs-repo) and Dependabot alerts #258 / #259.

## What

`instantsearch.js` (via `react-instantsearch`) pulls in `qs` 6.15.2, which is affected by two medium advisories:

- **CVE-2026-82562** ([GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx)) — array-limit bypass via bracket-key comma parsing
- **CVE-2026-82417** ([GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g)) — DoS via attacker-controlled `isBuffer`

Both are fixed in 6.16.0. Added a pnpm override pinning `qs` to `>=6.16.0 <7`, following the same pattern as the other overrides in `pnpm-workspace.yaml`. The cap keeps it inside `instantsearch.js`'s declared `^6.5.1` range.

`qs` 6.16.0 published 2026-08-29, so it's clear of the repo's 7-day `minimumReleaseAge` guard.

## Verification

- `pnpm install` resolves `qs@6.16.0` — no `6.15.2` left in the lockfile
- `pnpm build` succeeds
- `pnpm test` — 875 tests across 69 files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only security pin with no app code changes; minor risk if `qs` 6.16.0 breaks `instantsearch.js` query parsing, mitigated by existing tests/build verification.
> 
> **Overview**
> Adds a **pnpm workspace override** so transitive **`qs`** (from **`instantsearch.js`** / **`react-instantsearch`**) resolves to **`>=6.16.0 <7`** instead of **6.15.2**, addressing **CVE-2026-82562** and **CVE-2026-82417**.
> 
> The lockfile is refreshed accordingly (**`qs@6.16.0`** and related **`side-channel`** bumps); no application source changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2547f79b685d05ef69d23d15bbaa633b10accf51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->